### PR TITLE
Fix some analysis warnings in Channels

### DIFF
--- a/src/System.Threading.Tasks.Channels/README.md
+++ b/src/System.Threading.Tasks.Channels/README.md
@@ -15,7 +15,7 @@ combination of a few other interfaces that represent the reading and writing hal
 ```C#
 public interface IChannel<T> : IChannel<T, T> { }
 
-public interface IChannel<TInput, TOutput> : IWriteableChannel<TInput>, IReadableChannel<TOutput> { }
+public interface IChannel<TInput, TOutput> : IWritableChannel<TInput>, IReadableChannel<TOutput> { }
 
 public interface IReadableChannel<T>
 {
@@ -25,7 +25,7 @@ public interface IReadableChannel<T>
     Task Completion { get; }
 }
 
-public interface IWriteableChannel<in T>
+public interface IWritableChannel<in T>
 {
     bool TryWrite(T item);
     Task WriteAsync(T item, CancellationToken cancellationToken = default(CancellationToken));
@@ -33,7 +33,7 @@ public interface IWriteableChannel<in T>
     void Complete(Exception error = null);
 }
 ```
-The ```IReadableChannel<T>``` and ```IWriteableChannel<T>``` types represent these two halves,
+The ```IReadableChannel<T>``` and ```IWritableChannel<T>``` types represent these two halves,
 with the former allowing data to be read from it and the latter allowing data to be written to it.
 The interfaces mirror each other, with operations exposed on each that are counterparts of those
 on the other:
@@ -80,7 +80,7 @@ Several additional channel types are provided to highlight the kinds of things t
 public static class Channel
 {
     public static IReadableChannel<T> ReadFromStream<T>(Stream source);
-    public static IWriteableChannel<T> WriteToStream<T>(Stream destination);
+    public static IWritableChannel<T> WriteToStream<T>(Stream destination);
 	...
 }
 ```
@@ -108,7 +108,7 @@ pushes the enumerator forward.
 public static class Channel
 {
     public static IObservable<T> AsObservable<T>(this IReadableChannel<T> source);
-    public static IObserver<T> AsObserver<T>(this IWriteableChannel<T> target);
+    public static IObserver<T> AsObserver<T>(this IWritableChannel<T> target);
 	...
 }
 ```
