### PR TITLE
Removed the support for packages.txt and work towards making dotnet into a CoreCLR app.

### DIFF
--- a/demos/dotnet/dotnet/README.txt
+++ b/demos/dotnet/dotnet/README.txt
@@ -1,0 +1,5 @@
+dotnet.dotnetproj (along with the explicit list in references.txt and dependencies.txt) contains all the required packages to self-host dotnet.exe using NuGet as of now.
+
+The project.json file is used by dnu to restore the packages so that dotnet can be compiled into a coreclr app using msbuild and the dotnet-core.csproj file.
+
+The dotnet.csproj file is the default one (for now) which is used for development in Visual Studio targetting .NET Framework.

--- a/demos/dotnet/dotnet/dependencies.txt
+++ b/demos/dotnet/dotnet/dependencies.txt
@@ -1,10 +1,11 @@
 +packages\System.Xml.ReaderWriter\4.0.10\lib\dotnet
 +packages\System.Collections\4.0.10\lib\DNXCore50
-+packages\Microsoft.Win32.Registry\4.0.0-beta-23225\lib\DNXCore50
 +packages\System.Net.Http\4.0.0\lib\DNXCore50
++packages\System.IO\4.0.10\lib\DNXCore50
 +packages\System.Diagnostics.Process\4.0.0-beta-23225\lib\DNXCore50
 +packages\System.IO.FileSystem\4.0.1-beta-23225\lib\DNXCore50
 +packages\System.Runtime.Extensions\4.0.11-beta-23225\lib\DNXCore50
++packages\System.Text.Encoding\4.0.10\lib\DNXCore50
 +packages\System.ComponentModel\4.0.0\lib\dotnet
 +packages\Microsoft.Win32.Primitives\4.0.0\lib\dotnet
 +packages\System.Threading.Tasks\4.0.10\lib\DNXCore50
@@ -17,3 +18,7 @@
 +packages\System.Security.SecureString\4.0.0-beta-23225\lib\DNXCore50
 +packages\System.Globalization\4.0.10\lib\DNXCore50
 +packages\System.Threading.ThreadPool\4.0.10-beta-23225\lib\DNXCore50
++packages\System.Net.Primitives\4.0.10\lib\DNXCore50
++packages\System.Private.Networking\4.0.0\lib\DNXCore50
++packages\System.Collections.NonGeneric\4.0.0\lib\dotnet
++packages\System.Security.Cryptography.X509Certificates\4.0.0-beta-23225\lib\DNXCore50

--- a/demos/dotnet/dotnet/dotnet-core.csproj
+++ b/demos/dotnet/dotnet/dotnet-core.csproj
@@ -72,7 +72,6 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="project.json" />
     <None Include="project.lock.json" />
   </ItemGroup>

--- a/demos/dotnet/dotnet/dotnet-core.csproj
+++ b/demos/dotnet/dotnet/dotnet-core.csproj
@@ -1,0 +1,103 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{507301F7-B451-4C9F-8947-95E1CBE2049A}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>dotnet</RootNamespace>
+    <AssemblyName>dotnet</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkIdentifier>DNXCore</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
+    <NuGetTargetMoniker>DNXCore,Version=v5.0</NuGetTargetMoniker>
+    <BaseNuGetRuntimeIdentifier>win7</BaseNuGetRuntimeIdentifier>
+  </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="dotnet.cs" />
+    <Compile Include="Log.cs" />
+    <Compile Include="ProjectProperties.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="project.json" />
+    <None Include="project.lock.json" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <!-- Set up the debug target for portable executables -->
+  <PropertyGroup Condition="'$(OutputType)'=='Exe'">
+    <StartWorkingDirectory Condition="'$(StartWorkingDirectory)' == ''">$(TargetDir)</StartWorkingDirectory>
+    <StartAction Condition="'$(StartAction)' == ''">Program</StartAction>
+    <StartProgram Condition="'$(StartProgram)' == ''">$(TargetPath)</StartProgram>
+    <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
+  </PropertyGroup>
+  <Target Name="AfterBuild">
+    <Move SourceFiles="$(TargetPath)" DestinationFiles="$(TargetDir)\$(AssemblyName).dll" />
+    <Move SourceFiles="$(TargetDir)\CoreConsole.exe" DestinationFiles="$(TargetPath)" />
+  </Target>
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties project_1json__JSONSchema="http://json.schemastore.org/project-1.0.0-beta5" />
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/demos/dotnet/dotnet/dotnet.cs
+++ b/demos/dotnet/dotnet/dotnet.cs
@@ -155,7 +155,7 @@ static class Program
                     Console.WriteLine("Exception when trying to parse arguments: {0}", e.Message);
                     printUsage = true;
                 }
