### PR TITLE
Add the dotnet-corefx feed to the list of feeds used by nuget to resolve packages

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -47,6 +47,7 @@
   <ItemGroup>
     <NuGetSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-buildtools" />
     <NuGetSourceList Include="https:%2F%2Fwww.nuget.org/api/v2" />
+    <NuGetSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefx" />
   </ItemGroup>
 
   <!-- Common nuget properties -->


### PR DESCRIPTION
…lve packages

This enables the build to resolve the System.Reflection.Metadata package.