### PR TITLE
Optimized allocations when disposing UVStream

### DIFF
--- a/demos/LibuvWithNonAllocatingFormatters/sample/Program.cs
+++ b/demos/LibuvWithNonAllocatingFormatters/sample/Program.cs
@@ -12,7 +12,7 @@ static class Program
     {
         Console.WriteLine("browse to http://localhost:8080");
 
-        bool log = true;
+        bool log = false;
         if (args.Length > 0 && args[0] == "/log")
         {
             log = true;

--- a/demos/LibuvWithNonAllocatingFormatters/sample/Sample.csproj
+++ b/demos/LibuvWithNonAllocatingFormatters/sample/Sample.csproj
@@ -34,6 +34,8 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/demos/LibuvWithNonAllocatingFormatters/src/System.Net.Libuv.csproj
+++ b/demos/LibuvWithNonAllocatingFormatters/src/System.Net.Libuv.csproj
@@ -33,6 +33,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/demos/LibuvWithNonAllocatingFormatters/src/System/Net/Libuv/Handle.cs
+++ b/demos/LibuvWithNonAllocatingFormatters/src/System/Net/Libuv/Handle.cs
@@ -50,7 +50,7 @@ namespace System.Net.Libuv
             GC.SuppressFinalize(this);
         }
 
-        protected virtual void Dispose(bool disposing)
+        public virtual void Dispose(bool disposing)
         {
             if (!IsDisposing && !IsDisposed)
             {

--- a/demos/LibuvWithNonAllocatingFormatters/src/System/Net/Libuv/Stream.cs
+++ b/demos/LibuvWithNonAllocatingFormatters/src/System/Net/Libuv/Stream.cs
@@ -164,16 +164,10 @@ namespace System.Net.Libuv
             }
         }
 
-        protected override void Dispose(bool disposing)
+        public override void Dispose(bool disposing)
         {
             EnsureNotDisposed();
-
-            var request = new CallbackRequest(RequestType.UV_SHUTDOWN);
-            request.Callback = (status) =>
-            {
-                base.Dispose(disposing);
-            };
-            UVInterop.uv_shutdown(request.Handle, Handle, CallbackRequest.CallbackDelegate);
+            var request = new DisposeRequest(this);
         }
     }
 }


### PR DESCRIPTION
The change elimizates Action<int> and display class allocations.