@@ -169,8 +169,8 @@ public static class Channel
 {
     public static CaseBuilder CaseRead<T>(IReadableChannel<T> channel, Action<T> action);
     public static CaseBuilder CaseRead<T>(IReadableChannel<T> channel, Func<T, Task> func);
-    public static CaseBuilder CaseWrite<T>(IWriteableChannel<T> channel, T item, Action action);
-    public static CaseBuilder CaseWrite<T>(IWriteableChannel<T> channel, T item, Func<Task> func);
+    public static CaseBuilder CaseWrite<T>(IWritableChannel<T> channel, T item, Action action);
+    public static CaseBuilder CaseWrite<T>(IWritableChannel<T> channel, T item, Func<Task> func);
 	...
 }
 ```
@@ -181,8 +181,8 @@ public sealed class CaseBuilder
     public CaseBuilder CaseRead<T>(IReadableChannel<T> channel, Action<T> action)
     public CaseBuilder CaseRead<T>(IReadableChannel<T> channel, Func<T, Task> func)
 
-    public CaseBuilder CaseWrite<T>(IWriteableChannel<T> channel, T item, Action action)
-    public CaseBuilder CaseWrite<T>(IWriteableChannel<T> channel, T item, Func<Task> func)
+    public CaseBuilder CaseWrite<T>(IWritableChannel<T> channel, T item, Action action)
+    public CaseBuilder CaseWrite<T>(IWritableChannel<T> channel, T item, Func<Task> func)
 
     public CaseBuilder CaseDefault(Action action)
     public CaseBuilder CaseDefault(Func<Task> func)
@@ -238,5 +238,5 @@ consumption models.
 If these Channel interfaces were to become part of corefx, System.Threading.Tasks.Dataflow would likely take a dependency on 
 System.Threading.Tasks.Channels as a lower-level set of abstractions, and several of the blocks in System.Threading.Tasks.Dataflow 
 would likely be modified to implement them as well, enabling direct integration between the libraries.  For example, ```BufferBlock<T>``` 
-would  likely implement ```IChannel<T>```, ```ActionBlock<T>``` would likely implement ```IWriteableChannel<T>```, 
+would  likely implement ```IChannel<T>```, ```ActionBlock<T>``` would likely implement ```IWritableChannel<T>```, 
 ```TransformBlock<TInput,TOutput>``` would likely implement ```IChannel<TInput, TOutput>```, etc.

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.BoundedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.BoundedChannel.cs
@@ -119,7 +119,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public ValueTask<T> ReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public ValueTask<T> ReadAsync(CancellationToken cancellationToken)
             {
                 // Fast-path cancellation check
                 if (cancellationToken.IsCancellationRequested)
@@ -149,7 +149,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public Task<bool> WaitToReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public Task<bool> WaitToReadAsync(CancellationToken cancellationToken)
             {
                 if (cancellationToken.IsCancellationRequested)
                     return Task.FromCanceled<bool>(cancellationToken);
@@ -271,7 +271,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public Task<bool> WaitToWriteAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public Task<bool> WaitToWriteAsync(CancellationToken cancellationToken)
             {
                 if (cancellationToken.IsCancellationRequested)
                     return Task.FromCanceled<bool>(cancellationToken);
@@ -298,7 +298,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public Task WriteAsync(T item, CancellationToken cancellationToken = default(CancellationToken))
+            public Task WriteAsync(T item, CancellationToken cancellationToken)
             {
                 if (cancellationToken.IsCancellationRequested)
                     return Task.FromCanceled(cancellationToken);

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.CaseBuilder.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.CaseBuilder.cs
@@ -66,7 +66,7 @@ namespace System.Threading.Tasks.Channels
             /// <param name="item">The data to write to the channel.</param>
             /// <param name="action">The synchronous action to invoke once the write is successful.</param>
             /// <returns>This builder.</returns>
-            public CaseBuilder CaseWrite<T>(IWriteableChannel<T> channel, T item, Action action)
+            public CaseBuilder CaseWrite<T>(IWritableChannel<T> channel, T item, Action action)
             {
                 if (channel == null)
                     throw new ArgumentNullException("channel");
@@ -85,7 +85,7 @@ namespace System.Threading.Tasks.Channels
             /// <param name="item">The data to write to the channel.</param>
             /// <param name="func">The asynchronous function to invoke once the write is successful.</param>
             /// <returns>This builder.</returns>
-            public CaseBuilder CaseWrite<T>(IWriteableChannel<T> channel, T item, Func<Task> func)
+            public CaseBuilder CaseWrite<T>(IWritableChannel<T> channel, T item, Func<Task> func)
             {
                 if (channel == null)
                     throw new ArgumentNullException("channel");
@@ -360,11 +360,11 @@ namespace System.Threading.Tasks.Channels
             /// <summary>Provides the concrete case used for channel writes with synchronous processing.</summary>
             private sealed class SyncWriteCase<T> : Case
             {
-                private readonly IWriteableChannel<T> _channel;
+                private readonly IWritableChannel<T> _channel;
                 private readonly T _item;
                 private readonly Action _action;
 
-                internal SyncWriteCase(IWriteableChannel<T> channel, T item, Action action)
+                internal SyncWriteCase(IWritableChannel<T> channel, T item, Action action)
                 {
                     _channel = channel;
                     _item = item;
@@ -397,11 +397,11 @@ namespace System.Threading.Tasks.Channels
             /// <summary>Provides the concrete case used for channel writes with asynchronous processing.</summary>
             private sealed class AsyncWriteCase<T> : Case
             {
-                private readonly IWriteableChannel<T> _channel;
+                private readonly IWritableChannel<T> _channel;
                 private readonly T _item;
                 private readonly Func<Task> _action;
 
-                internal AsyncWriteCase(IWriteableChannel<T> channel, T item, Func<Task> action)
+                internal AsyncWriteCase(IWritableChannel<T> channel, T item, Func<Task> action)
                 {
                     _channel = channel;
                     _item = item;

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.CaseBuilder.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.CaseBuilder.cs
@@ -149,7 +149,7 @@ namespace System.Threading.Tasks.Channels
             }
 
             /// <summary>Core of the SelectUntilAsync operation.</summary>
-            private async Task<int> SelectUntilAsyncCore(Func<int, bool> condition, CancellationToken cancellationToken = default(CancellationToken))
+            private async Task<int> SelectUntilAsyncCore(Func<int, bool> condition, CancellationToken cancellationToken)
             {
                 // TODO: This can be optimized further, by reusing WaitForReadAsync tasks across iterations
                 // rather than getting a new one per iteration, by processing multiple completed-as-true WaitForReadTasks
@@ -214,7 +214,7 @@ namespace System.Threading.Tasks.Channels
             }
 
             /// <summary>Core of the SelectAsync operation.</summary>
-            private async Task<bool> SelectAsyncCore(CancellationToken cancellationToken = default(CancellationToken))
+            private async Task<bool> SelectAsyncCore(CancellationToken cancellationToken)
             {
                 // Loop until cancellation occurs or a case is available
                 Task<bool>[] tasks = new Task<bool>[_cases.Count];

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.EnumerableChannel.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.EnumerableChannel.cs
@@ -28,7 +28,7 @@ namespace System.Threading.Tasks.Channels
 
             public Task Completion { get { return _completion.Task; } }
 
-            public ValueTask<T> ReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public ValueTask<T> ReadAsync(CancellationToken cancellationToken)
             {
                 // Fast-path cancellation check
                 if (cancellationToken.IsCancellationRequested)
@@ -68,7 +68,7 @@ namespace System.Threading.Tasks.Channels
                 return false;
             }
 
-            public Task<bool> WaitToReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public Task<bool> WaitToReadAsync(CancellationToken cancellationToken)
             {
                 // Fast-path cancellation check
                 if (cancellationToken.IsCancellationRequested)

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.Observable.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.Observable.cs
@@ -11,9 +11,9 @@ namespace System.Threading.Tasks.Channels
         /// <summary>Provides an observer for a writeable channel.</summary>
         private sealed class ChannelObserver<T> : IObserver<T>
         {
-            private readonly IWriteableChannel<T> _channel;
+            private readonly IWritableChannel<T> _channel;
 
-            internal ChannelObserver(IWriteableChannel<T> channel)
+            internal ChannelObserver(IWritableChannel<T> channel)
             {
                 Debug.Assert(channel != null);
                 _channel = channel;

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.SerializationChannel.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.SerializationChannel.cs
@@ -15,7 +15,7 @@ namespace System.Threading.Tasks.Channels
     public static partial class Channel
     {
         /// <summary>Provides a channel for serializing data to a stream.</summary>
-        private sealed class SerializationChannel<T> : IWriteableChannel<T>
+        private sealed class SerializationChannel<T> : IWritableChannel<T>
         {
             /// <summary>The writer to which data is written.</summary>
             private readonly BinaryWriter _destination;

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.SerializationChannel.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.SerializationChannel.cs
@@ -71,7 +71,7 @@ namespace System.Threading.Tasks.Channels
                 return true;
             }
 
-            public Task<bool> WaitToWriteAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public Task<bool> WaitToWriteAsync(CancellationToken cancellationToken)
             {
                 // We assume we can always write to the stream (unless we're already canceled).
                 return 
@@ -80,7 +80,7 @@ namespace System.Threading.Tasks.Channels
                     s_trueTask;
             }
 
-            public Task WriteAsync(T item, CancellationToken cancellationToken = default(CancellationToken))
+            public Task WriteAsync(T item, CancellationToken cancellationToken)
             {
                 // Fast-path cancellation check
                 if (cancellationToken.IsCancellationRequested)
@@ -122,7 +122,7 @@ namespace System.Threading.Tasks.Channels
 
             public Task Completion { get { return _completion.Task; } }
 
-            public ValueTask<T> ReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public ValueTask<T> ReadAsync(CancellationToken cancellationToken)
             {
                 // Fast-path cancellation check
                 if (cancellationToken.IsCancellationRequested)
@@ -192,7 +192,7 @@ namespace System.Threading.Tasks.Channels
                 return false;
             }
 
-            public Task<bool> WaitToReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public Task<bool> WaitToReadAsync(CancellationToken cancellationToken)
             {
                 if (cancellationToken.IsCancellationRequested)
                     return Task.FromCanceled<bool>(cancellationToken);

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.SpscUnboundedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.SpscUnboundedChannel.cs
@@ -50,7 +50,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public ValueTask<T> ReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public ValueTask<T> ReadAsync(CancellationToken cancellationToken)
             {
                 T item;
                 if (TryRead(out item))
@@ -59,7 +59,7 @@ namespace System.Threading.Tasks.Channels
                 return ReadAsyncCore(cancellationToken);
             }
 
-            private ValueTask<T> ReadAsyncCore(CancellationToken cancellationToken = default(CancellationToken))
+            private ValueTask<T> ReadAsyncCore(CancellationToken cancellationToken)
             {
                 lock (SyncObj)
                 {
@@ -135,7 +135,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public Task<bool> WaitToReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public Task<bool> WaitToReadAsync(CancellationToken cancellationToken)
             {
                 var spinner = default(SpinWait);
                 do
@@ -169,7 +169,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public Task<bool> WaitToWriteAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public Task<bool> WaitToWriteAsync(CancellationToken cancellationToken)
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
@@ -183,7 +183,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public Task WriteAsync(T item, CancellationToken cancellationToken = default(CancellationToken))
+            public Task WriteAsync(T item, CancellationToken cancellationToken)
             {
                 // Writing always succeeds (unless we've already completed writing or cancellation has been requested),
                 // so just TryWrite and return a completed task.

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.TaskChannel.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.TaskChannel.cs
@@ -45,7 +45,7 @@ namespace System.Threading.Tasks.Channels
 
             public Task Completion { get { return _completion.Task; } }
 
-            public ValueTask<T> ReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public ValueTask<T> ReadAsync(CancellationToken cancellationToken)
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
@@ -86,7 +86,7 @@ namespace System.Threading.Tasks.Channels
                 return false;
             }
 
-            public Task<bool> WaitToReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public Task<bool> WaitToReadAsync(CancellationToken cancellationToken)
             {
                 if (cancellationToken.IsCancellationRequested)
                 {

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.UnboundedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.UnboundedChannel.cs
@@ -82,7 +82,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public ValueTask<T> ReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public ValueTask<T> ReadAsync(CancellationToken cancellationToken)
             {
                 T item;
                 if (TryRead(out item))
@@ -91,7 +91,7 @@ namespace System.Threading.Tasks.Channels
                 return ReadAsyncCore(cancellationToken);
             }
 
-            public ValueTask<T> ReadAsyncCore(CancellationToken cancellationToken = default(CancellationToken))
+            public ValueTask<T> ReadAsyncCore(CancellationToken cancellationToken)
             {
                 if (cancellationToken.IsCancellationRequested)
                     return Task.FromCanceled<T>(cancellationToken);
@@ -125,7 +125,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public Task<bool> WaitToReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public Task<bool> WaitToReadAsync(CancellationToken cancellationToken)
             {
                 lock (SyncObj)
                 {
@@ -207,7 +207,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public Task<bool> WaitToWriteAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public Task<bool> WaitToWriteAsync(CancellationToken cancellationToken)
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
@@ -221,7 +221,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public Task WriteAsync(T item, CancellationToken cancellationToken = default(CancellationToken))
+            public Task WriteAsync(T item, CancellationToken cancellationToken)
             {
                 // Writing always succeeds (unless we've already completed writing or cancellation has been requested),
                 // so just TryWrite and return a completed task.

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.UnbufferedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.UnbufferedChannel.cs
@@ -80,7 +80,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public ValueTask<T> ReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public ValueTask<T> ReadAsync(CancellationToken cancellationToken)
             {
                 T item;
                 if (TryRead(out item))
@@ -89,7 +89,7 @@ namespace System.Threading.Tasks.Channels
                 return ReadAsyncCore(cancellationToken);
             }
 
-            private ValueTask<T> ReadAsyncCore(CancellationToken cancellationToken = default(CancellationToken))
+            private ValueTask<T> ReadAsyncCore(CancellationToken cancellationToken)
             {
                 if (cancellationToken.IsCancellationRequested)
                     return Task.FromCanceled<T>(cancellationToken);
@@ -171,7 +171,7 @@ namespace System.Threading.Tasks.Channels
                 return false;
             }
 
-            public Task WriteAsync(T item, CancellationToken cancellationToken = default(CancellationToken))
+            public Task WriteAsync(T item, CancellationToken cancellationToken)
             {
                 if (cancellationToken.IsCancellationRequested)
                     return Task.FromCanceled(cancellationToken);
@@ -206,7 +206,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public Task<bool> WaitToReadAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public Task<bool> WaitToReadAsync(CancellationToken cancellationToken)
             {
                 lock (SyncObj)
                 {
@@ -229,7 +229,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public Task<bool> WaitToWriteAsync(CancellationToken cancellationToken = default(CancellationToken))
+            public Task<bool> WaitToWriteAsync(CancellationToken cancellationToken)
             {
                 lock (SyncObj)
                 {

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.cs
@@ -68,7 +68,7 @@ namespace System.Threading.Tasks.Channels
         /// <typeparam name="T">Specifies the type of data to be written.  This must be an unmanaged/primitive type.</typeparam>
         /// <param name="destination">The destination stream to which to write data.</param>
         /// <returns>A channel that write elements to the destination stream.</returns>
-        public static IWriteableChannel<T> WriteToStream<T>(Stream destination)
+        public static IWritableChannel<T> WriteToStream<T>(Stream destination)
         {
             if (destination == null)
                 throw new ArgumentNullException("destination");
@@ -123,7 +123,7 @@ namespace System.Threading.Tasks.Channels
         /// <typeparam name="T">Specifies the type of data in the channel.</typeparam>
         /// <param name="target">The channel to be treated as an observer.</param>
         /// <returns>An observer that forwards to the specified channel.</returns>
-        public static IObserver<T> AsObserver<T>(this IWriteableChannel<T> target)
+        public static IObserver<T> AsObserver<T>(this IWritableChannel<T> target)
         {
             if (target == null)
                 throw new ArgumentNullException("target");
@@ -185,7 +185,7 @@ namespace System.Threading.Tasks.Channels
         /// <param name="item">The data to write to the channel</param>
         /// <param name="action">The action to invoke after the data has been written.</param>
         /// <returns>This builder.</returns>
-        public static CaseBuilder CaseWrite<T>(IWriteableChannel<T> channel, T item, Action action)
+        public static CaseBuilder CaseWrite<T>(IWritableChannel<T> channel, T item, Action action)
         {
             return new CaseBuilder().CaseWrite(channel, item, action);
         }
@@ -196,7 +196,7 @@ namespace System.Threading.Tasks.Channels
         /// <param name="item">The data to write to the channel</param>
         /// <param name="func">The asynchronous function to invoke after the data has been written.</param>
         /// <returns>This builder.</returns>
-        public static CaseBuilder CaseWrite<T>(IWriteableChannel<T> channel, T item, Func<Task> func)
+        public static CaseBuilder CaseWrite<T>(IWritableChannel<T> channel, T item, Func<Task> func)
         {
             return new CaseBuilder().CaseWrite(channel, item, func);
         }

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/IChannel.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/IChannel.cs
@@ -12,7 +12,7 @@ namespace System.Threading.Tasks.Channels
     /// <summary>Represents a channel to and from which data can be written and read.</summary>
     /// <typeparam name="TInput">Specifies the type of data items writable to the channel.</typeparam>
     /// <typeparam name="TOutput">Specifies the type of data items readable from the channel.</typeparam>
-    public interface IChannel<TInput, TOutput> : IWriteableChannel<TInput>, IReadableChannel<TOutput>
+    public interface IChannel<TInput, TOutput> : IWritableChannel<TInput>, IReadableChannel<TOutput>
     {
     }
 
@@ -41,7 +41,7 @@ namespace System.Threading.Tasks.Channels
 
     /// <summary>Represents a channel to which data can be written.</summary>
     /// <typeparam name="T">Specifies the type of data items writable to the channel.</typeparam>
-    public interface IWriteableChannel<in T>
+    public interface IWritableChannel<in T>
     {
         /// <summary>Asynchronously writes a data item to the channel.</summary>
         /// <param name="item">The item to write.</param>

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/ValueTask.cs
@@ -9,7 +9,7 @@ namespace System.Threading.Tasks
     /// <summary>Value type discriminated union for a TResult and a <see cref="Task{TResult}"/>.</summary>
     /// <typeparam name="TResult">The type of the result.</typeparam>
     [DebuggerDisplay("Status = {DebuggerStatus}, Result = {DebuggerResult}")]
-    public struct ValueTask<TResult>
+    public struct ValueTask<TResult> : IEquatable<ValueTask<TResult>>
     {
         /// <summary>The task. this will be non-null iff the operation didn't complete successfully synchronously.</summary>
         private readonly Task<TResult> _task;
@@ -46,6 +46,53 @@ namespace System.Threading.Tasks
         public static implicit operator ValueTask<TResult>(TResult result)
         {
             return new ValueTask<TResult>(result);
+        }
+
+        /// <summary>Returns the hash code for this instance.</summary>
+        public override int GetHashCode()
+        {
+            return
+                _task != null ? _task.GetHashCode() :
+                _result != null ? _result.GetHashCode() :
+                0;
+        }
+
+        /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="object"/>.</summary>
+        public override bool Equals(object obj)
+        {
+            return 
+                obj is ValueTask<TResult> && 
+                Equals((ValueTask<TResult>)obj);
+        }
+
+        /// <summary>Returns a value indicating whether this value is equal to a specified <see cref="ValueTask{TResult}"/> value.</summary>
+        public bool Equals(ValueTask<TResult> other)
+        {
+            if (_task == null && other._task == null)
+            {
+                if (_result == null)
+                {
+                    return other._result == null;
+                }
+                else
+                {
+                    return other._result != null && _result.Equals(other._result);
+                }
+            }
+
+            return _task == other._task;
+        }
+
+        /// <summary>Returns a value indicating whether two <see cref="ValueTask{TResult}"/> values are equal.</summary>
+        public static bool operator==(ValueTask<TResult> left, ValueTask<TResult> right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>Returns a value indicating whether two <see cref="ValueTask{TResult}"/> values are not equal.</summary>
+        public static bool operator!=(ValueTask<TResult> left, ValueTask<TResult> right)
+        {
+            return !left.Equals(right);
         }
 
         /// <summary>

--- a/src/System.Threading.Tasks.Channels/tests/SerializationChannelTests.cs
+++ b/src/System.Threading.Tasks.Channels/tests/SerializationChannelTests.cs
@@ -36,7 +36,7 @@ namespace System.Threading.Tasks.Channels.Tests
             using (AnonymousPipeServerStream serverPipe = new AnonymousPipeServerStream(PipeDirection.Out))
             using (AnonymousPipeClientStream clientPipe = new AnonymousPipeClientStream(PipeDirection.In, serverPipe.ClientSafePipeHandle))
             {
-                IWriteableChannel<T> writer = Channel.WriteToStream<T>(serverPipe);
+                IWritableChannel<T> writer = Channel.WriteToStream<T>(serverPipe);
                 IReadableChannel<T> reader = Channel.ReadFromStream<T>(clientPipe);
 
                 for (int i = 0; i < numItems; i++)
@@ -63,7 +63,7 @@ namespace System.Threading.Tasks.Channels.Tests
         {
             using (AnonymousPipeServerStream serverPipe = new AnonymousPipeServerStream(PipeDirection.Out))
             {
-                IWriteableChannel<int> writer = Channel.WriteToStream<int>(serverPipe);
+                IWritableChannel<int> writer = Channel.WriteToStream<int>(serverPipe);
                 AssertSynchronousTrue(writer.WaitToWriteAsync());
 
                 writer.Complete();
@@ -78,7 +78,7 @@ namespace System.Threading.Tasks.Channels.Tests
         [Fact]
         public void WriteToStream_Precancellation()
         {
-            IWriteableChannel<int> w = Channel.WriteToStream<int>(new MemoryStream());
+            IWritableChannel<int> w = Channel.WriteToStream<int>(new MemoryStream());
             var cts = new CancellationTokenSource();
             cts.Cancel();
             AssertSynchronouslyCanceled(w.WaitToWriteAsync(cts.Token), cts.Token);
@@ -101,7 +101,7 @@ namespace System.Threading.Tasks.Channels.Tests
             using (AnonymousPipeServerStream serverPipe = new AnonymousPipeServerStream(PipeDirection.Out))
             using (AnonymousPipeClientStream clientPipe = new AnonymousPipeClientStream(PipeDirection.In, serverPipe.ClientSafePipeHandle))
             {
-                IWriteableChannel<int> writer = Channel.WriteToStream<int>(serverPipe);
+                IWritableChannel<int> writer = Channel.WriteToStream<int>(serverPipe);
                 IReadableChannel<int> reader = Channel.ReadFromStream<int>(clientPipe);
 
                 Task.WaitAll(
@@ -132,7 +132,7 @@ namespace System.Threading.Tasks.Channels.Tests
             using (AnonymousPipeServerStream serverPipe = new AnonymousPipeServerStream(PipeDirection.Out))
             using (AnonymousPipeClientStream clientPipe = new AnonymousPipeClientStream(PipeDirection.In, serverPipe.ClientSafePipeHandle))
             {
-                IWriteableChannel<int> writer = Channel.WriteToStream<int>(serverPipe);
+                IWritableChannel<int> writer = Channel.WriteToStream<int>(serverPipe);
                 IReadableChannel<int> reader = Channel.ReadFromStream<int>(clientPipe);
 
                 Task.WaitAll(

--- a/src/System.Threading.Tasks.Channels/tests/ValueTaskTests.cs
+++ b/src/System.Threading.Tasks.Channels/tests/ValueTaskTests.cs
@@ -123,5 +123,94 @@ namespace System.Threading.Tasks.Channels.Tests
             t.GetAwaiter().OnCompleted(() => mres.Set());
             Assert.True(mres.Wait(10000));
         }
+
+        [Fact]
+        public void GetHashCode_ContainsResult()
+        {
+            ValueTask<int> t = 42;
+            Assert.Equal(42, t.GetHashCode());
+        }
+
+        [Fact]
+        public void GetHashCode_ContainsTask()
+        {
+            ValueTask<string> t = Task.FromResult("42");
+            Assert.NotEqual(0, t.GetHashCode());
+        }
+
+        [Fact]
+        public void GetHashCode_ContainsNull()
+        {
+            ValueTask<string> t = (string)null;
+            Assert.Equal(0, t.GetHashCode());
+        }
+
+        [Fact]
+        public void OperatorEquals()
+        {
+            Assert.True((ValueTask<int>)42 == (ValueTask<int>)42);
+            Assert.False((ValueTask<int>)42 == (ValueTask<int>)43);
+
+            Assert.True((ValueTask<string>)"42" == (ValueTask<string>)"42");
+            Assert.True((ValueTask<string>)(string)null == (ValueTask<string>)(string)null);
+
+            Assert.False((ValueTask<string>)"42" == (ValueTask<string>)(string)null);
+            Assert.False((ValueTask<string>)(string)null == (ValueTask<string>)"42");
+
+            Assert.False((ValueTask<int>)42 == (ValueTask<int>)Task.FromResult(42));
+            Assert.False((ValueTask<int>)Task.FromResult(42) == (ValueTask<int>)42);
+        }
+
+        [Fact]
+        public void OperatorNotEquals()
+        {
+            Assert.False((ValueTask<int>)42 != (ValueTask<int>)42);
+            Assert.True((ValueTask<int>)42 != (ValueTask<int>)43);
+
+            Assert.False((ValueTask<string>)"42" != (ValueTask<string>)"42");
+            Assert.False((ValueTask<string>)(string)null != (ValueTask<string>)(string)null);
+
+            Assert.True((ValueTask<string>)"42" != (ValueTask<string>)(string)null);
+            Assert.True((ValueTask<string>)(string)null != (ValueTask<string>)"42");
+
+            Assert.True((ValueTask<int>)42 != (ValueTask<int>)Task.FromResult(42));
+            Assert.True((ValueTask<int>)Task.FromResult(42) != (ValueTask<int>)42);
+        }
+
+        [Fact]
+        public void Equals_ValueTask()
+        {
+            Assert.True(((ValueTask<int>)42).Equals((ValueTask<int>)42));
+            Assert.False(((ValueTask<int>)42).Equals((ValueTask<int>)43));
+
+            Assert.True(((ValueTask<string>)"42").Equals((ValueTask<string>)"42"));
+            Assert.True(((ValueTask<string>)(string)null).Equals((ValueTask<string>)(string)null));
+
+            Assert.False(((ValueTask<string>)"42").Equals((ValueTask<string>)(string)null));
+            Assert.False(((ValueTask<string>)(string)null).Equals((ValueTask<string>)"42"));
+
+            Assert.False(((ValueTask<int>)42).Equals((ValueTask<int>)Task.FromResult(42)));
+            Assert.False(((ValueTask<int>)Task.FromResult(42)).Equals((ValueTask<int>)42));
+        }
+
+        [Fact]
+        public void Equals_Object()
+        {
+            Assert.True(((ValueTask<int>)42).Equals((object)(ValueTask<int>)42));
+            Assert.False(((ValueTask<int>)42).Equals((object)(ValueTask<int>)43));
+
+            Assert.True(((ValueTask<string>)"42").Equals((object)(ValueTask<string>)"42"));
+            Assert.True(((ValueTask<string>)(string)null).Equals((object)(ValueTask<string>)(string)null));
+
+            Assert.False(((ValueTask<string>)"42").Equals((object)(ValueTask<string>)(string)null));
+            Assert.False(((ValueTask<string>)(string)null).Equals((object)(ValueTask<string>)"42"));
+
+            Assert.False(((ValueTask<int>)42).Equals((object)(ValueTask<int>)Task.FromResult(42)));
+            Assert.False(((ValueTask<int>)Task.FromResult(42)).Equals((object)(ValueTask<int>)42));
+
+            Assert.False(((ValueTask<int>)42).Equals((object)null));
+            Assert.False(((ValueTask<int>)42).Equals(new object()));
+            Assert.False(((ValueTask<int>)42).Equals((object)42));
+        }
     }
 }


### PR DESCRIPTION
Fix a few warnings generated by running code analysis on the System.Threading.Tasks.Channels library.