### PR TITLE
Add missing nuget.config

### DIFF
--- a/demos/CoreClrConsoleApplications/HelloWorld/nuget.config
+++ b/demos/CoreClrConsoleApplications/HelloWorld/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="dotnet-corefx" value="https://www.myget.org/F/dotnet-corefx/" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Some of the packages require CoreFX MyGet feed. In order to make restoring packages work out-of-the-box we need to add a nuget.config file that points to the correct feed.

@KrzysztofCwalina 