### PR TITLE
Replaced dummy buffer pool with a more real one

### DIFF
--- a/src/System.Text.Formatting/src/System/InternalHelpers/BufferPool.cs
+++ b/src/System.Text.Formatting/src/System/InternalHelpers/BufferPool.cs
@@ -3,33 +3,187 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace System.IO
 {
-    internal static class BufferPool
+    public class BufferPool
     {
-        // TODO: implement a real pool
-        // Maybe the pool should support renting Span<byte> instead of byte[]. This would make it cheaper to have many small buffers.
-        public static byte[] RentBuffer(int minSize)
+        static BufferPool s_instance = new BufferPool(1024 * 1024);
+
+        int _maxBufferSize; // larger buffers won't be pooled
+        Bin[] _bins;
+
+        int _largeAllocationCounter; // performance counter for non-pooled allocations
+
+        private BufferPool(int maxBufferSize)
         {
-            Precondition.Require(minSize > 0);
-            return new byte[minSize];
+            Precondition.Require(maxBufferSize > 0);
+
+            _maxBufferSize = maxBufferSize;
+
+            var maxSizeBin = SelectBinIndex(maxBufferSize);
+            _bins = new Bin[maxSizeBin + 1];
+
+            for (var binIndex = 0; binIndex < _bins.Length; binIndex++)
+            {
+                int maxSizeForBin = GetMaxSizeForBin(binIndex);
+                _bins[binIndex] = new Bin(maxSizeForBin, 10);
+            }
         }
 
-        public static void ReturnBuffer(ref byte[] buffer)
+        public byte[] RentBuffer(int minSize)
         {
-            Precondition.Require(buffer != null);
+            if (minSize > _maxBufferSize)
+            {
+                Interlocked.Increment(ref _largeAllocationCounter);
+                return new byte[minSize];
+            }
+            int poolIndex = SelectBinIndex(minSize);
+            byte[] buffer = _bins[poolIndex].RentBuffer();
+            return buffer;
+        }
+
+        public void ReturnBuffer(ref byte[] buffer)
+        {
+            int poolIndex = SelectBinIndex(buffer.Length);
+            if (poolIndex >= _bins.Length) // this happend if the returned buffer is a large buffer not managed by the pool
+            {
+                return;
+            }
+            _bins[poolIndex].ReturnBuffer(buffer);
             buffer = null;
         }
 
-        public static void Enlarge(ref byte[] buffer, int minSize)
+        public void Enlarge(ref byte[] buffer, int newBufferMinSize)
         {
-            Precondition.Require(minSize > buffer.Length);
-
-            byte[] newBuffer = BufferPool.RentBuffer(minSize);
+            var newBuffer = RentBuffer(newBufferMinSize);
             buffer.CopyTo(newBuffer, 0);
-            BufferPool.ReturnBuffer(ref buffer);
+            ReturnBuffer(ref buffer);
             buffer = newBuffer;
+        }
+
+        public long Allocations
+        {
+            get
+            {
+                long sum = 0;
+                foreach (var pool in _bins)
+                {
+                    sum += pool.Allocations;
+                }
+                return sum + _largeAllocationCounter;
+            }
+        }
+
+        public static BufferPool Shared
+        {
+            get
+            {
+                return s_instance;
+            }
+        }
+
+        private int SelectBinIndex(int bufferSize)
+        {
+            Precondition.Require(bufferSize > 0);
+            var _poolIndex = MaxBitIndexSet((ulong)bufferSize - 1) - 3;
+            if (_poolIndex < 0) return 0;
+            return _poolIndex;
+        }
+
+        private int GetMaxSizeForBin(int binIndex)
+        {
+            checked
+            {
+                int result = 2;
+                int shifts = binIndex + 3;
+                result <<= shifts;
+                return result;
+            }
+        }
+
+        private int MaxBitIndexSet(ulong value)
+        {
+            if (value == 0) return -1;
+            if (value == 1) return 0;
+            int bit = -1;
+            while (value > 0)
+            {
+                value >>= 1;
+                bit++;
+            }
+            return bit;
+        }
+    }
+
+    // stores buffers of equal size
+    struct Bin
+    {
+        int _bufferSize; // the size of buffers in this bin
+        int _capacity;
+        byte[][] _buffers;
+        int _top; // the array above is a stack. This filed is the top of the stack. Top points to the top most buffer
+
+        int _allocationCounter; // performance counter incremented when bin actually allocates a new buffer on the GC heap
+
+        public Bin(int bufferSize, int capacity)
+        {
+            _bufferSize = bufferSize;
+            _capacity = capacity;
+            _buffers = null;
+            _top = -1;
+            _allocationCounter = 0;
+        }
+
+        public byte[] RentBuffer()
+        {
+            if (_buffers == null)
+            {
+                var buffers = new byte[_capacity][];
+                Interlocked.CompareExchange(ref _buffers, buffers, null);
+            }
+            while (true)
+            {
+                int top = _top;
+                if (top == -1) // no buffers in the bin
+                {
+                    return Allocate();
+                }
+
+                var buffer = Interlocked.Exchange(ref _buffers[top], null);
+                if (buffer != null) // ok, I got a buffer
+                {
+                    // need to update _top
+                    var originalValue = Interlocked.CompareExchange(ref _top, top - 1, top);
+                    if (originalValue != top) // oops, somebody else changed _top
+                    {
+                        if (_buffers[top] == null) // moreover there is possibly a hole in the stack now
+                        {
+                            _buffers[top] = Allocate(); // we don't want to leave a hole
+                        }
+                    }
+                    return buffer;
+                }
+            }
+        }
+
+        public void ReturnBuffer(byte[] buffer)
+        {
+            int top = _top;
+            if (top == _buffers.Length - 1) return; // no room in the pool; just drop the buffer on the GC; maybe a counter for this would be good
+
+            var candidateIndex = top + 1;
+            _buffers[candidateIndex] = buffer;
+            var originalValue = Interlocked.CompareExchange(ref _top, candidateIndex, top);
+        }
+
+        public int Allocations { get { return _allocationCounter; } }
+
+        byte[] Allocate()
+        {
+            Interlocked.Increment(ref _allocationCounter);
+            return new byte[_bufferSize];
         }
     }
 }

