### PR TITLE
Changed string formatting APIs to use ByteSpan

### DIFF
--- a/src/System.Text.Formatting/src/System/Span.cs
+++ b/src/System.Text.Formatting/src/System/Span.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace System
@@ -133,6 +134,14 @@ namespace System
                 count--;
             }
             return array;
+        }
+
+        internal unsafe ByteSpan BorrowDisposableByteSpan()
+        {
+            var handle = GCHandle.Alloc(_array, GCHandleType.Pinned);
+            var pinned = handle.AddrOfPinnedObject() + _index;
+            var byteSpan = new ByteSpan(((byte*)pinned.ToPointer()), _length, handle);     
+            return byteSpan;
         }
     }
 

--- a/src/System.Text.Formatting/src/System/Text/Formatting/StringFormatter.cs
+++ b/src/System.Text.Formatting/src/System/Text/Formatting/StringFormatter.cs
@@ -27,14 +27,16 @@ namespace System.Text.Formatting
             _buffer[_count++] = (byte)(character >> 8);
         }
 
+        //TODO: this should use ByteSpan
         public void Append(string text)
         {
-            foreach(char character in text)
+            foreach (char character in text)
             {
                 Append(character);
             }
         }
 
+        //TODO: this should use ByteSpan
         public void Append(ReadOnlySpan<char> substring)
         {
             for (int i = 0; i < substring.Length; i++)


### PR DESCRIPTION
I tried to also use ByteSpan for formatting other types, but only in internal implementation.
This resulted in performance regressions, as there was too many ByteSpans created (when public method enters)
and then immediately destroyed (when it terminates).
I think I would have to make ByteSpan public to see the perf wins for small datatypes,
but I am not ready to make it public yet.