### PR TITLE
Add dnulist tool

### DIFF
--- a/tools/dnulist/package-file.cs
+++ b/tools/dnulist/package-file.cs
@@ -1,0 +1,7 @@
+using System.Collections.Generic;
+
+public class PackageFile
+{
+	public string Sha512 {get; set;}
+	public List<string> Files {get; set;}
+}

--- a/tools/dnulist/package.cs
+++ b/tools/dnulist/package.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+public class Package
+{
+	public string Name {get; set;}
+	public Dictionary<string,string> Dependencies {get; set;}
+	public Dictionary<string,object> Compile {get; set;}
+	public Dictionary<string,object> Runtime {get; set;}
+}

--- a/tools/dnulist/program.cs
+++ b/tools/dnulist/program.cs
@@ -1,0 +1,241 @@
+using System;
+using System.IO;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+public class Program
+{
+    private static void Main (string[] args)
+    {
+        // project.lock.json reader
+        // See PrintHelp for arg info
+        
+        const string Lockfile = "project.lock.json";
+        Project project;
+        
+        Console.WriteLine("project.json.lock file reader");
+        
+        using (var reader = new StreamReader(Lockfile))
+        {
+            project = JsonConvert.DeserializeObject<Project>(reader.ReadToEnd());
+        }
+        
+        if (args == null || args.Length == 0)
+        {
+            PrintTargets(project);
+            Console.WriteLine();
+            Console.WriteLine("Use --help argument to print help.");
+        }
+        else
+        {
+            var commands = GetArguments(args);
+            const string Target = "--target";
+            const string Copy = "--copy";
+            const string Verbose = "--verbose";
+            const string Help = "--help";
+            
+            if (commands == null)
+            {
+                Console.WriteLine("Bad argument!");
+                Console.WriteLine();
+                PrintHelp();
+            }
+            else if (commands.ContainsKey("--targets"))
+            {
+                PrintTargets(project);
+            }
+            else if (commands.ContainsKey(Target) && commands.ContainsKey(Copy) && !string.IsNullOrEmpty(commands[Copy]))
+            {
+                bool verbose = commands.ContainsKey(Verbose);
+                CopyTarget(project, commands[Target], commands[Copy], verbose);
+            }
+            else if (commands.ContainsKey(Target))
+            {
+                bool verbose = commands.ContainsKey(Verbose);
+                PrintTarget(project,commands[Target], verbose);
+            }
+            else if (commands.ContainsKey(Help))
+            {
+                Console.WriteLine();
+                PrintHelp();
+            }
+        }
+    }
+    
+    private static void PrintTargets(Project project)
+    {
+        Console.WriteLine ("This project has {0} targets.", project.Targets.Count);
+        Console.WriteLine();
+        
+        foreach (var t in project.Targets.Keys)
+        {
+            Console.WriteLine(t);
+        }
+    }
+    
+    private static void PrintTarget(Project project, string target, bool verbose = false)
+    {
+        Dictionary<string,Package> packages;
+        var targetFound = project.Targets.TryGetValue(target, out packages);
+        
+        if (targetFound && packages.Count > 0)
+        {
+            Console.WriteLine("Package dependencies for target: {0}",target);
+            
+            foreach (var package in packages.Keys)
+            {
+                Console.WriteLine(package);
+                if (verbose)
+                {
+                    var p = packages[package];
+               
+                    if (p.Compile != null)
+                    {
+                        foreach (var key in p.Compile.Keys)
+                        {
+                            Console.WriteLine("**Compile: {0}", key);
+                        }
+                    }
+                    
+                    if (p.Runtime != null)
+                    {
+                        foreach (var key in p.Runtime.Keys)
+                        {
+                            Console.WriteLine("**Runtime: {0}", key);
+                        }
+                    }
+                    
+                    if (p.Dependencies != null)
+                    {
+                        foreach (var key in p.Dependencies.Keys)
+                        {
+                            Console.WriteLine("**Dependencies: {0}", key);
+                        }
+                    }
+                }
+            }
+        }
+        else if (targetFound)
+        {
+            Console.WriteLine("No packages found for {0}.",target);
+        }
+        else
+        {
+            Console.WriteLine("{0} is not a target for this project.", target);
+        }
+    }    
+    
+    private static void CopyTarget(Project project, string target, string path, bool verbose = false)
+    {
+        const string packageRoot = "/Users/richlander/.dnx/packages";
+        string compilePath = Path.Combine(path, "compile");
+        string runtimePath = Path.Combine(path,"runtime");
+        
+        if (!Directory.Exists(path))
+        {
+            Directory.CreateDirectory(compilePath);
+            Directory.CreateDirectory(runtimePath);
+        }
+        else if (!Directory.Exists(compilePath))
+        {
+            Directory.CreateDirectory(compilePath);
+        }
+        else if (!Directory.Exists(runtimePath))
+        {
+            Directory.CreateDirectory(runtimePath);
+        }
+        
+        Dictionary<string,Package> packages;
+        var targetFound = project.Targets.TryGetValue(target, out packages);
+            
+        if (targetFound && packages.Count > 0)
+        {
+            foreach (var package in packages.Keys)
+            {   
+                Console.WriteLine("Copying package: {0}", package);
+                
+                var p = packages[package];         
+                if (p.Compile != null)
+                {
+                    foreach (var lib in p.Compile.Keys)
+                    {
+                        var source = Path.Combine(packageRoot,package,lib);
+                        var destination = Path.Combine(compilePath,Path.GetFileName(lib));;
+                        File.Copy(source,destination, true);
+                        
+                        if (verbose)
+                        {
+                            Console.WriteLine("**Compile: {0}", lib);
+                        }
+                    }
+                }
+                
+                if (p.Runtime != null)
+                {
+                    foreach (var lib in p.Runtime.Keys)
+                    {
+                        var source = Path.Combine(packageRoot,package,lib);
+                        var destination = Path.Combine(runtimePath,Path.GetFileName(lib));;
+                        File.Copy(source,destination,true);
+                        
+                        if (verbose)
+                        {
+                            Console.WriteLine("**Runtime: {0}", lib);
+                        }
+                    }
+                }
+            }
+        }
+        else if (targetFound)
+        {
+            Console.WriteLine("No packages found for {0}.",target);
+        }
+        else
+        {
+            Console.WriteLine("{0} is not a target for this project.", target);
+        }
+    }
+    
+    private static void PrintHelp()
+    {
+        Console.WriteLine("Primary arguments:");
+        Console.WriteLine("--target - prints targets");
+        Console.WriteLine("--target [target] - selects targets to print (the default) or otherwise act upon");
+        Console.WriteLine("--help - prints help");
+        Console.WriteLine();
+        Console.WriteLine("Additional arguments:");
+        Console.WriteLine("--copy [path to copy to] - copies reference and runtime assemblies for a target");
+        Console.WriteLine("--verbose - print maximum amount of info");
+    }
+    
+    private static Dictionary<string,string> GetArguments(string[] args)
+    {
+        const string ArgSyntax = "--";
+        var commands = new Dictionary<string,string>();
+        int count = 0;
+
+        while (count < args.Length)
+        {   
+            if (count +1 == args.Length && args[count].StartsWith(ArgSyntax))
+            {
+                commands.Add(args[count],string.Empty);
+            }
+            else if (count +1 == args.Length && !args[count].StartsWith(ArgSyntax))
+            {
+                // bad argument
+                return null;
+            }
+            else if (args[count].StartsWith(ArgSyntax) && !args[count+1].StartsWith(ArgSyntax))
+            {
+                commands.Add(args[count],args[count+1]);
+                count++;
+            }
+            else if (args[count].StartsWith(ArgSyntax))
+            {
+                commands.Add(args[count],string.Empty);
+            }
+            count++;
+        }  
+        return commands;
+    }
+}

