### PR TITLE
Fix issue #172 in System.Reflection.Metadata.Cil

### DIFF
--- a/src/System.Reflection.Metadata.Cil/src/CilAssembly.cs
+++ b/src/System.Reflection.Metadata.Cil/src/CilAssembly.cs
@@ -28,6 +28,7 @@ namespace System.Reflection.Metadata.Cil
         private CilHeaderOptions _headerOptions;
         private bool _isHeaderInitialized;
         private bool _isModuleInitialized;
+        private bool _disposed;
 
         #region Public APIs
 
@@ -40,6 +41,7 @@ namespace System.Reflection.Metadata.Cil
             assembly._assemblyDefinition = readers.MdReader.GetAssemblyDefinition();
             assembly._isModuleInitialized = false;
             assembly._isHeaderInitialized = false;
+            assembly._disposed = false;
             return assembly;
         }
 
@@ -299,12 +301,26 @@ namespace System.Reflection.Metadata.Cil
 
         public void Dispose()
         {
-            _readers.Dispose();
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         #endregion
 
         #region Private Methods
+
+        private void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _readers.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
 
         private IEnumerable<CilTypeDefinition> GetTypeDefinitions()
         {

--- a/src/System.Reflection.Metadata.Cil/tests/CilTests.cs
+++ b/src/System.Reflection.Metadata.Cil/tests/CilTests.cs
@@ -13,7 +13,7 @@ namespace System.Reflection.Metadata.Cil.Tests
             Stopwatch watch = new Stopwatch();
             try
             {
-                string path = "Assemblies/Demo1.exe";
+                string path = "Assemblies/mscorlib.dll";
                 if (!File.Exists(path))
                 {
                     Assert.Fail("File not found");

--- a/src/System.Reflection.Metadata.Cil/tests/app.config
+++ b/src/System.Reflection.Metadata.Cil/tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.37.0" newVersion="1.1.37.0" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.37.0" newVersion="1.1.36.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
This fixes dotnet/corefxlab#172 so that CilAssembly can't be disposed twice in order to avoid exceptions.

This was done keeping track of the current dispose status.

cc @AlexGhiondea 