### PR TITLE
Changed Matirices project to not use C# 6.0 features

### DIFF
--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x2.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -59,9 +60,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix1x2* p = &this)
                 {
@@ -72,9 +73,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix1x2* p = &this)
                 {
@@ -123,9 +124,11 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix1x2: "
-                 + $"{{|{M11:00}|}}"
-                 + $"{{|{M12:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix1x2: ");
+            sb.AppendFormat("{{|{0}|}}", M11);
+            sb.AppendFormat("{{|{0}|}}", M12);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x3.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -64,9 +65,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix1x3* p = &this)
                 {
@@ -77,9 +78,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix1x3* p = &this)
                 {
@@ -129,10 +130,12 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix1x3: "
-                 + $"{{|{M11:00}|}}"
-                 + $"{{|{M12:00}|}}"
-                 + $"{{|{M13:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix1x3: ");
+            sb.AppendFormat("{{|{0}|}}", M11);
+            sb.AppendFormat("{{|{0}|}}", M12);
+            sb.AppendFormat("{{|{0}|}}", M13);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix1x4.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -69,9 +70,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix1x4* p = &this)
                 {
@@ -82,9 +83,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix1x4* p = &this)
                 {
@@ -135,11 +136,13 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix1x4: "
-                 + $"{{|{M11:00}|}}"
-                 + $"{{|{M12:00}|}}"
-                 + $"{{|{M13:00}|}}"
-                 + $"{{|{M14:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix1x4: ");
+            sb.AppendFormat("{{|{0}|}}", M11);
+            sb.AppendFormat("{{|{0}|}}", M12);
+            sb.AppendFormat("{{|{0}|}}", M13);
+            sb.AppendFormat("{{|{0}|}}", M14);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x1.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x1.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -56,9 +57,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix2x1* p = &this)
                 {
@@ -69,9 +70,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix2x1* p = &this)
                 {
@@ -119,8 +120,10 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix2x1: "
-                 + $"{{|{M11:00}|{M21:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix2x1: ");
+            sb.AppendFormat("{{|{0}|{1}|}}", M11, M21);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x2.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -70,9 +71,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix2x2* p = &this)
                 {
@@ -83,9 +84,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix2x2* p = &this)
                 {
@@ -150,9 +151,11 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix2x2: "
-                 + $"{{|{M11:00}|{M21:00}|}}"
-                 + $"{{|{M12:00}|{M22:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix2x2: ");
+            sb.AppendFormat("{{|{0}|{1}|}}", M11, M21);
+            sb.AppendFormat("{{|{0}|{1}|}}", M12, M22);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x3.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -70,9 +71,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix2x3* p = &this)
                 {
@@ -83,9 +84,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix2x3* p = &this)
                 {
@@ -155,10 +156,12 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix2x3: "
-                 + $"{{|{M11:00}|{M21:00}|}}"
-                 + $"{{|{M12:00}|{M22:00}|}}"
-                 + $"{{|{M13:00}|{M23:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix2x3: ");
+            sb.AppendFormat("{{|{0}|{1}|}}", M11, M21);
+            sb.AppendFormat("{{|{0}|{1}|}}", M12, M22);
+            sb.AppendFormat("{{|{0}|{1}|}}", M13, M23);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix2x4.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -77,9 +78,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix2x4* p = &this)
                 {
@@ -90,9 +91,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix2x4* p = &this)
                 {
@@ -167,11 +168,13 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix2x4: "
-                 + $"{{|{M11:00}|{M21:00}|}}"
-                 + $"{{|{M12:00}|{M22:00}|}}"
-                 + $"{{|{M13:00}|{M23:00}|}}"
-                 + $"{{|{M14:00}|{M24:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix2x4: ");
+            sb.AppendFormat("{{|{0}|{1}|}}", M11, M21);
+            sb.AppendFormat("{{|{0}|{1}|}}", M12, M22);
+            sb.AppendFormat("{{|{0}|{1}|}}", M13, M23);
+            sb.AppendFormat("{{|{0}|{1}|}}", M14, M24);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x1.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x1.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -58,9 +59,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix3x1* p = &this)
                 {
@@ -71,9 +72,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix3x1* p = &this)
                 {
@@ -121,8 +122,10 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix3x1: "
-                 + $"{{|{M11:00}|{M21:00}|{M31:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix3x1: ");
+            sb.AppendFormat("{{|{0}|{1}|{2}|}}", M11, M21, M31);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x2.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -67,9 +68,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix3x2* p = &this)
                 {
@@ -80,9 +81,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix3x2* p = &this)
                 {
@@ -151,9 +152,11 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix3x2: "
-                 + $"{{|{M11:00}|{M21:00}|{M31:00}|}}"
-                 + $"{{|{M12:00}|{M22:00}|{M32:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix3x2: ");
+            sb.AppendFormat("{{|{0}|{1}|{2}|}}", M11, M21, M31);
+            sb.AppendFormat("{{|{0}|{1}|{2}|}}", M12, M22, M32);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x3.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -84,9 +85,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix3x3* p = &this)
                 {
@@ -97,9 +98,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix3x3* p = &this)
                 {
@@ -173,10 +174,12 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix3x3: "
-                 + $"{{|{M11:00}|{M21:00}|{M31:00}|}}"
-                 + $"{{|{M12:00}|{M22:00}|{M32:00}|}}"
-                 + $"{{|{M13:00}|{M23:00}|{M33:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix3x3: ");
+            sb.AppendFormat("{{|{0}|{1}|{2}|}}", M11, M21, M31);
+            sb.AppendFormat("{{|{0}|{1}|{2}|}}", M12, M22, M32);
+            sb.AppendFormat("{{|{0}|{1}|{2}|}}", M13, M23, M33);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix3x4.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -85,9 +86,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix3x4* p = &this)
                 {
@@ -98,9 +99,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix3x4* p = &this)
                 {
@@ -179,11 +180,13 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix3x4: "
-                 + $"{{|{M11:00}|{M21:00}|{M31:00}|}}"
-                 + $"{{|{M12:00}|{M22:00}|{M32:00}|}}"
-                 + $"{{|{M13:00}|{M23:00}|{M33:00}|}}"
-                 + $"{{|{M14:00}|{M24:00}|{M34:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix3x4: ");
+            sb.AppendFormat("{{|{0}|{1}|{2}|}}", M11, M21, M31);
+            sb.AppendFormat("{{|{0}|{1}|{2}|}}", M12, M22, M32);
+            sb.AppendFormat("{{|{0}|{1}|{2}|}}", M13, M23, M33);
+            sb.AppendFormat("{{|{0}|{1}|{2}|}}", M14, M24, M34);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x1.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x1.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -60,9 +61,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix4x1* p = &this)
                 {
@@ -73,9 +74,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix4x1* p = &this)
                 {
@@ -123,8 +124,10 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix4x1: "
-                 + $"{{|{M11:00}|{M21:00}|{M31:00}|{M41:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix4x1: ");
+            sb.AppendFormat("{{|{0}|{1}|{2}|{3}|}}", M11, M21, M31, M41);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x2.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x2.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -71,9 +72,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix4x2* p = &this)
                 {
@@ -84,9 +85,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix4x2* p = &this)
                 {
@@ -159,9 +160,11 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix4x2: "
-                 + $"{{|{M11:00}|{M21:00}|{M31:00}|{M41:00}|}}"
-                 + $"{{|{M12:00}|{M22:00}|{M32:00}|{M42:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix4x2: ");
+            sb.AppendFormat("{{|{0}|{1}|{2}|{3}|}}", M11, M21, M31, M41);
+            sb.AppendFormat("{{|{0}|{1}|{2}|{3}|}}", M12, M22, M32, M42);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x3.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x3.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -82,9 +83,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix4x3* p = &this)
                 {
@@ -95,9 +96,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix4x3* p = &this)
                 {
@@ -175,10 +176,12 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix4x3: "
-                 + $"{{|{M11:00}|{M21:00}|{M31:00}|{M41:00}|}}"
-                 + $"{{|{M12:00}|{M22:00}|{M32:00}|{M42:00}|}}"
-                 + $"{{|{M13:00}|{M23:00}|{M33:00}|{M43:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix4x3: ");
+            sb.AppendFormat("{{|{0}|{1}|{2}|{3}|}}", M11, M21, M31, M41);
+            sb.AppendFormat("{{|{0}|{1}|{2}|{3}|}}", M12, M22, M32, M42);
+            sb.AppendFormat("{{|{0}|{1}|{2}|{3}|}}", M13, M23, M33, M43);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x4.cs
+++ b/src/System.Numerics.Matrices/src/System/Numerics/Matrix4x4.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -102,9 +103,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix4x4* p = &this)
                 {
@@ -115,9 +116,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (Matrix4x4* p = &this)
                 {
@@ -200,11 +201,13 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "Matrix4x4: "
-                 + $"{{|{M11:00}|{M21:00}|{M31:00}|{M41:00}|}}"
-                 + $"{{|{M12:00}|{M22:00}|{M32:00}|{M42:00}|}}"
-                 + $"{{|{M13:00}|{M23:00}|{M33:00}|{M43:00}|}}"
-                 + $"{{|{M14:00}|{M24:00}|{M34:00}|{M44:00}|}}"; 
+		    var sb = new StringBuilder();
+            sb.Append("Matrix4x4: ");
+            sb.AppendFormat("{{|{0}|{1}|{2}|{3}|}}", M11, M21, M31, M41);
+            sb.AppendFormat("{{|{0}|{1}|{2}|{3}|}}", M12, M22, M32, M42);
+            sb.AppendFormat("{{|{0}|{1}|{2}|{3}|}}", M13, M23, M33, M43);
+            sb.AppendFormat("{{|{0}|{1}|{2}|{3}|}}", M14, M24, M34, M44);
+			return sb.ToString();
         }
 
         /// <summary>

--- a/src/System.Numerics.Matrices/src/System/Numerics/MatrixTemplate.tt
+++ b/src/System.Numerics.Matrices/src/System/Numerics/MatrixTemplate.tt
@@ -25,6 +25,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Numerics.Matrices
 {
@@ -184,9 +185,9 @@ namespace System.Numerics.Matrices
             get
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (<#= structName #>* p = &this)
                 {
@@ -197,9 +198,9 @@ namespace System.Numerics.Matrices
             set
             {
                 if (col < 0 || col >= ColumnCount)
-                    throw new ArgumentOutOfRangeException(nameof(col), $"Expected greater than or equal to 0 and less than {ColumnCount}, found {col}.");
+                    throw new ArgumentOutOfRangeException("col", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", ColumnCount, col));
                 if (row < 0 || row >= RowCount)
-                    throw new ArgumentOutOfRangeException(nameof(row), $"Expected greater than or equal to 0 and less than {RowCount}, found {row}.");
+                    throw new ArgumentOutOfRangeException("row", String.Format("Expected greater than or equal to 0 and less than {0}, found {1}.", RowCount, row));
 
                 fixed (<#= structName #>* p = &this)
                 {
@@ -320,24 +321,31 @@ namespace System.Numerics.Matrices
 
         public override string ToString()
         {
-            return "<#= structName #>: "<#
-            #><#= Environment.NewLine #><#
+		    var sb = new StringBuilder();
+            sb.Append("<#= structName #>: ");
+<#
             for (int y = 0; y < rowCount; y++)
             {
-                #>                 + $"{{<#
+				#>            sb.AppendFormat("{{|<#
+				
                 for (int x = 0; x < colCount; x++)
                 {
-                    #>|{<#= String.Format("M{0}{1}", x + 1, y + 1) #>:00}<#
+					#>{<#=x#>}|<#
                 }
-                #>|}}"<#
-                
-                if (y + 1 < rowCount)
+     
+	            #>}}"<#
+	            for (int x = 0; x < colCount; x++)
                 {
-                    #><#= Environment.NewLine #><#
+					#>, M<#=x+1#><#=y+1#><#
+                }
+
+                if (y + 1 <= rowCount)
+                {
+                    #>);<#= Environment.NewLine #><#
                 }
             }
-
-            #>; 
+            #>
+			return sb.ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
This is to fix a build break after updating to a new engineering system.
@whoisj, let me know if you are happy with the changes. At some point we might allow C# 6.0 features and we can change the templates back.
