### PR TITLE
Added better diagnostics

### DIFF
--- a/src/System.IO.FileSystem.Watcher.Polling/src/System.IO.FileSystem.Watcher.Polling.csproj
+++ b/src/System.IO.FileSystem.Watcher.Polling/src/System.IO.FileSystem.Watcher.Polling.csproj
@@ -28,5 +28,23 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.Diagnostics.TraceSource, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.TraceSource.4.0.0-beta-22816\lib\portable-wpa81+wp80+win80+net45+aspnetcore50\System.Diagnostics.TraceSource.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Reflection.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.Primitives.4.0.0-beta-22405\lib\portable-wpa80+win80+net45+aspnetcore50\System.Reflection.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Runtime.Handles, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.Handles.4.0.0-beta-22816\lib\portable-wpa81+wp80+win80+net45+aspnetcore50\System.Runtime.Handles.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading.Tasks, Version=4.0.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.4.0.10-beta-22816\lib\portable-wpa81+wp80+win80+net45+aspnetcore50\System.Threading.Tasks.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.FileSystem.Watcher.Polling/src/System/IO/Datastructures.cs
+++ b/src/System.IO.FileSystem.Watcher.Polling/src/System/IO/Datastructures.cs
@@ -15,6 +15,8 @@ namespace System.IO.FileSystem
 
         public bool IsEmpty { get { return _changes == null || _count == 0; } }
 
+        public int Count { get { return _count; } }
+
         internal void AddAdded(string directory, string path)
         {
             Debug.Assert(path != null);

--- a/src/System.IO.FileSystem.Watcher.Polling/src/packages.config
+++ b/src/System.IO.FileSystem.Watcher.Polling/src/packages.config
@@ -1,18 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Collections" version="4.0.10-beta-22816" targetFramework="portable-net45+win" />
-  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22405" targetFramework="portable-net45+win" />
-  <package id="System.Diagnostics.Tools" version="4.0.0-beta-22405" targetFramework="portable-net45+win" />
-  <package id="System.Globalization" version="4.0.10-beta-22405" targetFramework="portable-net45+win" />
-  <package id="System.IO" version="4.0.10-beta-22816" targetFramework="portable-net45+win" />
-  <package id="System.IO.FileSystem" version="4.0.0-beta-22816" targetFramework="portable-net45+win" />
-  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22816" targetFramework="net45" />
-  <package id="System.Reflection" version="4.0.10-beta-22405" targetFramework="portable-net45+win" />
-  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22405" targetFramework="portable-net45+win" />
-  <package id="System.Runtime" version="4.0.20-beta-22816" targetFramework="portable-net45+win" />
-  <package id="System.Runtime.Extensions" version="4.0.10-beta-22816" targetFramework="portable-net45+win" />
-  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22405" targetFramework="portable-net45+win" />
-  <package id="System.Text.Encoding" version="4.0.10-beta-22816" targetFramework="portable-net45+win" />
-  <package id="System.Threading" version="4.0.0-beta-22405" targetFramework="portable-net45+win" />
-  <package id="System.Threading.Timer" version="4.0.0-beta-22405" targetFramework="portable-net45+win" />
+  <package id="System.Collections" version="4.0.10-beta-22816" targetFramework="portable-net45+win8" userInstalled="true" />
+  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22405" targetFramework="portable-net45+win8" userInstalled="true" />
+  <package id="System.Diagnostics.Tools" version="4.0.0-beta-22405" targetFramework="portable-net45+win8" userInstalled="true" />
+  <package id="System.Diagnostics.TraceSource" version="4.0.0-beta-22816" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="System.Globalization" version="4.0.10-beta-22405" targetFramework="portable-net45+win8" userInstalled="true" />
+  <package id="System.IO" version="4.0.10-beta-22816" targetFramework="portable-net45+win8" userInstalled="true" />
+  <package id="System.IO.FileSystem" version="4.0.0-beta-22816" targetFramework="portable-net45+win8" userInstalled="true" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22816" targetFramework="net45" userInstalled="true" />
+  <package id="System.Reflection" version="4.0.10-beta-22405" targetFramework="portable-net45+win8" userInstalled="true" />
+  <package id="System.Reflection.Primitives" version="4.0.0-beta-22405" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22405" targetFramework="portable-net45+win8" userInstalled="true" />
+  <package id="System.Runtime" version="4.0.20-beta-22816" targetFramework="portable-net45+win8" userInstalled="true" />
+  <package id="System.Runtime.Extensions" version="4.0.10-beta-22816" targetFramework="portable-net45+win8" userInstalled="true" />
+  <package id="System.Runtime.Handles" version="4.0.0-beta-22816" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22405" targetFramework="portable-net45+win8" userInstalled="true" />
+  <package id="System.Text.Encoding" version="4.0.10-beta-22816" targetFramework="portable-net45+win8" userInstalled="true" />
+  <package id="System.Threading" version="4.0.0-beta-22405" targetFramework="portable-net45+win8" userInstalled="true" />
+  <package id="System.Threading.Tasks" version="4.0.10-beta-22816" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="System.Threading.Timer" version="4.0.0-beta-22405" targetFramework="portable-net45+win8" userInstalled="true" />
 </packages>

--- a/src/System.IO.FileSystem.Watcher.Polling/tests/packages.config
+++ b/src/System.IO.FileSystem.Watcher.Polling/tests/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Console" version="4.0.0-beta-22412" targetFramework="portable-net45+win" />
+  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22405" targetFramework="portable-net45+win8" userInstalled="true" />
+  <package id="System.Diagnostics.TraceSource" version="4.0.0-beta-22816" targetFramework="portable45-net45+win8" userInstalled="true" />
   <package id="System.Globalization" version="4.0.10-beta-22405" targetFramework="portable-net45+win" />
   <package id="System.IO" version="4.0.10-beta-22405" targetFramework="portable-net45+win" />
   <package id="System.IO.FileSystem" version="4.0.0-beta-22405" targetFramework="portable-net45+win" />


### PR DESCRIPTION
it's now possible to configure the PollingWatcher.Tracing property to get diagnostic information about the workings of the watcher. For example, 

```c#
var watcher = new PollingWatcher(@"C:\Users\kcwalina\Desktop\FSWTestFolder", true, 1000);
watcher.Tracing.Listeners.Add(new ConsoleTraceListener());
watcher.Tracing.Switch.Level = SourceLevels.All;
watcher.Tracing.TraceInformation("tracing enabled");
watcher.ChangedDetailed += (changes) => {
    foreach (var change in changes) {
        Console.WriteLine("{0} {1}", change.Path, change.ChangeType);
    }
};
watcher.Start();
while (true) { }
```