### PR TITLE
Create the BuildAndTest target for the System.Reflection.Metadata.Cil project

### DIFF
--- a/src/System.Reflection.Metadata.Cil/src/System.Reflection.Metadata.Cil.csproj
+++ b/src/System.Reflection.Metadata.Cil/src/System.Reflection.Metadata.Cil.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="BuildAndTest" DependsOnTargets="Build" />
+
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/System.Reflection.Metadata.Cil/tests/System.Reflection.Metadata.Cil.Tests.csproj
+++ b/src/System.Reflection.Metadata.Cil/tests/System.Reflection.Metadata.Cil.Tests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="BuildAndTest" DependsOnTargets="Build" />
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>


### PR DESCRIPTION
This is a quick fix to ensure the build of corefxlab is not broken by these
projects.