### PR TITLE
Added ByteSpan

### DIFF
--- a/src/System.Text.Formatting/src/System.Text.Formatting.csproj
+++ b/src/System.Text.Formatting/src/System.Text.Formatting.csproj
@@ -8,6 +8,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Text.Formatting</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -15,6 +16,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="System\ByteSpan.cs" />
     <Compile Include="System\Span.cs" />
     <Compile Include="System\ReadOnlySpan.cs" />
 

--- a/src/System.Text.Formatting/src/System/ByteSpan.cs
+++ b/src/System.Text.Formatting/src/System/ByteSpan.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System {
+
+    // I wish I could use just Span<byte>. 
+    // Unfortunatelly, Span<T> (as implementable currently) is too slow for some tight formatting loops.
+    // We might at some point get a fast Span<T>, and remove this type. 
+    // The main problem with Span<T> is that all indexer accessors need to do double pointer arrithmetic (offset from array and index into array)
+    // ByteSpan accessor just needs one pointer offset.
+    unsafe struct ByteSpan // Span<byte>
+    {
+        byte* _data;
+        int _length;
+
+        // Instances of this type will be created out of a memory buffer pool.
+        internal ByteSpan(byte* data, int length)
+        {
+            _data = data;
+            _length = length;
+        }
+
+        public byte this[int index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                // the range checks are super expensive. we need to optimize them out just like we do for arrays
+                //if (index >= Length) Environment.FailFast("index out of range");
+                return *(_data + index);
+            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set
+            {
+                // the range checks are super expensive. we need to optimize them out just like we do for arrays
+                //if (index >= Length) Environment.FailFast("index out of range");
+                *(_data + index) = value;
+            }
+        }
+
+        public int Length
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return _length;
+            }
+        }
+
+        public ByteSpan Slice(int index)
+        {
+            Precondition.Require(index < Length);
+
+            var data = _data + index;
+            var length = _length - index;
+            return new ByteSpan(data, length);
+        }
+
+        public ByteSpan Slice(int index, int count)
+        {
+            Precondition.Require(index + count < Length);
+
+            var data = _data + index;
+            return new ByteSpan(data, count);
+        }
+    }
+}


### PR DESCRIPTION
I wish I could use just Span<byte> in all cases.
Unfortunatelly, Span<T> (as implementable currently) is too slow for some tight formatting loops.
We might at some point get a fast Span<T>, and remove this type.
The main problem with Span<T> is that all indexer accessors need to do double pointer arrithmetic (offset from array and index into array)
ByteSpan accessor just needs one pointer offset.