### PR TITLE
ReadOnlySpan<T>.Slice now returns ReadOnlySpan<T>

### DIFF
--- a/src/System.Text.Formatting/src/System/ReadOnlySpan.cs
+++ b/src/System.Text.Formatting/src/System/ReadOnlySpan.cs
@@ -37,13 +37,13 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> Slice(int index, int count)
+        public ReadOnlySpan<T> Slice(int index, int count)
         {
             throw new NotImplementedException();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> Slice(int index)
+        public ReadOnlySpan<T> Slice(int index)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
It used to return Span<T>, which was a design bug.