### PR TITLE
Removed the need for ID field in ByteSpan

### DIFF
--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -20,6 +20,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="System\Buffers\ArrayBufferPool.cs" />
     <Compile Include="System\Buffers\BufferPool.cs" />
     <Compile Include="System\ByteSpan.cs" />
     <Compile Include="System\Diagnostics\Precondition.cs" />

--- a/src/System.Buffers/src/System/Buffers/ArrayBufferPool.cs
+++ b/src/System.Buffers/src/System/Buffers/ArrayBufferPool.cs
@@ -1,0 +1,194 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace System.Buffers
+{
+    public class BufferPool
+    {
+        static BufferPool s_instance = new BufferPool(1024 * 1024);
+
+        int _maxBufferSize; // larger buffers won't be pooled
+        BufferBin[] _bins;
+
+        int _largeAllocationCounter; // performance counter for non-pooled allocations
+
+        private BufferPool(int maxBufferSize)
+        {
+            Precondition.Require(maxBufferSize > 0);
+
+            _maxBufferSize = maxBufferSize;
+
+            var maxSizeBin = SelectBinIndex(maxBufferSize);
+            _bins = new BufferBin[maxSizeBin + 1];
+
+            for (var binIndex = 0; binIndex < _bins.Length; binIndex++)
+            {
+                int maxSizeForBin = GetMaxSizeForBin(binIndex);
+                _bins[binIndex] = new BufferBin(maxSizeForBin, 10);
+            }
+        }
+
+        public byte[] RentBuffer(int minSize)
+        {
+            if (minSize > _maxBufferSize)
+            {
+                Interlocked.Increment(ref _largeAllocationCounter);
+                return new byte[minSize];
+            }
+            int poolIndex = SelectBinIndex(minSize);
+            byte[] buffer = _bins[poolIndex].RentBuffer();
+            return buffer;
+        }
+
+        public void ReturnBuffer(ref byte[] buffer)
+        {
+            int poolIndex = SelectBinIndex(buffer.Length);
+            if (poolIndex >= _bins.Length) // this happend if the returned buffer is a large buffer not managed by the pool
+            {
+                return;
+            }
+            _bins[poolIndex].ReturnBuffer(buffer);
+            buffer = null;
+        }
+
+        public void Enlarge(ref byte[] buffer, int newBufferMinSize)
+        {
+            var newBuffer = RentBuffer(newBufferMinSize);
+            buffer.CopyTo(newBuffer, 0);
+            ReturnBuffer(ref buffer);
+            buffer = newBuffer;
+        }
+
+        public long Allocations
+        {
+            get
+            {
+                long sum = 0;
+                foreach (var pool in _bins)
+                {
+                    sum += pool.Allocations;
+                }
+                return sum + _largeAllocationCounter;
+            }
+        }
+
+        public static BufferPool Shared
+        {
+            get
+            {
+                return s_instance;
+            }
+        }
+
+        private int SelectBinIndex(int bufferSize)
+        {
+            Precondition.Require(bufferSize > 0);
+            var _poolIndex = MaxBitIndexSet((ulong)bufferSize - 1) - 3;
+            if (_poolIndex < 0) return 0;
+            return _poolIndex;
+        }
+
+        private int GetMaxSizeForBin(int binIndex)
+        {
+            checked
+            {
+                int result = 2;
+                int shifts = binIndex + 3;
+                result <<= shifts;
+                return result;
+            }
+        }
+
+        private int MaxBitIndexSet(ulong value)
+        {
+            if (value == 0) return -1;
+            if (value == 1) return 0;
+            int bit = -1;
+            while (value > 0)
+            {
+                value >>= 1;
+                bit++;
+            }
+            return bit;
+        }
+    }
+
+    // stores buffers of equal size
+    public class BufferBin
+    {
+        int _bufferSize; // the size of buffers in this bin
+        int _capacity;
+        byte[][] _buffers;
+        int _top; // the array above is a stack. This filed is the top of the stack. Top points to the top most buffer
+
+        int _allocationCounter; // performance counter incremented when bin actually allocates a new buffer on the GC heap
+
+        public BufferBin(int bufferSize, int capacity)
+        {
+            _bufferSize = bufferSize;
+            _capacity = capacity;
+            _buffers = null;
+            _top = -1;
+            _allocationCounter = 0;
+        }
+
+        public byte[] RentBuffer()
+        {
+            if (_buffers == null)
+            {
+                var buffers = new byte[_capacity][];
+                Interlocked.CompareExchange(ref _buffers, buffers, null);
+            }
+            while (true)
+            {
+                int top = _top;
+                if (top == -1) // no buffers in the bin
+                {
+                    return Allocate();
+                }
+
+                var buffer = Interlocked.Exchange(ref _buffers[top], null);
+                if (buffer != null) // ok, I got a buffer
+                {
+                    // need to update _top
+                    var originalValue = Interlocked.CompareExchange(ref _top, top - 1, top);
+                    if (originalValue != top) // oops, somebody else changed _top
+                    {
+                        if (_buffers[top] == null) // moreover there is possibly a hole in the stack now
+                        {
+                            _buffers[top] = Allocate(); // we don't want to leave a hole
+                        }
+                    }
+                    return buffer;
+                }
+            }
+        }
+
+        public void ReturnBuffer(byte[] buffer)
+        {
+            if (buffer.Length != _bufferSize)
+            {
+                throw new InvalidOperationException("buffer does not belong to this pool or bin");
+            }
+
+            int top = _top;
+            if (top == _buffers.Length - 1) return; // no room in the pool; just drop the buffer on the GC; maybe a counter for this would be good
+
+            var candidateIndex = top + 1;
+            _buffers[candidateIndex] = buffer;
+            var originalValue = Interlocked.CompareExchange(ref _top, candidateIndex, top);
+        }
+
+        public int Allocations { get { return _allocationCounter; } }
+
+        byte[] Allocate()
+        {
+            Interlocked.Increment(ref _allocationCounter);
+            return new byte[_bufferSize];
+        }
+    }
+}