--- a/src/System.Text.Formatting/src/System/Text/Formatting/StreamFormatter.cs
+++ b/src/System.Text.Formatting/src/System/Text/Formatting/StreamFormatter.cs
@@ -20,7 +20,7 @@ namespace System.Text.Formatting
             _buffer = null;
             if (bufferSize > 0)
             {
-                _buffer = BufferPool.RentBuffer(bufferSize);
+                _buffer = BufferPool.Shared.RentBuffer(bufferSize);
             }
             _formattingData = formattingData;
             _stream = stream;
@@ -32,7 +32,7 @@ namespace System.Text.Formatting
             {
                 if (_buffer == null)
                 {
-                    _buffer = BufferPool.RentBuffer(256);
+                    _buffer = BufferPool.Shared.RentBuffer(256);
                 }
                 return _buffer;
             }
@@ -48,7 +48,7 @@ namespace System.Text.Formatting
 
         void IFormatter.ResizeBuffer()
         {
-            BufferPool.Enlarge(ref _buffer, _buffer.Length * 2);
+            BufferPool.Shared.Enlarge(ref _buffer, _buffer.Length * 2);
         }
 
         // ISSUE

--- a/src/System.Text.Formatting/src/System/Text/Formatting/StringFormatter.cs
+++ b/src/System.Text.Formatting/src/System/Text/Formatting/StringFormatter.cs
@@ -19,7 +19,7 @@ namespace System.Text.Formatting
 
         public StringFormatter(int capacity)
         {
-            _buffer = BufferPool.RentBuffer(capacity * 2);
+            _buffer = BufferPool.Shared.RentBuffer(capacity * 2);
         }
 
         public void Append(char character) {
@@ -72,7 +72,7 @@ namespace System.Text.Formatting
 
         void IFormatter.ResizeBuffer()
         {
-            BufferPool.Enlarge(ref _buffer, _buffer.Length * 2);
+            BufferPool.Shared.Enlarge(ref _buffer, _buffer.Length * 2);
         }
         void IFormatter.CommitBytes(int bytes)
         {


### PR DESCRIPTION
Though it has so much policy burnt into it. Maybe it's unavoidable.

Also, maybe somebody can look through the lock free Bin implementation. There are never too many eyes looking at code like that.