--- a/tools/dnulist/project.cs
+++ b/tools/dnulist/project.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+public class Project
+{
+	public bool Locked {get; set;}
+	public string Version {get; set;}
+	public Dictionary<string,Dictionary<string,Package>> Targets {get; set;}
+	public Dictionary<string,PackageFile> Libraries {get; set;}
+	public Dictionary<string,List<string>> ProjectFileDependencyGroups {get; set;}
+}

--- a/tools/dnulist/project.json
+++ b/tools/dnulist/project.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0-*",
+    "dependencies": {
+        "System.Console": "4.0.0-beta-*",
+        "System.IO.FileSystem": "4.0.0-beta-*",
+        "System.IO.FileSystem.Primitives": "4.0.0-beta-*",
+        "System.IO": "4.0.10-beta-*",
+        "System.Collections": "4.0.10-beta-*",
+        "System.Runtime.Extensions": "4.0.10-beta-*", 
+        "Newtonsoft.Json": "6.0.8"
+    },
+    "frameworks" : {
+        "dnx451" : { },
+        "dnxcore50" : {}
+    }

--- a/tools/dnulist/project.lock.json
+++ b/tools/dnulist/project.lock.json
@@ -1,0 +1,408 @@
+{
+  "locked": false,
+  "version": -9996,
+  "targets": {
+    "DNX,Version=v4.5.1": {
+      "Newtonsoft.Json/6.0.8": {
+        "compile": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Newtonsoft.Json.dll": {}
+        }
+      },
+      "System.Collections/4.0.10-beta-22906": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22906"
+        },
+        "compile": {
+          "lib/net45/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/net45/System.Collections.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-22906": {
+        "dependencies": {
+          "System.IO": "4.0.0-beta-22906",
+          "System.Runtime": "4.0.0-beta-22906"
+        },
+        "compile": {
+          "lib/net45/System.Console.dll": {}
+        },
+        "runtime": {
+          "lib/net45/System.Console.dll": {}
+        }
+      },
+      "System.IO/4.0.10-beta-22906": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22906",
+          "System.Text.Encoding": "4.0.0-beta-22906",
+          "System.Threading.Tasks": "4.0.0-beta-22906"
+        },
+        "compile": {
+          "lib/net45/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/net45/System.IO.dll": {}
+        }
+      },
+      "System.IO.FileSystem/4.0.0-beta-22906": {
+        "dependencies": {
+          "System.IO": "4.0.0-beta-22906",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-22906",
+          "System.Runtime": "4.0.0-beta-22906",
+          "System.Runtime.Handles": "4.0.0-beta-22906",
+          "System.Text.Encoding": "4.0.0-beta-22906",
+          "System.Threading.Tasks": "4.0.0-beta-22906"
+        },
+        "compile": {
+          "lib/net45/System.IO.FileSystem.dll": {}
+        },
+        "runtime": {
+          "lib/net45/System.IO.FileSystem.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.0-beta-22906": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22906"
+        },
+        "compile": {
+          "lib/net45/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/net45/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20-beta-22906": {
+        "compile": {
+          "lib/net45/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/net45/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10-beta-22906": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22906"
+        },
+        "compile": {
+          "lib/net45/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/net45/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.0-beta-22906": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22906"
+        },
+        "compile": {
+          "lib/net45/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/net45/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10-beta-22231": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22231"
+        }
+      },
+      "System.Threading.Tasks/4.0.10-beta-22231": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22231"
+        }
+      }
+    },
+    "DNXCore,Version=v5.0": {
+      "Newtonsoft.Json/6.0.8": {
+        "compile": {
+          "lib/portable-net45+wp80+win8+wpa81+aspnetcore50/Newtonsoft.Json.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+wp80+win8+wpa81+aspnetcore50/Newtonsoft.Json.dll": {}
+        }
+      },
+      "System.Collections/4.0.10-beta-22906": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22906"
+        },
+        "compile": {
+          "lib/contract/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/aspnetcore50/System.Collections.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-22906": {
+        "dependencies": {
+          "System.IO": "4.0.0-beta-22906",
+          "System.Runtime": "4.0.0-beta-22906"
+        },
+        "compile": {
+          "lib/contract/System.Console.dll": {}
+        },
+        "runtime": {
+          "lib/aspnetcore50/System.Console.dll": {}
+        }
+      },
+      "System.IO/4.0.10-beta-22906": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22906",
+          "System.Text.Encoding": "4.0.0-beta-22906",
+          "System.Threading.Tasks": "4.0.0-beta-22906"
+        },
+        "compile": {
+          "lib/contract/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/aspnetcore50/System.IO.dll": {}
+        }
+      },
+      "System.IO.FileSystem/4.0.0-beta-22906": {
+        "dependencies": {
+          "System.IO": "4.0.0-beta-22906",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-22906",
+          "System.Runtime": "4.0.0-beta-22906",
+          "System.Runtime.Handles": "4.0.0-beta-22906",
+          "System.Text.Encoding": "4.0.0-beta-22906",
+          "System.Threading.Tasks": "4.0.0-beta-22906"
+        },
+        "compile": {
+          "lib/contract/System.IO.FileSystem.dll": {}
+        },
+        "runtime": {
+          "lib/aspnetcore50/System.IO.FileSystem.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.0-beta-22906": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22906"
+        },
+        "compile": {
+          "lib/contract/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/aspnetcore50/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20-beta-22906": {
+        "compile": {
+          "lib/contract/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/aspnetcore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10-beta-22906": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-22906"
+        },
+        "compile": {
+          "lib/contract/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/aspnetcore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.0-beta-22906": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22906"
+        },
+        "compile": {
+          "lib/contract/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/aspnetcore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10-beta-22231": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22231"
+        },
+        "compile": {
+          "lib/contract/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/aspnetcore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10-beta-22231": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-22231"
+        },
+        "compile": {
+          "lib/contract/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/aspnetcore50/System.Threading.Tasks.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Newtonsoft.Json/6.0.8": {
+      "sha512": "7ut47NDedTW19EbL0JpFDYUP62fcuz27hJrehCDNajdCS5NtqL+E39+7Um3OkNc2wl2ym7K8Ln5eNuLus6mVGQ==",
+      "files": [
+        "Newtonsoft.Json.6.0.8.nupkg",
+        "Newtonsoft.Json.6.0.8.nupkg.sha512",
+        "Newtonsoft.Json.nuspec",
+        "lib/net20/Newtonsoft.Json.dll",
+        "lib/net20/Newtonsoft.Json.xml",
+        "lib/net35/Newtonsoft.Json.dll",
+        "lib/net35/Newtonsoft.Json.xml",
+        "lib/net40/Newtonsoft.Json.dll",
+        "lib/net40/Newtonsoft.Json.xml",
+        "lib/net45/Newtonsoft.Json.dll",
+        "lib/net45/Newtonsoft.Json.xml",
+        "lib/netcore45/Newtonsoft.Json.dll",
+        "lib/netcore45/Newtonsoft.Json.xml",
+        "lib/portable-net40+sl5+wp80+win8+wpa81/Newtonsoft.Json.dll",
+        "lib/portable-net40+sl5+wp80+win8+wpa81/Newtonsoft.Json.xml",
+        "lib/portable-net45+wp80+win8+wpa81+aspnetcore50/Newtonsoft.Json.dll",
+        "lib/portable-net45+wp80+win8+wpa81+aspnetcore50/Newtonsoft.Json.xml",
+        "tools/install.ps1"
+      ]
+    },
+    "System.Collections/4.0.10-beta-22906": {
+      "sha512": "/8LyoJZV+hzuej25Qrx8NjjO51SAk2IrLVUxECYVB4ymA2jlsDPdfqP4LVVmPigmakmbHcLaah1Wfti2hBTk6Q==",
+      "files": [
+        "License.rtf",
+        "System.Collections.4.0.10-beta-22906.nupkg",
+        "System.Collections.4.0.10-beta-22906.nupkg.sha512",
+        "System.Collections.nuspec",
+        "lib/aspnetcore50/System.Collections.dll",
+        "lib/contract/System.Collections.dll",
+        "lib/net45/System.Collections.dll",
+        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.Collections.dll"
+      ]
+    },
+    "System.Console/4.0.0-beta-22906": {
+      "sha512": "MMLPoNAhEOSPNJH2qRUv2M0xw8lstDpGnQmwm5yYjG20K2AZHAkbUpSIaKRL3wYVYJp6+yPe8I5ZgvMGpaU9OQ==",
+      "files": [
+        "License.rtf",
+        "System.Console.4.0.0-beta-22906.nupkg",
+        "System.Console.4.0.0-beta-22906.nupkg.sha512",
+        "System.Console.nuspec",
+        "lib/aspnetcore50/System.Console.dll",
+        "lib/contract/System.Console.dll",
+        "lib/net45/System.Console.dll",
+        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.Console.dll"
+      ]
+    },
+    "System.IO/4.0.10-beta-22906": {
+      "sha512": "yY+abxo4xsQfaOiLa0+wPhHvzn6yzeBx7iSsky3ieDu+V7bLETAgDz59z7yn/IY0Ec6YGaezmc3EI8dl1A9pHQ==",
+      "files": [
+        "License.rtf",
+        "System.IO.4.0.10-beta-22906.nupkg",
+        "System.IO.4.0.10-beta-22906.nupkg.sha512",
+        "System.IO.nuspec",
+        "lib/aspnetcore50/System.IO.dll",
+        "lib/contract/System.IO.dll",
+        "lib/net45/System.IO.dll",
+        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.IO.dll"
+      ]
+    },
+    "System.IO.FileSystem/4.0.0-beta-22906": {
+      "sha512": "fXD8kblkZ9tsES5eZwqG3/p5NJAzGbHDK198VxveBiCf+BPPcTc+d8ZDyzzsP6Yov8w/fkbacysLtj5aCJitag==",
+      "files": [
+        "License.rtf",
+        "System.IO.FileSystem.4.0.0-beta-22906.nupkg",
+        "System.IO.FileSystem.4.0.0-beta-22906.nupkg.sha512",
+        "System.IO.FileSystem.nuspec",
+        "lib/aspnetcore50/System.IO.FileSystem.dll",
+        "lib/contract/System.IO.FileSystem.dll",
+        "lib/net45/System.IO.FileSystem.dll",
+        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.IO.FileSystem.dll"
+      ]
+    },
+    "System.IO.FileSystem.Primitives/4.0.0-beta-22906": {
+      "sha512": "ZeY9eW007zOU9Hvj/vSj2EPe4MYLVq+5Aez7nBzqKDkwwhXpYD/nRTM5n+VLL78WvwD4viTvYGCTJIQMRMl/zA==",
+      "files": [
+        "License.rtf",
+        "System.IO.FileSystem.Primitives.4.0.0-beta-22906.nupkg",
+        "System.IO.FileSystem.Primitives.4.0.0-beta-22906.nupkg.sha512",
+        "System.IO.FileSystem.Primitives.nuspec",
+        "lib/aspnetcore50/System.IO.FileSystem.Primitives.dll",
+        "lib/contract/System.IO.FileSystem.Primitives.dll",
+        "lib/net45/System.IO.FileSystem.Primitives.dll",
+        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.IO.FileSystem.Primitives.dll"
+      ]
+    },
+    "System.Runtime/4.0.20-beta-22906": {
+      "sha512": "uHOyllqTT/rBeL8xUxNGSaZPL8l2CyRkBPsKniFs+Glf45OXcvdUabSqMEmkU3a+iGxNsiBU14EFlK55Ur5oCw==",
+      "files": [
+        "License.rtf",
+        "System.Runtime.4.0.20-beta-22906.nupkg",
+        "System.Runtime.4.0.20-beta-22906.nupkg.sha512",
+        "System.Runtime.nuspec",
+        "lib/aspnetcore50/System.Runtime.dll",
+        "lib/contract/System.Runtime.dll",
+        "lib/net45/System.Runtime.dll",
+        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.Runtime.dll"
+      ]
+    },
+    "System.Runtime.Extensions/4.0.10-beta-22906": {
+      "sha512": "NhmOlF7d8q4zKYwC9sKri4R5SUdbXUHaA1e42J/4s/9YyP/I/+iTvrTkCcsq1/GQA3mJln8TCwYFhlSJy/EBuA==",
+      "files": [
+        "License.rtf",
+        "System.Runtime.Extensions.4.0.10-beta-22906.nupkg",
+        "System.Runtime.Extensions.4.0.10-beta-22906.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec",
+        "lib/aspnetcore50/System.Runtime.Extensions.dll",
+        "lib/contract/System.Runtime.Extensions.dll",
+        "lib/net45/System.Runtime.Extensions.dll",
+        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.Runtime.Extensions.dll"
+      ]
+    },
+    "System.Runtime.Handles/4.0.0-beta-22906": {
+      "sha512": "2KAGilz8panptOCjuQhZOtrfe0anzm7c+RUKaeH+98yxyeCPjkhuRHGB4XB/nDr4JOcpTC4LQ2xl6T5WWxYIcw==",
+      "files": [
+        "License.rtf",
+        "System.Runtime.Handles.4.0.0-beta-22906.nupkg",
+        "System.Runtime.Handles.4.0.0-beta-22906.nupkg.sha512",
+        "System.Runtime.Handles.nuspec",
+        "lib/aspnetcore50/System.Runtime.Handles.dll",
+        "lib/contract/System.Runtime.Handles.dll",
+        "lib/net45/System.Runtime.Handles.dll",
+        "lib/portable-wpa81+wp80+win80+net45+aspnetcore50/System.Runtime.Handles.dll"
+      ]
+    },
+    "System.Text.Encoding/4.0.10-beta-22231": {
+      "sha512": "qHdaFAtqeplZ4VHyxmkJDs38UN3rP9OzayYd3I7sGQD4GRFtnpJF0NGWIUMVqd229z4GrsaVVPvNNwd0mgbr+w==",
+      "files": [
+        "License.rtf",
+        "System.Text.Encoding.4.0.10-beta-22231.nupkg",
+        "System.Text.Encoding.4.0.10-beta-22231.nupkg.sha512",
+        "System.Text.Encoding.nuspec",
+        "lib/aspnetcore50/System.Text.Encoding.dll",
+        "lib/contract/System.Text.Encoding.dll"
+      ]
+    },
+    "System.Threading.Tasks/4.0.10-beta-22231": {
+      "sha512": "lPHfw+jq9ENtRDTRgY9gCpiiphQzIi5Oh/Wg/2Jf6xJN+FH+oWWcCozaKvRT8Ovt5iNraDLbGBLoUoQvGTTXog==",
+      "files": [
+        "License.rtf",
+        "System.Threading.Tasks.4.0.10-beta-22231.nupkg",
+        "System.Threading.Tasks.4.0.10-beta-22231.nupkg.sha512",
+        "System.Threading.Tasks.nuspec",
+        "lib/aspnetcore50/System.Threading.Tasks.dll",
+        "lib/contract/System.Threading.Tasks.dll"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Console >= 4.0.0-beta-*",
+      "System.IO.FileSystem >= 4.0.0-beta-*",
+      "System.IO.FileSystem.Primitives >= 4.0.0-beta-*",
+      "System.IO >= 4.0.10-beta-*",
+      "System.Collections >= 4.0.10-beta-*",
+      "System.Runtime.Extensions >= 4.0.10-beta-*",
+      "Newtonsoft.Json >= 6.0.8"
+    ],
+    "DNX,Version=v4.5.1": [],
+    "DNXCore,Version=v5.0": []
+  }
+}

--- a/tools/dnulist/target.cs
+++ b/tools/dnulist/target.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+public class Target 
+{
+	public string Name {get; set;}
+	public Dictionary<string,Package> Packages {get; set;}
+	
+}


### PR DESCRIPTION
This is a tool that is intended to solve the problem of using NuGet package artifacts w/o needing to understand the format / binding semantics. This is discussed here: https://github.com/dotnet/coreclr/issues/995.

The tool overlaps a fair bit with dnu. Hopefully, this functionality is added to dnu. Currently, the tool has the following basic functions:

- List targets.
- List packages by target.
- Copy packages to a directory, by target.

@davidfowl, @ericstj, @blackdwarf, @akoeplinger, @KrzysztofCwalina 