### PR TITLE
Address more PR feedback on System.Threading.Tasks.Channels

### DIFF
--- a/src/System.Threading.Tasks.Channels/README.md
+++ b/src/System.Threading.Tasks.Channels/README.md
@@ -48,6 +48,13 @@ marked as completed and all existing data in the channel has been consumed.  Cha
 an optional ```Exception``` to Complete; this exception will emerge when awaiting on the Completion Task, as well as when trying
 to ```ReadAsync``` from an empty completed collection.
 
+```ReadAsync``` is defined to return a ```ValueTask<T>```, a new struct type included in this library.  ```ValueTask<T>``` is a discriminated 
+union of a ```T``` and a ```Task<T>```, making it allocation-free for ```ReadAsync<T>``` to synchronously return a ```T``` value it has 
+available (in contrast to using ```Task.FromResult<T>```, which needs to allocate a ```Task<T>``` instance).   ```ValueTask<T>``` is awaitable, 
+so most consumption of instances will be indistinguishable from with a ```Task<T>```.  If a ```Task<T>``` is needed, one can be retrieved using 
+```ValueTask<T>```'s ```AsTask()``` method, which will either return the ```Task<T>``` it stores internally or will return an instance created
+from the ```T``` it stores.
+
 ## Core Channels
 
 Any type may implement one or more of these interfaces to be considered a channel.  However, several core channels are built-in

--- a/src/System.Threading.Tasks.Channels/src/System.Threading.Tasks.Channels.csproj
+++ b/src/System.Threading.Tasks.Channels/src/System.Threading.Tasks.Channels.csproj
@@ -8,7 +8,6 @@
     <RootNamespace>System.Threading.Tasks.Channels</RootNamespace>
     <AssemblyName>System.Threading.Tasks.Channels</AssemblyName>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{C5FD8740-19EA-4BCC-B518-7F16B55D23CA}</ProjectGuid>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>

--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.SerializationChannel.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.SerializationChannel.cs
@@ -45,7 +45,7 @@ namespace System.Threading.Tasks.Channels
                 return true;
             }
 
-            public unsafe bool TryWrite(T item)
+            public bool TryWrite(T item)
             {
                 // Write it out
                 lock (_destination)
@@ -179,7 +179,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public unsafe bool TryRead(out T item)
+            public bool TryRead(out T item)
             {
                 lock (SyncObj)
                 {


### PR DESCRIPTION
- Removed unnecessary ```unsafe``` usage
- Added comments to README about ```ValueTask<T>```