--- a/src/System.Buffers/src/System/Buffers/BufferPool.cs
+++ b/src/System.Buffers/src/System/Buffers/BufferPool.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -27,22 +26,31 @@ namespace System.Buffers
         {
             var freeIndex = Reserve();
             if (freeIndex == -1) {
-                throw new NotImplementedException();
+                throw new NotSupportedException("buffer resizing not supported");
             }
             var start = _bufferSizeInBytes * freeIndex;
-            return new ByteSpan(_memory + start, _bufferSizeInBytes, freeIndex);
+            return new ByteSpan(_memory + start, _bufferSizeInBytes);
+        }
+
+        public int BufferIndexFromSpanAddress(ref ByteSpan span)
+        {
+            var buffer = (ulong)span._data;
+            var firstBuffer = (ulong)_memory;
+            var offset = buffer - firstBuffer;
+            var index = offset / (ulong)_bufferSizeInBytes;
+            return (int)index;
         }
 
         public void Return(ref ByteSpan span)
         {
+            int spanIndex = BufferIndexFromSpanAddress(ref span);
             span._data = null;
-            if (Interlocked.CompareExchange(ref _freeList[span._id], 0, 1) != 1) {
+            if (Interlocked.CompareExchange(ref _freeList[spanIndex], 0, 1) != 1) {
                 throw new InvalidOperationException("this span has been already returned");
             }
-            if (span._id < _nextFree) {
-                _nextFree = span._id;
+            if (spanIndex < _nextFree) {
+                _nextFree = spanIndex;
             }
-            span._id = -1;
         }
 
         int Reserve()
@@ -70,191 +78,6 @@ namespace System.Buffers
             }
             Marshal.FreeHGlobal(new IntPtr(_memory));
             _memory = null;
-        }
-    }
-
-    public class BufferPool
-    {
-        static BufferPool s_instance = new BufferPool(1024 * 1024);
-
-        int _maxBufferSize; // larger buffers won't be pooled
-        BufferBin[] _bins;
-
-        int _largeAllocationCounter; // performance counter for non-pooled allocations
-
-        private BufferPool(int maxBufferSize)
-        {
-            Precondition.Require(maxBufferSize > 0);
-
-            _maxBufferSize = maxBufferSize;
-
-            var maxSizeBin = SelectBinIndex(maxBufferSize);
-            _bins = new BufferBin[maxSizeBin + 1];
-
-            for (var binIndex = 0; binIndex < _bins.Length; binIndex++)
-            {
-                int maxSizeForBin = GetMaxSizeForBin(binIndex);
-                _bins[binIndex] = new BufferBin(maxSizeForBin, 10);
-            }
-        }
-
-        public byte[] RentBuffer(int minSize)
-        {
-            if (minSize > _maxBufferSize)
-            {
-                Interlocked.Increment(ref _largeAllocationCounter);
-                return new byte[minSize];
-            }
-            int poolIndex = SelectBinIndex(minSize);
-            byte[] buffer = _bins[poolIndex].RentBuffer();
-            return buffer;
-        }
-
-        public void ReturnBuffer(ref byte[] buffer)
-        {
-            int poolIndex = SelectBinIndex(buffer.Length);
-            if (poolIndex >= _bins.Length) // this happend if the returned buffer is a large buffer not managed by the pool
-            {
-                return;
-            }
-            _bins[poolIndex].ReturnBuffer(buffer);
-            buffer = null;
-        }
-
-        public void Enlarge(ref byte[] buffer, int newBufferMinSize)
-        {
-            var newBuffer = RentBuffer(newBufferMinSize);
-            buffer.CopyTo(newBuffer, 0);
-            ReturnBuffer(ref buffer);
-            buffer = newBuffer;
-        }
-
-        public long Allocations
-        {
-            get
-            {
-                long sum = 0;
-                foreach (var pool in _bins)
-                {
-                    sum += pool.Allocations;
-                }
-                return sum + _largeAllocationCounter;
-            }
-        }
-
-        public static BufferPool Shared
-        {
-            get
-            {
-                return s_instance;
-            }
-        }
-
-        private int SelectBinIndex(int bufferSize)
-        {
-            Precondition.Require(bufferSize > 0);
-            var _poolIndex = MaxBitIndexSet((ulong)bufferSize - 1) - 3;
-            if (_poolIndex < 0) return 0;
-            return _poolIndex;
-        }
-
-        private int GetMaxSizeForBin(int binIndex)
-        {
-            checked
-            {
-                int result = 2;
-                int shifts = binIndex + 3;
-                result <<= shifts;
-                return result;
-            }
-        }
-
-        private int MaxBitIndexSet(ulong value)
-        {
-            if (value == 0) return -1;
-            if (value == 1) return 0;
-            int bit = -1;
-            while (value > 0)
-            {
-                value >>= 1;
-                bit++;
-            }
-            return bit;
-        }
-    }
-
-    // stores buffers of equal size
-    public class BufferBin
-    {
-        int _bufferSize; // the size of buffers in this bin
-        int _capacity;
-        byte[][] _buffers;
-        int _top; // the array above is a stack. This filed is the top of the stack. Top points to the top most buffer
-
-        int _allocationCounter; // performance counter incremented when bin actually allocates a new buffer on the GC heap
-
-        public BufferBin(int bufferSize, int capacity)
-        {
-            _bufferSize = bufferSize;
-            _capacity = capacity;
-            _buffers = null;
-            _top = -1;
-            _allocationCounter = 0;
-        }
-
-        public byte[] RentBuffer()
-        {
-            if (_buffers == null)
-            {
-                var buffers = new byte[_capacity][];
-                Interlocked.CompareExchange(ref _buffers, buffers, null);
-            }
-            while (true)
-            {
-                int top = _top;
-                if (top == -1) // no buffers in the bin
-                {
-                    return Allocate();
-                }
-
-                var buffer = Interlocked.Exchange(ref _buffers[top], null);
-                if (buffer != null) // ok, I got a buffer
-                {
-                    // need to update _top
-                    var originalValue = Interlocked.CompareExchange(ref _top, top - 1, top);
-                    if (originalValue != top) // oops, somebody else changed _top
-                    {
-                        if (_buffers[top] == null) // moreover there is possibly a hole in the stack now
-                        {
-                            _buffers[top] = Allocate(); // we don't want to leave a hole
-                        }
-                    }
-                    return buffer;
-                }
-            }
-        }
-
-        public void ReturnBuffer(byte[] buffer)
-        {
-            if(buffer.Length != _bufferSize)
-            {
-                throw new InvalidOperationException("buffer does not belong to this pool or bin");
-            }
-
-            int top = _top;
-            if (top == _buffers.Length - 1) return; // no room in the pool; just drop the buffer on the GC; maybe a counter for this would be good
-
-            var candidateIndex = top + 1;
-            _buffers[candidateIndex] = buffer;
-            var originalValue = Interlocked.CompareExchange(ref _top, candidateIndex, top);
-        }
-
-        public int Allocations { get { return _allocationCounter; } }
-
-        byte[] Allocate()
-        {
-            Interlocked.Increment(ref _allocationCounter);
-            return new byte[_bufferSize];
         }
     }
 }