-                
+
             }
 
         }
@@ -189,7 +189,7 @@ static class Program
         Console.WriteLine("           ProjectFile - specifies which project file to use, default to the one in the current directory, if only one exists");
         Console.WriteLine("           SourceFiles - specifices which source files to compile");
         Console.WriteLine("NOTE #1: uses csc.exe in <project>\\tools subdirectory, or csc.exe on the path.");
-        Console.WriteLine("NOTE #2: packages.txt, dependencies.txt, references.txt, cscoptions.txt can be used to override details.");
+        Console.WriteLine("NOTE #2: packages.txt, dependencies.txt, references.txt can be used to override details.");
     }
 
     static void Clean(string[] args, Log log)
@@ -272,7 +272,7 @@ static class Program
 
         var defaultOption = "/platform:anycpu";
         var platformOption = properties.CscOptions.Find(x => x.StartsWith("/platform"));
-        var coreConsolePath = ProjectPropertiesHelpers.GetConsoleHostNative(ProjectPropertiesHelpers.GetPlatformOption(platformOption == null ? defaultOption: platformOption), "win7") + "\\CoreConsole.exe";
+        var coreConsolePath = ProjectPropertiesHelpers.GetConsoleHostNative(ProjectPropertiesHelpers.GetPlatformOption(platformOption == null ? defaultOption : platformOption), "win7") + "\\CoreConsole.exe";
         File.Copy(Path.Combine(properties.PackagesDirectory, coreConsolePath), properties.OutputAssemblyPath);
     }
 }
@@ -387,7 +387,7 @@ static class ProjectPropertiesHelpers
         // CSC OPTIONS
         properties.CscOptions.Add("/nostdlib");
         properties.CscOptions.Add("/noconfig");
-        if (Array.Exists(args, element => element == "/unsafe")) 
+        if (Array.Exists(args, element => element == "/unsafe"))
         {
             properties.CscOptions.Add("/unsafe");
         }
@@ -401,14 +401,13 @@ static class ProjectPropertiesHelpers
 
         if (debugOption != null)
         {
-           properties.CscOptions.Add(debugOption);
+            properties.CscOptions.Add(debugOption);
         }
 
         LogProperties(log, properties, "Initialized Properties Log:", buildDll);
 
         Adjust(Path.Combine(properties.ProjectDirectory, "dependencies.txt"), properties.Dependencies);
         Adjust(Path.Combine(properties.ProjectDirectory, "references.txt"), properties.References);
-        Adjust(Path.Combine(properties.ProjectDirectory, "cscoptions.txt"), properties.CscOptions);
         Adjust(Path.Combine(properties.ProjectDirectory, "packages.txt"), properties.Packages);
 
         LogProperties(log, properties, "Adjusted Properties Log:", buildDll);
@@ -463,7 +462,7 @@ static class ProjectPropertiesHelpers
 
     static void AddToListWithoutDuplicates(List<string> list, List<string> files)
     {
-        foreach(var file in files)
+        foreach (var file in files)
         {
             if (!list.Contains(file))
             {
@@ -520,7 +519,7 @@ static class ProjectPropertiesHelpers
                 if (String.IsNullOrWhiteSpace(line)) continue;
                 if (line.StartsWith("//")) continue; // commented out line
                 var adjustment = line.Substring(1).Trim();
-                if (line.StartsWith(" - "))
+                if (line.StartsWith("-"))
                 {
                     list.Remove(adjustment);
                 }
@@ -547,7 +546,7 @@ static class ProjectPropertiesHelpers
                     {
                         sourceFiles.AddRange(Directory.GetFiles(properties.ProjectDirectory, "*.cs"));
                     }
-                    else if(sourceFile.EndsWith("\\*.cs"))
+                    else if (sourceFile.EndsWith("\\*.cs"))
                     {
                         sourceFiles.AddRange(Directory.GetFiles(Path.Combine(properties.ProjectDirectory, sourceFile.Replace("\\*.cs", "")), "*.cs"));
                     }
@@ -794,7 +793,7 @@ static class NugetAction
                 }
             }
         }
