### PR TITLE
Changed to use FindFirstFileExW instead of FindFirstFile

### DIFF
--- a/src/System.IO.FileSystem.Watcher.Polling/src/System/IO/InteropDeclarations.cs
+++ b/src/System.IO.FileSystem.Watcher.Polling/src/System/IO/InteropDeclarations.cs
@@ -9,6 +9,10 @@ namespace System.IO.FileSystem
     {
         internal static IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
 
+        // dwAdditionalFlags:
+        public const int FIND_FIRST_EX_CASE_SENSITIVE = 1;
+        public const int FIND_FIRST_EX_LARGE_FETCH = 2;
+
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static unsafe extern IntPtr FindFirstFileW(string lpFileName, void* lpFindFileData);
 
@@ -17,6 +21,22 @@ namespace System.IO.FileSystem
 
         [DllImport("kernel32.dll", SetLastError = true)]
         internal static extern bool FindClose(IntPtr hFindFile);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static unsafe extern IntPtr FindFirstFileExW(string lpFileName, FINDEX_INFO_LEVELS fInfoLevelId, void* lpFindFileData, FINDEX_SEARCH_OPS fSearchOp, IntPtr lpSearchFilter, int dwAdditionalFlags);
+    }
+
+    enum FINDEX_INFO_LEVELS
+    {
+        FindExInfoStandard = 0,
+        FindExInfoBasic = 1
+    }
+
+    enum FINDEX_SEARCH_OPS
+    {
+        FindExSearchNameMatch = 0,
+        FindExSearchLimitToDirectories = 1,
+        FindExSearchLimitToDevices = 2
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]

--- a/src/System.IO.FileSystem.Watcher.Polling/src/System/IO/PollingWatcher.cs
+++ b/src/System.IO.FileSystem.Watcher.Polling/src/System/IO/PollingWatcher.cs
@@ -65,8 +65,7 @@ namespace System.IO.FileSystem
                 WIN32_FIND_DATAW* pFileData = &fileData;
 
                 foreach (var directory in _directories) {
-                    // TODO: move this to Ex version of the API. Ex version is faster
-                    var file = DllImports.FindFirstFileW(directory, pFileData);
+                    var file = DllImports.FindFirstFileExW(directory, FINDEX_INFO_LEVELS.FindExInfoBasic, pFileData, FINDEX_SEARCH_OPS.FindExSearchNameMatch, IntPtr.Zero, DllImports.FIND_FIRST_EX_LARGE_FETCH);
                     if (file == DllImports.INVALID_HANDLE_VALUE) {
                         throw new IOException();
                     }


### PR DESCRIPTION
This improves performance approximatelly by 2x

Now, on my home computer, the node_modules folder (and its subfolders) can be processed in ~35ms