### PR TITLE
Added ability to control the size of buffer pool

### DIFF
--- a/demos/LowAllocationWebServer/LowAllocationServer.csproj
+++ b/demos/LowAllocationWebServer/LowAllocationServer.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <UseVSHostingProcess>false</UseVSHostingProcess>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -37,8 +38,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Text.Formatting">
-      <HintPath>packages\System.Text.Formatting.0.1.0.0-d031915\lib\portable-net45+win8+wpa81\System.Text.Formatting.dll</HintPath>
+    <Reference Include="System.Text.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Formatting.0.1.0.0-d060815\lib\portable-net45+win8+wpa81+aspnetcore50\System.Text.Formatting.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/demos/LowAllocationWebServer/SampleServer.cs
+++ b/demos/LowAllocationWebServer/SampleServer.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Buffers;
 using System.Net;
 using System.Net.Http.Buffered;
 using System.Text.Formatting;
@@ -40,7 +41,7 @@ class SampleRestServer : HttpServer
         formatter.Append(HttpNewline);
 
         formatter.Append(@"<html><head><title>Time</title></head><body>");
-        formatter.Append(DateTime.UtcNow, Format.Symbol.O);
+        formatter.Append(DateTime.UtcNow, 'O');
         formatter.Append(@"</body></html>");
         return new HttpServerBuffer(formatter.Buffer, formatter.CommitedByteCount, BufferPool.Shared);
     }

--- a/demos/LowAllocationWebServer/packages.config
+++ b/demos/LowAllocationWebServer/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Text.Formatting" version="0.1.0.0-d031915" targetFramework="net45" />
+  <package id="System.Text.Formatting" version="0.1.0.0-d060815" targetFramework="net45" userInstalled="true" />
 </packages>

--- a/nuget/System.Text.Formatting.nuspec
+++ b/nuget/System.Text.Formatting.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>System.Text.Formatting</id>
-    <version>0.1.0.0-d032715</version>
+    <version>0.1.0.0-d060815</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
@@ -15,7 +15,7 @@
     <tags>.NET formatting corefxlab</tags>
   </metadata>
   <files>
-    <file src="..\bin\Release\System.Text.Formatting\System.Text.Formatting.dll" target="lib/portable-net45+win8+wpa81+aspnetcore50"/>
+    <file src="..\bin\Windows_NT.AnyCPU.Release\System.Text.Formatting\System.Text.Formatting.dll" target="lib/portable-net45+win8+wpa81+aspnetcore50"/>
   </files>
 </package>
 

--- a/src/System.Text.Formatting/src/System/Text/Formatting/BufferFormatter.cs
+++ b/src/System.Text.Formatting/src/System/Text/Formatting/BufferFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+﻿using System.IO.Buffers;
 
 namespace System.Text.Formatting
 {

--- a/src/System.Text.Formatting/src/System/Text/Formatting/StreamFormatter.cs
+++ b/src/System.Text.Formatting/src/System/Text/Formatting/StreamFormatter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.IO;
+using System.IO.Buffers;
 
 namespace System.Text.Formatting
 {

--- a/src/System.Text.Formatting/src/System/Text/Formatting/StringFormatter.cs
+++ b/src/System.Text.Formatting/src/System/Text/Formatting/StringFormatter.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.IO;
-using System.Text.Formatting;
+using System.IO.Buffers;
 
 namespace System.Text.Formatting
 {


### PR DESCRIPTION
In highly concurent scenarios, buffer pool of 10 is not large enough.
This change allows web servers to create custom buffer pools (BufferBin) with custom capacity.