--- a/src/System.Buffers/src/System/ByteSpan.cs
+++ b/src/System.Buffers/src/System/ByteSpan.cs
@@ -9,12 +9,10 @@ namespace System {
     public unsafe struct ByteSpan {
         internal byte* _data;
         internal int _length;
-        internal int _id;
 
         [CLSCompliant(false)]
-        public ByteSpan(byte* data, int length, int id = -1)
+        public ByteSpan(byte* data, int length)
         {
-            _id = id;
             _data = data;
             _length = length;
         }
@@ -63,7 +61,7 @@ namespace System {
 
             var data = _data + index;
             var length = _length - index;
-            return new ByteSpan(data, length, -1);
+            return new ByteSpan(data, length);
         }
 
         public ByteSpan Slice(int index, int count)
@@ -71,7 +69,7 @@ namespace System {
             Precondition.Require(index + count < Length);
 
             var data = _data + index;
-            return new ByteSpan(data, count, -1);
+            return new ByteSpan(data, count);
         }
     }
 }

--- a/src/System.Buffers/src/System/Span.cs
+++ b/src/System.Buffers/src/System/Span.cs
@@ -193,7 +193,7 @@ namespace System
         {
             handle = GCHandle.Alloc(source._array, GCHandleType.Pinned);
             var pinned = handle.AddrOfPinnedObject() + source._index;
-            var byteSpan = new ByteSpan(((byte*)pinned.ToPointer()), source._length, -1);
+            var byteSpan = new ByteSpan(((byte*)pinned.ToPointer()), source._length);
             return byteSpan;
         }
     }


### PR DESCRIPTION
The field was used to identify the location of the span in a buffer pool
This change removes the field and now the location is computed using memory addresses.

Also, I split the BufferPool.cs file into two: one for native pool and the other for array pool. The code in the new file (ArrayBufferPool.cs) is just copy paste (no changes) from the original file.