-        
+
         return true;
     }
 

--- a/demos/dotnet/dotnet/dotnet.dotnetproj
+++ b/demos/dotnet/dotnet/dotnet.dotnetproj
@@ -1,0 +1,11 @@
+<Project>
+  <ItemGroup>
+    <Package Id="System.Diagnostics.Process" Version="4.0.0-beta-23225" />
+    <Package Id="System.IO.FileSystem" Version="4.0.1-beta-23225" />
+    <Package Id="System.Runtime.Extensions" Version="4.0.11-beta-23225" />
+    <Package Id="System.Security.Cryptography.X509Certificates" Version="4.0.0-beta-23225" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="dotnet\*.cs" />
+  </ItemGroup>
+</Project>

--- a/demos/dotnet/dotnet/packages.txt
+++ b/demos/dotnet/dotnet/packages.txt
@@ -1,4 +1,0 @@
-+"Microsoft.Win32.Registry":"4.0.0-beta-23225"
-+"System.Diagnostics.Process":"4.0.0-beta-23225"
-+"System.IO.FileSystem":"4.0.1-beta-23225"
-+"System.Runtime.Extensions":"4.0.11-beta-23225"

--- a/demos/dotnet/dotnet/project.json
+++ b/demos/dotnet/dotnet/project.json
@@ -1,8 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.NetCore.Console": "1.0.0-beta-23321",
-    "Newtonsoft.Json": "7.0.1",
-    "System.IO.Compression": "4.0.1-beta-23321",
+    "System.IO.Compression": "4.0.1-beta-23321"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/demos/dotnet/dotnet/project.json
+++ b/demos/dotnet/dotnet/project.json
@@ -1,0 +1,13 @@
+﻿{
+  "dependencies": {
+    "Microsoft.NetCore.Console": "1.0.0-beta-23321",
+    "Newtonsoft.Json": "7.0.1",
+    "System.IO.Compression": "4.0.1-beta-23321",
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {}
+  }
+}

--- a/demos/dotnet/dotnet/references.txt
+++ b/demos/dotnet/dotnet/references.txt
@@ -1,6 +1,5 @@
 +System.Xml.ReaderWriter\4.0.10\ref\dotnet\System.Xml.ReaderWriter.dll
 +System.Collections\4.0.10\ref\dotnet\System.Collections.dll
-+Microsoft.Win32.Registry\4.0.0-beta-23225\ref\dotnet\Microsoft.Win32.Registry.dll
 +System.Net.Http\4.0.0\ref\dotnet\System.Net.Http.dll
 +System.IO\4.0.10\ref\dotnet\System.IO.dll
 +System.Diagnostics.Process\4.0.0-beta-23225\ref\dotnet\System.Diagnostics.Process.dll
@@ -18,3 +17,6 @@
 +System.Security.SecureString\4.0.0-beta-23225\ref\dotnet\System.Security.SecureString.dll
 +System.Globalization\4.0.10\ref\dotnet\System.Globalization.dll
 +System.Threading.ThreadPool\4.0.10-beta-23225\ref\dotnet\System.Threading.ThreadPool.dll
++System.Net.Primitives\4.0.10\ref\dotnet\System.Net.Primitives.dll
++System.Collections.NonGeneric\4.0.0\ref\dotnet\System.Collections.NonGeneric.dll
++System.Security.Cryptography.X509Certificates\4.0.0-beta-23225\ref\dotnet\System.Security.Cryptography.X509Certificates.dll


### PR DESCRIPTION
Removed support for packages.txt file (use packages listed in .dotnetproj file).
Added a new .csproj file which can be used to build against coreclr.
Removed the /edit command.