### PR TITLE
Add System.Numerics.Matrices

### DIFF
--- a/src/System.Numerics.Matrices/.gitignore
+++ b/src/System.Numerics.Matrices/.gitignore
@@ -1,0 +1,2 @@
+src/System/Numerics/MatrixTemplate.txt
+test/System/Numerics/TestTemplate.txt

--- a/src/System.Numerics.Matrices/System.Numerics.Matrices.sln
+++ b/src/System.Numerics.Matrices/System.Numerics.Matrices.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Numerics.Matrices", "src\System.Numerics.Matrices.csproj", "{A7402731-F3B8-4DFE-8507-88623CA1B2BA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Numerics.Matrices.Tests", "test\System.Numerics.Matrices.Tests.csproj", "{CDD81D2A-45AF-4980-8A3C-D4E9AB8F02C3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A7402731-F3B8-4DFE-8507-88623CA1B2BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A7402731-F3B8-4DFE-8507-88623CA1B2BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A7402731-F3B8-4DFE-8507-88623CA1B2BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A7402731-F3B8-4DFE-8507-88623CA1B2BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CDD81D2A-45AF-4980-8A3C-D4E9AB8F02C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CDD81D2A-45AF-4980-8A3C-D4E9AB8F02C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CDD81D2A-45AF-4980-8A3C-D4E9AB8F02C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CDD81D2A-45AF-4980-8A3C-D4E9AB8F02C3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/System.Numerics.Matrices/src/System.Numerics.Matrices.csproj
+++ b/src/System.Numerics.Matrices/src/System.Numerics.Matrices.csproj
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A7402731-F3B8-4DFE-8507-88623CA1B2BA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>System.Numerics.Matrices</RootNamespace>
+    <AssemblyName>System.Numerics.Matrices</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="System\Numerics\IMatrix.cs" />
+    <Compile Include="System\Numerics\Matrix1x2.cs" />
+    <Compile Include="System\Numerics\Matrix1x3.cs" />
+    <Compile Include="System\Numerics\Matrix1x4.cs" />
+    <Compile Include="System\Numerics\Matrix2x1.cs" />
+    <Compile Include="System\Numerics\Matrix2x2.cs" />
+    <Compile Include="System\Numerics\Matrix2x3.cs" />
+    <Compile Include="System\Numerics\Matrix2x4.cs" />
+    <Compile Include="System\Numerics\Matrix3x1.cs" />
+    <Compile Include="System\Numerics\Matrix3x2.cs" />
+    <Compile Include="System\Numerics\Matrix3x3.cs" />
+    <Compile Include="System\Numerics\Matrix3x4.cs" />
+    <Compile Include="System\Numerics\Matrix4x1.cs" />
+    <Compile Include="System\Numerics\Matrix4x2.cs" />
+    <Compile Include="System\Numerics\Matrix4x3.cs" />
+    <Compile Include="System\Numerics\Matrix4x4.cs" />
+    <Compile Include="System\Numerics\MatrixHelper.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="System\Numerics\MatrixTemplate.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>MatrixTemplate.txt</LastGenOutput>
+    </Content>
+    <Content Include="System\Numerics\MatrixTemplate.txt">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>MatrixTemplate.tt</DependentUpon>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/System.Numerics.Matrices/src/System/Numerics/IMatrix.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/IMatrix.cs
@@ -1,0 +1,9 @@
+﻿namespace System.Numerics.Matrices
+{
+    interface IMatrix
+    {
+        double this[int col, int row] { get; set; }
+        int Columns { get; }
+        int Rows { get; }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x2.cs
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix1x2: IEquatable<Matrix1x2>, IMatrix
+    {
+        public const int ColumnCount = 1;
+        public const int RowCount = 2;
+
+        static Matrix1x2()
+        {
+            Zero = new Matrix1x2(0);
+        }
+
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix1x2 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix1x2 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix1x2 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        public Matrix1x2(double m11, 
+                         double m12)
+        {
+            M11 = m11; 
+            M12 = m12; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix1x2 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix1x2(double value)
+        {
+            M11 = 
+            M12 = value;
+        }
+
+        public double M11;
+        public double M12;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix1x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix1x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix1x2)
+                return this == (Matrix1x2)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix1x2 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix1x2* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0)) << 0)
+                         + 7 * ((((x[01] ^ x[02]) << 0)) << 1);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix1x2: "
+                 + $"{{|{M11:00}|}}"
+                 + $"{{|{M12:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix2x1 Transpose()
+        {
+            return new Matrix2x1(M11, M12);
+        }
+
+        public static bool operator ==(Matrix1x2 matrix1, Matrix1x2 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M12, matrix2.M12);
+        }
+
+        public static bool operator !=(Matrix1x2 matrix1, Matrix1x2 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M12, matrix2.M12);
+        }
+
+        public static Matrix1x2 operator +(Matrix1x2 matrix1, Matrix1x2 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m12 = matrix1.M12 + matrix2.M12;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+
+        public static Matrix1x2 operator -(Matrix1x2 matrix1, Matrix1x2 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m12 = matrix1.M12 - matrix2.M12;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+
+        public static Matrix1x2 operator *(Matrix1x2 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m12 = matrix.M12 * scalar;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+
+        public static Matrix1x2 operator *(double scalar, Matrix1x2 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m12 = scalar * matrix.M12;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+
+        public static Matrix2x2 operator *(Matrix1x2 matrix1, Matrix2x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+        public static Matrix3x2 operator *(Matrix1x2 matrix1, Matrix3x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+        public static Matrix4x2 operator *(Matrix1x2 matrix1, Matrix4x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x3.cs
@@ -1,0 +1,254 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix1x3: IEquatable<Matrix1x3>, IMatrix
+    {
+        public const int ColumnCount = 1;
+        public const int RowCount = 3;
+
+        static Matrix1x3()
+        {
+            Zero = new Matrix1x3(0);
+        }
+
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix1x3 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix1x3 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix1x3 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        public Matrix1x3(double m11, 
+                         double m12, 
+                         double m13)
+        {
+            M11 = m11; 
+            M12 = m12; 
+            M13 = m13; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix1x3 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix1x3(double value)
+        {
+            M11 = 
+            M12 = 
+            M13 = value;
+        }
+
+        public double M11;
+        public double M12;
+        public double M13;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix1x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix1x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix1x3)
+                return this == (Matrix1x3)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix1x3 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix1x3* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0)) << 0)
+                         + 7 * ((((x[01] ^ x[02]) << 0)) << 1)
+                         + 7 * ((((x[02] ^ x[03]) << 0)) << 2);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix1x3: "
+                 + $"{{|{M11:00}|}}"
+                 + $"{{|{M12:00}|}}"
+                 + $"{{|{M13:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix3x1 Transpose()
+        {
+            return new Matrix3x1(M11, M12, M13);
+        }
+
+        public static bool operator ==(Matrix1x3 matrix1, Matrix1x3 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M12, matrix2.M12)
+                && MatrixHelper.AreEqual(matrix1.M13, matrix2.M13);
+        }
+
+        public static bool operator !=(Matrix1x3 matrix1, Matrix1x3 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M12, matrix2.M12)
+                || MatrixHelper.NotEqual(matrix1.M13, matrix2.M13);
+        }
+
+        public static Matrix1x3 operator +(Matrix1x3 matrix1, Matrix1x3 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m13 = matrix1.M13 + matrix2.M13;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+
+        public static Matrix1x3 operator -(Matrix1x3 matrix1, Matrix1x3 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m13 = matrix1.M13 - matrix2.M13;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+
+        public static Matrix1x3 operator *(Matrix1x3 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m13 = matrix.M13 * scalar;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+
+        public static Matrix1x3 operator *(double scalar, Matrix1x3 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m12 = scalar * matrix.M12;
+            double m13 = scalar * matrix.M13;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+
+        public static Matrix2x3 operator *(Matrix1x3 matrix1, Matrix2x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+        public static Matrix3x3 operator *(Matrix1x3 matrix1, Matrix3x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+        public static Matrix4x3 operator *(Matrix1x3 matrix1, Matrix4x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x4.cs
@@ -1,0 +1,283 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix1x4: IEquatable<Matrix1x4>, IMatrix
+    {
+        public const int ColumnCount = 1;
+        public const int RowCount = 4;
+
+        static Matrix1x4()
+        {
+            Zero = new Matrix1x4(0);
+        }
+
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix1x4 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix1x4 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix1x4 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        public Matrix1x4(double m11, 
+                         double m12, 
+                         double m13, 
+                         double m14)
+        {
+            M11 = m11; 
+            M12 = m12; 
+            M13 = m13; 
+            M14 = m14; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix1x4 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix1x4(double value)
+        {
+            M11 = 
+            M12 = 
+            M13 = 
+            M14 = value;
+        }
+
+        public double M11;
+        public double M12;
+        public double M13;
+        public double M14;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix1x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix1x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix1x4)
+                return this == (Matrix1x4)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix1x4 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix1x4* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0)) << 0)
+                         + 7 * ((((x[01] ^ x[02]) << 0)) << 1)
+                         + 7 * ((((x[02] ^ x[03]) << 0)) << 2)
+                         + 7 * ((((x[03] ^ x[04]) << 0)) << 3);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix1x4: "
+                 + $"{{|{M11:00}|}}"
+                 + $"{{|{M12:00}|}}"
+                 + $"{{|{M13:00}|}}"
+                 + $"{{|{M14:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix4x1 Transpose()
+        {
+            return new Matrix4x1(M11, M12, M13, M14);
+        }
+
+        public static bool operator ==(Matrix1x4 matrix1, Matrix1x4 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M12, matrix2.M12)
+                && MatrixHelper.AreEqual(matrix1.M13, matrix2.M13)
+                && MatrixHelper.AreEqual(matrix1.M14, matrix2.M14);
+        }
+
+        public static bool operator !=(Matrix1x4 matrix1, Matrix1x4 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M12, matrix2.M12)
+                || MatrixHelper.NotEqual(matrix1.M13, matrix2.M13)
+                || MatrixHelper.NotEqual(matrix1.M14, matrix2.M14);
+        }
+
+        public static Matrix1x4 operator +(Matrix1x4 matrix1, Matrix1x4 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m14 = matrix1.M14 + matrix2.M14;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+
+        public static Matrix1x4 operator -(Matrix1x4 matrix1, Matrix1x4 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m14 = matrix1.M14 - matrix2.M14;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+
+        public static Matrix1x4 operator *(Matrix1x4 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m14 = matrix.M14 * scalar;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+
+        public static Matrix1x4 operator *(double scalar, Matrix1x4 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m12 = scalar * matrix.M12;
+            double m13 = scalar * matrix.M13;
+            double m14 = scalar * matrix.M14;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+
+        public static Matrix2x4 operator *(Matrix1x4 matrix1, Matrix2x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+        public static Matrix3x4 operator *(Matrix1x4 matrix1, Matrix3x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+        public static Matrix4x4 operator *(Matrix1x4 matrix1, Matrix4x1 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11;
+            double m21 = matrix1.M11 * matrix2.M21;
+            double m31 = matrix1.M11 * matrix2.M31;
+            double m41 = matrix1.M11 * matrix2.M41;
+            double m12 = matrix1.M12 * matrix2.M11;
+            double m22 = matrix1.M12 * matrix2.M21;
+            double m32 = matrix1.M12 * matrix2.M31;
+            double m42 = matrix1.M12 * matrix2.M41;
+            double m13 = matrix1.M13 * matrix2.M11;
+            double m23 = matrix1.M13 * matrix2.M21;
+            double m33 = matrix1.M13 * matrix2.M31;
+            double m43 = matrix1.M13 * matrix2.M41;
+            double m14 = matrix1.M14 * matrix2.M11;
+            double m24 = matrix1.M14 * matrix2.M21;
+            double m34 = matrix1.M14 * matrix2.M31;
+            double m44 = matrix1.M14 * matrix2.M41;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x1.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x1.cs
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix2x1: IEquatable<Matrix2x1>, IMatrix
+    {
+        public const int ColumnCount = 2;
+        public const int RowCount = 1;
+
+        static Matrix2x1()
+        {
+            Zero = new Matrix2x1(0);
+        }
+
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix2x1 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix2x1 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix2x1 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        public Matrix2x1(double m11, double m21)
+        {
+            M11 = m11; M21 = m21; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix2x1 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix2x1(double value)
+        {
+            M11 = M21 = value;
+        }
+
+        public double M11;
+        public double M21;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix2x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix2x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix2x1)
+                return this == (Matrix2x1)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix2x1 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix2x1* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0) + ((x[02] ^ x[03]) << 1)) << 0);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix2x1: "
+                 + $"{{|{M11:00}|{M21:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix1x2 Transpose()
+        {
+            return new Matrix1x2(M11, 
+                                 M21);
+        }
+
+        public static bool operator ==(Matrix2x1 matrix1, Matrix2x1 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M21, matrix2.M21);
+        }
+
+        public static bool operator !=(Matrix2x1 matrix1, Matrix2x1 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M21, matrix2.M21);
+        }
+
+        public static Matrix2x1 operator +(Matrix2x1 matrix1, Matrix2x1 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+
+            return new Matrix2x1(m11, m21);
+        }
+
+        public static Matrix2x1 operator -(Matrix2x1 matrix1, Matrix2x1 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+
+            return new Matrix2x1(m11, m21);
+        }
+
+        public static Matrix2x1 operator *(Matrix2x1 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+
+            return new Matrix2x1(m11, m21);
+        }
+
+        public static Matrix2x1 operator *(double scalar, Matrix2x1 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+
+            return new Matrix2x1(m11, m21);
+        }
+
+        public static Matrix2x1 operator *(Matrix2x1 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+
+            return new Matrix2x1(m11, m21);
+        }
+        public static Matrix3x1 operator *(Matrix2x1 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+        public static Matrix4x1 operator *(Matrix2x1 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x2.cs
@@ -1,0 +1,273 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix2x2: IEquatable<Matrix2x2>, IMatrix
+    {
+        public const int ColumnCount = 2;
+        public const int RowCount = 2;
+
+        static Matrix2x2()
+        {
+            Zero = new Matrix2x2(0);
+            Identity = new Matrix2x2(1, 0, 
+                                     0, 1);
+        }
+
+        
+        /// <summary>
+        /// Constant Matrix2x2 with value intialized to the identity of a 2 x 2 matrix
+        /// </summary>
+        public static readonly Matrix2x2 Identity;
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix2x2 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix2x2 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix2x2 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        public Matrix2x2(double m11, double m21, 
+                         double m12, double m22)
+        {
+            M11 = m11; M21 = m21; 
+            M12 = m12; M22 = m22; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix2x2 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix2x2(double value)
+        {
+            M11 = M21 = 
+            M12 = M22 = value;
+        }
+
+        public double M11;
+        public double M21;
+        public double M12;
+        public double M22;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix2x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix2x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 1
+        /// </summary>
+        public Matrix1x2 Column1 { get { return new Matrix1x2(M11, M12); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 2
+        /// </summary>
+        public Matrix1x2 Column2 { get { return new Matrix1x2(M21, M22); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 1
+        /// </summary>
+        public Matrix2x1 Row1 { get { return new Matrix2x1(M11, M21); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 2
+        /// </summary>
+        public Matrix2x1 Row2 { get { return new Matrix2x1(M12, M22); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix2x2)
+                return this == (Matrix2x2)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix2x2 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix2x2* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0) + ((x[02] ^ x[03]) << 1)) << 0)
+                         + 7 * ((((x[02] ^ x[03]) << 0) + ((x[04] ^ x[05]) << 1)) << 1);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix2x2: "
+                 + $"{{|{M11:00}|{M21:00}|}}"
+                 + $"{{|{M12:00}|{M22:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix2x2 Transpose()
+        {
+            return new Matrix2x2(M11, M12, 
+                                 M21, M22);
+        }
+
+        public static bool operator ==(Matrix2x2 matrix1, Matrix2x2 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M21, matrix2.M21)
+                && MatrixHelper.AreEqual(matrix1.M12, matrix2.M12)
+                && MatrixHelper.AreEqual(matrix1.M22, matrix2.M22);
+        }
+
+        public static bool operator !=(Matrix2x2 matrix1, Matrix2x2 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M21, matrix2.M21)
+                || MatrixHelper.NotEqual(matrix1.M12, matrix2.M12)
+                || MatrixHelper.NotEqual(matrix1.M22, matrix2.M22);
+        }
+
+        public static Matrix2x2 operator +(Matrix2x2 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+
+        public static Matrix2x2 operator -(Matrix2x2 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+
+        public static Matrix2x2 operator *(Matrix2x2 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+
+        public static Matrix2x2 operator *(double scalar, Matrix2x2 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+
+        public static Matrix1x2 operator *(Matrix2x2 matrix1, Matrix1x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+        public static Matrix2x2 operator *(Matrix2x2 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+        public static Matrix3x2 operator *(Matrix2x2 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+        public static Matrix4x2 operator *(Matrix2x2 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x3.cs
@@ -1,0 +1,309 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix2x3: IEquatable<Matrix2x3>, IMatrix
+    {
+        public const int ColumnCount = 2;
+        public const int RowCount = 3;
+
+        static Matrix2x3()
+        {
+            Zero = new Matrix2x3(0);
+        }
+
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix2x3 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix2x3 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix2x3 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        public Matrix2x3(double m11, double m21, 
+                         double m12, double m22, 
+                         double m13, double m23)
+        {
+            M11 = m11; M21 = m21; 
+            M12 = m12; M22 = m22; 
+            M13 = m13; M23 = m23; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix2x3 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix2x3(double value)
+        {
+            M11 = M21 = 
+            M12 = M22 = 
+            M13 = M23 = value;
+        }
+
+        public double M11;
+        public double M21;
+        public double M12;
+        public double M22;
+        public double M13;
+        public double M23;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix2x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix2x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 1
+        /// </summary>
+        public Matrix1x3 Column1 { get { return new Matrix1x3(M11, M12, M13); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 2
+        /// </summary>
+        public Matrix1x3 Column2 { get { return new Matrix1x3(M21, M22, M23); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 1
+        /// </summary>
+        public Matrix2x1 Row1 { get { return new Matrix2x1(M11, M21); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 2
+        /// </summary>
+        public Matrix2x1 Row2 { get { return new Matrix2x1(M12, M22); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 3
+        /// </summary>
+        public Matrix2x1 Row3 { get { return new Matrix2x1(M13, M23); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix2x3)
+                return this == (Matrix2x3)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix2x3 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix2x3* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0) + ((x[02] ^ x[03]) << 1)) << 0)
+                         + 7 * ((((x[02] ^ x[03]) << 0) + ((x[04] ^ x[05]) << 1)) << 1)
+                         + 7 * ((((x[04] ^ x[05]) << 0) + ((x[06] ^ x[07]) << 1)) << 2);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix2x3: "
+                 + $"{{|{M11:00}|{M21:00}|}}"
+                 + $"{{|{M12:00}|{M22:00}|}}"
+                 + $"{{|{M13:00}|{M23:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix3x2 Transpose()
+        {
+            return new Matrix3x2(M11, M12, M13, 
+                                 M21, M22, M23);
+        }
+
+        public static bool operator ==(Matrix2x3 matrix1, Matrix2x3 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M21, matrix2.M21)
+                && MatrixHelper.AreEqual(matrix1.M12, matrix2.M12)
+                && MatrixHelper.AreEqual(matrix1.M22, matrix2.M22)
+                && MatrixHelper.AreEqual(matrix1.M13, matrix2.M13)
+                && MatrixHelper.AreEqual(matrix1.M23, matrix2.M23);
+        }
+
+        public static bool operator !=(Matrix2x3 matrix1, Matrix2x3 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M21, matrix2.M21)
+                || MatrixHelper.NotEqual(matrix1.M12, matrix2.M12)
+                || MatrixHelper.NotEqual(matrix1.M22, matrix2.M22)
+                || MatrixHelper.NotEqual(matrix1.M13, matrix2.M13)
+                || MatrixHelper.NotEqual(matrix1.M23, matrix2.M23);
+        }
+
+        public static Matrix2x3 operator +(Matrix2x3 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+
+        public static Matrix2x3 operator -(Matrix2x3 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+
+        public static Matrix2x3 operator *(Matrix2x3 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+
+        public static Matrix2x3 operator *(double scalar, Matrix2x3 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+
+        public static Matrix1x3 operator *(Matrix2x3 matrix1, Matrix1x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+        public static Matrix2x3 operator *(Matrix2x3 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+        public static Matrix3x3 operator *(Matrix2x3 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+        public static Matrix4x3 operator *(Matrix2x3 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x4.cs
@@ -1,0 +1,352 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix2x4: IEquatable<Matrix2x4>, IMatrix
+    {
+        public const int ColumnCount = 2;
+        public const int RowCount = 4;
+
+        static Matrix2x4()
+        {
+            Zero = new Matrix2x4(0);
+        }
+
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix2x4 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix2x4 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix2x4 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        public Matrix2x4(double m11, double m21, 
+                         double m12, double m22, 
+                         double m13, double m23, 
+                         double m14, double m24)
+        {
+            M11 = m11; M21 = m21; 
+            M12 = m12; M22 = m22; 
+            M13 = m13; M23 = m23; 
+            M14 = m14; M24 = m24; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix2x4 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix2x4(double value)
+        {
+            M11 = M21 = 
+            M12 = M22 = 
+            M13 = M23 = 
+            M14 = M24 = value;
+        }
+
+        public double M11;
+        public double M21;
+        public double M12;
+        public double M22;
+        public double M13;
+        public double M23;
+        public double M14;
+        public double M24;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix2x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix2x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 1
+        /// </summary>
+        public Matrix1x4 Column1 { get { return new Matrix1x4(M11, M12, M13, M14); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 2
+        /// </summary>
+        public Matrix1x4 Column2 { get { return new Matrix1x4(M21, M22, M23, M24); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 1
+        /// </summary>
+        public Matrix2x1 Row1 { get { return new Matrix2x1(M11, M21); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 2
+        /// </summary>
+        public Matrix2x1 Row2 { get { return new Matrix2x1(M12, M22); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 3
+        /// </summary>
+        public Matrix2x1 Row3 { get { return new Matrix2x1(M13, M23); } }
+        /// <summary>
+        /// Gets a new Matrix2x1 containing the values of column 4
+        /// </summary>
+        public Matrix2x1 Row4 { get { return new Matrix2x1(M14, M24); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix2x4)
+                return this == (Matrix2x4)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix2x4 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix2x4* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0) + ((x[02] ^ x[03]) << 1)) << 0)
+                         + 7 * ((((x[02] ^ x[03]) << 0) + ((x[04] ^ x[05]) << 1)) << 1)
+                         + 7 * ((((x[04] ^ x[05]) << 0) + ((x[06] ^ x[07]) << 1)) << 2)
+                         + 7 * ((((x[06] ^ x[07]) << 0) + ((x[08] ^ x[09]) << 1)) << 3);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix2x4: "
+                 + $"{{|{M11:00}|{M21:00}|}}"
+                 + $"{{|{M12:00}|{M22:00}|}}"
+                 + $"{{|{M13:00}|{M23:00}|}}"
+                 + $"{{|{M14:00}|{M24:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix4x2 Transpose()
+        {
+            return new Matrix4x2(M11, M12, M13, M14, 
+                                 M21, M22, M23, M24);
+        }
+
+        public static bool operator ==(Matrix2x4 matrix1, Matrix2x4 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M21, matrix2.M21)
+                && MatrixHelper.AreEqual(matrix1.M12, matrix2.M12)
+                && MatrixHelper.AreEqual(matrix1.M22, matrix2.M22)
+                && MatrixHelper.AreEqual(matrix1.M13, matrix2.M13)
+                && MatrixHelper.AreEqual(matrix1.M23, matrix2.M23)
+                && MatrixHelper.AreEqual(matrix1.M14, matrix2.M14)
+                && MatrixHelper.AreEqual(matrix1.M24, matrix2.M24);
+        }
+
+        public static bool operator !=(Matrix2x4 matrix1, Matrix2x4 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M21, matrix2.M21)
+                || MatrixHelper.NotEqual(matrix1.M12, matrix2.M12)
+                || MatrixHelper.NotEqual(matrix1.M22, matrix2.M22)
+                || MatrixHelper.NotEqual(matrix1.M13, matrix2.M13)
+                || MatrixHelper.NotEqual(matrix1.M23, matrix2.M23)
+                || MatrixHelper.NotEqual(matrix1.M14, matrix2.M14)
+                || MatrixHelper.NotEqual(matrix1.M24, matrix2.M24);
+        }
+
+        public static Matrix2x4 operator +(Matrix2x4 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+
+        public static Matrix2x4 operator -(Matrix2x4 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+
+        public static Matrix2x4 operator *(Matrix2x4 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+
+        public static Matrix2x4 operator *(double scalar, Matrix2x4 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+
+        public static Matrix1x4 operator *(Matrix2x4 matrix1, Matrix1x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+        public static Matrix2x4 operator *(Matrix2x4 matrix1, Matrix2x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+        public static Matrix3x4 operator *(Matrix2x4 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+        public static Matrix4x4 operator *(Matrix2x4 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x1.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x1.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix3x1: IEquatable<Matrix3x1>, IMatrix
+    {
+        public const int ColumnCount = 3;
+        public const int RowCount = 1;
+
+        static Matrix3x1()
+        {
+            Zero = new Matrix3x1(0);
+        }
+
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix3x1 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix3x1 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix3x1 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        public Matrix3x1(double m11, double m21, double m31)
+        {
+            M11 = m11; M21 = m21; M31 = m31; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix3x1 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix3x1(double value)
+        {
+            M11 = M21 = M31 = value;
+        }
+
+        public double M11;
+        public double M21;
+        public double M31;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix3x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix3x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix3x1)
+                return this == (Matrix3x1)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix3x1 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix3x1* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0) + ((x[02] ^ x[03]) << 1) + ((x[04] ^ x[05]) << 2)) << 0);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix3x1: "
+                 + $"{{|{M11:00}|{M21:00}|{M31:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix1x3 Transpose()
+        {
+            return new Matrix1x3(M11, 
+                                 M21, 
+                                 M31);
+        }
+
+        public static bool operator ==(Matrix3x1 matrix1, Matrix3x1 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M21, matrix2.M21)
+                && MatrixHelper.AreEqual(matrix1.M31, matrix2.M31);
+        }
+
+        public static bool operator !=(Matrix3x1 matrix1, Matrix3x1 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M21, matrix2.M21)
+                || MatrixHelper.NotEqual(matrix1.M31, matrix2.M31);
+        }
+
+        public static Matrix3x1 operator +(Matrix3x1 matrix1, Matrix3x1 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+
+        public static Matrix3x1 operator -(Matrix3x1 matrix1, Matrix3x1 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+
+        public static Matrix3x1 operator *(Matrix3x1 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+
+        public static Matrix3x1 operator *(double scalar, Matrix3x1 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+
+        public static Matrix2x1 operator *(Matrix3x1 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+
+            return new Matrix2x1(m11, m21);
+        }
+        public static Matrix3x1 operator *(Matrix3x1 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+        public static Matrix4x1 operator *(Matrix3x1 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x2.cs
@@ -1,0 +1,287 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix3x2: IEquatable<Matrix3x2>, IMatrix
+    {
+        public const int ColumnCount = 3;
+        public const int RowCount = 2;
+
+        static Matrix3x2()
+        {
+            Zero = new Matrix3x2(0);
+        }
+
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix3x2 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix3x2 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix3x2 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        public Matrix3x2(double m11, double m21, double m31, 
+                         double m12, double m22, double m32)
+        {
+            M11 = m11; M21 = m21; M31 = m31; 
+            M12 = m12; M22 = m22; M32 = m32; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix3x2 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix3x2(double value)
+        {
+            M11 = M21 = M31 = 
+            M12 = M22 = M32 = value;
+        }
+
+        public double M11;
+        public double M21;
+        public double M31;
+        public double M12;
+        public double M22;
+        public double M32;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix3x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix3x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 1
+        /// </summary>
+        public Matrix1x2 Column1 { get { return new Matrix1x2(M11, M12); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 2
+        /// </summary>
+        public Matrix1x2 Column2 { get { return new Matrix1x2(M21, M22); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 3
+        /// </summary>
+        public Matrix1x2 Column3 { get { return new Matrix1x2(M31, M32); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 1
+        /// </summary>
+        public Matrix3x1 Row1 { get { return new Matrix3x1(M11, M21, M31); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 2
+        /// </summary>
+        public Matrix3x1 Row2 { get { return new Matrix3x1(M12, M22, M32); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix3x2)
+                return this == (Matrix3x2)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix3x2 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix3x2* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0) + ((x[02] ^ x[03]) << 1) + ((x[04] ^ x[05]) << 2)) << 0)
+                         + 7 * ((((x[03] ^ x[04]) << 0) + ((x[05] ^ x[06]) << 1) + ((x[07] ^ x[08]) << 2)) << 1);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix3x2: "
+                 + $"{{|{M11:00}|{M21:00}|{M31:00}|}}"
+                 + $"{{|{M12:00}|{M22:00}|{M32:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix2x3 Transpose()
+        {
+            return new Matrix2x3(M11, M12, 
+                                 M21, M22, 
+                                 M31, M32);
+        }
+
+        public static bool operator ==(Matrix3x2 matrix1, Matrix3x2 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M21, matrix2.M21)
+                && MatrixHelper.AreEqual(matrix1.M31, matrix2.M31)
+                && MatrixHelper.AreEqual(matrix1.M12, matrix2.M12)
+                && MatrixHelper.AreEqual(matrix1.M22, matrix2.M22)
+                && MatrixHelper.AreEqual(matrix1.M32, matrix2.M32);
+        }
+
+        public static bool operator !=(Matrix3x2 matrix1, Matrix3x2 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M21, matrix2.M21)
+                || MatrixHelper.NotEqual(matrix1.M31, matrix2.M31)
+                || MatrixHelper.NotEqual(matrix1.M12, matrix2.M12)
+                || MatrixHelper.NotEqual(matrix1.M22, matrix2.M22)
+                || MatrixHelper.NotEqual(matrix1.M32, matrix2.M32);
+        }
+
+        public static Matrix3x2 operator +(Matrix3x2 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+
+        public static Matrix3x2 operator -(Matrix3x2 matrix1, Matrix3x2 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+
+        public static Matrix3x2 operator *(Matrix3x2 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+
+        public static Matrix3x2 operator *(double scalar, Matrix3x2 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+
+        public static Matrix1x2 operator *(Matrix3x2 matrix1, Matrix1x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+        public static Matrix2x2 operator *(Matrix3x2 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+        public static Matrix3x2 operator *(Matrix3x2 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+        public static Matrix4x2 operator *(Matrix3x2 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x3.cs
@@ -1,0 +1,346 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix3x3: IEquatable<Matrix3x3>, IMatrix
+    {
+        public const int ColumnCount = 3;
+        public const int RowCount = 3;
+
+        static Matrix3x3()
+        {
+            Zero = new Matrix3x3(0);
+            Identity = new Matrix3x3(1, 0, 0, 
+                                     0, 1, 0, 
+                                     0, 0, 1);
+        }
+
+        
+        /// <summary>
+        /// Constant Matrix3x3 with value intialized to the identity of a 3 x 3 matrix
+        /// </summary>
+        public static readonly Matrix3x3 Identity;
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix3x3 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix3x3 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix3x3 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        public Matrix3x3(double m11, double m21, double m31, 
+                         double m12, double m22, double m32, 
+                         double m13, double m23, double m33)
+        {
+            M11 = m11; M21 = m21; M31 = m31; 
+            M12 = m12; M22 = m22; M32 = m32; 
+            M13 = m13; M23 = m23; M33 = m33; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix3x3 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix3x3(double value)
+        {
+            M11 = M21 = M31 = 
+            M12 = M22 = M32 = 
+            M13 = M23 = M33 = value;
+        }
+
+        public double M11;
+        public double M21;
+        public double M31;
+        public double M12;
+        public double M22;
+        public double M32;
+        public double M13;
+        public double M23;
+        public double M33;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix3x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix3x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 1
+        /// </summary>
+        public Matrix1x3 Column1 { get { return new Matrix1x3(M11, M12, M13); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 2
+        /// </summary>
+        public Matrix1x3 Column2 { get { return new Matrix1x3(M21, M22, M23); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 3
+        /// </summary>
+        public Matrix1x3 Column3 { get { return new Matrix1x3(M31, M32, M33); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 1
+        /// </summary>
+        public Matrix3x1 Row1 { get { return new Matrix3x1(M11, M21, M31); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 2
+        /// </summary>
+        public Matrix3x1 Row2 { get { return new Matrix3x1(M12, M22, M32); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 3
+        /// </summary>
+        public Matrix3x1 Row3 { get { return new Matrix3x1(M13, M23, M33); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix3x3)
+                return this == (Matrix3x3)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix3x3 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix3x3* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0) + ((x[02] ^ x[03]) << 1) + ((x[04] ^ x[05]) << 2)) << 0)
+                         + 7 * ((((x[03] ^ x[04]) << 0) + ((x[05] ^ x[06]) << 1) + ((x[07] ^ x[08]) << 2)) << 1)
+                         + 7 * ((((x[06] ^ x[07]) << 0) + ((x[08] ^ x[09]) << 1) + ((x[10] ^ x[11]) << 2)) << 2);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix3x3: "
+                 + $"{{|{M11:00}|{M21:00}|{M31:00}|}}"
+                 + $"{{|{M12:00}|{M22:00}|{M32:00}|}}"
+                 + $"{{|{M13:00}|{M23:00}|{M33:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix3x3 Transpose()
+        {
+            return new Matrix3x3(M11, M12, M13, 
+                                 M21, M22, M23, 
+                                 M31, M32, M33);
+        }
+
+        public static bool operator ==(Matrix3x3 matrix1, Matrix3x3 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M21, matrix2.M21)
+                && MatrixHelper.AreEqual(matrix1.M31, matrix2.M31)
+                && MatrixHelper.AreEqual(matrix1.M12, matrix2.M12)
+                && MatrixHelper.AreEqual(matrix1.M22, matrix2.M22)
+                && MatrixHelper.AreEqual(matrix1.M32, matrix2.M32)
+                && MatrixHelper.AreEqual(matrix1.M13, matrix2.M13)
+                && MatrixHelper.AreEqual(matrix1.M23, matrix2.M23)
+                && MatrixHelper.AreEqual(matrix1.M33, matrix2.M33);
+        }
+
+        public static bool operator !=(Matrix3x3 matrix1, Matrix3x3 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M21, matrix2.M21)
+                || MatrixHelper.NotEqual(matrix1.M31, matrix2.M31)
+                || MatrixHelper.NotEqual(matrix1.M12, matrix2.M12)
+                || MatrixHelper.NotEqual(matrix1.M22, matrix2.M22)
+                || MatrixHelper.NotEqual(matrix1.M32, matrix2.M32)
+                || MatrixHelper.NotEqual(matrix1.M13, matrix2.M13)
+                || MatrixHelper.NotEqual(matrix1.M23, matrix2.M23)
+                || MatrixHelper.NotEqual(matrix1.M33, matrix2.M33);
+        }
+
+        public static Matrix3x3 operator +(Matrix3x3 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+
+        public static Matrix3x3 operator -(Matrix3x3 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+
+        public static Matrix3x3 operator *(Matrix3x3 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+
+        public static Matrix3x3 operator *(double scalar, Matrix3x3 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+
+        public static Matrix1x3 operator *(Matrix3x3 matrix1, Matrix1x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+        public static Matrix2x3 operator *(Matrix3x3 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+        public static Matrix3x3 operator *(Matrix3x3 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+        public static Matrix4x3 operator *(Matrix3x3 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x4.cs
@@ -1,0 +1,389 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix3x4: IEquatable<Matrix3x4>, IMatrix
+    {
+        public const int ColumnCount = 3;
+        public const int RowCount = 4;
+
+        static Matrix3x4()
+        {
+            Zero = new Matrix3x4(0);
+        }
+
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix3x4 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix3x4 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix3x4 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        public Matrix3x4(double m11, double m21, double m31, 
+                         double m12, double m22, double m32, 
+                         double m13, double m23, double m33, 
+                         double m14, double m24, double m34)
+        {
+            M11 = m11; M21 = m21; M31 = m31; 
+            M12 = m12; M22 = m22; M32 = m32; 
+            M13 = m13; M23 = m23; M33 = m33; 
+            M14 = m14; M24 = m24; M34 = m34; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix3x4 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix3x4(double value)
+        {
+            M11 = M21 = M31 = 
+            M12 = M22 = M32 = 
+            M13 = M23 = M33 = 
+            M14 = M24 = M34 = value;
+        }
+
+        public double M11;
+        public double M21;
+        public double M31;
+        public double M12;
+        public double M22;
+        public double M32;
+        public double M13;
+        public double M23;
+        public double M33;
+        public double M14;
+        public double M24;
+        public double M34;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix3x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix3x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 1
+        /// </summary>
+        public Matrix1x4 Column1 { get { return new Matrix1x4(M11, M12, M13, M14); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 2
+        /// </summary>
+        public Matrix1x4 Column2 { get { return new Matrix1x4(M21, M22, M23, M24); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 3
+        /// </summary>
+        public Matrix1x4 Column3 { get { return new Matrix1x4(M31, M32, M33, M34); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 1
+        /// </summary>
+        public Matrix3x1 Row1 { get { return new Matrix3x1(M11, M21, M31); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 2
+        /// </summary>
+        public Matrix3x1 Row2 { get { return new Matrix3x1(M12, M22, M32); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 3
+        /// </summary>
+        public Matrix3x1 Row3 { get { return new Matrix3x1(M13, M23, M33); } }
+        /// <summary>
+        /// Gets a new Matrix3x1 containing the values of column 4
+        /// </summary>
+        public Matrix3x1 Row4 { get { return new Matrix3x1(M14, M24, M34); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix3x4)
+                return this == (Matrix3x4)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix3x4 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix3x4* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0) + ((x[02] ^ x[03]) << 1) + ((x[04] ^ x[05]) << 2)) << 0)
+                         + 7 * ((((x[03] ^ x[04]) << 0) + ((x[05] ^ x[06]) << 1) + ((x[07] ^ x[08]) << 2)) << 1)
+                         + 7 * ((((x[06] ^ x[07]) << 0) + ((x[08] ^ x[09]) << 1) + ((x[10] ^ x[11]) << 2)) << 2)
+                         + 7 * ((((x[09] ^ x[10]) << 0) + ((x[11] ^ x[12]) << 1) + ((x[13] ^ x[14]) << 2)) << 3);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix3x4: "
+                 + $"{{|{M11:00}|{M21:00}|{M31:00}|}}"
+                 + $"{{|{M12:00}|{M22:00}|{M32:00}|}}"
+                 + $"{{|{M13:00}|{M23:00}|{M33:00}|}}"
+                 + $"{{|{M14:00}|{M24:00}|{M34:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix4x3 Transpose()
+        {
+            return new Matrix4x3(M11, M12, M13, M14, 
+                                 M21, M22, M23, M24, 
+                                 M31, M32, M33, M34);
+        }
+
+        public static bool operator ==(Matrix3x4 matrix1, Matrix3x4 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M21, matrix2.M21)
+                && MatrixHelper.AreEqual(matrix1.M31, matrix2.M31)
+                && MatrixHelper.AreEqual(matrix1.M12, matrix2.M12)
+                && MatrixHelper.AreEqual(matrix1.M22, matrix2.M22)
+                && MatrixHelper.AreEqual(matrix1.M32, matrix2.M32)
+                && MatrixHelper.AreEqual(matrix1.M13, matrix2.M13)
+                && MatrixHelper.AreEqual(matrix1.M23, matrix2.M23)
+                && MatrixHelper.AreEqual(matrix1.M33, matrix2.M33)
+                && MatrixHelper.AreEqual(matrix1.M14, matrix2.M14)
+                && MatrixHelper.AreEqual(matrix1.M24, matrix2.M24)
+                && MatrixHelper.AreEqual(matrix1.M34, matrix2.M34);
+        }
+
+        public static bool operator !=(Matrix3x4 matrix1, Matrix3x4 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M21, matrix2.M21)
+                || MatrixHelper.NotEqual(matrix1.M31, matrix2.M31)
+                || MatrixHelper.NotEqual(matrix1.M12, matrix2.M12)
+                || MatrixHelper.NotEqual(matrix1.M22, matrix2.M22)
+                || MatrixHelper.NotEqual(matrix1.M32, matrix2.M32)
+                || MatrixHelper.NotEqual(matrix1.M13, matrix2.M13)
+                || MatrixHelper.NotEqual(matrix1.M23, matrix2.M23)
+                || MatrixHelper.NotEqual(matrix1.M33, matrix2.M33)
+                || MatrixHelper.NotEqual(matrix1.M14, matrix2.M14)
+                || MatrixHelper.NotEqual(matrix1.M24, matrix2.M24)
+                || MatrixHelper.NotEqual(matrix1.M34, matrix2.M34);
+        }
+
+        public static Matrix3x4 operator +(Matrix3x4 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+
+        public static Matrix3x4 operator -(Matrix3x4 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+
+        public static Matrix3x4 operator *(Matrix3x4 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+
+        public static Matrix3x4 operator *(double scalar, Matrix3x4 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+
+        public static Matrix1x4 operator *(Matrix3x4 matrix1, Matrix1x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+        public static Matrix2x4 operator *(Matrix3x4 matrix1, Matrix2x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+        public static Matrix3x4 operator *(Matrix3x4 matrix1, Matrix3x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+        public static Matrix4x4 operator *(Matrix3x4 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x1.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x1.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix4x1: IEquatable<Matrix4x1>, IMatrix
+    {
+        public const int ColumnCount = 4;
+        public const int RowCount = 1;
+
+        static Matrix4x1()
+        {
+            Zero = new Matrix4x1(0);
+        }
+
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix4x1 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix4x1 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix4x1 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        public Matrix4x1(double m11, double m21, double m31, double m41)
+        {
+            M11 = m11; M21 = m21; M31 = m31; M41 = m41; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix4x1 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix4x1(double value)
+        {
+            M11 = M21 = M31 = M41 = value;
+        }
+
+        public double M11;
+        public double M21;
+        public double M31;
+        public double M41;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix4x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix4x1* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix4x1)
+                return this == (Matrix4x1)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix4x1 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix4x1* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0) + ((x[02] ^ x[03]) << 1) + ((x[04] ^ x[05]) << 2) + ((x[06] ^ x[07]) << 3)) << 0);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix4x1: "
+                 + $"{{|{M11:00}|{M21:00}|{M31:00}|{M41:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix1x4 Transpose()
+        {
+            return new Matrix1x4(M11, 
+                                 M21, 
+                                 M31, 
+                                 M41);
+        }
+
+        public static bool operator ==(Matrix4x1 matrix1, Matrix4x1 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M21, matrix2.M21)
+                && MatrixHelper.AreEqual(matrix1.M31, matrix2.M31)
+                && MatrixHelper.AreEqual(matrix1.M41, matrix2.M41);
+        }
+
+        public static bool operator !=(Matrix4x1 matrix1, Matrix4x1 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M21, matrix2.M21)
+                || MatrixHelper.NotEqual(matrix1.M31, matrix2.M31)
+                || MatrixHelper.NotEqual(matrix1.M41, matrix2.M41);
+        }
+
+        public static Matrix4x1 operator +(Matrix4x1 matrix1, Matrix4x1 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+
+        public static Matrix4x1 operator -(Matrix4x1 matrix1, Matrix4x1 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+
+        public static Matrix4x1 operator *(Matrix4x1 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+
+        public static Matrix4x1 operator *(double scalar, Matrix4x1 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+
+        public static Matrix2x1 operator *(Matrix4x1 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+
+            return new Matrix2x1(m11, m21);
+        }
+        public static Matrix3x1 operator *(Matrix4x1 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+
+            return new Matrix3x1(m11, m21, m31);
+        }
+        public static Matrix4x1 operator *(Matrix4x1 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+
+            return new Matrix4x1(m11, m21, m31, m41);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x2.cs
@@ -1,0 +1,308 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix4x2: IEquatable<Matrix4x2>, IMatrix
+    {
+        public const int ColumnCount = 4;
+        public const int RowCount = 2;
+
+        static Matrix4x2()
+        {
+            Zero = new Matrix4x2(0);
+        }
+
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix4x2 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix4x2 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix4x2 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        public Matrix4x2(double m11, double m21, double m31, double m41, 
+                         double m12, double m22, double m32, double m42)
+        {
+            M11 = m11; M21 = m21; M31 = m31; M41 = m41; 
+            M12 = m12; M22 = m22; M32 = m32; M42 = m42; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix4x2 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix4x2(double value)
+        {
+            M11 = M21 = M31 = M41 = 
+            M12 = M22 = M32 = M42 = value;
+        }
+
+        public double M11;
+        public double M21;
+        public double M31;
+        public double M41;
+        public double M12;
+        public double M22;
+        public double M32;
+        public double M42;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix4x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix4x2* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 1
+        /// </summary>
+        public Matrix1x2 Column1 { get { return new Matrix1x2(M11, M12); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 2
+        /// </summary>
+        public Matrix1x2 Column2 { get { return new Matrix1x2(M21, M22); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 3
+        /// </summary>
+        public Matrix1x2 Column3 { get { return new Matrix1x2(M31, M32); } }
+        /// <summary>
+        /// Gets a new Matrix1x2 containing the values of column 4
+        /// </summary>
+        public Matrix1x2 Column4 { get { return new Matrix1x2(M41, M42); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 1
+        /// </summary>
+        public Matrix4x1 Row1 { get { return new Matrix4x1(M11, M21, M31, M41); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 2
+        /// </summary>
+        public Matrix4x1 Row2 { get { return new Matrix4x1(M12, M22, M32, M42); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix4x2)
+                return this == (Matrix4x2)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix4x2 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix4x2* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0) + ((x[02] ^ x[03]) << 1) + ((x[04] ^ x[05]) << 2) + ((x[06] ^ x[07]) << 3)) << 0)
+                         + 7 * ((((x[04] ^ x[05]) << 0) + ((x[06] ^ x[07]) << 1) + ((x[08] ^ x[09]) << 2) + ((x[10] ^ x[11]) << 3)) << 1);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix4x2: "
+                 + $"{{|{M11:00}|{M21:00}|{M31:00}|{M41:00}|}}"
+                 + $"{{|{M12:00}|{M22:00}|{M32:00}|{M42:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix2x4 Transpose()
+        {
+            return new Matrix2x4(M11, M12, 
+                                 M21, M22, 
+                                 M31, M32, 
+                                 M41, M42);
+        }
+
+        public static bool operator ==(Matrix4x2 matrix1, Matrix4x2 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M21, matrix2.M21)
+                && MatrixHelper.AreEqual(matrix1.M31, matrix2.M31)
+                && MatrixHelper.AreEqual(matrix1.M41, matrix2.M41)
+                && MatrixHelper.AreEqual(matrix1.M12, matrix2.M12)
+                && MatrixHelper.AreEqual(matrix1.M22, matrix2.M22)
+                && MatrixHelper.AreEqual(matrix1.M32, matrix2.M32)
+                && MatrixHelper.AreEqual(matrix1.M42, matrix2.M42);
+        }
+
+        public static bool operator !=(Matrix4x2 matrix1, Matrix4x2 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M21, matrix2.M21)
+                || MatrixHelper.NotEqual(matrix1.M31, matrix2.M31)
+                || MatrixHelper.NotEqual(matrix1.M41, matrix2.M41)
+                || MatrixHelper.NotEqual(matrix1.M12, matrix2.M12)
+                || MatrixHelper.NotEqual(matrix1.M22, matrix2.M22)
+                || MatrixHelper.NotEqual(matrix1.M32, matrix2.M32)
+                || MatrixHelper.NotEqual(matrix1.M42, matrix2.M42);
+        }
+
+        public static Matrix4x2 operator +(Matrix4x2 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+
+        public static Matrix4x2 operator -(Matrix4x2 matrix1, Matrix4x2 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+
+        public static Matrix4x2 operator *(Matrix4x2 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+
+        public static Matrix4x2 operator *(double scalar, Matrix4x2 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+
+        public static Matrix1x2 operator *(Matrix4x2 matrix1, Matrix1x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+
+            return new Matrix1x2(m11, 
+                                 m12);
+        }
+        public static Matrix2x2 operator *(Matrix4x2 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+
+            return new Matrix2x2(m11, m21, 
+                                 m12, m22);
+        }
+        public static Matrix3x2 operator *(Matrix4x2 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+
+            return new Matrix3x2(m11, m21, m31, 
+                                 m12, m22, m32);
+        }
+        public static Matrix4x2 operator *(Matrix4x2 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+
+            return new Matrix4x2(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x3.cs
@@ -1,0 +1,367 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix4x3: IEquatable<Matrix4x3>, IMatrix
+    {
+        public const int ColumnCount = 4;
+        public const int RowCount = 3;
+
+        static Matrix4x3()
+        {
+            Zero = new Matrix4x3(0);
+        }
+
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix4x3 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix4x3 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix4x3 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        public Matrix4x3(double m11, double m21, double m31, double m41, 
+                         double m12, double m22, double m32, double m42, 
+                         double m13, double m23, double m33, double m43)
+        {
+            M11 = m11; M21 = m21; M31 = m31; M41 = m41; 
+            M12 = m12; M22 = m22; M32 = m32; M42 = m42; 
+            M13 = m13; M23 = m23; M33 = m33; M43 = m43; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix4x3 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix4x3(double value)
+        {
+            M11 = M21 = M31 = M41 = 
+            M12 = M22 = M32 = M42 = 
+            M13 = M23 = M33 = M43 = value;
+        }
+
+        public double M11;
+        public double M21;
+        public double M31;
+        public double M41;
+        public double M12;
+        public double M22;
+        public double M32;
+        public double M42;
+        public double M13;
+        public double M23;
+        public double M33;
+        public double M43;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix4x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix4x3* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 1
+        /// </summary>
+        public Matrix1x3 Column1 { get { return new Matrix1x3(M11, M12, M13); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 2
+        /// </summary>
+        public Matrix1x3 Column2 { get { return new Matrix1x3(M21, M22, M23); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 3
+        /// </summary>
+        public Matrix1x3 Column3 { get { return new Matrix1x3(M31, M32, M33); } }
+        /// <summary>
+        /// Gets a new Matrix1x3 containing the values of column 4
+        /// </summary>
+        public Matrix1x3 Column4 { get { return new Matrix1x3(M41, M42, M43); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 1
+        /// </summary>
+        public Matrix4x1 Row1 { get { return new Matrix4x1(M11, M21, M31, M41); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 2
+        /// </summary>
+        public Matrix4x1 Row2 { get { return new Matrix4x1(M12, M22, M32, M42); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 3
+        /// </summary>
+        public Matrix4x1 Row3 { get { return new Matrix4x1(M13, M23, M33, M43); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix4x3)
+                return this == (Matrix4x3)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix4x3 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix4x3* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0) + ((x[02] ^ x[03]) << 1) + ((x[04] ^ x[05]) << 2) + ((x[06] ^ x[07]) << 3)) << 0)
+                         + 7 * ((((x[04] ^ x[05]) << 0) + ((x[06] ^ x[07]) << 1) + ((x[08] ^ x[09]) << 2) + ((x[10] ^ x[11]) << 3)) << 1)
+                         + 7 * ((((x[08] ^ x[09]) << 0) + ((x[10] ^ x[11]) << 1) + ((x[12] ^ x[13]) << 2) + ((x[14] ^ x[15]) << 3)) << 2);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix4x3: "
+                 + $"{{|{M11:00}|{M21:00}|{M31:00}|{M41:00}|}}"
+                 + $"{{|{M12:00}|{M22:00}|{M32:00}|{M42:00}|}}"
+                 + $"{{|{M13:00}|{M23:00}|{M33:00}|{M43:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix3x4 Transpose()
+        {
+            return new Matrix3x4(M11, M12, M13, 
+                                 M21, M22, M23, 
+                                 M31, M32, M33, 
+                                 M41, M42, M43);
+        }
+
+        public static bool operator ==(Matrix4x3 matrix1, Matrix4x3 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M21, matrix2.M21)
+                && MatrixHelper.AreEqual(matrix1.M31, matrix2.M31)
+                && MatrixHelper.AreEqual(matrix1.M41, matrix2.M41)
+                && MatrixHelper.AreEqual(matrix1.M12, matrix2.M12)
+                && MatrixHelper.AreEqual(matrix1.M22, matrix2.M22)
+                && MatrixHelper.AreEqual(matrix1.M32, matrix2.M32)
+                && MatrixHelper.AreEqual(matrix1.M42, matrix2.M42)
+                && MatrixHelper.AreEqual(matrix1.M13, matrix2.M13)
+                && MatrixHelper.AreEqual(matrix1.M23, matrix2.M23)
+                && MatrixHelper.AreEqual(matrix1.M33, matrix2.M33)
+                && MatrixHelper.AreEqual(matrix1.M43, matrix2.M43);
+        }
+
+        public static bool operator !=(Matrix4x3 matrix1, Matrix4x3 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M21, matrix2.M21)
+                || MatrixHelper.NotEqual(matrix1.M31, matrix2.M31)
+                || MatrixHelper.NotEqual(matrix1.M41, matrix2.M41)
+                || MatrixHelper.NotEqual(matrix1.M12, matrix2.M12)
+                || MatrixHelper.NotEqual(matrix1.M22, matrix2.M22)
+                || MatrixHelper.NotEqual(matrix1.M32, matrix2.M32)
+                || MatrixHelper.NotEqual(matrix1.M42, matrix2.M42)
+                || MatrixHelper.NotEqual(matrix1.M13, matrix2.M13)
+                || MatrixHelper.NotEqual(matrix1.M23, matrix2.M23)
+                || MatrixHelper.NotEqual(matrix1.M33, matrix2.M33)
+                || MatrixHelper.NotEqual(matrix1.M43, matrix2.M43);
+        }
+
+        public static Matrix4x3 operator +(Matrix4x3 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+
+        public static Matrix4x3 operator -(Matrix4x3 matrix1, Matrix4x3 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+
+        public static Matrix4x3 operator *(Matrix4x3 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+
+        public static Matrix4x3 operator *(double scalar, Matrix4x3 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+
+        public static Matrix1x3 operator *(Matrix4x3 matrix1, Matrix1x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+
+            return new Matrix1x3(m11, 
+                                 m12, 
+                                 m13);
+        }
+        public static Matrix2x3 operator *(Matrix4x3 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+
+            return new Matrix2x3(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23);
+        }
+        public static Matrix3x3 operator *(Matrix4x3 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+
+            return new Matrix3x3(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33);
+        }
+        public static Matrix4x3 operator *(Matrix4x3 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+
+            return new Matrix4x3(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x4.cs
@@ -1,0 +1,435 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Matrix4x4: IEquatable<Matrix4x4>, IMatrix
+    {
+        public const int ColumnCount = 4;
+        public const int RowCount = 4;
+
+        static Matrix4x4()
+        {
+            Zero = new Matrix4x4(0);
+            Identity = new Matrix4x4(1, 0, 0, 0, 
+                                     0, 1, 0, 0, 
+                                     0, 0, 1, 0, 
+                                     0, 0, 0, 1);
+        }
+
+        
+        /// <summary>
+        /// Constant Matrix4x4 with value intialized to the identity of a 4 x 4 matrix
+        /// </summary>
+        public static readonly Matrix4x4 Identity;
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant Matrix4x4 with all values initialized to zero
+        /// </summary>
+        public static readonly Matrix4x4 Zero;
+
+        /// <summary>
+        /// Initializes a Matrix4x4 with all of it values specifically set
+        /// </summary>
+        /// <param name="m11">The column 1, row 1 value</param>
+        /// <param name="m21">The column 2, row 1 value</param>
+        /// <param name="m31">The column 3, row 1 value</param>
+        /// <param name="m41">The column 4, row 1 value</param>
+        /// <param name="m12">The column 1, row 2 value</param>
+        /// <param name="m22">The column 2, row 2 value</param>
+        /// <param name="m32">The column 3, row 2 value</param>
+        /// <param name="m42">The column 4, row 2 value</param>
+        /// <param name="m13">The column 1, row 3 value</param>
+        /// <param name="m23">The column 2, row 3 value</param>
+        /// <param name="m33">The column 3, row 3 value</param>
+        /// <param name="m43">The column 4, row 3 value</param>
+        /// <param name="m14">The column 1, row 4 value</param>
+        /// <param name="m24">The column 2, row 4 value</param>
+        /// <param name="m34">The column 3, row 4 value</param>
+        /// <param name="m44">The column 4, row 4 value</param>
+        public Matrix4x4(double m11, double m21, double m31, double m41, 
+                         double m12, double m22, double m32, double m42, 
+                         double m13, double m23, double m33, double m43, 
+                         double m14, double m24, double m34, double m44)
+        {
+            M11 = m11; M21 = m21; M31 = m31; M41 = m41; 
+            M12 = m12; M22 = m22; M32 = m32; M42 = m42; 
+            M13 = m13; M23 = m23; M33 = m33; M43 = m43; 
+            M14 = m14; M24 = m24; M34 = m34; M44 = m44; 
+        }
+
+        /// <summary>
+        /// Initialized a Matrix4x4 with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public Matrix4x4(double value)
+        {
+            M11 = M21 = M31 = M41 = 
+            M12 = M22 = M32 = M42 = 
+            M13 = M23 = M33 = M43 = 
+            M14 = M24 = M34 = M44 = value;
+        }
+
+        public double M11;
+        public double M21;
+        public double M31;
+        public double M41;
+        public double M12;
+        public double M22;
+        public double M32;
+        public double M42;
+        public double M13;
+        public double M23;
+        public double M33;
+        public double M43;
+        public double M14;
+        public double M24;
+        public double M34;
+        public double M44;
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix4x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (Matrix4x4* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 1
+        /// </summary>
+        public Matrix1x4 Column1 { get { return new Matrix1x4(M11, M12, M13, M14); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 2
+        /// </summary>
+        public Matrix1x4 Column2 { get { return new Matrix1x4(M21, M22, M23, M24); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 3
+        /// </summary>
+        public Matrix1x4 Column3 { get { return new Matrix1x4(M31, M32, M33, M34); } }
+        /// <summary>
+        /// Gets a new Matrix1x4 containing the values of column 4
+        /// </summary>
+        public Matrix1x4 Column4 { get { return new Matrix1x4(M41, M42, M43, M44); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 1
+        /// </summary>
+        public Matrix4x1 Row1 { get { return new Matrix4x1(M11, M21, M31, M41); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 2
+        /// </summary>
+        public Matrix4x1 Row2 { get { return new Matrix4x1(M12, M22, M32, M42); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 3
+        /// </summary>
+        public Matrix4x1 Row3 { get { return new Matrix4x1(M13, M23, M33, M43); } }
+        /// <summary>
+        /// Gets a new Matrix4x1 containing the values of column 4
+        /// </summary>
+        public Matrix4x1 Row4 { get { return new Matrix4x1(M14, M24, M34, M44); } }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is Matrix4x4)
+                return this == (Matrix4x4)obj;
+
+            return false;
+        }
+
+        public bool Equals(Matrix4x4 other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (Matrix4x4* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1
+                         + 7 * ((((x[00] ^ x[01]) << 0) + ((x[02] ^ x[03]) << 1) + ((x[04] ^ x[05]) << 2) + ((x[06] ^ x[07]) << 3)) << 0)
+                         + 7 * ((((x[04] ^ x[05]) << 0) + ((x[06] ^ x[07]) << 1) + ((x[08] ^ x[09]) << 2) + ((x[10] ^ x[11]) << 3)) << 1)
+                         + 7 * ((((x[08] ^ x[09]) << 0) + ((x[10] ^ x[11]) << 1) + ((x[12] ^ x[13]) << 2) + ((x[14] ^ x[15]) << 3)) << 2)
+                         + 7 * ((((x[12] ^ x[13]) << 0) + ((x[14] ^ x[15]) << 1) + ((x[16] ^ x[17]) << 2) + ((x[18] ^ x[19]) << 3)) << 3);
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "Matrix4x4: "
+                 + $"{{|{M11:00}|{M21:00}|{M31:00}|{M41:00}|}}"
+                 + $"{{|{M12:00}|{M22:00}|{M32:00}|{M42:00}|}}"
+                 + $"{{|{M13:00}|{M23:00}|{M33:00}|{M43:00}|}}"
+                 + $"{{|{M14:00}|{M24:00}|{M34:00}|{M44:00}|}}"; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public Matrix4x4 Transpose()
+        {
+            return new Matrix4x4(M11, M12, M13, M14, 
+                                 M21, M22, M23, M24, 
+                                 M31, M32, M33, M34, 
+                                 M41, M42, M43, M44);
+        }
+
+        public static bool operator ==(Matrix4x4 matrix1, Matrix4x4 matrix2)
+        {
+            return MatrixHelper.AreEqual(matrix1.M11, matrix2.M11)
+                && MatrixHelper.AreEqual(matrix1.M21, matrix2.M21)
+                && MatrixHelper.AreEqual(matrix1.M31, matrix2.M31)
+                && MatrixHelper.AreEqual(matrix1.M41, matrix2.M41)
+                && MatrixHelper.AreEqual(matrix1.M12, matrix2.M12)
+                && MatrixHelper.AreEqual(matrix1.M22, matrix2.M22)
+                && MatrixHelper.AreEqual(matrix1.M32, matrix2.M32)
+                && MatrixHelper.AreEqual(matrix1.M42, matrix2.M42)
+                && MatrixHelper.AreEqual(matrix1.M13, matrix2.M13)
+                && MatrixHelper.AreEqual(matrix1.M23, matrix2.M23)
+                && MatrixHelper.AreEqual(matrix1.M33, matrix2.M33)
+                && MatrixHelper.AreEqual(matrix1.M43, matrix2.M43)
+                && MatrixHelper.AreEqual(matrix1.M14, matrix2.M14)
+                && MatrixHelper.AreEqual(matrix1.M24, matrix2.M24)
+                && MatrixHelper.AreEqual(matrix1.M34, matrix2.M34)
+                && MatrixHelper.AreEqual(matrix1.M44, matrix2.M44);
+        }
+
+        public static bool operator !=(Matrix4x4 matrix1, Matrix4x4 matrix2)
+        {
+            return MatrixHelper.NotEqual(matrix1.M11, matrix2.M11)
+                || MatrixHelper.NotEqual(matrix1.M21, matrix2.M21)
+                || MatrixHelper.NotEqual(matrix1.M31, matrix2.M31)
+                || MatrixHelper.NotEqual(matrix1.M41, matrix2.M41)
+                || MatrixHelper.NotEqual(matrix1.M12, matrix2.M12)
+                || MatrixHelper.NotEqual(matrix1.M22, matrix2.M22)
+                || MatrixHelper.NotEqual(matrix1.M32, matrix2.M32)
+                || MatrixHelper.NotEqual(matrix1.M42, matrix2.M42)
+                || MatrixHelper.NotEqual(matrix1.M13, matrix2.M13)
+                || MatrixHelper.NotEqual(matrix1.M23, matrix2.M23)
+                || MatrixHelper.NotEqual(matrix1.M33, matrix2.M33)
+                || MatrixHelper.NotEqual(matrix1.M43, matrix2.M43)
+                || MatrixHelper.NotEqual(matrix1.M14, matrix2.M14)
+                || MatrixHelper.NotEqual(matrix1.M24, matrix2.M24)
+                || MatrixHelper.NotEqual(matrix1.M34, matrix2.M34)
+                || MatrixHelper.NotEqual(matrix1.M44, matrix2.M44);
+        }
+
+        public static Matrix4x4 operator +(Matrix4x4 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 + matrix2.M11;
+            double m21 = matrix1.M21 + matrix2.M21;
+            double m31 = matrix1.M31 + matrix2.M31;
+            double m41 = matrix1.M41 + matrix2.M41;
+            double m12 = matrix1.M12 + matrix2.M12;
+            double m22 = matrix1.M22 + matrix2.M22;
+            double m32 = matrix1.M32 + matrix2.M32;
+            double m42 = matrix1.M42 + matrix2.M42;
+            double m13 = matrix1.M13 + matrix2.M13;
+            double m23 = matrix1.M23 + matrix2.M23;
+            double m33 = matrix1.M33 + matrix2.M33;
+            double m43 = matrix1.M43 + matrix2.M43;
+            double m14 = matrix1.M14 + matrix2.M14;
+            double m24 = matrix1.M24 + matrix2.M24;
+            double m34 = matrix1.M34 + matrix2.M34;
+            double m44 = matrix1.M44 + matrix2.M44;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+
+        public static Matrix4x4 operator -(Matrix4x4 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 - matrix2.M11;
+            double m21 = matrix1.M21 - matrix2.M21;
+            double m31 = matrix1.M31 - matrix2.M31;
+            double m41 = matrix1.M41 - matrix2.M41;
+            double m12 = matrix1.M12 - matrix2.M12;
+            double m22 = matrix1.M22 - matrix2.M22;
+            double m32 = matrix1.M32 - matrix2.M32;
+            double m42 = matrix1.M42 - matrix2.M42;
+            double m13 = matrix1.M13 - matrix2.M13;
+            double m23 = matrix1.M23 - matrix2.M23;
+            double m33 = matrix1.M33 - matrix2.M33;
+            double m43 = matrix1.M43 - matrix2.M43;
+            double m14 = matrix1.M14 - matrix2.M14;
+            double m24 = matrix1.M24 - matrix2.M24;
+            double m34 = matrix1.M34 - matrix2.M34;
+            double m44 = matrix1.M44 - matrix2.M44;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+
+        public static Matrix4x4 operator *(Matrix4x4 matrix, double scalar)
+        {
+            double m11 = matrix.M11 * scalar;
+            double m21 = matrix.M21 * scalar;
+            double m31 = matrix.M31 * scalar;
+            double m41 = matrix.M41 * scalar;
+            double m12 = matrix.M12 * scalar;
+            double m22 = matrix.M22 * scalar;
+            double m32 = matrix.M32 * scalar;
+            double m42 = matrix.M42 * scalar;
+            double m13 = matrix.M13 * scalar;
+            double m23 = matrix.M23 * scalar;
+            double m33 = matrix.M33 * scalar;
+            double m43 = matrix.M43 * scalar;
+            double m14 = matrix.M14 * scalar;
+            double m24 = matrix.M24 * scalar;
+            double m34 = matrix.M34 * scalar;
+            double m44 = matrix.M44 * scalar;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+
+        public static Matrix4x4 operator *(double scalar, Matrix4x4 matrix)
+        {
+            double m11 = scalar * matrix.M11;
+            double m21 = scalar * matrix.M21;
+            double m31 = scalar * matrix.M31;
+            double m41 = scalar * matrix.M41;
+            double m12 = scalar * matrix.M12;
+            double m22 = scalar * matrix.M22;
+            double m32 = scalar * matrix.M32;
+            double m42 = scalar * matrix.M42;
+            double m13 = scalar * matrix.M13;
+            double m23 = scalar * matrix.M23;
+            double m33 = scalar * matrix.M33;
+            double m43 = scalar * matrix.M43;
+            double m14 = scalar * matrix.M14;
+            double m24 = scalar * matrix.M24;
+            double m34 = scalar * matrix.M34;
+            double m44 = scalar * matrix.M44;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+
+        public static Matrix1x4 operator *(Matrix4x4 matrix1, Matrix1x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+
+            return new Matrix1x4(m11, 
+                                 m12, 
+                                 m13, 
+                                 m14);
+        }
+        public static Matrix2x4 operator *(Matrix4x4 matrix1, Matrix2x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+
+            return new Matrix2x4(m11, m21, 
+                                 m12, m22, 
+                                 m13, m23, 
+                                 m14, m24);
+        }
+        public static Matrix3x4 operator *(Matrix4x4 matrix1, Matrix3x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+
+            return new Matrix3x4(m11, m21, m31, 
+                                 m12, m22, m32, 
+                                 m13, m23, m33, 
+                                 m14, m24, m34);
+        }
+        public static Matrix4x4 operator *(Matrix4x4 matrix1, Matrix4x4 matrix2)
+        {
+            double m11 = matrix1.M11 * matrix2.M11 + matrix1.M21 * matrix2.M12 + matrix1.M31 * matrix2.M13 + matrix1.M41 * matrix2.M14;
+            double m21 = matrix1.M11 * matrix2.M21 + matrix1.M21 * matrix2.M22 + matrix1.M31 * matrix2.M23 + matrix1.M41 * matrix2.M24;
+            double m31 = matrix1.M11 * matrix2.M31 + matrix1.M21 * matrix2.M32 + matrix1.M31 * matrix2.M33 + matrix1.M41 * matrix2.M34;
+            double m41 = matrix1.M11 * matrix2.M41 + matrix1.M21 * matrix2.M42 + matrix1.M31 * matrix2.M43 + matrix1.M41 * matrix2.M44;
+            double m12 = matrix1.M12 * matrix2.M11 + matrix1.M22 * matrix2.M12 + matrix1.M32 * matrix2.M13 + matrix1.M42 * matrix2.M14;
+            double m22 = matrix1.M12 * matrix2.M21 + matrix1.M22 * matrix2.M22 + matrix1.M32 * matrix2.M23 + matrix1.M42 * matrix2.M24;
+            double m32 = matrix1.M12 * matrix2.M31 + matrix1.M22 * matrix2.M32 + matrix1.M32 * matrix2.M33 + matrix1.M42 * matrix2.M34;
+            double m42 = matrix1.M12 * matrix2.M41 + matrix1.M22 * matrix2.M42 + matrix1.M32 * matrix2.M43 + matrix1.M42 * matrix2.M44;
+            double m13 = matrix1.M13 * matrix2.M11 + matrix1.M23 * matrix2.M12 + matrix1.M33 * matrix2.M13 + matrix1.M43 * matrix2.M14;
+            double m23 = matrix1.M13 * matrix2.M21 + matrix1.M23 * matrix2.M22 + matrix1.M33 * matrix2.M23 + matrix1.M43 * matrix2.M24;
+            double m33 = matrix1.M13 * matrix2.M31 + matrix1.M23 * matrix2.M32 + matrix1.M33 * matrix2.M33 + matrix1.M43 * matrix2.M34;
+            double m43 = matrix1.M13 * matrix2.M41 + matrix1.M23 * matrix2.M42 + matrix1.M33 * matrix2.M43 + matrix1.M43 * matrix2.M44;
+            double m14 = matrix1.M14 * matrix2.M11 + matrix1.M24 * matrix2.M12 + matrix1.M34 * matrix2.M13 + matrix1.M44 * matrix2.M14;
+            double m24 = matrix1.M14 * matrix2.M21 + matrix1.M24 * matrix2.M22 + matrix1.M34 * matrix2.M23 + matrix1.M44 * matrix2.M24;
+            double m34 = matrix1.M14 * matrix2.M31 + matrix1.M24 * matrix2.M32 + matrix1.M34 * matrix2.M33 + matrix1.M44 * matrix2.M34;
+            double m44 = matrix1.M14 * matrix2.M41 + matrix1.M24 * matrix2.M42 + matrix1.M34 * matrix2.M43 + matrix1.M44 * matrix2.M44;
+
+            return new Matrix4x4(m11, m21, m31, m41, 
+                                 m12, m22, m32, m42, 
+                                 m13, m23, m33, m43, 
+                                 m14, m24, m34, m44);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/MatrixHelper.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/MatrixHelper.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.CompilerServices;
+
+namespace System.Numerics.Matrices
+{
+    internal static class MatrixHelper
+    {
+        public const double Epsilon = Double.Epsilon * 10;
+
+        /// <summary>
+        /// Checks two doubldes for quality using <see cref="Epsilon"/> as the smallest unit of difference.
+        /// </summary>
+        /// <param name="value1">The first value to compare.</param>
+        /// <param name="value2">The second value to compare.</param>
+        /// <returns>True if the values are within <see cref="Epsilon"/> in value; False otherwise.</returns>
+        /// <remarks>see the Precision in Comparisons section of https://msdn.microsoft.com/en-us/library/ya2zha7s(v=vs.110).aspx</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool AreEqual(double value1, double value2)
+        {
+            if (Double.IsNaN(value1) || Double.IsNaN(value2))
+                return false;
+
+            return value1 == value2
+                || (Math.Abs(Math.Abs(value1) - Math.Abs(value2)) < Epsilon);
+        }
+
+        /// <summary>
+        /// Checks two doubldes for quality using <see cref="Epsilon"/> as the smallest unit of difference.
+        /// </summary>
+        /// <param name="value1">The first value to compare.</param>
+        /// <param name="value2">The second value to compare.</param>
+        /// <returns>False if the values are within <see cref="Epsilon"/> in value; True otherwise.</returns>
+        /// <remarks>see the Precision in Comparisons section of https://msdn.microsoft.com/en-us/library/ya2zha7s(v=vs.110).aspx</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool NotEqual(double value1, double value2)
+        {
+            if (Double.IsNaN(value1) || Double.IsNaN(value2))
+                return true;
+
+            return value1 != value2
+                && !(Math.Abs(Math.Abs(value1) - Math.Abs(value2)) < Epsilon);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/src/System/Numerics/MatrixTemplate.tt
+++ b/src/System.Numerics.Matrices/src/System/Numerics/MatrixTemplate.tt
@@ -1,0 +1,642 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.IO" #>
+<#@ import namespace="System.Text" #>
+<#@ output extension=".txt" #>
+<#
+    const int MinColCount = 1;
+    const int MaxColCount = 4;
+    const int MinRowCount = 1;
+    const int MaxRowCount = 4;
+
+    for (int rowCount = MinRowCount; rowCount <= MaxRowCount; rowCount ++)
+    {
+        for (int colCount = MinColCount; colCount <= MaxColCount; colCount++)
+        {
+            if (rowCount == MinRowCount && colCount == MinColCount)
+                continue;
+
+            string structName = String.Format("Matrix{0}x{1}", colCount, rowCount);
+            string outputFileName = structName + ".cs";
+#>
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Runtime.InteropServices;
+
+namespace System.Numerics.Matrices
+{
+    /// <summary>
+    /// Represents a matrix of double precision floating-point values defined by its number of columns and rows
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct <#= structName #>: IEquatable<<#= structName #>>, IMatrix
+    {
+        public const int ColumnCount = <#= colCount #>;
+        public const int RowCount = <#= rowCount #>;
+
+        static <#= structName #>()
+        {
+            Zero = new <#= structName #>(0);
+<#
+            if (rowCount == colCount)
+            {
+#>            Identity = new <#= structName #>(<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    if (x == y)
+                    {
+                        #>1<#
+                    }
+                    else 
+                    {
+                        #>0<#
+                    }
+
+                    if (x + 1 < colCount || y + 1 < rowCount)
+                    {
+                        #>, <#
+                    }
+                }
+
+                if (y + 1 < rowCount)
+                {
+                    #><#= Environment.NewLine #><#
+                    #>                                     <#
+                }
+            }
+#>);
+<#
+            }
+#>
+        }
+
+<#
+            if (rowCount == colCount)
+            {
+#>        
+        /// <summary>
+        /// Constant <#= structName #> with value intialized to the identity of a <#= colCount #> x <#= rowCount #> matrix
+        /// </summary>
+        public static readonly <#= structName #> Identity;
+<#
+            }
+#>
+        /// <summary>
+        /// Gets the smallest value used to determine equality
+        /// </summary>
+        public double Epsilon { get { return MatrixHelper.Epsilon; } }
+
+        /// <summary>
+        /// Constant <#= structName #> with all values initialized to zero
+        /// </summary>
+        public static readonly <#= structName #> Zero;
+
+        /// <summary>
+        /// Initializes a <#= structName #> with all of it values specifically set
+        /// </summary>
+<#
+        for (int y = 0; y < rowCount; y++)
+        {
+            for (int x = 0; x < colCount; x++)
+            {
+                #>        /// <param name="m<#= x + 1 #><#= y + 1 #>">The column <#= x + 1 #>, row <#= y + 1 #> value</param><#
+                #><#= Environment.NewLine #><#
+            }
+        }
+#>
+        public <#= structName #>(<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("double m{0}{1}", x + 1, y + 1) #><#
+
+                    if (x + 1 != colCount || y + 1 != rowCount)
+                    {
+                        #>, <#
+                    }
+                }
+
+                if (y + 1 < rowCount)
+                {
+                    #><#= Environment.NewLine #><#
+                    #>                         <#
+                }
+            }
+#>)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+#>            <#
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("M{0}{1} = m{0}{1}; ", x + 1, y + 1) #><#
+                }
+                #><#= Environment.NewLine #><#
+            }
+#>
+        }
+
+        /// <summary>
+        /// Initialized a <#= structName #> with all values set to the same value
+        /// </summary>
+        /// <param name="value">The value to set all values to</param>
+        public <#= structName #>(double value)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+#>            <#
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("M{0}{1} = ", x + 1, y + 1) #><#
+
+                    if (x + 1 == colCount && y + 1 == rowCount)
+                    {
+                        #>value;<#
+                    }
+                }
+                #><#= Environment.NewLine #><#
+            }
+#>
+        }
+
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #>        <#
+                    #><#= String.Format("public double M{0}{1}", x + 1, y + 1) #>;<#
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+
+        public unsafe double this[int col, int row]
+        {
+            get
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (<#= structName #>* p = &this)
+                {
+                    double* d = (double*)p;
+                    return d[row * ColumnCount + col];
+                }
+            }
+            set
+            {
+                if (col < 0 || col >= ColumnCount)
+                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                if (row < 0 || row >= RowCount)
+                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+
+                fixed (<#= structName #>* p = &this)
+                {
+                    double* d = (double*)p;
+                    d[row * ColumnCount + col] = value;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of columns in the matrix
+        /// </summary>
+        public int Columns { get { return ColumnCount; } }
+        /// <summary>
+        /// Get the number of rows in the matrix
+        /// </summary>
+        public int Rows { get { return RowCount; } }
+
+<#
+        if (rowCount > 1 && colCount > 1)
+        {
+            for (int x = 0; x < colCount; x++)
+            {
+                string retType = String.Format("Matrix1x{0}", rowCount);
+#>
+        /// <summary>
+        /// Gets a new <#= retType #> containing the values of column <#= x + 1 #>
+        /// </summary>
+        public <#= retType #> Column<#= x + 1 #> { get { return new <#= retType #>(<#
+                for (int y = 0; y < rowCount; y++)
+                {
+                    #><#= String.Format("M{0}{1}", x + 1, y + 1) #><#
+
+                    if (y + 1 < rowCount)
+                    {
+                        #>, <#
+                    }
+                }
+                #>); } }
+<#
+            }
+
+            for (int y = 0; y < rowCount; y++)
+            {
+                string retType = String.Format("Matrix{0}x1", colCount);
+#>
+        /// <summary>
+        /// Gets a new <#= retType #> containing the values of column <#= y + 1 #>
+        /// </summary>
+        public <#= retType #> Row<#= y + 1 #> { get { return new <#= retType #>(<#
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("M{0}{1}", x + 1, y + 1) #><#
+
+                    if (x + 1 < colCount)
+                    {
+                        #>, <#
+                    }
+                }
+                #>); } }
+<#
+            }
+        }
+#>
+
+        public override bool Equals(object obj)
+        {
+            if (obj is <#= structName #>)
+                return this == (<#= structName #>)obj;
+
+            return false;
+        }
+
+        public bool Equals(<#= structName #> other)
+        {
+            return this == other;
+        }
+
+        public unsafe override int GetHashCode()
+        {
+            fixed (<#= structName #>* p = &this)
+            {
+                int* x = (int*)p;
+                unchecked
+                {
+                    return 0xFFE1<#
+                    #><#= Environment.NewLine #><#
+
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    if (x == 0)           
+                    {
+                        #>                         + 7 * ((<# 
+                    }
+                    #><#= String.Format("((x[{0:00}] ^ x[{1:00}]) << {2})", y * colCount + x * 2, y * colCount + x * 2 + 1, x % 32) #><#
+            
+                    if (x + 1 == colCount)
+                    {
+                        #>) << <#= y % 32 #>)<#
+                        if (y + 1 == rowCount)
+                        {
+                            #>;<#
+                        }
+                        #><#= Environment.NewLine #><#
+                    }
+                    else
+                    {
+                        #> + <#
+                    }
+                }
+            }
+#>
+                }
+            }
+        }
+
+        public override string ToString()
+        {
+            return "<#= structName #>: "<#
+            #><#= Environment.NewLine #><#
+            for (int y = 0; y < rowCount; y++)
+            {
+                #>                 + $"{{<#
+                for (int x = 0; x < colCount; x++)
+                {
+                    #>|{<#= String.Format("M{0}{1}", x + 1, y + 1) #>:00}<#
+                }
+                #>|}}"<#
+                
+                if (y + 1 < rowCount)
+                {
+                    #><#= Environment.NewLine #><#
+                }
+            }
+
+            #>; 
+        }
+
+        /// <summary>
+        /// Creates and returns a transposed matrix
+        /// </summary>
+        /// <returns>Matrix with transposed values</returns>
+        public <#= String.Format("Matrix{0}x{1}", rowCount, colCount) #> Transpose()
+        {
+            return new <#= String.Format("Matrix{0}x{1}", rowCount, colCount) #>(<#
+
+            for (int y = 0; y < colCount; y++)
+            {
+                for (int x = 0; x < rowCount; x++)
+                {
+                    #><#= String.Format("M{1}{0}", x + 1, y + 1) #><#
+
+                    if (x + 1 < rowCount || y + 1 < colCount)
+                    {
+                        #>, <#
+                    }
+                }
+
+                if (y + 1 < colCount)
+                {
+                    #><#= Environment.NewLine #><#
+                    #>                                 <#
+                }
+            }
+            
+            #>);
+        }
+
+        public static bool operator ==(<#= structName #> matrix1, <#= structName #> matrix2)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    if (x == 0 && y == 0)
+                    {
+                        #>            return <#
+                    }
+                    else
+                    {
+                        #>                && <#
+                    }
+
+                    #><#= String.Format("MatrixHelper.AreEqual(matrix1.M{0}{1}, matrix2.M{0}{1})", x + 1, y + 1) #><#
+
+                    if (x + 1 == colCount && y + 1 == rowCount)
+                    {
+                        #>;<#
+                    }
+            
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+        }
+
+        public static bool operator !=(<#= structName #> matrix1, <#= structName #> matrix2)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    if (x == 0 && y == 0)
+                    {
+                        #>            return <#
+                    }
+                    else
+                    {
+                        #>                || <#
+                    }
+
+                    #><#= String.Format("MatrixHelper.NotEqual(matrix1.M{0}{1}, matrix2.M{0}{1})", x + 1, y + 1) #><#
+
+                    if (x + 1 == colCount && y + 1 == rowCount)
+                    {
+                        #>;<#
+                    }
+            
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+        }
+
+        public static <#= structName #> operator +(<#= structName #> matrix1, <#= structName #> matrix2)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #>            <#= String.Format("double m{0}{1} = matrix1.M{0}{1} + matrix2.M{0}{1}", x + 1, y + 1) #>;<#
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+
+            return new <#= structName #>(<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("m{0}{1}", x + 1, y + 1) #><#
+        
+                    if (x + 1 != colCount || y + 1 != rowCount)
+                    {
+                        #>, <#
+                    }
+                    if (x + 1 == colCount && y + 1 != rowCount)
+                    {
+                        #>
+
+                                 <#
+                    }
+                }
+            }
+            #>);
+        }
+
+        public static <#= structName #> operator -(<#= structName #> matrix1, <#= structName #> matrix2)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #>            <#= String.Format("double m{0}{1} = matrix1.M{0}{1} - matrix2.M{0}{1}", x + 1, y + 1) #>;<#
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+
+            return new <#= structName #>(<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("m{0}{1}", x + 1, y + 1) #><#
+        
+                    if (x + 1 != colCount || y + 1 != rowCount)
+                    {
+                        #>, <#
+                    }
+                    if (x + 1 == colCount && y + 1 != rowCount)
+                    {
+                        #>
+
+                                 <#
+                    }
+                }
+            }
+            #>);
+        }
+
+        public static <#= structName #> operator *(<#= structName #> matrix, double scalar)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #>            <#= String.Format("double m{0}{1} = matrix.M{0}{1} * scalar", x + 1, y + 1) #>;<#
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+
+            return new <#= structName #>(<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("m{0}{1}", x + 1, y + 1) #><#
+        
+                    if (x + 1 != colCount || y + 1 != rowCount)
+                    {
+                        #>, <#
+                    }
+                    if (x + 1 == colCount && y + 1 != rowCount)
+                    {
+                        #>
+
+                                 <#
+                    }
+                }
+            }
+            #>);
+        }
+
+        public static <#= structName #> operator *(double scalar, <#= structName #> matrix)
+        {
+<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #>            <#= String.Format("double m{0}{1} = scalar * matrix.M{0}{1}", x + 1, y + 1) #>;<#
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+
+            return new <#= structName #>(<#
+            for (int y = 0; y < rowCount; y++)
+            {
+                for (int x = 0; x < colCount; x++)
+                {
+                    #><#= String.Format("m{0}{1}", x + 1, y + 1) #><#
+        
+                    if (x + 1 != colCount || y + 1 != rowCount)
+                    {
+                        #>, <#
+                    }
+                    if (x + 1 == colCount && y + 1 != rowCount)
+                    {
+                        #><#= Environment.NewLine #><#
+                        #>                                 <#
+                    }
+                }
+            }
+            #>);
+        }
+
+<#
+                for (int j = MinColCount; j <= MaxColCount; j++)
+                {
+                    int srcCols = j;
+                    int srcRows = colCount;
+                    int dstCols = srcCols;
+                    int dstRows = rowCount;
+
+                    if ((srcCols == MinColCount && srcRows == MinRowCount) || (dstCols == MinColCount && dstRows == MinRowCount))
+                        continue;
+
+                    string mulName = String.Format("Matrix{0}x{1}", srcCols, srcRows);
+                    string prodName = String.Format("Matrix{0}x{1}", dstCols, dstRows);
+#>
+        public static <#= prodName #> operator *(<#= structName #> matrix1, <#= mulName #> matrix2)
+        {
+<#
+                    for (int y = 0; y < dstRows; y++)
+                    {
+                        for (int x = 0; x < dstCols; x++)
+                        {
+                            #>            <#= String.Format("double m{0}{1} = ", x + 1, y + 1) #><#
+
+                            for (int y1 = 0, x1 = 0; y1 < srcRows && x1 < colCount; y1++, x1++)
+                            {
+                                #><#= String.Format("matrix1.M{0}{1} * matrix2.M{2}{3}", x1 + 1, y + 1, x + 1, y1 + 1) #><#
+
+                                if (y1 + 1 < srcRows && x1 + 1 < colCount)
+                                {
+                                    #> + <#
+                                }
+                            }
+
+                            #>;<#= Environment.NewLine #><#
+                        
+                        }
+                    }
+#>
+
+            return new <#= prodName #>(<#
+                    for (int y = 0; y < dstRows; y++)
+                    {
+                        for (int x = 0; x < dstCols; x++)
+                        {
+                            #><#= String.Format("m{0}{1}", x + 1, y + 1) #><#
+
+                            if (x + 1 < dstCols || y + 1 < dstRows)
+                            {
+                                #>, <#
+                            }
+                            if (x + 1 == dstCols && y + 1 < dstRows)
+                            {
+                                #><#= Environment.NewLine #><#
+                                #>                                 <#
+                            }
+                        }
+                    }
+                    #>);
+        }
+<#
+                }
+#>
+    }
+}
+<#
+            string templateDirectory = Path.GetDirectoryName(Host.TemplateFile);
+            string outputFilePath = Path.Combine(templateDirectory, outputFileName);
+            File.WriteAllText(outputFilePath, this.GenerationEnvironment.ToString()); 
+
+            this.GenerationEnvironment.Remove(0, this.GenerationEnvironment.Length);
+        }
+    }
+#>

--- a/src/System.Numerics.Matrices/test/System.Numerics.Matrices.Tests.csproj
+++ b/src/System.Numerics.Matrices/test/System.Numerics.Matrices.Tests.csproj
@@ -1,0 +1,119 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CDD81D2A-45AF-4980-8A3C-D4E9AB8F02C3}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Tests</RootNamespace>
+    <AssemblyName>Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Content Include="System\Numerics\TestTemplate.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>TestTemplate.txt</LastGenOutput>
+    </Content>
+    <Content Include="System\Numerics\TestTemplate.txt">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>TestTemplate.tt</DependentUpon>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Numerics.Matrices.csproj">
+      <Project>{a7402731-f3b8-4dfe-8507-88623ca1b2ba}</Project>
+      <Name>System.Numerics.Matrices</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="System\Numerics\Test1x2.cs" />
+    <Compile Include="System\Numerics\Test1x3.cs" />
+    <Compile Include="System\Numerics\Test1x4.cs" />
+    <Compile Include="System\Numerics\Test2x1.cs" />
+    <Compile Include="System\Numerics\Test2x2.cs" />
+    <Compile Include="System\Numerics\Test2x3.cs" />
+    <Compile Include="System\Numerics\Test2x4.cs" />
+    <Compile Include="System\Numerics\Test3x1.cs" />
+    <Compile Include="System\Numerics\Test3x2.cs" />
+    <Compile Include="System\Numerics\Test3x3.cs" />
+    <Compile Include="System\Numerics\Test3x4.cs" />
+    <Compile Include="System\Numerics\Test4x1.cs" />
+    <Compile Include="System\Numerics\Test4x2.cs" />
+    <Compile Include="System\Numerics\Test4x3.cs" />
+    <Compile Include="System\Numerics\Test4x4.cs" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test1x2.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test1x2.cs
@@ -1,0 +1,260 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix1x2 structure.
+    /// </summary>
+    [TestClass]
+    public class Test1x2
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix1x2 matrix1x2;
+
+            matrix1x2 = new Matrix1x2();
+
+            for (int x = 0; x < matrix1x2.Columns; x++)
+            {
+                for (int y = 0; y < matrix1x2.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix1x2[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix1x2 = new Matrix1x2(value);
+
+            for (int x = 0; x < matrix1x2.Columns; x++)
+            {
+                for (int y = 0; y < matrix1x2.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix1x2[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix1x2);
+
+            for (int y = 0; y < matrix1x2.Rows; y++)
+            {
+                for (int x = 0; x < matrix1x2.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix1x2.Columns + x, matrix1x2[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix1x2 matrix1x2 = new Matrix1x2();
+
+            for (int x = 0; x < matrix1x2.Columns; x++)
+            {
+                for (int y = 0; y < matrix1x2.Rows; y++)
+                {
+                    matrix1x2[x, y] = y * matrix1x2.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix1x2.Rows; y++)
+            {
+                for (int x = 0; x < matrix1x2.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix1x2.Columns + x, matrix1x2[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix1x2 matrix1x2 = new Matrix1x2();
+
+            Assert.AreEqual(1, matrix1x2.Columns);
+            Assert.AreEqual(2, matrix1x2.Rows);
+            Assert.AreEqual(Matrix1x2.ColumnCount, matrix1x2.Columns);
+            Assert.AreEqual(Matrix1x2.RowCount, matrix1x2.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix1x2 matrix1x2;
+
+            GenerateFilledMatrixWithValues(out matrix1x2);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix1x2 result = matrix1x2 * c;
+
+                for (int y = 0; y < matrix1x2.Rows; y++)
+                {
+                    for (int x = 0; x < matrix1x2.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix1x2[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix1x2 matrix1x2 = new Matrix1x2();
+
+            matrix1x2.M11 = 0;
+            matrix1x2.M12 = 1;
+
+            Assert.AreEqual(0, matrix1x2.M11, Epsilon);
+            Assert.AreEqual(1, matrix1x2.M12, Epsilon);
+
+            Assert.AreEqual(matrix1x2[0, 0], matrix1x2.M11, Epsilon);
+            Assert.AreEqual(matrix1x2[0, 1], matrix1x2.M12, Epsilon);
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix1x2 value = new Matrix1x2(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix1x2 value1 = new Matrix1x2(1);
+            Matrix1x2 value2 = new Matrix1x2(99);
+            Matrix1x2 result = value1 + value2;
+
+            for (int y = 0; y < Matrix1x2.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix1x2.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix1x2 value1 = new Matrix1x2(100);
+            Matrix1x2 value2 = new Matrix1x2(1);
+            Matrix1x2 result = value1 - value2;
+
+            for (int y = 0; y < Matrix1x2.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix1x2.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix1x2 value1 = new Matrix1x2(100);
+            Matrix1x2 value2 = new Matrix1x2(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix1x2 matrix1x2 = new Matrix1x2();
+
+            try
+            {
+                matrix1x2[-1, 0] = 0;
+                Assert.Fail("Matrix1x2[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix1x2[0, -1] = 0;
+                Assert.Fail("Matrix1x2[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix1x2[1, 0] = 0;
+                Assert.Fail("Matrix1x2[1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix1x2[0, 2] = 0;
+                Assert.Fail("Matrix1x2[0, 2] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix2x1ProducesMatrix2x2()
+        {
+            Matrix1x2 matrix1 = new Matrix1x2(3);
+            Matrix2x1 matrix2 = new Matrix2x1(2);
+            Matrix2x2 result = matrix1 * matrix2;
+            Matrix2x2 expected = new Matrix2x2(6, 6, 
+                                               6, 6);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x1ProducesMatrix3x2()
+        {
+            Matrix1x2 matrix1 = new Matrix1x2(3);
+            Matrix3x1 matrix2 = new Matrix3x1(2);
+            Matrix3x2 result = matrix1 * matrix2;
+            Matrix3x2 expected = new Matrix3x2(6, 6, 6, 
+                                               6, 6, 6);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x1ProducesMatrix4x2()
+        {
+            Matrix1x2 matrix1 = new Matrix1x2(3);
+            Matrix4x1 matrix2 = new Matrix4x1(2);
+            Matrix4x2 result = matrix1 * matrix2;
+            Matrix4x2 expected = new Matrix4x2(6, 6, 6, 6, 
+                                               6, 6, 6, 6);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix1x2 matrix)
+        {
+            matrix = new Matrix1x2(0, 
+                                   1);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test1x3.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test1x3.cs
@@ -1,0 +1,267 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix1x3 structure.
+    /// </summary>
+    [TestClass]
+    public class Test1x3
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix1x3 matrix1x3;
+
+            matrix1x3 = new Matrix1x3();
+
+            for (int x = 0; x < matrix1x3.Columns; x++)
+            {
+                for (int y = 0; y < matrix1x3.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix1x3[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix1x3 = new Matrix1x3(value);
+
+            for (int x = 0; x < matrix1x3.Columns; x++)
+            {
+                for (int y = 0; y < matrix1x3.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix1x3[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix1x3);
+
+            for (int y = 0; y < matrix1x3.Rows; y++)
+            {
+                for (int x = 0; x < matrix1x3.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix1x3.Columns + x, matrix1x3[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix1x3 matrix1x3 = new Matrix1x3();
+
+            for (int x = 0; x < matrix1x3.Columns; x++)
+            {
+                for (int y = 0; y < matrix1x3.Rows; y++)
+                {
+                    matrix1x3[x, y] = y * matrix1x3.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix1x3.Rows; y++)
+            {
+                for (int x = 0; x < matrix1x3.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix1x3.Columns + x, matrix1x3[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix1x3 matrix1x3 = new Matrix1x3();
+
+            Assert.AreEqual(1, matrix1x3.Columns);
+            Assert.AreEqual(3, matrix1x3.Rows);
+            Assert.AreEqual(Matrix1x3.ColumnCount, matrix1x3.Columns);
+            Assert.AreEqual(Matrix1x3.RowCount, matrix1x3.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix1x3 matrix1x3;
+
+            GenerateFilledMatrixWithValues(out matrix1x3);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix1x3 result = matrix1x3 * c;
+
+                for (int y = 0; y < matrix1x3.Rows; y++)
+                {
+                    for (int x = 0; x < matrix1x3.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix1x3[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix1x3 matrix1x3 = new Matrix1x3();
+
+            matrix1x3.M11 = 0;
+            matrix1x3.M12 = 1;
+            matrix1x3.M13 = 2;
+
+            Assert.AreEqual(0, matrix1x3.M11, Epsilon);
+            Assert.AreEqual(1, matrix1x3.M12, Epsilon);
+            Assert.AreEqual(2, matrix1x3.M13, Epsilon);
+
+            Assert.AreEqual(matrix1x3[0, 0], matrix1x3.M11, Epsilon);
+            Assert.AreEqual(matrix1x3[0, 1], matrix1x3.M12, Epsilon);
+            Assert.AreEqual(matrix1x3[0, 2], matrix1x3.M13, Epsilon);
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix1x3 value = new Matrix1x3(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix1x3 value1 = new Matrix1x3(1);
+            Matrix1x3 value2 = new Matrix1x3(99);
+            Matrix1x3 result = value1 + value2;
+
+            for (int y = 0; y < Matrix1x3.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix1x3.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix1x3 value1 = new Matrix1x3(100);
+            Matrix1x3 value2 = new Matrix1x3(1);
+            Matrix1x3 result = value1 - value2;
+
+            for (int y = 0; y < Matrix1x3.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix1x3.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix1x3 value1 = new Matrix1x3(100);
+            Matrix1x3 value2 = new Matrix1x3(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix1x3 matrix1x3 = new Matrix1x3();
+
+            try
+            {
+                matrix1x3[-1, 0] = 0;
+                Assert.Fail("Matrix1x3[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix1x3[0, -1] = 0;
+                Assert.Fail("Matrix1x3[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix1x3[1, 0] = 0;
+                Assert.Fail("Matrix1x3[1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix1x3[0, 3] = 0;
+                Assert.Fail("Matrix1x3[0, 3] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix2x1ProducesMatrix2x3()
+        {
+            Matrix1x3 matrix1 = new Matrix1x3(3);
+            Matrix2x1 matrix2 = new Matrix2x1(2);
+            Matrix2x3 result = matrix1 * matrix2;
+            Matrix2x3 expected = new Matrix2x3(6, 6, 
+                                               6, 6, 
+                                               6, 6);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x1ProducesMatrix3x3()
+        {
+            Matrix1x3 matrix1 = new Matrix1x3(3);
+            Matrix3x1 matrix2 = new Matrix3x1(2);
+            Matrix3x3 result = matrix1 * matrix2;
+            Matrix3x3 expected = new Matrix3x3(6, 6, 6, 
+                                               6, 6, 6, 
+                                               6, 6, 6);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x1ProducesMatrix4x3()
+        {
+            Matrix1x3 matrix1 = new Matrix1x3(3);
+            Matrix4x1 matrix2 = new Matrix4x1(2);
+            Matrix4x3 result = matrix1 * matrix2;
+            Matrix4x3 expected = new Matrix4x3(6, 6, 6, 6, 
+                                               6, 6, 6, 6, 
+                                               6, 6, 6, 6);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix1x3 matrix)
+        {
+            matrix = new Matrix1x3(0, 
+                                   1, 
+                                   2);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test1x4.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test1x4.cs
@@ -1,0 +1,274 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix1x4 structure.
+    /// </summary>
+    [TestClass]
+    public class Test1x4
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix1x4 matrix1x4;
+
+            matrix1x4 = new Matrix1x4();
+
+            for (int x = 0; x < matrix1x4.Columns; x++)
+            {
+                for (int y = 0; y < matrix1x4.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix1x4[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix1x4 = new Matrix1x4(value);
+
+            for (int x = 0; x < matrix1x4.Columns; x++)
+            {
+                for (int y = 0; y < matrix1x4.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix1x4[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix1x4);
+
+            for (int y = 0; y < matrix1x4.Rows; y++)
+            {
+                for (int x = 0; x < matrix1x4.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix1x4.Columns + x, matrix1x4[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix1x4 matrix1x4 = new Matrix1x4();
+
+            for (int x = 0; x < matrix1x4.Columns; x++)
+            {
+                for (int y = 0; y < matrix1x4.Rows; y++)
+                {
+                    matrix1x4[x, y] = y * matrix1x4.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix1x4.Rows; y++)
+            {
+                for (int x = 0; x < matrix1x4.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix1x4.Columns + x, matrix1x4[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix1x4 matrix1x4 = new Matrix1x4();
+
+            Assert.AreEqual(1, matrix1x4.Columns);
+            Assert.AreEqual(4, matrix1x4.Rows);
+            Assert.AreEqual(Matrix1x4.ColumnCount, matrix1x4.Columns);
+            Assert.AreEqual(Matrix1x4.RowCount, matrix1x4.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix1x4 matrix1x4;
+
+            GenerateFilledMatrixWithValues(out matrix1x4);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix1x4 result = matrix1x4 * c;
+
+                for (int y = 0; y < matrix1x4.Rows; y++)
+                {
+                    for (int x = 0; x < matrix1x4.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix1x4[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix1x4 matrix1x4 = new Matrix1x4();
+
+            matrix1x4.M11 = 0;
+            matrix1x4.M12 = 1;
+            matrix1x4.M13 = 2;
+            matrix1x4.M14 = 3;
+
+            Assert.AreEqual(0, matrix1x4.M11, Epsilon);
+            Assert.AreEqual(1, matrix1x4.M12, Epsilon);
+            Assert.AreEqual(2, matrix1x4.M13, Epsilon);
+            Assert.AreEqual(3, matrix1x4.M14, Epsilon);
+
+            Assert.AreEqual(matrix1x4[0, 0], matrix1x4.M11, Epsilon);
+            Assert.AreEqual(matrix1x4[0, 1], matrix1x4.M12, Epsilon);
+            Assert.AreEqual(matrix1x4[0, 2], matrix1x4.M13, Epsilon);
+            Assert.AreEqual(matrix1x4[0, 3], matrix1x4.M14, Epsilon);
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix1x4 value = new Matrix1x4(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix1x4 value1 = new Matrix1x4(1);
+            Matrix1x4 value2 = new Matrix1x4(99);
+            Matrix1x4 result = value1 + value2;
+
+            for (int y = 0; y < Matrix1x4.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix1x4.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix1x4 value1 = new Matrix1x4(100);
+            Matrix1x4 value2 = new Matrix1x4(1);
+            Matrix1x4 result = value1 - value2;
+
+            for (int y = 0; y < Matrix1x4.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix1x4.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix1x4 value1 = new Matrix1x4(100);
+            Matrix1x4 value2 = new Matrix1x4(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix1x4 matrix1x4 = new Matrix1x4();
+
+            try
+            {
+                matrix1x4[-1, 0] = 0;
+                Assert.Fail("Matrix1x4[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix1x4[0, -1] = 0;
+                Assert.Fail("Matrix1x4[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix1x4[1, 0] = 0;
+                Assert.Fail("Matrix1x4[1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix1x4[0, 4] = 0;
+                Assert.Fail("Matrix1x4[0, 4] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix2x1ProducesMatrix2x4()
+        {
+            Matrix1x4 matrix1 = new Matrix1x4(3);
+            Matrix2x1 matrix2 = new Matrix2x1(2);
+            Matrix2x4 result = matrix1 * matrix2;
+            Matrix2x4 expected = new Matrix2x4(6, 6, 
+                                               6, 6, 
+                                               6, 6, 
+                                               6, 6);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x1ProducesMatrix3x4()
+        {
+            Matrix1x4 matrix1 = new Matrix1x4(3);
+            Matrix3x1 matrix2 = new Matrix3x1(2);
+            Matrix3x4 result = matrix1 * matrix2;
+            Matrix3x4 expected = new Matrix3x4(6, 6, 6, 
+                                               6, 6, 6, 
+                                               6, 6, 6, 
+                                               6, 6, 6);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x1ProducesMatrix4x4()
+        {
+            Matrix1x4 matrix1 = new Matrix1x4(3);
+            Matrix4x1 matrix2 = new Matrix4x1(2);
+            Matrix4x4 result = matrix1 * matrix2;
+            Matrix4x4 expected = new Matrix4x4(6, 6, 6, 6, 
+                                               6, 6, 6, 6, 
+                                               6, 6, 6, 6, 
+                                               6, 6, 6, 6);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix1x4 matrix)
+        {
+            matrix = new Matrix1x4(0, 
+                                   1, 
+                                   2, 
+                                   3);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test2x1.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test2x1.cs
@@ -1,0 +1,256 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix2x1 structure.
+    /// </summary>
+    [TestClass]
+    public class Test2x1
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix2x1 matrix2x1;
+
+            matrix2x1 = new Matrix2x1();
+
+            for (int x = 0; x < matrix2x1.Columns; x++)
+            {
+                for (int y = 0; y < matrix2x1.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix2x1[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix2x1 = new Matrix2x1(value);
+
+            for (int x = 0; x < matrix2x1.Columns; x++)
+            {
+                for (int y = 0; y < matrix2x1.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix2x1[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix2x1);
+
+            for (int y = 0; y < matrix2x1.Rows; y++)
+            {
+                for (int x = 0; x < matrix2x1.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix2x1.Columns + x, matrix2x1[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix2x1 matrix2x1 = new Matrix2x1();
+
+            for (int x = 0; x < matrix2x1.Columns; x++)
+            {
+                for (int y = 0; y < matrix2x1.Rows; y++)
+                {
+                    matrix2x1[x, y] = y * matrix2x1.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix2x1.Rows; y++)
+            {
+                for (int x = 0; x < matrix2x1.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix2x1.Columns + x, matrix2x1[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix2x1 matrix2x1 = new Matrix2x1();
+
+            Assert.AreEqual(2, matrix2x1.Columns);
+            Assert.AreEqual(1, matrix2x1.Rows);
+            Assert.AreEqual(Matrix2x1.ColumnCount, matrix2x1.Columns);
+            Assert.AreEqual(Matrix2x1.RowCount, matrix2x1.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix2x1 matrix2x1;
+
+            GenerateFilledMatrixWithValues(out matrix2x1);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix2x1 result = matrix2x1 * c;
+
+                for (int y = 0; y < matrix2x1.Rows; y++)
+                {
+                    for (int x = 0; x < matrix2x1.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix2x1[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix2x1 matrix2x1 = new Matrix2x1();
+
+            matrix2x1.M11 = 0;
+            matrix2x1.M21 = 1;
+
+            Assert.AreEqual(0, matrix2x1.M11, Epsilon);
+            Assert.AreEqual(1, matrix2x1.M21, Epsilon);
+
+            Assert.AreEqual(matrix2x1[0, 0], matrix2x1.M11, Epsilon);
+            Assert.AreEqual(matrix2x1[1, 0], matrix2x1.M21, Epsilon);
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix2x1 value = new Matrix2x1(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix2x1 value1 = new Matrix2x1(1);
+            Matrix2x1 value2 = new Matrix2x1(99);
+            Matrix2x1 result = value1 + value2;
+
+            for (int y = 0; y < Matrix2x1.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix2x1.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix2x1 value1 = new Matrix2x1(100);
+            Matrix2x1 value2 = new Matrix2x1(1);
+            Matrix2x1 result = value1 - value2;
+
+            for (int y = 0; y < Matrix2x1.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix2x1.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix2x1 value1 = new Matrix2x1(100);
+            Matrix2x1 value2 = new Matrix2x1(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix2x1 matrix2x1 = new Matrix2x1();
+
+            try
+            {
+                matrix2x1[-1, 0] = 0;
+                Assert.Fail("Matrix2x1[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix2x1[0, -1] = 0;
+                Assert.Fail("Matrix2x1[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix2x1[2, 0] = 0;
+                Assert.Fail("Matrix2x1[2, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix2x1[0, 1] = 0;
+                Assert.Fail("Matrix2x1[0, 1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix2x2ProducesMatrix2x1()
+        {
+            Matrix2x1 matrix1 = new Matrix2x1(3);
+            Matrix2x2 matrix2 = new Matrix2x2(2);
+            Matrix2x1 result = matrix1 * matrix2;
+            Matrix2x1 expected = new Matrix2x1(12, 12);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x2ProducesMatrix3x1()
+        {
+            Matrix2x1 matrix1 = new Matrix2x1(3);
+            Matrix3x2 matrix2 = new Matrix3x2(2);
+            Matrix3x1 result = matrix1 * matrix2;
+            Matrix3x1 expected = new Matrix3x1(12, 12, 12);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x2ProducesMatrix4x1()
+        {
+            Matrix2x1 matrix1 = new Matrix2x1(3);
+            Matrix4x2 matrix2 = new Matrix4x2(2);
+            Matrix4x1 result = matrix1 * matrix2;
+            Matrix4x1 expected = new Matrix4x1(12, 12, 12, 12);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix2x1 matrix)
+        {
+            matrix = new Matrix2x1(0, 1);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test2x2.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test2x2.cs
@@ -1,0 +1,314 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix2x2 structure.
+    /// </summary>
+    [TestClass]
+    public class Test2x2
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix2x2 matrix2x2;
+
+            matrix2x2 = new Matrix2x2();
+
+            for (int x = 0; x < matrix2x2.Columns; x++)
+            {
+                for (int y = 0; y < matrix2x2.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix2x2[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix2x2 = new Matrix2x2(value);
+
+            for (int x = 0; x < matrix2x2.Columns; x++)
+            {
+                for (int y = 0; y < matrix2x2.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix2x2[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix2x2);
+
+            for (int y = 0; y < matrix2x2.Rows; y++)
+            {
+                for (int x = 0; x < matrix2x2.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix2x2.Columns + x, matrix2x2[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix2x2 matrix2x2 = new Matrix2x2();
+
+            for (int x = 0; x < matrix2x2.Columns; x++)
+            {
+                for (int y = 0; y < matrix2x2.Rows; y++)
+                {
+                    matrix2x2[x, y] = y * matrix2x2.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix2x2.Rows; y++)
+            {
+                for (int x = 0; x < matrix2x2.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix2x2.Columns + x, matrix2x2[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix2x2 matrix2x2 = new Matrix2x2();
+
+            Assert.AreEqual(2, matrix2x2.Columns);
+            Assert.AreEqual(2, matrix2x2.Rows);
+            Assert.AreEqual(Matrix2x2.ColumnCount, matrix2x2.Columns);
+            Assert.AreEqual(Matrix2x2.RowCount, matrix2x2.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix2x2 matrix2x2;
+
+            GenerateFilledMatrixWithValues(out matrix2x2);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix2x2 result = matrix2x2 * c;
+
+                for (int y = 0; y < matrix2x2.Rows; y++)
+                {
+                    for (int x = 0; x < matrix2x2.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix2x2[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix2x2 matrix2x2 = new Matrix2x2();
+
+            matrix2x2.M11 = 0;
+            matrix2x2.M21 = 1;
+            matrix2x2.M12 = 2;
+            matrix2x2.M22 = 3;
+
+            Assert.AreEqual(0, matrix2x2.M11, Epsilon);
+            Assert.AreEqual(1, matrix2x2.M21, Epsilon);
+            Assert.AreEqual(2, matrix2x2.M12, Epsilon);
+            Assert.AreEqual(3, matrix2x2.M22, Epsilon);
+
+            Assert.AreEqual(matrix2x2[0, 0], matrix2x2.M11, Epsilon);
+            Assert.AreEqual(matrix2x2[1, 0], matrix2x2.M21, Epsilon);
+            Assert.AreEqual(matrix2x2[0, 1], matrix2x2.M12, Epsilon);
+            Assert.AreEqual(matrix2x2[1, 1], matrix2x2.M22, Epsilon);
+        }
+
+        [TestMethod]
+        public void ColumnAccessorAreCorrect()
+        {
+            Matrix2x2 value;
+            GenerateFilledMatrixWithValues(out value);
+
+            Matrix1x2 column1 = value.Column1;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[0, y], column1[0, y]);
+            }
+        }
+
+        [TestMethod]
+        public void RowAccessorAreCorrect()
+        {
+            Matrix2x2 value;
+            GenerateFilledMatrixWithValues(out value);
+
+
+            Matrix2x1 row1 = value.Row1;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 0], row1[x, 0]);
+            }
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix2x2 value = new Matrix2x2(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix2x2 value1 = new Matrix2x2(1);
+            Matrix2x2 value2 = new Matrix2x2(99);
+            Matrix2x2 result = value1 + value2;
+
+            for (int y = 0; y < Matrix2x2.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix2x2.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix2x2 value1 = new Matrix2x2(100);
+            Matrix2x2 value2 = new Matrix2x2(1);
+            Matrix2x2 result = value1 - value2;
+
+            for (int y = 0; y < Matrix2x2.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix2x2.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MultiplyByIdentityReturnsEqualValue()
+        {
+            Matrix2x2 value;
+            GenerateFilledMatrixWithValues(out value);
+            Matrix2x2 result = value * Matrix2x2.Identity;
+
+            Assert.AreEqual(value, result);
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix2x2 value1 = new Matrix2x2(100);
+            Matrix2x2 value2 = new Matrix2x2(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix2x2 matrix2x2 = new Matrix2x2();
+
+            try
+            {
+                matrix2x2[-1, 0] = 0;
+                Assert.Fail("Matrix2x2[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix2x2[0, -1] = 0;
+                Assert.Fail("Matrix2x2[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix2x2[2, 0] = 0;
+                Assert.Fail("Matrix2x2[2, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix2x2[0, 2] = 0;
+                Assert.Fail("Matrix2x2[0, 2] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix1x2ProducesMatrix1x2()
+        {
+            Matrix2x2 matrix1 = new Matrix2x2(3);
+            Matrix1x2 matrix2 = new Matrix1x2(2);
+            Matrix1x2 result = matrix1 * matrix2;
+            Matrix1x2 expected = new Matrix1x2(12, 
+                                               12);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix2x2ProducesMatrix2x2()
+        {
+            Matrix2x2 matrix1 = new Matrix2x2(3);
+            Matrix2x2 matrix2 = new Matrix2x2(2);
+            Matrix2x2 result = matrix1 * matrix2;
+            Matrix2x2 expected = new Matrix2x2(12, 12, 
+                                               12, 12);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x2ProducesMatrix3x2()
+        {
+            Matrix2x2 matrix1 = new Matrix2x2(3);
+            Matrix3x2 matrix2 = new Matrix3x2(2);
+            Matrix3x2 result = matrix1 * matrix2;
+            Matrix3x2 expected = new Matrix3x2(12, 12, 12, 
+                                               12, 12, 12);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x2ProducesMatrix4x2()
+        {
+            Matrix2x2 matrix1 = new Matrix2x2(3);
+            Matrix4x2 matrix2 = new Matrix4x2(2);
+            Matrix4x2 result = matrix1 * matrix2;
+            Matrix4x2 expected = new Matrix4x2(12, 12, 12, 12, 
+                                               12, 12, 12, 12);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix2x2 matrix)
+        {
+            matrix = new Matrix2x2(0, 1, 
+                                   2, 3);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test2x3.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test2x3.cs
@@ -1,0 +1,321 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix2x3 structure.
+    /// </summary>
+    [TestClass]
+    public class Test2x3
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix2x3 matrix2x3;
+
+            matrix2x3 = new Matrix2x3();
+
+            for (int x = 0; x < matrix2x3.Columns; x++)
+            {
+                for (int y = 0; y < matrix2x3.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix2x3[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix2x3 = new Matrix2x3(value);
+
+            for (int x = 0; x < matrix2x3.Columns; x++)
+            {
+                for (int y = 0; y < matrix2x3.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix2x3[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix2x3);
+
+            for (int y = 0; y < matrix2x3.Rows; y++)
+            {
+                for (int x = 0; x < matrix2x3.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix2x3.Columns + x, matrix2x3[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix2x3 matrix2x3 = new Matrix2x3();
+
+            for (int x = 0; x < matrix2x3.Columns; x++)
+            {
+                for (int y = 0; y < matrix2x3.Rows; y++)
+                {
+                    matrix2x3[x, y] = y * matrix2x3.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix2x3.Rows; y++)
+            {
+                for (int x = 0; x < matrix2x3.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix2x3.Columns + x, matrix2x3[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix2x3 matrix2x3 = new Matrix2x3();
+
+            Assert.AreEqual(2, matrix2x3.Columns);
+            Assert.AreEqual(3, matrix2x3.Rows);
+            Assert.AreEqual(Matrix2x3.ColumnCount, matrix2x3.Columns);
+            Assert.AreEqual(Matrix2x3.RowCount, matrix2x3.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix2x3 matrix2x3;
+
+            GenerateFilledMatrixWithValues(out matrix2x3);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix2x3 result = matrix2x3 * c;
+
+                for (int y = 0; y < matrix2x3.Rows; y++)
+                {
+                    for (int x = 0; x < matrix2x3.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix2x3[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix2x3 matrix2x3 = new Matrix2x3();
+
+            matrix2x3.M11 = 0;
+            matrix2x3.M21 = 1;
+            matrix2x3.M12 = 2;
+            matrix2x3.M22 = 3;
+            matrix2x3.M13 = 4;
+            matrix2x3.M23 = 5;
+
+            Assert.AreEqual(0, matrix2x3.M11, Epsilon);
+            Assert.AreEqual(1, matrix2x3.M21, Epsilon);
+            Assert.AreEqual(2, matrix2x3.M12, Epsilon);
+            Assert.AreEqual(3, matrix2x3.M22, Epsilon);
+            Assert.AreEqual(4, matrix2x3.M13, Epsilon);
+            Assert.AreEqual(5, matrix2x3.M23, Epsilon);
+
+            Assert.AreEqual(matrix2x3[0, 0], matrix2x3.M11, Epsilon);
+            Assert.AreEqual(matrix2x3[1, 0], matrix2x3.M21, Epsilon);
+            Assert.AreEqual(matrix2x3[0, 1], matrix2x3.M12, Epsilon);
+            Assert.AreEqual(matrix2x3[1, 1], matrix2x3.M22, Epsilon);
+            Assert.AreEqual(matrix2x3[0, 2], matrix2x3.M13, Epsilon);
+            Assert.AreEqual(matrix2x3[1, 2], matrix2x3.M23, Epsilon);
+        }
+
+        [TestMethod]
+        public void ColumnAccessorAreCorrect()
+        {
+            Matrix2x3 value;
+            GenerateFilledMatrixWithValues(out value);
+
+            Matrix1x3 column1 = value.Column1;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[0, y], column1[0, y]);
+            }
+        }
+
+        [TestMethod]
+        public void RowAccessorAreCorrect()
+        {
+            Matrix2x3 value;
+            GenerateFilledMatrixWithValues(out value);
+
+
+            Matrix2x1 row1 = value.Row1;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 0], row1[x, 0]);
+            }
+
+            Matrix2x1 row2 = value.Row2;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 1], row2[x, 0]);
+            }
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix2x3 value = new Matrix2x3(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix2x3 value1 = new Matrix2x3(1);
+            Matrix2x3 value2 = new Matrix2x3(99);
+            Matrix2x3 result = value1 + value2;
+
+            for (int y = 0; y < Matrix2x3.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix2x3.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix2x3 value1 = new Matrix2x3(100);
+            Matrix2x3 value2 = new Matrix2x3(1);
+            Matrix2x3 result = value1 - value2;
+
+            for (int y = 0; y < Matrix2x3.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix2x3.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix2x3 value1 = new Matrix2x3(100);
+            Matrix2x3 value2 = new Matrix2x3(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix2x3 matrix2x3 = new Matrix2x3();
+
+            try
+            {
+                matrix2x3[-1, 0] = 0;
+                Assert.Fail("Matrix2x3[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix2x3[0, -1] = 0;
+                Assert.Fail("Matrix2x3[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix2x3[2, 0] = 0;
+                Assert.Fail("Matrix2x3[2, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix2x3[0, 3] = 0;
+                Assert.Fail("Matrix2x3[0, 3] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix1x2ProducesMatrix1x3()
+        {
+            Matrix2x3 matrix1 = new Matrix2x3(3);
+            Matrix1x2 matrix2 = new Matrix1x2(2);
+            Matrix1x3 result = matrix1 * matrix2;
+            Matrix1x3 expected = new Matrix1x3(12, 
+                                               12, 
+                                               12);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix2x2ProducesMatrix2x3()
+        {
+            Matrix2x3 matrix1 = new Matrix2x3(3);
+            Matrix2x2 matrix2 = new Matrix2x2(2);
+            Matrix2x3 result = matrix1 * matrix2;
+            Matrix2x3 expected = new Matrix2x3(12, 12, 
+                                               12, 12, 
+                                               12, 12);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x2ProducesMatrix3x3()
+        {
+            Matrix2x3 matrix1 = new Matrix2x3(3);
+            Matrix3x2 matrix2 = new Matrix3x2(2);
+            Matrix3x3 result = matrix1 * matrix2;
+            Matrix3x3 expected = new Matrix3x3(12, 12, 12, 
+                                               12, 12, 12, 
+                                               12, 12, 12);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x2ProducesMatrix4x3()
+        {
+            Matrix2x3 matrix1 = new Matrix2x3(3);
+            Matrix4x2 matrix2 = new Matrix4x2(2);
+            Matrix4x3 result = matrix1 * matrix2;
+            Matrix4x3 expected = new Matrix4x3(12, 12, 12, 12, 
+                                               12, 12, 12, 12, 
+                                               12, 12, 12, 12);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix2x3 matrix)
+        {
+            matrix = new Matrix2x3(0, 1, 
+                                   2, 3, 
+                                   4, 5);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test2x4.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test2x4.cs
@@ -1,0 +1,338 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix2x4 structure.
+    /// </summary>
+    [TestClass]
+    public class Test2x4
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix2x4 matrix2x4;
+
+            matrix2x4 = new Matrix2x4();
+
+            for (int x = 0; x < matrix2x4.Columns; x++)
+            {
+                for (int y = 0; y < matrix2x4.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix2x4[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix2x4 = new Matrix2x4(value);
+
+            for (int x = 0; x < matrix2x4.Columns; x++)
+            {
+                for (int y = 0; y < matrix2x4.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix2x4[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix2x4);
+
+            for (int y = 0; y < matrix2x4.Rows; y++)
+            {
+                for (int x = 0; x < matrix2x4.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix2x4.Columns + x, matrix2x4[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix2x4 matrix2x4 = new Matrix2x4();
+
+            for (int x = 0; x < matrix2x4.Columns; x++)
+            {
+                for (int y = 0; y < matrix2x4.Rows; y++)
+                {
+                    matrix2x4[x, y] = y * matrix2x4.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix2x4.Rows; y++)
+            {
+                for (int x = 0; x < matrix2x4.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix2x4.Columns + x, matrix2x4[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix2x4 matrix2x4 = new Matrix2x4();
+
+            Assert.AreEqual(2, matrix2x4.Columns);
+            Assert.AreEqual(4, matrix2x4.Rows);
+            Assert.AreEqual(Matrix2x4.ColumnCount, matrix2x4.Columns);
+            Assert.AreEqual(Matrix2x4.RowCount, matrix2x4.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix2x4 matrix2x4;
+
+            GenerateFilledMatrixWithValues(out matrix2x4);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix2x4 result = matrix2x4 * c;
+
+                for (int y = 0; y < matrix2x4.Rows; y++)
+                {
+                    for (int x = 0; x < matrix2x4.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix2x4[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix2x4 matrix2x4 = new Matrix2x4();
+
+            matrix2x4.M11 = 0;
+            matrix2x4.M21 = 1;
+            matrix2x4.M12 = 2;
+            matrix2x4.M22 = 3;
+            matrix2x4.M13 = 4;
+            matrix2x4.M23 = 5;
+            matrix2x4.M14 = 6;
+            matrix2x4.M24 = 7;
+
+            Assert.AreEqual(0, matrix2x4.M11, Epsilon);
+            Assert.AreEqual(1, matrix2x4.M21, Epsilon);
+            Assert.AreEqual(2, matrix2x4.M12, Epsilon);
+            Assert.AreEqual(3, matrix2x4.M22, Epsilon);
+            Assert.AreEqual(4, matrix2x4.M13, Epsilon);
+            Assert.AreEqual(5, matrix2x4.M23, Epsilon);
+            Assert.AreEqual(6, matrix2x4.M14, Epsilon);
+            Assert.AreEqual(7, matrix2x4.M24, Epsilon);
+
+            Assert.AreEqual(matrix2x4[0, 0], matrix2x4.M11, Epsilon);
+            Assert.AreEqual(matrix2x4[1, 0], matrix2x4.M21, Epsilon);
+            Assert.AreEqual(matrix2x4[0, 1], matrix2x4.M12, Epsilon);
+            Assert.AreEqual(matrix2x4[1, 1], matrix2x4.M22, Epsilon);
+            Assert.AreEqual(matrix2x4[0, 2], matrix2x4.M13, Epsilon);
+            Assert.AreEqual(matrix2x4[1, 2], matrix2x4.M23, Epsilon);
+            Assert.AreEqual(matrix2x4[0, 3], matrix2x4.M14, Epsilon);
+            Assert.AreEqual(matrix2x4[1, 3], matrix2x4.M24, Epsilon);
+        }
+
+        [TestMethod]
+        public void ColumnAccessorAreCorrect()
+        {
+            Matrix2x4 value;
+            GenerateFilledMatrixWithValues(out value);
+
+            Matrix1x4 column1 = value.Column1;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[0, y], column1[0, y]);
+            }
+        }
+
+        [TestMethod]
+        public void RowAccessorAreCorrect()
+        {
+            Matrix2x4 value;
+            GenerateFilledMatrixWithValues(out value);
+
+
+            Matrix2x1 row1 = value.Row1;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 0], row1[x, 0]);
+            }
+
+            Matrix2x1 row2 = value.Row2;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 1], row2[x, 0]);
+            }
+
+            Matrix2x1 row3 = value.Row3;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 2], row3[x, 0]);
+            }
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix2x4 value = new Matrix2x4(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix2x4 value1 = new Matrix2x4(1);
+            Matrix2x4 value2 = new Matrix2x4(99);
+            Matrix2x4 result = value1 + value2;
+
+            for (int y = 0; y < Matrix2x4.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix2x4.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix2x4 value1 = new Matrix2x4(100);
+            Matrix2x4 value2 = new Matrix2x4(1);
+            Matrix2x4 result = value1 - value2;
+
+            for (int y = 0; y < Matrix2x4.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix2x4.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix2x4 value1 = new Matrix2x4(100);
+            Matrix2x4 value2 = new Matrix2x4(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix2x4 matrix2x4 = new Matrix2x4();
+
+            try
+            {
+                matrix2x4[-1, 0] = 0;
+                Assert.Fail("Matrix2x4[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix2x4[0, -1] = 0;
+                Assert.Fail("Matrix2x4[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix2x4[2, 0] = 0;
+                Assert.Fail("Matrix2x4[2, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix2x4[0, 4] = 0;
+                Assert.Fail("Matrix2x4[0, 4] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix1x2ProducesMatrix1x4()
+        {
+            Matrix2x4 matrix1 = new Matrix2x4(3);
+            Matrix1x2 matrix2 = new Matrix1x2(2);
+            Matrix1x4 result = matrix1 * matrix2;
+            Matrix1x4 expected = new Matrix1x4(12, 
+                                               12, 
+                                               12, 
+                                               12);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix2x2ProducesMatrix2x4()
+        {
+            Matrix2x4 matrix1 = new Matrix2x4(3);
+            Matrix2x2 matrix2 = new Matrix2x2(2);
+            Matrix2x4 result = matrix1 * matrix2;
+            Matrix2x4 expected = new Matrix2x4(12, 12, 
+                                               12, 12, 
+                                               12, 12, 
+                                               12, 12);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x2ProducesMatrix3x4()
+        {
+            Matrix2x4 matrix1 = new Matrix2x4(3);
+            Matrix3x2 matrix2 = new Matrix3x2(2);
+            Matrix3x4 result = matrix1 * matrix2;
+            Matrix3x4 expected = new Matrix3x4(12, 12, 12, 
+                                               12, 12, 12, 
+                                               12, 12, 12, 
+                                               12, 12, 12);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x2ProducesMatrix4x4()
+        {
+            Matrix2x4 matrix1 = new Matrix2x4(3);
+            Matrix4x2 matrix2 = new Matrix4x2(2);
+            Matrix4x4 result = matrix1 * matrix2;
+            Matrix4x4 expected = new Matrix4x4(12, 12, 12, 12, 
+                                               12, 12, 12, 12, 
+                                               12, 12, 12, 12, 
+                                               12, 12, 12, 12);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix2x4 matrix)
+        {
+            matrix = new Matrix2x4(0, 1, 
+                                   2, 3, 
+                                   4, 5, 
+                                   6, 7);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test3x1.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test3x1.cs
@@ -1,0 +1,259 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix3x1 structure.
+    /// </summary>
+    [TestClass]
+    public class Test3x1
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix3x1 matrix3x1;
+
+            matrix3x1 = new Matrix3x1();
+
+            for (int x = 0; x < matrix3x1.Columns; x++)
+            {
+                for (int y = 0; y < matrix3x1.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix3x1[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix3x1 = new Matrix3x1(value);
+
+            for (int x = 0; x < matrix3x1.Columns; x++)
+            {
+                for (int y = 0; y < matrix3x1.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix3x1[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix3x1);
+
+            for (int y = 0; y < matrix3x1.Rows; y++)
+            {
+                for (int x = 0; x < matrix3x1.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix3x1.Columns + x, matrix3x1[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix3x1 matrix3x1 = new Matrix3x1();
+
+            for (int x = 0; x < matrix3x1.Columns; x++)
+            {
+                for (int y = 0; y < matrix3x1.Rows; y++)
+                {
+                    matrix3x1[x, y] = y * matrix3x1.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix3x1.Rows; y++)
+            {
+                for (int x = 0; x < matrix3x1.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix3x1.Columns + x, matrix3x1[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix3x1 matrix3x1 = new Matrix3x1();
+
+            Assert.AreEqual(3, matrix3x1.Columns);
+            Assert.AreEqual(1, matrix3x1.Rows);
+            Assert.AreEqual(Matrix3x1.ColumnCount, matrix3x1.Columns);
+            Assert.AreEqual(Matrix3x1.RowCount, matrix3x1.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix3x1 matrix3x1;
+
+            GenerateFilledMatrixWithValues(out matrix3x1);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix3x1 result = matrix3x1 * c;
+
+                for (int y = 0; y < matrix3x1.Rows; y++)
+                {
+                    for (int x = 0; x < matrix3x1.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix3x1[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix3x1 matrix3x1 = new Matrix3x1();
+
+            matrix3x1.M11 = 0;
+            matrix3x1.M21 = 1;
+            matrix3x1.M31 = 2;
+
+            Assert.AreEqual(0, matrix3x1.M11, Epsilon);
+            Assert.AreEqual(1, matrix3x1.M21, Epsilon);
+            Assert.AreEqual(2, matrix3x1.M31, Epsilon);
+
+            Assert.AreEqual(matrix3x1[0, 0], matrix3x1.M11, Epsilon);
+            Assert.AreEqual(matrix3x1[1, 0], matrix3x1.M21, Epsilon);
+            Assert.AreEqual(matrix3x1[2, 0], matrix3x1.M31, Epsilon);
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix3x1 value = new Matrix3x1(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix3x1 value1 = new Matrix3x1(1);
+            Matrix3x1 value2 = new Matrix3x1(99);
+            Matrix3x1 result = value1 + value2;
+
+            for (int y = 0; y < Matrix3x1.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix3x1.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix3x1 value1 = new Matrix3x1(100);
+            Matrix3x1 value2 = new Matrix3x1(1);
+            Matrix3x1 result = value1 - value2;
+
+            for (int y = 0; y < Matrix3x1.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix3x1.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix3x1 value1 = new Matrix3x1(100);
+            Matrix3x1 value2 = new Matrix3x1(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix3x1 matrix3x1 = new Matrix3x1();
+
+            try
+            {
+                matrix3x1[-1, 0] = 0;
+                Assert.Fail("Matrix3x1[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix3x1[0, -1] = 0;
+                Assert.Fail("Matrix3x1[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix3x1[3, 0] = 0;
+                Assert.Fail("Matrix3x1[3, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix3x1[0, 1] = 0;
+                Assert.Fail("Matrix3x1[0, 1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix2x3ProducesMatrix2x1()
+        {
+            Matrix3x1 matrix1 = new Matrix3x1(3);
+            Matrix2x3 matrix2 = new Matrix2x3(2);
+            Matrix2x1 result = matrix1 * matrix2;
+            Matrix2x1 expected = new Matrix2x1(18, 18);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x3ProducesMatrix3x1()
+        {
+            Matrix3x1 matrix1 = new Matrix3x1(3);
+            Matrix3x3 matrix2 = new Matrix3x3(2);
+            Matrix3x1 result = matrix1 * matrix2;
+            Matrix3x1 expected = new Matrix3x1(18, 18, 18);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x3ProducesMatrix4x1()
+        {
+            Matrix3x1 matrix1 = new Matrix3x1(3);
+            Matrix4x3 matrix2 = new Matrix4x3(2);
+            Matrix4x1 result = matrix1 * matrix2;
+            Matrix4x1 expected = new Matrix4x1(18, 18, 18, 18);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix3x1 matrix)
+        {
+            matrix = new Matrix3x1(0, 1, 2);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test3x2.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test3x2.cs
@@ -1,0 +1,316 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix3x2 structure.
+    /// </summary>
+    [TestClass]
+    public class Test3x2
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix3x2 matrix3x2;
+
+            matrix3x2 = new Matrix3x2();
+
+            for (int x = 0; x < matrix3x2.Columns; x++)
+            {
+                for (int y = 0; y < matrix3x2.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix3x2[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix3x2 = new Matrix3x2(value);
+
+            for (int x = 0; x < matrix3x2.Columns; x++)
+            {
+                for (int y = 0; y < matrix3x2.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix3x2[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix3x2);
+
+            for (int y = 0; y < matrix3x2.Rows; y++)
+            {
+                for (int x = 0; x < matrix3x2.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix3x2.Columns + x, matrix3x2[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix3x2 matrix3x2 = new Matrix3x2();
+
+            for (int x = 0; x < matrix3x2.Columns; x++)
+            {
+                for (int y = 0; y < matrix3x2.Rows; y++)
+                {
+                    matrix3x2[x, y] = y * matrix3x2.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix3x2.Rows; y++)
+            {
+                for (int x = 0; x < matrix3x2.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix3x2.Columns + x, matrix3x2[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix3x2 matrix3x2 = new Matrix3x2();
+
+            Assert.AreEqual(3, matrix3x2.Columns);
+            Assert.AreEqual(2, matrix3x2.Rows);
+            Assert.AreEqual(Matrix3x2.ColumnCount, matrix3x2.Columns);
+            Assert.AreEqual(Matrix3x2.RowCount, matrix3x2.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix3x2 matrix3x2;
+
+            GenerateFilledMatrixWithValues(out matrix3x2);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix3x2 result = matrix3x2 * c;
+
+                for (int y = 0; y < matrix3x2.Rows; y++)
+                {
+                    for (int x = 0; x < matrix3x2.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix3x2[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix3x2 matrix3x2 = new Matrix3x2();
+
+            matrix3x2.M11 = 0;
+            matrix3x2.M21 = 1;
+            matrix3x2.M31 = 2;
+            matrix3x2.M12 = 3;
+            matrix3x2.M22 = 4;
+            matrix3x2.M32 = 5;
+
+            Assert.AreEqual(0, matrix3x2.M11, Epsilon);
+            Assert.AreEqual(1, matrix3x2.M21, Epsilon);
+            Assert.AreEqual(2, matrix3x2.M31, Epsilon);
+            Assert.AreEqual(3, matrix3x2.M12, Epsilon);
+            Assert.AreEqual(4, matrix3x2.M22, Epsilon);
+            Assert.AreEqual(5, matrix3x2.M32, Epsilon);
+
+            Assert.AreEqual(matrix3x2[0, 0], matrix3x2.M11, Epsilon);
+            Assert.AreEqual(matrix3x2[1, 0], matrix3x2.M21, Epsilon);
+            Assert.AreEqual(matrix3x2[2, 0], matrix3x2.M31, Epsilon);
+            Assert.AreEqual(matrix3x2[0, 1], matrix3x2.M12, Epsilon);
+            Assert.AreEqual(matrix3x2[1, 1], matrix3x2.M22, Epsilon);
+            Assert.AreEqual(matrix3x2[2, 1], matrix3x2.M32, Epsilon);
+        }
+
+        [TestMethod]
+        public void ColumnAccessorAreCorrect()
+        {
+            Matrix3x2 value;
+            GenerateFilledMatrixWithValues(out value);
+
+            Matrix1x2 column1 = value.Column1;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[0, y], column1[0, y]);
+            }
+
+            Matrix1x2 column2 = value.Column2;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[1, y], column2[0, y]);
+            }
+        }
+
+        [TestMethod]
+        public void RowAccessorAreCorrect()
+        {
+            Matrix3x2 value;
+            GenerateFilledMatrixWithValues(out value);
+
+
+            Matrix3x1 row1 = value.Row1;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 0], row1[x, 0]);
+            }
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix3x2 value = new Matrix3x2(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix3x2 value1 = new Matrix3x2(1);
+            Matrix3x2 value2 = new Matrix3x2(99);
+            Matrix3x2 result = value1 + value2;
+
+            for (int y = 0; y < Matrix3x2.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix3x2.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix3x2 value1 = new Matrix3x2(100);
+            Matrix3x2 value2 = new Matrix3x2(1);
+            Matrix3x2 result = value1 - value2;
+
+            for (int y = 0; y < Matrix3x2.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix3x2.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix3x2 value1 = new Matrix3x2(100);
+            Matrix3x2 value2 = new Matrix3x2(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix3x2 matrix3x2 = new Matrix3x2();
+
+            try
+            {
+                matrix3x2[-1, 0] = 0;
+                Assert.Fail("Matrix3x2[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix3x2[0, -1] = 0;
+                Assert.Fail("Matrix3x2[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix3x2[3, 0] = 0;
+                Assert.Fail("Matrix3x2[3, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix3x2[0, 2] = 0;
+                Assert.Fail("Matrix3x2[0, 2] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix1x3ProducesMatrix1x2()
+        {
+            Matrix3x2 matrix1 = new Matrix3x2(3);
+            Matrix1x3 matrix2 = new Matrix1x3(2);
+            Matrix1x2 result = matrix1 * matrix2;
+            Matrix1x2 expected = new Matrix1x2(18, 
+                                               18);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix2x3ProducesMatrix2x2()
+        {
+            Matrix3x2 matrix1 = new Matrix3x2(3);
+            Matrix2x3 matrix2 = new Matrix2x3(2);
+            Matrix2x2 result = matrix1 * matrix2;
+            Matrix2x2 expected = new Matrix2x2(18, 18, 
+                                               18, 18);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x3ProducesMatrix3x2()
+        {
+            Matrix3x2 matrix1 = new Matrix3x2(3);
+            Matrix3x3 matrix2 = new Matrix3x3(2);
+            Matrix3x2 result = matrix1 * matrix2;
+            Matrix3x2 expected = new Matrix3x2(18, 18, 18, 
+                                               18, 18, 18);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x3ProducesMatrix4x2()
+        {
+            Matrix3x2 matrix1 = new Matrix3x2(3);
+            Matrix4x3 matrix2 = new Matrix4x3(2);
+            Matrix4x2 result = matrix1 * matrix2;
+            Matrix4x2 expected = new Matrix4x2(18, 18, 18, 18, 
+                                               18, 18, 18, 18);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix3x2 matrix)
+        {
+            matrix = new Matrix3x2(0, 1, 2, 
+                                   3, 4, 5);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test3x3.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test3x3.cs
@@ -1,0 +1,346 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix3x3 structure.
+    /// </summary>
+    [TestClass]
+    public class Test3x3
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix3x3 matrix3x3;
+
+            matrix3x3 = new Matrix3x3();
+
+            for (int x = 0; x < matrix3x3.Columns; x++)
+            {
+                for (int y = 0; y < matrix3x3.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix3x3[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix3x3 = new Matrix3x3(value);
+
+            for (int x = 0; x < matrix3x3.Columns; x++)
+            {
+                for (int y = 0; y < matrix3x3.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix3x3[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix3x3);
+
+            for (int y = 0; y < matrix3x3.Rows; y++)
+            {
+                for (int x = 0; x < matrix3x3.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix3x3.Columns + x, matrix3x3[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix3x3 matrix3x3 = new Matrix3x3();
+
+            for (int x = 0; x < matrix3x3.Columns; x++)
+            {
+                for (int y = 0; y < matrix3x3.Rows; y++)
+                {
+                    matrix3x3[x, y] = y * matrix3x3.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix3x3.Rows; y++)
+            {
+                for (int x = 0; x < matrix3x3.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix3x3.Columns + x, matrix3x3[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix3x3 matrix3x3 = new Matrix3x3();
+
+            Assert.AreEqual(3, matrix3x3.Columns);
+            Assert.AreEqual(3, matrix3x3.Rows);
+            Assert.AreEqual(Matrix3x3.ColumnCount, matrix3x3.Columns);
+            Assert.AreEqual(Matrix3x3.RowCount, matrix3x3.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix3x3 matrix3x3;
+
+            GenerateFilledMatrixWithValues(out matrix3x3);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix3x3 result = matrix3x3 * c;
+
+                for (int y = 0; y < matrix3x3.Rows; y++)
+                {
+                    for (int x = 0; x < matrix3x3.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix3x3[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix3x3 matrix3x3 = new Matrix3x3();
+
+            matrix3x3.M11 = 0;
+            matrix3x3.M21 = 1;
+            matrix3x3.M31 = 2;
+            matrix3x3.M12 = 3;
+            matrix3x3.M22 = 4;
+            matrix3x3.M32 = 5;
+            matrix3x3.M13 = 6;
+            matrix3x3.M23 = 7;
+            matrix3x3.M33 = 8;
+
+            Assert.AreEqual(0, matrix3x3.M11, Epsilon);
+            Assert.AreEqual(1, matrix3x3.M21, Epsilon);
+            Assert.AreEqual(2, matrix3x3.M31, Epsilon);
+            Assert.AreEqual(3, matrix3x3.M12, Epsilon);
+            Assert.AreEqual(4, matrix3x3.M22, Epsilon);
+            Assert.AreEqual(5, matrix3x3.M32, Epsilon);
+            Assert.AreEqual(6, matrix3x3.M13, Epsilon);
+            Assert.AreEqual(7, matrix3x3.M23, Epsilon);
+            Assert.AreEqual(8, matrix3x3.M33, Epsilon);
+
+            Assert.AreEqual(matrix3x3[0, 0], matrix3x3.M11, Epsilon);
+            Assert.AreEqual(matrix3x3[1, 0], matrix3x3.M21, Epsilon);
+            Assert.AreEqual(matrix3x3[2, 0], matrix3x3.M31, Epsilon);
+            Assert.AreEqual(matrix3x3[0, 1], matrix3x3.M12, Epsilon);
+            Assert.AreEqual(matrix3x3[1, 1], matrix3x3.M22, Epsilon);
+            Assert.AreEqual(matrix3x3[2, 1], matrix3x3.M32, Epsilon);
+            Assert.AreEqual(matrix3x3[0, 2], matrix3x3.M13, Epsilon);
+            Assert.AreEqual(matrix3x3[1, 2], matrix3x3.M23, Epsilon);
+            Assert.AreEqual(matrix3x3[2, 2], matrix3x3.M33, Epsilon);
+        }
+
+        [TestMethod]
+        public void ColumnAccessorAreCorrect()
+        {
+            Matrix3x3 value;
+            GenerateFilledMatrixWithValues(out value);
+
+            Matrix1x3 column1 = value.Column1;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[0, y], column1[0, y]);
+            }
+
+            Matrix1x3 column2 = value.Column2;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[1, y], column2[0, y]);
+            }
+        }
+
+        [TestMethod]
+        public void RowAccessorAreCorrect()
+        {
+            Matrix3x3 value;
+            GenerateFilledMatrixWithValues(out value);
+
+
+            Matrix3x1 row1 = value.Row1;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 0], row1[x, 0]);
+            }
+
+            Matrix3x1 row2 = value.Row2;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 1], row2[x, 0]);
+            }
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix3x3 value = new Matrix3x3(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix3x3 value1 = new Matrix3x3(1);
+            Matrix3x3 value2 = new Matrix3x3(99);
+            Matrix3x3 result = value1 + value2;
+
+            for (int y = 0; y < Matrix3x3.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix3x3.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix3x3 value1 = new Matrix3x3(100);
+            Matrix3x3 value2 = new Matrix3x3(1);
+            Matrix3x3 result = value1 - value2;
+
+            for (int y = 0; y < Matrix3x3.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix3x3.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MultiplyByIdentityReturnsEqualValue()
+        {
+            Matrix3x3 value;
+            GenerateFilledMatrixWithValues(out value);
+            Matrix3x3 result = value * Matrix3x3.Identity;
+
+            Assert.AreEqual(value, result);
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix3x3 value1 = new Matrix3x3(100);
+            Matrix3x3 value2 = new Matrix3x3(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix3x3 matrix3x3 = new Matrix3x3();
+
+            try
+            {
+                matrix3x3[-1, 0] = 0;
+                Assert.Fail("Matrix3x3[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix3x3[0, -1] = 0;
+                Assert.Fail("Matrix3x3[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix3x3[3, 0] = 0;
+                Assert.Fail("Matrix3x3[3, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix3x3[0, 3] = 0;
+                Assert.Fail("Matrix3x3[0, 3] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix1x3ProducesMatrix1x3()
+        {
+            Matrix3x3 matrix1 = new Matrix3x3(3);
+            Matrix1x3 matrix2 = new Matrix1x3(2);
+            Matrix1x3 result = matrix1 * matrix2;
+            Matrix1x3 expected = new Matrix1x3(18, 
+                                               18, 
+                                               18);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix2x3ProducesMatrix2x3()
+        {
+            Matrix3x3 matrix1 = new Matrix3x3(3);
+            Matrix2x3 matrix2 = new Matrix2x3(2);
+            Matrix2x3 result = matrix1 * matrix2;
+            Matrix2x3 expected = new Matrix2x3(18, 18, 
+                                               18, 18, 
+                                               18, 18);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x3ProducesMatrix3x3()
+        {
+            Matrix3x3 matrix1 = new Matrix3x3(3);
+            Matrix3x3 matrix2 = new Matrix3x3(2);
+            Matrix3x3 result = matrix1 * matrix2;
+            Matrix3x3 expected = new Matrix3x3(18, 18, 18, 
+                                               18, 18, 18, 
+                                               18, 18, 18);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x3ProducesMatrix4x3()
+        {
+            Matrix3x3 matrix1 = new Matrix3x3(3);
+            Matrix4x3 matrix2 = new Matrix4x3(2);
+            Matrix4x3 result = matrix1 * matrix2;
+            Matrix4x3 expected = new Matrix4x3(18, 18, 18, 18, 
+                                               18, 18, 18, 18, 
+                                               18, 18, 18, 18);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix3x3 matrix)
+        {
+            matrix = new Matrix3x3(0, 1, 2, 
+                                   3, 4, 5, 
+                                   6, 7, 8);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test3x4.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test3x4.cs
@@ -1,0 +1,356 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix3x4 structure.
+    /// </summary>
+    [TestClass]
+    public class Test3x4
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix3x4 matrix3x4;
+
+            matrix3x4 = new Matrix3x4();
+
+            for (int x = 0; x < matrix3x4.Columns; x++)
+            {
+                for (int y = 0; y < matrix3x4.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix3x4[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix3x4 = new Matrix3x4(value);
+
+            for (int x = 0; x < matrix3x4.Columns; x++)
+            {
+                for (int y = 0; y < matrix3x4.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix3x4[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix3x4);
+
+            for (int y = 0; y < matrix3x4.Rows; y++)
+            {
+                for (int x = 0; x < matrix3x4.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix3x4.Columns + x, matrix3x4[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix3x4 matrix3x4 = new Matrix3x4();
+
+            for (int x = 0; x < matrix3x4.Columns; x++)
+            {
+                for (int y = 0; y < matrix3x4.Rows; y++)
+                {
+                    matrix3x4[x, y] = y * matrix3x4.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix3x4.Rows; y++)
+            {
+                for (int x = 0; x < matrix3x4.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix3x4.Columns + x, matrix3x4[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix3x4 matrix3x4 = new Matrix3x4();
+
+            Assert.AreEqual(3, matrix3x4.Columns);
+            Assert.AreEqual(4, matrix3x4.Rows);
+            Assert.AreEqual(Matrix3x4.ColumnCount, matrix3x4.Columns);
+            Assert.AreEqual(Matrix3x4.RowCount, matrix3x4.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix3x4 matrix3x4;
+
+            GenerateFilledMatrixWithValues(out matrix3x4);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix3x4 result = matrix3x4 * c;
+
+                for (int y = 0; y < matrix3x4.Rows; y++)
+                {
+                    for (int x = 0; x < matrix3x4.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix3x4[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix3x4 matrix3x4 = new Matrix3x4();
+
+            matrix3x4.M11 = 0;
+            matrix3x4.M21 = 1;
+            matrix3x4.M31 = 2;
+            matrix3x4.M12 = 3;
+            matrix3x4.M22 = 4;
+            matrix3x4.M32 = 5;
+            matrix3x4.M13 = 6;
+            matrix3x4.M23 = 7;
+            matrix3x4.M33 = 8;
+            matrix3x4.M14 = 9;
+            matrix3x4.M24 = 10;
+            matrix3x4.M34 = 11;
+
+            Assert.AreEqual(0, matrix3x4.M11, Epsilon);
+            Assert.AreEqual(1, matrix3x4.M21, Epsilon);
+            Assert.AreEqual(2, matrix3x4.M31, Epsilon);
+            Assert.AreEqual(3, matrix3x4.M12, Epsilon);
+            Assert.AreEqual(4, matrix3x4.M22, Epsilon);
+            Assert.AreEqual(5, matrix3x4.M32, Epsilon);
+            Assert.AreEqual(6, matrix3x4.M13, Epsilon);
+            Assert.AreEqual(7, matrix3x4.M23, Epsilon);
+            Assert.AreEqual(8, matrix3x4.M33, Epsilon);
+            Assert.AreEqual(9, matrix3x4.M14, Epsilon);
+            Assert.AreEqual(10, matrix3x4.M24, Epsilon);
+            Assert.AreEqual(11, matrix3x4.M34, Epsilon);
+
+            Assert.AreEqual(matrix3x4[0, 0], matrix3x4.M11, Epsilon);
+            Assert.AreEqual(matrix3x4[1, 0], matrix3x4.M21, Epsilon);
+            Assert.AreEqual(matrix3x4[2, 0], matrix3x4.M31, Epsilon);
+            Assert.AreEqual(matrix3x4[0, 1], matrix3x4.M12, Epsilon);
+            Assert.AreEqual(matrix3x4[1, 1], matrix3x4.M22, Epsilon);
+            Assert.AreEqual(matrix3x4[2, 1], matrix3x4.M32, Epsilon);
+            Assert.AreEqual(matrix3x4[0, 2], matrix3x4.M13, Epsilon);
+            Assert.AreEqual(matrix3x4[1, 2], matrix3x4.M23, Epsilon);
+            Assert.AreEqual(matrix3x4[2, 2], matrix3x4.M33, Epsilon);
+            Assert.AreEqual(matrix3x4[0, 3], matrix3x4.M14, Epsilon);
+            Assert.AreEqual(matrix3x4[1, 3], matrix3x4.M24, Epsilon);
+            Assert.AreEqual(matrix3x4[2, 3], matrix3x4.M34, Epsilon);
+        }
+
+        [TestMethod]
+        public void ColumnAccessorAreCorrect()
+        {
+            Matrix3x4 value;
+            GenerateFilledMatrixWithValues(out value);
+
+            Matrix1x4 column1 = value.Column1;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[0, y], column1[0, y]);
+            }
+
+            Matrix1x4 column2 = value.Column2;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[1, y], column2[0, y]);
+            }
+        }
+
+        [TestMethod]
+        public void RowAccessorAreCorrect()
+        {
+            Matrix3x4 value;
+            GenerateFilledMatrixWithValues(out value);
+
+
+            Matrix3x1 row1 = value.Row1;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 0], row1[x, 0]);
+            }
+
+            Matrix3x1 row2 = value.Row2;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 1], row2[x, 0]);
+            }
+
+            Matrix3x1 row3 = value.Row3;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 2], row3[x, 0]);
+            }
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix3x4 value = new Matrix3x4(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix3x4 value1 = new Matrix3x4(1);
+            Matrix3x4 value2 = new Matrix3x4(99);
+            Matrix3x4 result = value1 + value2;
+
+            for (int y = 0; y < Matrix3x4.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix3x4.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix3x4 value1 = new Matrix3x4(100);
+            Matrix3x4 value2 = new Matrix3x4(1);
+            Matrix3x4 result = value1 - value2;
+
+            for (int y = 0; y < Matrix3x4.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix3x4.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix3x4 value1 = new Matrix3x4(100);
+            Matrix3x4 value2 = new Matrix3x4(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix3x4 matrix3x4 = new Matrix3x4();
+
+            try
+            {
+                matrix3x4[-1, 0] = 0;
+                Assert.Fail("Matrix3x4[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix3x4[0, -1] = 0;
+                Assert.Fail("Matrix3x4[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix3x4[3, 0] = 0;
+                Assert.Fail("Matrix3x4[3, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix3x4[0, 4] = 0;
+                Assert.Fail("Matrix3x4[0, 4] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix1x3ProducesMatrix1x4()
+        {
+            Matrix3x4 matrix1 = new Matrix3x4(3);
+            Matrix1x3 matrix2 = new Matrix1x3(2);
+            Matrix1x4 result = matrix1 * matrix2;
+            Matrix1x4 expected = new Matrix1x4(18, 
+                                               18, 
+                                               18, 
+                                               18);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix2x3ProducesMatrix2x4()
+        {
+            Matrix3x4 matrix1 = new Matrix3x4(3);
+            Matrix2x3 matrix2 = new Matrix2x3(2);
+            Matrix2x4 result = matrix1 * matrix2;
+            Matrix2x4 expected = new Matrix2x4(18, 18, 
+                                               18, 18, 
+                                               18, 18, 
+                                               18, 18);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x3ProducesMatrix3x4()
+        {
+            Matrix3x4 matrix1 = new Matrix3x4(3);
+            Matrix3x3 matrix2 = new Matrix3x3(2);
+            Matrix3x4 result = matrix1 * matrix2;
+            Matrix3x4 expected = new Matrix3x4(18, 18, 18, 
+                                               18, 18, 18, 
+                                               18, 18, 18, 
+                                               18, 18, 18);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x3ProducesMatrix4x4()
+        {
+            Matrix3x4 matrix1 = new Matrix3x4(3);
+            Matrix4x3 matrix2 = new Matrix4x3(2);
+            Matrix4x4 result = matrix1 * matrix2;
+            Matrix4x4 expected = new Matrix4x4(18, 18, 18, 18, 
+                                               18, 18, 18, 18, 
+                                               18, 18, 18, 18, 
+                                               18, 18, 18, 18);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix3x4 matrix)
+        {
+            matrix = new Matrix3x4( 0,  1,  2, 
+                                    3,  4,  5, 
+                                    6,  7,  8, 
+                                    9, 10, 11);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test4x1.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test4x1.cs
@@ -1,0 +1,262 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix4x1 structure.
+    /// </summary>
+    [TestClass]
+    public class Test4x1
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix4x1 matrix4x1;
+
+            matrix4x1 = new Matrix4x1();
+
+            for (int x = 0; x < matrix4x1.Columns; x++)
+            {
+                for (int y = 0; y < matrix4x1.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix4x1[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix4x1 = new Matrix4x1(value);
+
+            for (int x = 0; x < matrix4x1.Columns; x++)
+            {
+                for (int y = 0; y < matrix4x1.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix4x1[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix4x1);
+
+            for (int y = 0; y < matrix4x1.Rows; y++)
+            {
+                for (int x = 0; x < matrix4x1.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix4x1.Columns + x, matrix4x1[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix4x1 matrix4x1 = new Matrix4x1();
+
+            for (int x = 0; x < matrix4x1.Columns; x++)
+            {
+                for (int y = 0; y < matrix4x1.Rows; y++)
+                {
+                    matrix4x1[x, y] = y * matrix4x1.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix4x1.Rows; y++)
+            {
+                for (int x = 0; x < matrix4x1.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix4x1.Columns + x, matrix4x1[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix4x1 matrix4x1 = new Matrix4x1();
+
+            Assert.AreEqual(4, matrix4x1.Columns);
+            Assert.AreEqual(1, matrix4x1.Rows);
+            Assert.AreEqual(Matrix4x1.ColumnCount, matrix4x1.Columns);
+            Assert.AreEqual(Matrix4x1.RowCount, matrix4x1.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix4x1 matrix4x1;
+
+            GenerateFilledMatrixWithValues(out matrix4x1);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix4x1 result = matrix4x1 * c;
+
+                for (int y = 0; y < matrix4x1.Rows; y++)
+                {
+                    for (int x = 0; x < matrix4x1.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix4x1[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix4x1 matrix4x1 = new Matrix4x1();
+
+            matrix4x1.M11 = 0;
+            matrix4x1.M21 = 1;
+            matrix4x1.M31 = 2;
+            matrix4x1.M41 = 3;
+
+            Assert.AreEqual(0, matrix4x1.M11, Epsilon);
+            Assert.AreEqual(1, matrix4x1.M21, Epsilon);
+            Assert.AreEqual(2, matrix4x1.M31, Epsilon);
+            Assert.AreEqual(3, matrix4x1.M41, Epsilon);
+
+            Assert.AreEqual(matrix4x1[0, 0], matrix4x1.M11, Epsilon);
+            Assert.AreEqual(matrix4x1[1, 0], matrix4x1.M21, Epsilon);
+            Assert.AreEqual(matrix4x1[2, 0], matrix4x1.M31, Epsilon);
+            Assert.AreEqual(matrix4x1[3, 0], matrix4x1.M41, Epsilon);
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix4x1 value = new Matrix4x1(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix4x1 value1 = new Matrix4x1(1);
+            Matrix4x1 value2 = new Matrix4x1(99);
+            Matrix4x1 result = value1 + value2;
+
+            for (int y = 0; y < Matrix4x1.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix4x1.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix4x1 value1 = new Matrix4x1(100);
+            Matrix4x1 value2 = new Matrix4x1(1);
+            Matrix4x1 result = value1 - value2;
+
+            for (int y = 0; y < Matrix4x1.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix4x1.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix4x1 value1 = new Matrix4x1(100);
+            Matrix4x1 value2 = new Matrix4x1(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix4x1 matrix4x1 = new Matrix4x1();
+
+            try
+            {
+                matrix4x1[-1, 0] = 0;
+                Assert.Fail("Matrix4x1[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix4x1[0, -1] = 0;
+                Assert.Fail("Matrix4x1[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix4x1[4, 0] = 0;
+                Assert.Fail("Matrix4x1[4, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix4x1[0, 1] = 0;
+                Assert.Fail("Matrix4x1[0, 1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix2x4ProducesMatrix2x1()
+        {
+            Matrix4x1 matrix1 = new Matrix4x1(3);
+            Matrix2x4 matrix2 = new Matrix2x4(2);
+            Matrix2x1 result = matrix1 * matrix2;
+            Matrix2x1 expected = new Matrix2x1(24, 24);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x4ProducesMatrix3x1()
+        {
+            Matrix4x1 matrix1 = new Matrix4x1(3);
+            Matrix3x4 matrix2 = new Matrix3x4(2);
+            Matrix3x1 result = matrix1 * matrix2;
+            Matrix3x1 expected = new Matrix3x1(24, 24, 24);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x4ProducesMatrix4x1()
+        {
+            Matrix4x1 matrix1 = new Matrix4x1(3);
+            Matrix4x4 matrix2 = new Matrix4x4(2);
+            Matrix4x1 result = matrix1 * matrix2;
+            Matrix4x1 expected = new Matrix4x1(24, 24, 24, 24);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix4x1 matrix)
+        {
+            matrix = new Matrix4x1(0, 1, 2, 3);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test4x2.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test4x2.cs
@@ -1,0 +1,328 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix4x2 structure.
+    /// </summary>
+    [TestClass]
+    public class Test4x2
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix4x2 matrix4x2;
+
+            matrix4x2 = new Matrix4x2();
+
+            for (int x = 0; x < matrix4x2.Columns; x++)
+            {
+                for (int y = 0; y < matrix4x2.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix4x2[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix4x2 = new Matrix4x2(value);
+
+            for (int x = 0; x < matrix4x2.Columns; x++)
+            {
+                for (int y = 0; y < matrix4x2.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix4x2[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix4x2);
+
+            for (int y = 0; y < matrix4x2.Rows; y++)
+            {
+                for (int x = 0; x < matrix4x2.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix4x2.Columns + x, matrix4x2[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix4x2 matrix4x2 = new Matrix4x2();
+
+            for (int x = 0; x < matrix4x2.Columns; x++)
+            {
+                for (int y = 0; y < matrix4x2.Rows; y++)
+                {
+                    matrix4x2[x, y] = y * matrix4x2.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix4x2.Rows; y++)
+            {
+                for (int x = 0; x < matrix4x2.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix4x2.Columns + x, matrix4x2[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix4x2 matrix4x2 = new Matrix4x2();
+
+            Assert.AreEqual(4, matrix4x2.Columns);
+            Assert.AreEqual(2, matrix4x2.Rows);
+            Assert.AreEqual(Matrix4x2.ColumnCount, matrix4x2.Columns);
+            Assert.AreEqual(Matrix4x2.RowCount, matrix4x2.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix4x2 matrix4x2;
+
+            GenerateFilledMatrixWithValues(out matrix4x2);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix4x2 result = matrix4x2 * c;
+
+                for (int y = 0; y < matrix4x2.Rows; y++)
+                {
+                    for (int x = 0; x < matrix4x2.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix4x2[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix4x2 matrix4x2 = new Matrix4x2();
+
+            matrix4x2.M11 = 0;
+            matrix4x2.M21 = 1;
+            matrix4x2.M31 = 2;
+            matrix4x2.M41 = 3;
+            matrix4x2.M12 = 4;
+            matrix4x2.M22 = 5;
+            matrix4x2.M32 = 6;
+            matrix4x2.M42 = 7;
+
+            Assert.AreEqual(0, matrix4x2.M11, Epsilon);
+            Assert.AreEqual(1, matrix4x2.M21, Epsilon);
+            Assert.AreEqual(2, matrix4x2.M31, Epsilon);
+            Assert.AreEqual(3, matrix4x2.M41, Epsilon);
+            Assert.AreEqual(4, matrix4x2.M12, Epsilon);
+            Assert.AreEqual(5, matrix4x2.M22, Epsilon);
+            Assert.AreEqual(6, matrix4x2.M32, Epsilon);
+            Assert.AreEqual(7, matrix4x2.M42, Epsilon);
+
+            Assert.AreEqual(matrix4x2[0, 0], matrix4x2.M11, Epsilon);
+            Assert.AreEqual(matrix4x2[1, 0], matrix4x2.M21, Epsilon);
+            Assert.AreEqual(matrix4x2[2, 0], matrix4x2.M31, Epsilon);
+            Assert.AreEqual(matrix4x2[3, 0], matrix4x2.M41, Epsilon);
+            Assert.AreEqual(matrix4x2[0, 1], matrix4x2.M12, Epsilon);
+            Assert.AreEqual(matrix4x2[1, 1], matrix4x2.M22, Epsilon);
+            Assert.AreEqual(matrix4x2[2, 1], matrix4x2.M32, Epsilon);
+            Assert.AreEqual(matrix4x2[3, 1], matrix4x2.M42, Epsilon);
+        }
+
+        [TestMethod]
+        public void ColumnAccessorAreCorrect()
+        {
+            Matrix4x2 value;
+            GenerateFilledMatrixWithValues(out value);
+
+            Matrix1x2 column1 = value.Column1;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[0, y], column1[0, y]);
+            }
+
+            Matrix1x2 column2 = value.Column2;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[1, y], column2[0, y]);
+            }
+
+            Matrix1x2 column3 = value.Column3;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[2, y], column3[0, y]);
+            }
+        }
+
+        [TestMethod]
+        public void RowAccessorAreCorrect()
+        {
+            Matrix4x2 value;
+            GenerateFilledMatrixWithValues(out value);
+
+
+            Matrix4x1 row1 = value.Row1;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 0], row1[x, 0]);
+            }
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix4x2 value = new Matrix4x2(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix4x2 value1 = new Matrix4x2(1);
+            Matrix4x2 value2 = new Matrix4x2(99);
+            Matrix4x2 result = value1 + value2;
+
+            for (int y = 0; y < Matrix4x2.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix4x2.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix4x2 value1 = new Matrix4x2(100);
+            Matrix4x2 value2 = new Matrix4x2(1);
+            Matrix4x2 result = value1 - value2;
+
+            for (int y = 0; y < Matrix4x2.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix4x2.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix4x2 value1 = new Matrix4x2(100);
+            Matrix4x2 value2 = new Matrix4x2(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix4x2 matrix4x2 = new Matrix4x2();
+
+            try
+            {
+                matrix4x2[-1, 0] = 0;
+                Assert.Fail("Matrix4x2[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix4x2[0, -1] = 0;
+                Assert.Fail("Matrix4x2[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix4x2[4, 0] = 0;
+                Assert.Fail("Matrix4x2[4, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix4x2[0, 2] = 0;
+                Assert.Fail("Matrix4x2[0, 2] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix1x4ProducesMatrix1x2()
+        {
+            Matrix4x2 matrix1 = new Matrix4x2(3);
+            Matrix1x4 matrix2 = new Matrix1x4(2);
+            Matrix1x2 result = matrix1 * matrix2;
+            Matrix1x2 expected = new Matrix1x2(24, 
+                                               24);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix2x4ProducesMatrix2x2()
+        {
+            Matrix4x2 matrix1 = new Matrix4x2(3);
+            Matrix2x4 matrix2 = new Matrix2x4(2);
+            Matrix2x2 result = matrix1 * matrix2;
+            Matrix2x2 expected = new Matrix2x2(24, 24, 
+                                               24, 24);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x4ProducesMatrix3x2()
+        {
+            Matrix4x2 matrix1 = new Matrix4x2(3);
+            Matrix3x4 matrix2 = new Matrix3x4(2);
+            Matrix3x2 result = matrix1 * matrix2;
+            Matrix3x2 expected = new Matrix3x2(24, 24, 24, 
+                                               24, 24, 24);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x4ProducesMatrix4x2()
+        {
+            Matrix4x2 matrix1 = new Matrix4x2(3);
+            Matrix4x4 matrix2 = new Matrix4x4(2);
+            Matrix4x2 result = matrix1 * matrix2;
+            Matrix4x2 expected = new Matrix4x2(24, 24, 24, 24, 
+                                               24, 24, 24, 24);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix4x2 matrix)
+        {
+            matrix = new Matrix4x2(0, 1, 2, 3, 
+                                   4, 5, 6, 7);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test4x3.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test4x3.cs
@@ -1,0 +1,351 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix4x3 structure.
+    /// </summary>
+    [TestClass]
+    public class Test4x3
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix4x3 matrix4x3;
+
+            matrix4x3 = new Matrix4x3();
+
+            for (int x = 0; x < matrix4x3.Columns; x++)
+            {
+                for (int y = 0; y < matrix4x3.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix4x3[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix4x3 = new Matrix4x3(value);
+
+            for (int x = 0; x < matrix4x3.Columns; x++)
+            {
+                for (int y = 0; y < matrix4x3.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix4x3[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix4x3);
+
+            for (int y = 0; y < matrix4x3.Rows; y++)
+            {
+                for (int x = 0; x < matrix4x3.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix4x3.Columns + x, matrix4x3[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix4x3 matrix4x3 = new Matrix4x3();
+
+            for (int x = 0; x < matrix4x3.Columns; x++)
+            {
+                for (int y = 0; y < matrix4x3.Rows; y++)
+                {
+                    matrix4x3[x, y] = y * matrix4x3.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix4x3.Rows; y++)
+            {
+                for (int x = 0; x < matrix4x3.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix4x3.Columns + x, matrix4x3[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix4x3 matrix4x3 = new Matrix4x3();
+
+            Assert.AreEqual(4, matrix4x3.Columns);
+            Assert.AreEqual(3, matrix4x3.Rows);
+            Assert.AreEqual(Matrix4x3.ColumnCount, matrix4x3.Columns);
+            Assert.AreEqual(Matrix4x3.RowCount, matrix4x3.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix4x3 matrix4x3;
+
+            GenerateFilledMatrixWithValues(out matrix4x3);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix4x3 result = matrix4x3 * c;
+
+                for (int y = 0; y < matrix4x3.Rows; y++)
+                {
+                    for (int x = 0; x < matrix4x3.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix4x3[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix4x3 matrix4x3 = new Matrix4x3();
+
+            matrix4x3.M11 = 0;
+            matrix4x3.M21 = 1;
+            matrix4x3.M31 = 2;
+            matrix4x3.M41 = 3;
+            matrix4x3.M12 = 4;
+            matrix4x3.M22 = 5;
+            matrix4x3.M32 = 6;
+            matrix4x3.M42 = 7;
+            matrix4x3.M13 = 8;
+            matrix4x3.M23 = 9;
+            matrix4x3.M33 = 10;
+            matrix4x3.M43 = 11;
+
+            Assert.AreEqual(0, matrix4x3.M11, Epsilon);
+            Assert.AreEqual(1, matrix4x3.M21, Epsilon);
+            Assert.AreEqual(2, matrix4x3.M31, Epsilon);
+            Assert.AreEqual(3, matrix4x3.M41, Epsilon);
+            Assert.AreEqual(4, matrix4x3.M12, Epsilon);
+            Assert.AreEqual(5, matrix4x3.M22, Epsilon);
+            Assert.AreEqual(6, matrix4x3.M32, Epsilon);
+            Assert.AreEqual(7, matrix4x3.M42, Epsilon);
+            Assert.AreEqual(8, matrix4x3.M13, Epsilon);
+            Assert.AreEqual(9, matrix4x3.M23, Epsilon);
+            Assert.AreEqual(10, matrix4x3.M33, Epsilon);
+            Assert.AreEqual(11, matrix4x3.M43, Epsilon);
+
+            Assert.AreEqual(matrix4x3[0, 0], matrix4x3.M11, Epsilon);
+            Assert.AreEqual(matrix4x3[1, 0], matrix4x3.M21, Epsilon);
+            Assert.AreEqual(matrix4x3[2, 0], matrix4x3.M31, Epsilon);
+            Assert.AreEqual(matrix4x3[3, 0], matrix4x3.M41, Epsilon);
+            Assert.AreEqual(matrix4x3[0, 1], matrix4x3.M12, Epsilon);
+            Assert.AreEqual(matrix4x3[1, 1], matrix4x3.M22, Epsilon);
+            Assert.AreEqual(matrix4x3[2, 1], matrix4x3.M32, Epsilon);
+            Assert.AreEqual(matrix4x3[3, 1], matrix4x3.M42, Epsilon);
+            Assert.AreEqual(matrix4x3[0, 2], matrix4x3.M13, Epsilon);
+            Assert.AreEqual(matrix4x3[1, 2], matrix4x3.M23, Epsilon);
+            Assert.AreEqual(matrix4x3[2, 2], matrix4x3.M33, Epsilon);
+            Assert.AreEqual(matrix4x3[3, 2], matrix4x3.M43, Epsilon);
+        }
+
+        [TestMethod]
+        public void ColumnAccessorAreCorrect()
+        {
+            Matrix4x3 value;
+            GenerateFilledMatrixWithValues(out value);
+
+            Matrix1x3 column1 = value.Column1;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[0, y], column1[0, y]);
+            }
+
+            Matrix1x3 column2 = value.Column2;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[1, y], column2[0, y]);
+            }
+
+            Matrix1x3 column3 = value.Column3;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[2, y], column3[0, y]);
+            }
+        }
+
+        [TestMethod]
+        public void RowAccessorAreCorrect()
+        {
+            Matrix4x3 value;
+            GenerateFilledMatrixWithValues(out value);
+
+
+            Matrix4x1 row1 = value.Row1;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 0], row1[x, 0]);
+            }
+
+            Matrix4x1 row2 = value.Row2;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 1], row2[x, 0]);
+            }
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix4x3 value = new Matrix4x3(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix4x3 value1 = new Matrix4x3(1);
+            Matrix4x3 value2 = new Matrix4x3(99);
+            Matrix4x3 result = value1 + value2;
+
+            for (int y = 0; y < Matrix4x3.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix4x3.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix4x3 value1 = new Matrix4x3(100);
+            Matrix4x3 value2 = new Matrix4x3(1);
+            Matrix4x3 result = value1 - value2;
+
+            for (int y = 0; y < Matrix4x3.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix4x3.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix4x3 value1 = new Matrix4x3(100);
+            Matrix4x3 value2 = new Matrix4x3(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix4x3 matrix4x3 = new Matrix4x3();
+
+            try
+            {
+                matrix4x3[-1, 0] = 0;
+                Assert.Fail("Matrix4x3[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix4x3[0, -1] = 0;
+                Assert.Fail("Matrix4x3[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix4x3[4, 0] = 0;
+                Assert.Fail("Matrix4x3[4, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix4x3[0, 3] = 0;
+                Assert.Fail("Matrix4x3[0, 3] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix1x4ProducesMatrix1x3()
+        {
+            Matrix4x3 matrix1 = new Matrix4x3(3);
+            Matrix1x4 matrix2 = new Matrix1x4(2);
+            Matrix1x3 result = matrix1 * matrix2;
+            Matrix1x3 expected = new Matrix1x3(24, 
+                                               24, 
+                                               24);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix2x4ProducesMatrix2x3()
+        {
+            Matrix4x3 matrix1 = new Matrix4x3(3);
+            Matrix2x4 matrix2 = new Matrix2x4(2);
+            Matrix2x3 result = matrix1 * matrix2;
+            Matrix2x3 expected = new Matrix2x3(24, 24, 
+                                               24, 24, 
+                                               24, 24);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x4ProducesMatrix3x3()
+        {
+            Matrix4x3 matrix1 = new Matrix4x3(3);
+            Matrix3x4 matrix2 = new Matrix3x4(2);
+            Matrix3x3 result = matrix1 * matrix2;
+            Matrix3x3 expected = new Matrix3x3(24, 24, 24, 
+                                               24, 24, 24, 
+                                               24, 24, 24);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x4ProducesMatrix4x3()
+        {
+            Matrix4x3 matrix1 = new Matrix4x3(3);
+            Matrix4x4 matrix2 = new Matrix4x4(2);
+            Matrix4x3 result = matrix1 * matrix2;
+            Matrix4x3 expected = new Matrix4x3(24, 24, 24, 24, 
+                                               24, 24, 24, 24, 
+                                               24, 24, 24, 24);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix4x3 matrix)
+        {
+            matrix = new Matrix4x3( 0,  1,  2,  3, 
+                                    4,  5,  6,  7, 
+                                    8,  9, 10, 11);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/Test4x4.cs
+++ b/src/System.Numerics.Matrices/test/System/Numerics/Test4x4.cs
@@ -1,0 +1,384 @@
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the Matrix4x4 structure.
+    /// </summary>
+    [TestClass]
+    public class Test4x4
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            Matrix4x4 matrix4x4;
+
+            matrix4x4 = new Matrix4x4();
+
+            for (int x = 0; x < matrix4x4.Columns; x++)
+            {
+                for (int y = 0; y < matrix4x4.Rows; y++)
+                {
+                    Assert.AreEqual(0, matrix4x4[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            matrix4x4 = new Matrix4x4(value);
+
+            for (int x = 0; x < matrix4x4.Columns; x++)
+            {
+                for (int y = 0; y < matrix4x4.Rows; y++)
+                {
+                    Assert.AreEqual(value, matrix4x4[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out matrix4x4);
+
+            for (int y = 0; y < matrix4x4.Rows; y++)
+            {
+                for (int x = 0; x < matrix4x4.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix4x4.Columns + x, matrix4x4[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            Matrix4x4 matrix4x4 = new Matrix4x4();
+
+            for (int x = 0; x < matrix4x4.Columns; x++)
+            {
+                for (int y = 0; y < matrix4x4.Rows; y++)
+                {
+                    matrix4x4[x, y] = y * matrix4x4.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < matrix4x4.Rows; y++)
+            {
+                for (int x = 0; x < matrix4x4.Columns; x++)
+                {
+                    Assert.AreEqual(y * matrix4x4.Columns + x, matrix4x4[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            Matrix4x4 matrix4x4 = new Matrix4x4();
+
+            Assert.AreEqual(4, matrix4x4.Columns);
+            Assert.AreEqual(4, matrix4x4.Rows);
+            Assert.AreEqual(Matrix4x4.ColumnCount, matrix4x4.Columns);
+            Assert.AreEqual(Matrix4x4.RowCount, matrix4x4.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            Matrix4x4 matrix4x4;
+
+            GenerateFilledMatrixWithValues(out matrix4x4);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                Matrix4x4 result = matrix4x4 * c;
+
+                for (int y = 0; y < matrix4x4.Rows; y++)
+                {
+                    for (int x = 0; x < matrix4x4.Columns; x++)
+                    {
+                        Assert.AreEqual(matrix4x4[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            Matrix4x4 matrix4x4 = new Matrix4x4();
+
+            matrix4x4.M11 = 0;
+            matrix4x4.M21 = 1;
+            matrix4x4.M31 = 2;
+            matrix4x4.M41 = 3;
+            matrix4x4.M12 = 4;
+            matrix4x4.M22 = 5;
+            matrix4x4.M32 = 6;
+            matrix4x4.M42 = 7;
+            matrix4x4.M13 = 8;
+            matrix4x4.M23 = 9;
+            matrix4x4.M33 = 10;
+            matrix4x4.M43 = 11;
+            matrix4x4.M14 = 12;
+            matrix4x4.M24 = 13;
+            matrix4x4.M34 = 14;
+            matrix4x4.M44 = 15;
+
+            Assert.AreEqual(0, matrix4x4.M11, Epsilon);
+            Assert.AreEqual(1, matrix4x4.M21, Epsilon);
+            Assert.AreEqual(2, matrix4x4.M31, Epsilon);
+            Assert.AreEqual(3, matrix4x4.M41, Epsilon);
+            Assert.AreEqual(4, matrix4x4.M12, Epsilon);
+            Assert.AreEqual(5, matrix4x4.M22, Epsilon);
+            Assert.AreEqual(6, matrix4x4.M32, Epsilon);
+            Assert.AreEqual(7, matrix4x4.M42, Epsilon);
+            Assert.AreEqual(8, matrix4x4.M13, Epsilon);
+            Assert.AreEqual(9, matrix4x4.M23, Epsilon);
+            Assert.AreEqual(10, matrix4x4.M33, Epsilon);
+            Assert.AreEqual(11, matrix4x4.M43, Epsilon);
+            Assert.AreEqual(12, matrix4x4.M14, Epsilon);
+            Assert.AreEqual(13, matrix4x4.M24, Epsilon);
+            Assert.AreEqual(14, matrix4x4.M34, Epsilon);
+            Assert.AreEqual(15, matrix4x4.M44, Epsilon);
+
+            Assert.AreEqual(matrix4x4[0, 0], matrix4x4.M11, Epsilon);
+            Assert.AreEqual(matrix4x4[1, 0], matrix4x4.M21, Epsilon);
+            Assert.AreEqual(matrix4x4[2, 0], matrix4x4.M31, Epsilon);
+            Assert.AreEqual(matrix4x4[3, 0], matrix4x4.M41, Epsilon);
+            Assert.AreEqual(matrix4x4[0, 1], matrix4x4.M12, Epsilon);
+            Assert.AreEqual(matrix4x4[1, 1], matrix4x4.M22, Epsilon);
+            Assert.AreEqual(matrix4x4[2, 1], matrix4x4.M32, Epsilon);
+            Assert.AreEqual(matrix4x4[3, 1], matrix4x4.M42, Epsilon);
+            Assert.AreEqual(matrix4x4[0, 2], matrix4x4.M13, Epsilon);
+            Assert.AreEqual(matrix4x4[1, 2], matrix4x4.M23, Epsilon);
+            Assert.AreEqual(matrix4x4[2, 2], matrix4x4.M33, Epsilon);
+            Assert.AreEqual(matrix4x4[3, 2], matrix4x4.M43, Epsilon);
+            Assert.AreEqual(matrix4x4[0, 3], matrix4x4.M14, Epsilon);
+            Assert.AreEqual(matrix4x4[1, 3], matrix4x4.M24, Epsilon);
+            Assert.AreEqual(matrix4x4[2, 3], matrix4x4.M34, Epsilon);
+            Assert.AreEqual(matrix4x4[3, 3], matrix4x4.M44, Epsilon);
+        }
+
+        [TestMethod]
+        public void ColumnAccessorAreCorrect()
+        {
+            Matrix4x4 value;
+            GenerateFilledMatrixWithValues(out value);
+
+            Matrix1x4 column1 = value.Column1;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[0, y], column1[0, y]);
+            }
+
+            Matrix1x4 column2 = value.Column2;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[1, y], column2[0, y]);
+            }
+
+            Matrix1x4 column3 = value.Column3;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[2, y], column3[0, y]);
+            }
+        }
+
+        [TestMethod]
+        public void RowAccessorAreCorrect()
+        {
+            Matrix4x4 value;
+            GenerateFilledMatrixWithValues(out value);
+
+
+            Matrix4x1 row1 = value.Row1;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 0], row1[x, 0]);
+            }
+
+            Matrix4x1 row2 = value.Row2;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 1], row2[x, 0]);
+            }
+
+            Matrix4x1 row3 = value.Row3;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, 2], row3[x, 0]);
+            }
+        }
+
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            Matrix4x4 value = new Matrix4x4(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            Matrix4x4 value1 = new Matrix4x4(1);
+            Matrix4x4 value2 = new Matrix4x4(99);
+            Matrix4x4 result = value1 + value2;
+
+            for (int y = 0; y < Matrix4x4.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix4x4.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            Matrix4x4 value1 = new Matrix4x4(100);
+            Matrix4x4 value2 = new Matrix4x4(1);
+            Matrix4x4 result = value1 - value2;
+
+            for (int y = 0; y < Matrix4x4.RowCount; y++)
+            {
+                for (int x = 0; x < Matrix4x4.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MultiplyByIdentityReturnsEqualValue()
+        {
+            Matrix4x4 value;
+            GenerateFilledMatrixWithValues(out value);
+            Matrix4x4 result = value * Matrix4x4.Identity;
+
+            Assert.AreEqual(value, result);
+        }
+
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            Matrix4x4 value1 = new Matrix4x4(100);
+            Matrix4x4 value2 = new Matrix4x4(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            Matrix4x4 matrix4x4 = new Matrix4x4();
+
+            try
+            {
+                matrix4x4[-1, 0] = 0;
+                Assert.Fail("Matrix4x4[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix4x4[0, -1] = 0;
+                Assert.Fail("Matrix4x4[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix4x4[4, 0] = 0;
+                Assert.Fail("Matrix4x4[4, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                matrix4x4[0, 4] = 0;
+                Assert.Fail("Matrix4x4[0, 4] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+        [TestMethod]
+        public void MuliplyByMatrix1x4ProducesMatrix1x4()
+        {
+            Matrix4x4 matrix1 = new Matrix4x4(3);
+            Matrix1x4 matrix2 = new Matrix1x4(2);
+            Matrix1x4 result = matrix1 * matrix2;
+            Matrix1x4 expected = new Matrix1x4(24, 
+                                               24, 
+                                               24, 
+                                               24);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix2x4ProducesMatrix2x4()
+        {
+            Matrix4x4 matrix1 = new Matrix4x4(3);
+            Matrix2x4 matrix2 = new Matrix2x4(2);
+            Matrix2x4 result = matrix1 * matrix2;
+            Matrix2x4 expected = new Matrix2x4(24, 24, 
+                                               24, 24, 
+                                               24, 24, 
+                                               24, 24);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix3x4ProducesMatrix3x4()
+        {
+            Matrix4x4 matrix1 = new Matrix4x4(3);
+            Matrix3x4 matrix2 = new Matrix3x4(2);
+            Matrix3x4 result = matrix1 * matrix2;
+            Matrix3x4 expected = new Matrix3x4(24, 24, 24, 
+                                               24, 24, 24, 
+                                               24, 24, 24, 
+                                               24, 24, 24);
+
+            Assert.AreEqual(expected, result);
+        }
+        [TestMethod]
+        public void MuliplyByMatrix4x4ProducesMatrix4x4()
+        {
+            Matrix4x4 matrix1 = new Matrix4x4(3);
+            Matrix4x4 matrix2 = new Matrix4x4(2);
+            Matrix4x4 result = matrix1 * matrix2;
+            Matrix4x4 expected = new Matrix4x4(24, 24, 24, 24, 
+                                               24, 24, 24, 24, 
+                                               24, 24, 24, 24, 
+                                               24, 24, 24, 24);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        private void GenerateFilledMatrixWithValues(out Matrix4x4 matrix)
+        {
+            matrix = new Matrix4x4( 0,  1,  2,  3, 
+                                    4,  5,  6,  7, 
+                                    8,  9, 10, 11, 
+                                   12, 13, 14, 15);
+        }
+    }
+}

--- a/src/System.Numerics.Matrices/test/System/Numerics/TestTemplate.tt
+++ b/src/System.Numerics.Matrices/test/System/Numerics/TestTemplate.tt
@@ -1,0 +1,422 @@
+﻿<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.IO" #>
+<#@ import namespace="System.Text" #>
+<#@ output extension=".txt" #>
+<#
+    const int MinColCount = 1;
+    const int MaxColCount = 4;
+    const int MinRowCount = 1;
+    const int MaxRowCount = 4;
+
+    for (int rowCount = MinRowCount; rowCount <= MaxRowCount; rowCount ++)
+    {
+        for (int colCount = MinColCount; colCount <= MaxColCount; colCount++)
+        {
+            if (rowCount == MinRowCount && colCount == MinColCount)
+                continue;
+
+            string structName = String.Format("Matrix{0}x{1}", colCount, rowCount);
+            string testName = String.Format("Test{0}x{1}", colCount, rowCount);
+            string outputFileName = testName + ".cs";
+            string typeName = structName.ToLower();
+#>
+// Copyright (c) Microsoft. All rights reserved. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace System.Numerics.Matrices.Tests
+{
+    /// <summary>
+    /// Tests for the <#= structName #> structure.
+    /// </summary>
+    [TestClass]
+    public class <#= testName #>
+    {
+        const double Epsilon = Double.Epsilon * 10;
+
+        [TestMethod]
+        public void ConstructorValuesAreAccessibleByIndexer()
+        {
+            <#= structName #> <#= typeName #>;
+
+            <#= typeName #> = new <#= structName #>();
+
+            for (int x = 0; x < <#= typeName #>.Columns; x++)
+            {
+                for (int y = 0; y < <#= typeName #>.Rows; y++)
+                {
+                    Assert.AreEqual(0, <#= typeName #>[x, y], Epsilon);
+                }
+            }
+
+            double value = 33.33;
+            <#= typeName #> = new <#= structName #>(value);
+
+            for (int x = 0; x < <#= typeName #>.Columns; x++)
+            {
+                for (int y = 0; y < <#= typeName #>.Rows; y++)
+                {
+                    Assert.AreEqual(value, <#= typeName #>[x, y], Epsilon);
+                }
+            }
+
+            GenerateFilledMatrixWithValues(out <#= typeName #>);
+
+            for (int y = 0; y < <#= typeName #>.Rows; y++)
+            {
+                for (int x = 0; x < <#= typeName #>.Columns; x++)
+                {
+                    Assert.AreEqual(y * <#= typeName #>.Columns + x, <#= typeName #>[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void IndexerGetAndSetValuesCorrectly()
+        {
+            <#= structName #> <#= typeName #> = new <#= structName #>();
+
+            for (int x = 0; x < <#= typeName #>.Columns; x++)
+            {
+                for (int y = 0; y < <#= typeName #>.Rows; y++)
+                {
+                    <#= typeName #>[x, y] = y * <#= typeName #>.Columns + x;
+                }
+            }
+
+            for (int y = 0; y < <#= typeName #>.Rows; y++)
+            {
+                for (int x = 0; x < <#= typeName #>.Columns; x++)
+                {
+                    Assert.AreEqual(y * <#= typeName #>.Columns + x, <#= typeName #>[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConstantValuesAreCorrect()
+        {
+            <#= structName #> <#= typeName #> = new <#= structName #>();
+
+            Assert.AreEqual(<#= colCount #>, <#= typeName #>.Columns);
+            Assert.AreEqual(<#= rowCount #>, <#= typeName #>.Rows);
+            Assert.AreEqual(<#= structName #>.ColumnCount, <#= typeName #>.Columns);
+            Assert.AreEqual(<#= structName #>.RowCount, <#= typeName #>.Rows);
+        }
+
+        [TestMethod]
+        public void ScalarMultiplicationIsCorrect()
+        {
+            <#= structName #> <#= typeName #>;
+
+            GenerateFilledMatrixWithValues(out <#= typeName #>);
+
+            for (double c = -10; c <= 10; c += 0.5)
+            {
+                <#= structName #> result = <#= typeName #> * c;
+
+                for (int y = 0; y < <#= typeName #>.Rows; y++)
+                {
+                    for (int x = 0; x < <#= typeName #>.Columns; x++)
+                    {
+                        Assert.AreEqual(<#= typeName #>[x, y] * c, result[x, y], Epsilon);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MemberGetAndSetValuesCorrectly()
+        {
+            <#= structName #> <#= typeName #> = new <#= structName #>();
+
+<#
+            for (int row = 0; row < rowCount; row++)
+            {
+                for (int col = 0; col < colCount; col++)
+                {
+                    #>            <#= typeName #>.M<#= col + 1 #><#= row + 1 #> = <#= row * colCount + col #>;<#
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+
+<#
+            for (int row = 0; row < rowCount; row++)
+            {
+                for (int col = 0; col < colCount; col++)
+                {
+                    #>            Assert.AreEqual(<#= row * colCount + col #>, <#= typeName #>.M<#= col + 1 #><#= row + 1 #>, Epsilon);<#
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+
+<#
+            for (int row = 0; row < rowCount; row++)
+            {
+                for (int col = 0; col < colCount; col++)
+                {
+                    #>            Assert.AreEqual(<#= typeName #>[<#= col#>, <#= row #>], <#= typeName #>.M<#= col + 1 #><#= row + 1 #>, Epsilon);<#
+                    #><#= Environment.NewLine #><#
+                }
+            }
+#>
+        }
+
+<#
+            if (colCount > 1 && rowCount > 1)
+            {
+#>
+        [TestMethod]
+        public void ColumnAccessorAreCorrect()
+        {
+            <#= structName #> value;
+            GenerateFilledMatrixWithValues(out value);
+<#
+                for (int col = 1; col < colCount; col++)
+                {
+#>
+
+            Matrix1x<#= rowCount #> column<#= col #> = value.Column<#= col #>;
+            for (int y = 0; y < value.Rows; y++)
+            {
+                Assert.AreEqual(value[<#= col - 1 #>, y], column<#= col #>[0, y]);
+            }
+<#
+                }
+#>
+        }
+
+        [TestMethod]
+        public void RowAccessorAreCorrect()
+        {
+            <#= structName #> value;
+            GenerateFilledMatrixWithValues(out value);
+
+<#
+                for (int row = 1; row < rowCount; row++)
+                {
+#>
+
+            Matrix<#= colCount #>x1 row<#= row #> = value.Row<#= row #>;
+            for (int x = 0; x < value.Columns; x++)
+            {
+                Assert.AreEqual(value[x, <#= row - 1 #>], row<#= row #>[x, 0]);
+            }
+<#
+                }
+#>
+        }
+
+<#
+            }
+#>
+        [TestMethod]
+        public void HashCodeGenerationWorksCorrectly()
+        {
+            HashSet<int> hashCodes = new HashSet<int>();
+            <#= structName #> value = new <#= structName #>(1);
+
+            for (int i = 2; i <= 100; i++)
+            {
+                if (!hashCodes.Add(value.GetHashCode()))
+                {
+                    Assert.Fail("Unique hash code generation failure.");
+                }
+
+                value *= i;
+            }
+        }
+
+        [TestMethod]
+        public void SimpleAdditionGeneratesCorrectValues()
+        {
+            <#= structName #> value1 = new <#= structName #>(1);
+            <#= structName #> value2 = new <#= structName #>(99);
+            <#= structName #> result = value1 + value2;
+
+            for (int y = 0; y < <#= structName #>.RowCount; y++)
+            {
+                for (int x = 0; x < <#= structName #>.ColumnCount; x++)
+                {
+                    Assert.AreEqual(1 + 99, result[x, y], Epsilon);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void SimpleSubtractionGeneratesCorrectValues()
+        {
+            <#= structName #> value1 = new <#= structName #>(100);
+            <#= structName #> value2 = new <#= structName #>(1);
+            <#= structName #> result = value1 - value2;
+
+            for (int y = 0; y < <#= structName #>.RowCount; y++)
+            {
+                for (int x = 0; x < <#= structName #>.ColumnCount; x++)
+                {
+                    Assert.AreEqual(100 - 1, result[x, y], Epsilon);
+                }
+            }
+        }
+
+<#
+            if (colCount == rowCount)
+            {
+#>
+        [TestMethod]
+        public void MultiplyByIdentityReturnsEqualValue()
+        {
+            <#= structName #> value;
+            GenerateFilledMatrixWithValues(out value);
+            <#= structName #> result = value * <#= structName #>.Identity;
+
+            Assert.AreEqual(value, result);
+        }
+
+<#
+            }
+#>
+        [TestMethod]
+        public void EqualityOperatorWorksCorrectly()
+        {
+            <#= structName #> value1 = new <#= structName #>(100);
+            <#= structName #> value2 = new <#= structName #>(50) * 2;
+
+            Assert.AreEqual(value1, value2);
+            Assert.IsTrue(value1 == value2, "Equality operator failed.");
+        }
+
+        [TestMethod]
+        public void AccessorThrowsWhenOutOfBounds()
+        {
+            <#= structName #> <#= typeName #> = new <#= structName #>();
+
+            try
+            {
+                <#= typeName #>[-1, 0] = 0;
+                Assert.Fail("<#= structName #>[-1, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                <#= typeName #>[0, -1] = 0;
+                Assert.Fail("<#= structName #>[0, -1] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                <#= typeName #>[<#= colCount #>, 0] = 0;
+                Assert.Fail("<#= structName #>[<#= colCount #>, 0] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+
+            try
+            {
+                <#= typeName #>[0, <#= rowCount #>] = 0;
+                Assert.Fail("<#= structName #>[0, <#= rowCount #>] did not throw when it should have.");
+            }
+            catch (ArgumentOutOfRangeException)
+            { }
+        }
+
+<#
+                for (int j = MinColCount; j <= MaxColCount; j++)
+                {
+                    int srcCols = j;
+                    int srcRows = colCount;
+                    int dstCols = srcCols;
+                    int dstRows = rowCount;
+
+                    if ((srcCols == MinColCount && srcRows == MinRowCount) || (dstCols == MinColCount && dstRows == MinRowCount))
+                        continue;
+
+                    string mulName = String.Format("Matrix{0}x{1}", srcCols, srcRows);
+                    string prodName = String.Format("Matrix{0}x{1}", dstCols, dstRows);
+#>
+        [TestMethod]
+        public void MuliplyBy<#= mulName #>Produces<#= prodName #>()
+        {
+            <#= structName #> matrix1 = new <#= structName #>(3);
+            <#= mulName #> matrix2 = new <#= mulName #>(2);
+            <#= prodName #> result = matrix1 * matrix2;
+            <#= prodName #> expected = new <#= prodName #>(<#
+            
+                    for (int y = 0; y < dstRows; y++)
+                    {
+                        for (int x = 0; x < dstCols; x++)
+                        {
+                            #><#= 3 * 2 * srcRows #><#
+
+                            if (x + 1 < dstCols || y + 1 < dstRows)
+                            {
+                                #>, <#
+                            }
+
+                            if (x + 1 >= dstCols && y + 1 < dstRows)
+                            {
+                                #><#= Environment.NewLine #><#
+                                #>                                               <#
+                            }
+                        
+                        }
+                    }
+
+            #>);
+
+            Assert.AreEqual(expected, result);
+        }
+<#
+                }
+#>
+
+        private void GenerateFilledMatrixWithValues(out <#= structName #> matrix)
+        {
+            matrix = new <#= structName #>(<#
+
+            int maxValue = colCount * rowCount;
+            int len = maxValue.ToString().Length;
+            string format = "{0, " + len + "}";
+
+            for (int row = 0; row < rowCount; row++)
+            {
+                for (int col = 0; col < colCount; col++)
+                {
+                    #><#= String.Format(format, row * colCount + col) #><#
+
+                    if (col + 1 < colCount || row + 1 < rowCount)
+                    {
+                        #>, <#
+                    }
+                }
+
+                if (row + 1 < rowCount)
+                {
+                    #><#= Environment.NewLine #><#
+                    #>                                   <#
+                }
+            }
+#>);
+        }
+    }
+}
+<#
+            string templateDirectory = Path.GetDirectoryName(Host.TemplateFile);
+            string outputFilePath = Path.Combine(templateDirectory, outputFileName);
+            File.WriteAllText(outputFilePath, this.GenerationEnvironment.ToString()); 
+
+            this.GenerationEnvironment.Remove(0, this.GenerationEnvironment.Length);
+        }
+    }
+#>


### PR DESCRIPTION
Adds System.Numerics.Matrices

Based on a text-template which can support any sized matrix

Created up to 4x4 matrices initially (up for discussion)

Adds tests for each matrix type

Tests are text template generated, therefore easy to add to each matrix type

Adds a .gitignore to the System.Numerics.Matrices directory to ignore TT temp files