### PR TITLE
Changed non-allocating web server to use native memory for request bu…

### DIFF
--- a/demos/LowAllocationWebServer/LowAllocationServer.csproj
+++ b/demos/LowAllocationWebServer/LowAllocationServer.csproj
@@ -38,9 +38,8 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Text.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Formatting.0.1.0.0-d060815\lib\portable-net45+win8+wpa81+aspnetcore50\System.Text.Formatting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Text.Formatting">
+      <HintPath>packages\System.Text.Formatting.0.1.0.0-d061015-3\lib\portable-net45+win8+wpa81+aspnetcore50\System.Text.Formatting.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/demos/LowAllocationWebServer/RoutingTable.cs
+++ b/demos/LowAllocationWebServer/RoutingTable.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http.Buffered
         {
             for(int i=0; i<count; i++)
             {
-                if (Uris[i].Equals(requestLine.RequestUri)) return Apis[i];
+                if (requestLine.RequestUri.Equals(Uris[i])) return Apis[i];
             }
             return default(T);
         }

--- a/demos/LowAllocationWebServer/SampleServer.cs
+++ b/demos/LowAllocationWebServer/SampleServer.cs
@@ -23,7 +23,7 @@ class SampleRestServer : HttpServer
         Apis.Add(Api.GetTime, HttpMethod.Get, requestUri: "/time");
     }
 
-    protected override HttpServerBuffer CreateResponse(HttpRequestLine requestLine, Span<byte> headerAndBody)
+    protected override HttpServerBuffer CreateResponse(HttpRequestLine requestLine, ByteSpan headerAndBody)
     {
         var api = Apis.Map(requestLine);
         switch (api) {

--- a/demos/LowAllocationWebServer/TcpServer.cs
+++ b/demos/LowAllocationWebServer/TcpServer.cs
@@ -173,5 +173,19 @@ namespace Microsoft.Net.Http.Server.Socket
                 }
             }
         }
+
+        internal int Receive(ByteSpan buffer)
+        {
+            unsafe
+            {
+                IntPtr ptr = new IntPtr(buffer.UnsafeBuffer);
+                int bytesReceived = SocketImports.recv(Handle, ptr, buffer.Length, 0);
+                if (bytesReceived < 0) {
+                    var error = SocketImports.WSAGetLastError();
+                    throw new Exception(String.Format("receive failed with {0}", error));
+                }
+                return bytesReceived;
+            }
+        }
     }
 }

--- a/demos/LowAllocationWebServer/packages.config
+++ b/demos/LowAllocationWebServer/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Text.Formatting" version="0.1.0.0-d060815" targetFramework="net45" userInstalled="true" />
+  <package id="System.Text.Formatting" version="0.1.0.0-d061015-3" targetFramework="net45" />
 </packages>

--- a/nuget/System.Text.Formatting.nuspec
+++ b/nuget/System.Text.Formatting.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>System.Text.Formatting</id>
-    <version>0.1.0.0-d060815</version>
+    <version>0.1.0.0-d061015-3</version>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>
     <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>

--- a/src/System.Text.Formatting/src/System/ByteSpan.cs
+++ b/src/System.Text.Formatting/src/System/ByteSpan.cs
@@ -42,6 +42,12 @@ namespace System {
             Buffer.MemoryCopy(value, _data, _length, valueLength);
         }
 
+        [CLSCompliant(false)]
+        public unsafe byte* UnsafeBuffer
+        {
+            get { return _data; }
+        }
+
         public int Length
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
…ffers

This should improve perfromance, but unfortunatelly because I am not using a real Span<byte>, the APIs
are not as safe as before. User code needs to be careful to not store Utf8Span on the heap past each request
as the native memory will be returned to the pool.