### PR TITLE
Initial open-sourcing commit of the MultiValueDictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ hand-offs between participants explicitly coded to use the storage. The library 
 This project augments the date and time APIs in .NET.  It adds two new core types: `Date` and `TimeOfDay`.
 It also provides extension methods to enhance the functionality of the existing `DateTime`, `DateTimeOffset` and `TimeZoneInfo` types.
 
+* **System.Collections.Generic.MultiValueDictionary**.
+The MultiValueDictionary is a generic collection that functions similarly to a Dictionary<TKey, ICollection<TValue>> with some added validation
+and ease of use functions. It can also be compared to a Lookup with the exception that the MultiValueDictionary is mutable. It allows custom 
+setting of the internal collections so that uniqueness of values can be chosen by specifying either a HashSet<TValue> or List<TValue>. Some of the
+design decisions as well as introductions to usage can be found in the old blog posts introducing it [here](http://blogs.msdn.com/b/dotnet/archive/2014/06/20/would-you-like-a-multidictionary.aspx) and [here](http://blogs.msdn.com/b/dotnet/archive/2014/08/05/multidictionary-becomes-multivaluedictionary.aspx).
+
 More libraries are coming soon. Stay tuned!
 
 [blog post]: http://blogs.msdn.com/b/dotnet/archive/2014/11/12/net-core-is-open-source.aspx

--- a/dir.props
+++ b/dir.props
@@ -10,7 +10,7 @@
 
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00070</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00107</BuildToolsVersion>
     <DnxVersion>1.0.0-beta5-12101</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>

--- a/nuget/System.Collections.Generic.MultiValueDictionary.nuspec
+++ b/nuget/System.Collections.Generic.MultiValueDictionary.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>System.Collections.Generic.MultiValueDictionary</id>
+    <version>0.1.0-d102115-1</version>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <projectUrl>https://github.com/dotnet/corefxlab</projectUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Dictionary allowing multiple values per key</description>
+    <releaseNotes>Initial package</releaseNotes>
+    <copyright> Microsoft Corporation.  All rights reserved.</copyright>
+    <tags>.NET Core MultiValueDictionary MultiDictionary Dictionary corefxlab</tags>
+  </metadata>
+  <files>
+    <file src="..\bin\Windows_NT.AnyCPU.Release\System.Collections.Generic.MultiValueDictionary\System.Collections.Generic.MultiValueDictionary.dll" target="lib/portable-net45+win8+wpa81+aspnetcore50"/>
+  </files>
+</package>
+

--- a/nuget/pack.bat
+++ b/nuget/pack.bat
@@ -4,4 +4,5 @@
 ..\packages\NuGet.exe pack System.Text.Utf8.nuspec
 ..\packages\NuGet.exe pack System.Text.Formatting.nuspec
 ..\packages\NuGet.exe pack System.Text.Json.nuspec
+..\packages\NuGet.exe pack System.Collections.Generic.MultiValueDictionary.nuspec
 

--- a/nuget/push.bat
+++ b/nuget/push.bat
@@ -4,6 +4,7 @@
 ..\packages\nuget push System.Text.Json.0.1.0-d102115-1.nupkg %1% -Source https://www.myget.org/F/netcore-package-prototyping/api/v2/package
 ..\packages\nuget push System.Text.Utf8.0.1.0-d102115-1.nupkg %1% -Source https://www.myget.org/F/netcore-package-prototyping/api/v2/package
 ..\packages\nuget push System.Text.Formatting.0.1.0-d102115-1.nupkg %1% -Source https://www.myget.org/F/netcore-package-prototyping/api/v2/package
+..\packages\nuget push System.Collections.Generic.MultiValueDictionary.0.1.0-d102115-1.nupkg %1% -Source https://www.myget.org/F/netcore-package-prototyping/api/v2/package
 
 
 

--- a/src/.nuget/packages.Unix.config
+++ b/src/.nuget/packages.Unix.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00070" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00107" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
   <package id="dnx-mono" version="1.0.0-beta5-12101" />
   <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc3-20150510-01" />

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00070" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00107" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-12101" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>

--- a/src/System.Collections.Generic.MultiValueDictionary/System.Collections.sln
+++ b/src/System.Collections.Generic.MultiValueDictionary/System.Collections.sln
@@ -1,0 +1,32 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Collections.Tests", "tests\System.Collections.Tests.csproj", "{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Collections", "src\System.Collections.csproj", "{D5FF747F-7A0B-9003-885A-FE9A63E755E5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/System.Collections.Generic.MultiValueDictionary/src/Resources/Strings.resx
+++ b/src/System.Collections.Generic.MultiValueDictionary/src/Resources/Strings.resx
@@ -1,0 +1,240 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ArgumentOutOfRange_NeedNonNegNumRequired" xml:space="preserve">
+    <value>Non-negative number required.</value>
+  </data>
+  <data name="Arg_MultiRank" xml:space="preserve">
+    <value>Multi dimension array is not supported on this operation.</value>
+  </data>
+  <data name="Arg_NonZeroLowerBound" xml:space="preserve">
+    <value>The lower bound of target array must be zero.</value>
+  </data>
+  <data name="Arg_WrongType" xml:space="preserve">
+    <value>The value '{0}' is not of type '{1}' and cannot be used in this generic collection.</value>
+  </data>
+  <data name="Arg_ArrayPlusOffTooSmall" xml:space="preserve">
+    <value>Destination array is not long enough to copy all the items in the collection. Check array index and length.</value>
+  </data>
+  <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
+    <value>Non-negative number required.</value>
+  </data>
+  <data name="ArgumentOutOfRange_SmallCapacity" xml:space="preserve">
+    <value>capacity was less than the current size.</value>
+  </data>
+  <data name="Argument_InvalidOffLen" xml:space="preserve">
+    <value>Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.</value>
+  </data>
+  <data name="Argument_ImplementIComparable" xml:space="preserve">
+    <value>At least one object must implement IComparable.</value>
+  </data>
+  <data name="Argument_AddingDuplicate" xml:space="preserve">
+    <value>An item with the same key has already been added.</value>
+  </data>
+  <data name="Invalid_Array_Type" xml:space="preserve">
+    <value>Target array type is not compatible with the type of items in the collection.</value>
+  </data>
+  <data name="InvalidOperation_EmptyQueue" xml:space="preserve">
+    <value>Queue empty.</value>
+  </data>
+  <data name="InvalidOperation_EnumOpCantHappen" xml:space="preserve">
+    <value>Enumeration has either not started or has already finished.</value>
+  </data>
+  <data name="InvalidOperation_EnumFailedVersion" xml:space="preserve">
+    <value>Collection was modified; enumeration operation may not execute.</value>
+  </data>
+  <data name="InvalidOperation_EmptyStack" xml:space="preserve">
+    <value>Stack empty.</value>
+  </data>
+  <data name="InvalidOperation_EnumNotStarted" xml:space="preserve">
+    <value>Enumeration has not started. Call MoveNext.</value>
+  </data>
+  <data name="InvalidOperation_EnumEnded" xml:space="preserve">
+    <value>Enumeration already finished.</value>
+  </data>
+  <data name="NotSupported_KeyCollectionSet" xml:space="preserve">
+    <value>Mutating a key collection derived from a dictionary is not allowed.</value>
+  </data>
+  <data name="NotSupported_ValueCollectionSet" xml:space="preserve">
+    <value>Mutating a value collection derived from a dictionary is not allowed.</value>
+  </data>
+  <data name="Arg_ArrayLengthsDiffer" xml:space="preserve">
+    <value>Array lengths must be the same.</value>
+  </data>
+  <data name="Arg_BitArrayTypeUnsupported" xml:space="preserve">
+    <value>Only supported array types for CopyTo on BitArrays are Boolean[], Int32[] and Byte[].</value>
+  </data>
+  <data name="Arg_HSCapacityOverflow" xml:space="preserve">
+    <value>HashSet capacity is too big.</value>
+  </data>
+  <data name="Arg_HTCapacityOverflow" xml:space="preserve">
+    <value>Hashtable's capacity overflowed and went negative. Check load factor, capacity and the current size of the table.</value>
+  </data>
+  <data name="Arg_InsufficientSpace" xml:space="preserve">
+    <value>Insufficient space in the target location to copy the information.</value>
+  </data>
+  <data name="Arg_RankMultiDimNotSupported" xml:space="preserve">
+    <value>Only single dimensional arrays are supported for the requested action.</value>
+  </data>
+  <data name="Argument_ArrayTooLarge" xml:space="preserve">
+    <value>The input array length must not exceed Int32.MaxValue / {0}. Otherwise BitArray.Length would exceed Int32.MaxValue.</value>
+  </data>
+  <data name="Argument_InvalidArgumentForComparison" xml:space="preserve">
+    <value>Type of argument is not compatible with the generic comparer.</value>
+  </data>
+  <data name="Argument_InvalidArrayType" xml:space="preserve">
+    <value>Target array type is not compatible with the type of items in the collection.</value>
+  </data>
+  <data name="ArgumentOutOfRange_BiggerThanCollection" xml:space="preserve">
+    <value>Larger than collection size.</value>
+  </data>
+  <data name="ArgumentOutOfRange_Count" xml:space="preserve">
+    <value>Count must be positive and count must refer to a location within the string/array/collection.</value>
+  </data>
+  <data name="ArgumentOutOfRange_Index" xml:space="preserve">
+    <value>Index was out of range. Must be non-negative and less than the size of the collection.</value>
+  </data>
+  <data name="ArgumentOutOfRange_ListInsert" xml:space="preserve">
+    <value>Index must be within the bounds of the List.</value>
+  </data>
+  <data name="ExternalLinkedListNode" xml:space="preserve">
+    <value>The LinkedList node does not belong to current LinkedList.</value>
+  </data>
+  <data name="IndexOutOfRange" xml:space="preserve">
+    <value>Index {0} is out of range.</value>
+  </data>
+  <data name="LinkedListEmpty" xml:space="preserve">
+    <value>The LinkedList is empty.</value>
+  </data>
+  <data name="LinkedListNodeIsAttached" xml:space="preserve">
+    <value>The LinkedList node already belongs to a LinkedList.</value>
+  </data>
+  <data name="NotSupported_SortedListNestedWrite" xml:space="preserve">
+    <value>This operation is not supported on SortedList nested types because they require modifying the original SortedList.</value>
+  </data>
+  <data name="CopyTo_ArgumentsTooSmall" xml:space="preserve">
+    <value>Destination array is not long enough to copy all the items in the collection. Check array index and length.</value>
+  </data>
+  <data name="Create_TValueCollectionReadOnly" xml:space="preserve">
+    <value>The specified TValueCollection creates collections that have IsReadOnly set to true by default. TValueCollection must be a mutable ICollection.</value>
+  </data>
+  <data name="ReadOnly_Modification" xml:space="preserve">
+    <value>The collection is read-only</value>
+  </data>
+</root>

--- a/src/System.Collections.Generic.MultiValueDictionary/src/System.Collections.csproj
+++ b/src/System.Collections.Generic.MultiValueDictionary/src/System.Collections.csproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D5FF747F-7A0B-9003-885A-FE9A63E755E5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <!-- <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly> -->
+    <AssemblyName>System.Collections.Generic.MultiValueDictionary</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+<!--     <NuGetTargetFrameworkMoniker>DNXCore,Version=v5.0</NuGetTargetFrameworkMoniker>
+ -->  </PropertyGroup>
+  <!-- Default configurations to help VS understand the options -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+<!--   <ItemGroup>
+    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.CoreCLR.csproj">
+      <Name>System.Runtime</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">
+      <Project>{E7E8DE8A-9EC1-46A8-A6EE-727DB32DBEB8}</Project>
+      <Name>System.Diagnostics.Debug</Name>
+    </ProjectReference>
+  </ItemGroup> -->
+  <ItemGroup>
+    <Compile Include="System\Collections\Generic\MultiValueDictionary.cs" />
+  </ItemGroup>
+<!--   <ItemGroup>
+    <Compile Include="$(CommonPath)\System\Collections\HashHelpers.cs">
+      <Link>Common\System\Collections\HashHelpers.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.cs">
+      <Link>Common\System\Collections\Generic\EnumerableHelpers.cs</Link>
+    </Compile>
+  </ItemGroup> -->
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Collections.Generic.MultiValueDictionary/src/System/Collections/Generic/MultiValueDictionary.cs
+++ b/src/System.Collections.Generic.MultiValueDictionary/src/System/Collections/Generic/MultiValueDictionary.cs
@@ -1,0 +1,1102 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Collections.Generic
+{
+    /// <summary>
+    /// A MultiValueDictionary can be viewed as a <see cref="IDictionary" /> that allows multiple 
+    /// values for any given unique key. While the MultiValueDictionary API is 
+    /// mostly the same as that of a regular <see cref="IDictionary" />, there is a distinction
+    /// in that getting the value for a key returns a <see cref="IReadOnlyCollection{TValue}" /> of values
+    /// rather than a single value associated with that key. Additionally, 
+    /// there is functionality to allow adding or removing more than a single
+    /// value at once. 
+    /// 
+    /// The MultiValueDictionary can also be viewed as a IReadOnlyDictionary&lt;TKey,IReadOnlyCollection&lt;TValue&gt;t&gt;
+    /// where the <see cref="IReadOnlyCollection{TValue}" /> is abstracted from the view of the programmer.
+    /// 
+    /// For a read-only MultiValueDictionary, see <see cref="ILookup{TKey, TValue}" />.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key.</typeparam>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    public class MultiValueDictionary<TKey, TValue> :
+        IReadOnlyDictionary<TKey, IReadOnlyCollection<TValue>>
+    {
+        #region Variables
+        /*======================================================================
+        ** Variables
+        ======================================================================*/
+
+        /// <summary>
+        /// The private dictionary that this class effectively wraps around
+        /// </summary>
+        private Dictionary<TKey, InnerCollectionView> dictionary;
+
+        /// <summary>
+        /// The function to construct a new <see cref="ICollection{TValue}"/>
+        /// </summary>
+        /// <returns></returns>
+        private Func<ICollection<TValue>> NewCollectionFactory = () => new List<TValue>();
+
+        /// <summary>
+        /// The current version of this MultiValueDictionary used to determine MultiValueDictionary modification
+        /// during enumeration
+        /// </summary>
+        private int version;
+
+        #endregion
+
+        #region Constructors
+        /*======================================================================
+        ** Constructors
+        ======================================================================*/
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> 
+        /// class that is empty, has the default initial capacity, and uses the default
+        /// <see cref="IEqualityComparer{TKey}" /> for <typeparamref name="TKey"/>.
+        /// </summary>
+        public MultiValueDictionary()
+        {
+            dictionary = new Dictionary<TKey, InnerCollectionView>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> class that is 
+        /// empty, has the specified initial capacity, and uses the default <see cref="IEqualityComparer{TKey}"/>
+        /// for <typeparamref name="TKey"/>.
+        /// </summary>
+        /// <param name="capacity">Initial number of keys that the <see cref="MultiValueDictionary{TKey, TValue}" /> will allocate space for</param>
+        /// <exception cref="ArgumentOutOfRangeException">capacity must be >= 0</exception>
+        public MultiValueDictionary(int capacity)
+        {
+            if (capacity < 0)
+                throw new ArgumentOutOfRangeException("capacity", SR.ArgumentOutOfRange_NeedNonNegNum);
+            dictionary = new Dictionary<TKey, InnerCollectionView>(capacity);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> class 
+        /// that is empty, has the default initial capacity, and uses the 
+        /// specified <see cref="IEqualityComparer{TKey}" />.
+        /// </summary>
+        /// <param name="comparer">Specified comparer to use for the <typeparamref name="TKey"/>s</param>
+        /// <remarks>If <paramref name="comparer"/> is set to null, then the default <see cref="IEqualityComparer" /> for <typeparamref name="TKey"/> is used.</remarks>
+        public MultiValueDictionary(IEqualityComparer<TKey> comparer)
+        {
+            dictionary = new Dictionary<TKey, InnerCollectionView>(comparer);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> class 
+        /// that is empty, has the specified initial capacity, and uses the 
+        /// specified <see cref="IEqualityComparer{TKey}" />.
+        /// </summary>
+        /// <param name="capacity">Initial number of keys that the <see cref="MultiValueDictionary{TKey, TValue}" /> will allocate space for</param>
+        /// <param name="comparer">Specified comparer to use for the <typeparamref name="TKey"/>s</param>
+        /// <exception cref="ArgumentOutOfRangeException">Capacity must be >= 0</exception>
+        /// <remarks>If <paramref name="comparer"/> is set to null, then the default <see cref="IEqualityComparer" /> for <typeparamref name="TKey"/> is used.</remarks>
+        public MultiValueDictionary(int capacity, IEqualityComparer<TKey> comparer)
+        {
+            if (capacity < 0)
+                throw new ArgumentOutOfRangeException("capacity", SR.ArgumentOutOfRange_NeedNonNegNum);
+            dictionary = new Dictionary<TKey, InnerCollectionView>(capacity, comparer);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> class that contains 
+        /// elements copied from the specified IEnumerable&lt;KeyValuePair&lt;TKey, IReadOnlyCollection&lt;TValue&gt;&gt;&gt; and uses the 
+        /// default <see cref="IEqualityComparer{TKey}" /> for the <typeparamref name="TKey"/> type.
+        /// </summary>
+        /// <param name="enumerable">IEnumerable to copy elements into this from</param>
+        /// <exception cref="ArgumentNullException">enumerable must be non-null</exception>
+        public MultiValueDictionary(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable)
+            : this(enumerable, null)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> class that contains 
+        /// elements copied from the specified IEnumerable&lt;KeyValuePair&lt;TKey, IReadOnlyCollection&lt;TValue&gt;&gt;&gt; and uses the 
+        /// specified <see cref="IEqualityComparer{TKey}" />.
+        /// </summary>
+        /// <param name="enumerable">IEnumerable to copy elements into this from</param>
+        /// <param name="comparer">Specified comparer to use for the <typeparamref name="TKey"/>s</param>
+        /// <exception cref="ArgumentNullException">enumerable must be non-null</exception>
+        /// <remarks>If <paramref name="comparer"/> is set to null, then the default <see cref="IEqualityComparer" /> for <typeparamref name="TKey"/> is used.</remarks>
+        public MultiValueDictionary(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, IEqualityComparer<TKey> comparer)
+        {
+            if (enumerable == null)
+                throw new ArgumentNullException("enumerable");
+
+            dictionary = new Dictionary<TKey, InnerCollectionView>(comparer);
+            foreach (var pair in enumerable)
+                AddRange(pair.Key, pair.Value);
+        }
+
+        #endregion
+
+        #region Static Factories
+        /*======================================================================
+        ** Static Factories
+        ======================================================================*/
+
+        /// <summary>
+        /// Creates a new new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> 
+        /// class that is empty, has the default initial capacity, and uses the default
+        /// <see cref="IEqualityComparer{TKey}" /> for <typeparamref name="TKey"/>. The 
+        /// internal dictionary will use instances of the <typeparamref name="TValueCollection"/>
+        /// class as its collection type.
+        /// </summary>
+        /// <typeparam name="TValueCollection">
+        /// The collection type that this <see cref="MultiValueDictionary{TKey, TValue}" />
+        /// will contain in its internal dictionary.
+        /// </typeparam>
+        /// <returns>A new <see cref="MultiValueDictionary{TKey, TValue}" /> with the specified
+        /// parameters.</returns>
+        /// <exception cref="InvalidOperationException"><typeparamref name="TValueCollection"/> must not have
+        /// IsReadOnly set to true by default.</exception>
+        /// <remarks>
+        /// Note that <typeparamref name="TValueCollection"/> must implement <see cref="ICollection{TValue}"/>
+        /// in addition to being constructable through new(). The collection returned from the constructor
+        /// must also not have IsReadOnly set to True by default.
+        /// </remarks>
+        public static MultiValueDictionary<TKey, TValue> Create<TValueCollection>()
+            where TValueCollection : ICollection<TValue>, new()
+        {
+            if (new TValueCollection().IsReadOnly)
+                throw new InvalidOperationException(SR.Create_TValueCollectionReadOnly);
+
+            var multiValueDictionary = new MultiValueDictionary<TKey, TValue>();
+            multiValueDictionary.NewCollectionFactory = () => new TValueCollection();
+            return multiValueDictionary;
+        }
+
+        /// <summary>
+        /// Creates a new new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> 
+        /// class that is empty, has the specified initial capacity, and uses the default
+        /// <see cref="IEqualityComparer{TKey}" /> for <typeparamref name="TKey"/>. The 
+        /// internal dictionary will use instances of the <typeparamref name="TValueCollection"/>
+        /// class as its collection type.
+        /// </summary>
+        /// <typeparam name="TValueCollection">
+        /// The collection type that this <see cref="MultiValueDictionary{TKey, TValue}" />
+        /// will contain in its internal dictionary.
+        /// </typeparam>
+        /// <param name="capacity">Initial number of keys that the <see cref="MultiValueDictionary{TKey, TValue}" /> will allocate space for</param>
+        /// <returns>A new <see cref="MultiValueDictionary{TKey, TValue}" /> with the specified
+        /// parameters.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Capacity must be >= 0</exception>
+        /// <exception cref="InvalidOperationException"><typeparamref name="TValueCollection"/> must not have
+        /// IsReadOnly set to true by default.</exception>
+        /// <remarks>
+        /// Note that <typeparamref name="TValueCollection"/> must implement <see cref="ICollection{TValue}"/>
+        /// in addition to being constructable through new(). The collection returned from the constructor
+        /// must also not have IsReadOnly set to True by default.
+        /// </remarks>
+        public static MultiValueDictionary<TKey, TValue> Create<TValueCollection>(int capacity)
+            where TValueCollection : ICollection<TValue>, new()
+        {
+            if (capacity < 0)
+                throw new ArgumentOutOfRangeException("capacity", SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (new TValueCollection().IsReadOnly)
+                throw new InvalidOperationException(SR.Create_TValueCollectionReadOnly);
+
+            var multiValueDictionary = new MultiValueDictionary<TKey, TValue>(capacity);
+            multiValueDictionary.NewCollectionFactory = () => new TValueCollection();
+            return multiValueDictionary;
+        }
+
+        /// <summary>
+        /// Creates a new new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> 
+        /// class that is empty, has the default initial capacity, and uses the specified
+        /// <see cref="IEqualityComparer{TKey}" /> for <typeparamref name="TKey"/>. The 
+        /// internal dictionary will use instances of the <typeparamref name="TValueCollection"/>
+        /// class as its collection type.
+        /// </summary>
+        /// <typeparam name="TValueCollection">
+        /// The collection type that this <see cref="MultiValueDictionary{TKey, TValue}" />
+        /// will contain in its internal dictionary.
+        /// </typeparam>
+        /// <param name="comparer">Specified comparer to use for the <typeparamref name="TKey"/>s</param>
+        /// <exception cref="InvalidOperationException"><typeparamref name="TValueCollection"/> must not have
+        /// IsReadOnly set to true by default.</exception>
+        /// <returns>A new <see cref="MultiValueDictionary{TKey, TValue}" /> with the specified
+        /// parameters.</returns>
+        /// <remarks>If <paramref name="comparer"/> is set to null, then the default <see cref="IEqualityComparer" /> for <typeparamref name="TKey"/> is used.</remarks>
+        /// <remarks>
+        /// Note that <typeparamref name="TValueCollection"/> must implement <see cref="ICollection{TValue}"/>
+        /// in addition to being constructable through new(). The collection returned from the constructor
+        /// must also not have IsReadOnly set to True by default.
+        /// </remarks>
+        public static MultiValueDictionary<TKey, TValue> Create<TValueCollection>(IEqualityComparer<TKey> comparer)
+            where TValueCollection : ICollection<TValue>, new()
+        {
+            if (new TValueCollection().IsReadOnly)
+                throw new InvalidOperationException(SR.Create_TValueCollectionReadOnly);
+
+            var multiValueDictionary = new MultiValueDictionary<TKey, TValue>(comparer);
+            multiValueDictionary.NewCollectionFactory = () => new TValueCollection();
+            return multiValueDictionary;
+        }
+
+        /// <summary>
+        /// Creates a new new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> 
+        /// class that is empty, has the specified initial capacity, and uses the specified
+        /// <see cref="IEqualityComparer{TKey}" /> for <typeparamref name="TKey"/>. The 
+        /// internal dictionary will use instances of the <typeparamref name="TValueCollection"/>
+        /// class as its collection type.
+        /// </summary>
+        /// <typeparam name="TValueCollection">
+        /// The collection type that this <see cref="MultiValueDictionary{TKey, TValue}" />
+        /// will contain in its internal dictionary.
+        /// </typeparam>
+        /// <param name="capacity">Initial number of keys that the <see cref="MultiValueDictionary{TKey, TValue}" /> will allocate space for</param>
+        /// <param name="comparer">Specified comparer to use for the <typeparamref name="TKey"/>s</param>
+        /// <returns>A new <see cref="MultiValueDictionary{TKey, TValue}" /> with the specified
+        /// parameters.</returns>
+        /// <exception cref="InvalidOperationException"><typeparamref name="TValueCollection"/> must not have
+        /// IsReadOnly set to true by default.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Capacity must be >= 0</exception>
+        /// <remarks>If <paramref name="comparer"/> is set to null, then the default <see cref="IEqualityComparer" /> for <typeparamref name="TKey"/> is used.</remarks>
+        /// <remarks>
+        /// Note that <typeparamref name="TValueCollection"/> must implement <see cref="ICollection{TValue}"/>
+        /// in addition to being constructable through new(). The collection returned from the constructor
+        /// must also not have IsReadOnly set to True by default.
+        /// </remarks>
+        public static MultiValueDictionary<TKey, TValue> Create<TValueCollection>(int capacity, IEqualityComparer<TKey> comparer)
+            where TValueCollection : ICollection<TValue>, new()
+        {
+            if (capacity < 0)
+                throw new ArgumentOutOfRangeException("capacity", SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (new TValueCollection().IsReadOnly)
+                throw new InvalidOperationException(SR.Create_TValueCollectionReadOnly);
+
+            var multiValueDictionary = new MultiValueDictionary<TKey, TValue>(capacity, comparer);
+            multiValueDictionary.NewCollectionFactory = () => new TValueCollection();
+            return multiValueDictionary;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> class that contains 
+        /// elements copied from the specified IEnumerable&lt;KeyValuePair&lt;TKey, IReadOnlyCollection&lt;TValue&gt;&gt;&gt;
+        /// and uses the default <see cref="IEqualityComparer{TKey}" /> for the <typeparamref name="TKey"/> type.
+        /// The internal dictionary will use instances of the <typeparamref name="TValueCollection"/>
+        /// class as its collection type.
+        /// </summary>
+        /// <typeparam name="TValueCollection">
+        /// The collection type that this <see cref="MultiValueDictionary{TKey, TValue}" />
+        /// will contain in its internal dictionary.
+        /// </typeparam>
+        /// <param name="enumerable">IEnumerable to copy elements into this from</param>
+        /// <returns>A new <see cref="MultiValueDictionary{TKey, TValue}" /> with the specified
+        /// parameters.</returns>
+        /// <exception cref="InvalidOperationException"><typeparamref name="TValueCollection"/> must not have
+        /// IsReadOnly set to true by default.</exception>
+        /// <exception cref="ArgumentNullException">enumerable must be non-null</exception>
+        /// <remarks>
+        /// Note that <typeparamref name="TValueCollection"/> must implement <see cref="ICollection{TValue}"/>
+        /// in addition to being constructable through new(). The collection returned from the constructor
+        /// must also not have IsReadOnly set to True by default.
+        /// </remarks>
+        public static MultiValueDictionary<TKey, TValue> Create<TValueCollection>(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable)
+            where TValueCollection : ICollection<TValue>, new()
+        {
+            if (enumerable == null)
+                throw new ArgumentNullException("enumerable");
+            if (new TValueCollection().IsReadOnly)
+                throw new InvalidOperationException(SR.Create_TValueCollectionReadOnly);
+
+            var multiValueDictionary = new MultiValueDictionary<TKey, TValue>();
+            multiValueDictionary.NewCollectionFactory = () => new TValueCollection();
+            foreach (var pair in enumerable)
+                multiValueDictionary.AddRange(pair.Key, pair.Value);
+            return multiValueDictionary;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> class that contains 
+        /// elements copied from the specified IEnumerable&lt;KeyValuePair&lt;TKey, IReadOnlyCollection&lt;TValue&gt;&gt;&gt;
+        /// and uses the specified <see cref="IEqualityComparer{TKey}" /> for the <typeparamref name="TKey"/> type.
+        /// The internal dictionary will use instances of the <typeparamref name="TValueCollection"/>
+        /// class as its collection type.
+        /// </summary>
+        /// <typeparam name="TValueCollection">
+        /// The collection type that this <see cref="MultiValueDictionary{TKey, TValue}" />
+        /// will contain in its internal dictionary.
+        /// </typeparam>
+        /// <param name="enumerable">IEnumerable to copy elements into this from</param>
+        /// <param name="comparer">Specified comparer to use for the <typeparamref name="TKey"/>s</param>
+        /// <returns>A new <see cref="MultiValueDictionary{TKey, TValue}" /> with the specified
+        /// parameters.</returns>
+        /// <exception cref="InvalidOperationException"><typeparamref name="TValueCollection"/> must not have
+        /// IsReadOnly set to true by default.</exception>
+        /// <exception cref="ArgumentNullException">enumerable must be non-null</exception>
+        /// <remarks>If <paramref name="comparer"/> is set to null, then the default <see cref="IEqualityComparer" /> for <typeparamref name="TKey"/> is used.</remarks>
+        /// <remarks>
+        /// Note that <typeparamref name="TValueCollection"/> must implement <see cref="ICollection{TValue}"/>
+        /// in addition to being constructable through new(). The collection returned from the constructor
+        /// must also not have IsReadOnly set to True by default.
+        /// </remarks>
+        public static MultiValueDictionary<TKey, TValue> Create<TValueCollection>(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, IEqualityComparer<TKey> comparer)
+            where TValueCollection : ICollection<TValue>, new()
+        {
+            if (enumerable == null)
+                throw new ArgumentNullException("enumerable");
+            if (new TValueCollection().IsReadOnly)
+                throw new InvalidOperationException(SR.Create_TValueCollectionReadOnly);
+
+            var multiValueDictionary = new MultiValueDictionary<TKey, TValue>(comparer);
+            multiValueDictionary.NewCollectionFactory = () => new TValueCollection();
+            foreach (var pair in enumerable)
+                multiValueDictionary.AddRange(pair.Key, pair.Value);
+            return multiValueDictionary;
+        }
+
+        #endregion
+
+        #region Static Factories with Func parameters
+        /*======================================================================
+        ** Static Factories with Func parameters
+        ======================================================================*/
+
+        /// <summary>
+        /// Creates a new new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> 
+        /// class that is empty, has the default initial capacity, and uses the default
+        /// <see cref="IEqualityComparer{TKey}" /> for <typeparamref name="TKey"/>. The 
+        /// internal dictionary will use instances of the <typeparamref name="TValueCollection"/>
+        /// class as its collection type.
+        /// </summary>
+        /// <typeparam name="TValueCollection">
+        /// The collection type that this <see cref="MultiValueDictionary{TKey, TValue}" />
+        /// will contain in its internal dictionary.
+        /// </typeparam>
+        /// <param name="collectionFactory">A function to create a new <see cref="ICollection{TValue}"/> to use
+        /// in the internal dictionary store of this <see cref="MultiValueDictionary{TKey, TValue}" />.</param>
+        /// <returns>A new <see cref="MultiValueDictionary{TKey, TValue}" /> with the specified
+        /// parameters.</returns>
+        /// <exception cref="InvalidOperationException"><paramref name="collectionFactory"/> must create collections with
+        /// IsReadOnly set to true by default.</exception>
+        /// <remarks>
+        /// Note that <typeparamref name="TValueCollection"/> must implement <see cref="ICollection{TValue}"/>
+        /// in addition to being constructable through new(). The collection returned from the constructor
+        /// must also not have IsReadOnly set to True by default.
+        /// </remarks>
+        public static MultiValueDictionary<TKey, TValue> Create<TValueCollection>(Func<TValueCollection> collectionFactory)
+            where TValueCollection : ICollection<TValue>
+        {
+            if (collectionFactory().IsReadOnly)
+                throw new InvalidOperationException((SR.Create_TValueCollectionReadOnly));
+
+            var multiValueDictionary = new MultiValueDictionary<TKey, TValue>();
+            multiValueDictionary.NewCollectionFactory = (Func<ICollection<TValue>>)(Delegate)collectionFactory;
+            return multiValueDictionary;
+        }
+
+        /// <summary>
+        /// Creates a new new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> 
+        /// class that is empty, has the specified initial capacity, and uses the default
+        /// <see cref="IEqualityComparer{TKey}" /> for <typeparamref name="TKey"/>. The 
+        /// internal dictionary will use instances of the <typeparamref name="TValueCollection"/>
+        /// class as its collection type.
+        /// </summary>
+        /// <typeparam name="TValueCollection">
+        /// The collection type that this <see cref="MultiValueDictionary{TKey, TValue}" />
+        /// will contain in its internal dictionary.
+        /// </typeparam>
+        /// <param name="capacity">Initial number of keys that the <see cref="MultiValueDictionary{TKey, TValue}" /> will allocate space for</param>
+        /// <param name="collectionFactory">A function to create a new <see cref="ICollection{TValue}"/> to use
+        /// in the internal dictionary store of this <see cref="MultiValueDictionary{TKey, TValue}" />.</param> 
+        /// <returns>A new <see cref="MultiValueDictionary{TKey, TValue}" /> with the specified
+        /// parameters.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Capacity must be >= 0</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="collectionFactory"/> must create collections with
+        /// IsReadOnly set to true by default.</exception>
+        /// <remarks>
+        /// Note that <typeparamref name="TValueCollection"/> must implement <see cref="ICollection{TValue}"/>
+        /// in addition to being constructable through new(). The collection returned from the constructor
+        /// must also not have IsReadOnly set to True by default.
+        /// </remarks>
+        public static MultiValueDictionary<TKey, TValue> Create<TValueCollection>(int capacity, Func<TValueCollection> collectionFactory)
+            where TValueCollection : ICollection<TValue>
+        {
+            if (capacity < 0)
+                throw new ArgumentOutOfRangeException("capacity", SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (collectionFactory().IsReadOnly)
+                throw new InvalidOperationException((SR.Create_TValueCollectionReadOnly));
+
+            var multiValueDictionary = new MultiValueDictionary<TKey, TValue>(capacity);
+            multiValueDictionary.NewCollectionFactory = (Func<ICollection<TValue>>)(Delegate)collectionFactory;
+            return multiValueDictionary;
+        }
+
+        /// <summary>
+        /// Creates a new new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> 
+        /// class that is empty, has the default initial capacity, and uses the specified
+        /// <see cref="IEqualityComparer{TKey}" /> for <typeparamref name="TKey"/>. The 
+        /// internal dictionary will use instances of the <typeparamref name="TValueCollection"/>
+        /// class as its collection type.
+        /// </summary>
+        /// <typeparam name="TValueCollection">
+        /// The collection type that this <see cref="MultiValueDictionary{TKey, TValue}" />
+        /// will contain in its internal dictionary.
+        /// </typeparam>
+        /// <param name="comparer">Specified comparer to use for the <typeparamref name="TKey"/>s</param>
+        /// <param name="collectionFactory">A function to create a new <see cref="ICollection{TValue}"/> to use
+        /// in the internal dictionary store of this <see cref="MultiValueDictionary{TKey, TValue}" />.</param> 
+        /// <exception cref="InvalidOperationException"><paramref name="collectionFactory"/> must create collections with
+        /// IsReadOnly set to true by default.</exception>
+        /// <returns>A new <see cref="MultiValueDictionary{TKey, TValue}" /> with the specified
+        /// parameters.</returns>
+        /// <remarks>If <paramref name="comparer"/> is set to null, then the default <see cref="IEqualityComparer" /> for <typeparamref name="TKey"/> is used.</remarks>
+        /// <remarks>
+        /// Note that <typeparamref name="TValueCollection"/> must implement <see cref="ICollection{TValue}"/>
+        /// in addition to being constructable through new(). The collection returned from the constructor
+        /// must also not have IsReadOnly set to True by default.
+        /// </remarks>
+        public static MultiValueDictionary<TKey, TValue> Create<TValueCollection>(IEqualityComparer<TKey> comparer, Func<TValueCollection> collectionFactory)
+            where TValueCollection : ICollection<TValue>
+        {
+            if (collectionFactory().IsReadOnly)
+                throw new InvalidOperationException((SR.Create_TValueCollectionReadOnly));
+
+            var multiValueDictionary = new MultiValueDictionary<TKey, TValue>(comparer);
+            multiValueDictionary.NewCollectionFactory = (Func<ICollection<TValue>>)(Delegate)collectionFactory;
+            return multiValueDictionary;
+        }
+
+        /// <summary>
+        /// Creates a new new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> 
+        /// class that is empty, has the specified initial capacity, and uses the specified
+        /// <see cref="IEqualityComparer{TKey}" /> for <typeparamref name="TKey"/>. The 
+        /// internal dictionary will use instances of the <typeparamref name="TValueCollection"/>
+        /// class as its collection type.
+        /// </summary>
+        /// <typeparam name="TValueCollection">
+        /// The collection type that this <see cref="MultiValueDictionary{TKey, TValue}" />
+        /// will contain in its internal dictionary.
+        /// </typeparam>
+        /// <param name="capacity">Initial number of keys that the <see cref="MultiValueDictionary{TKey, TValue}" /> will allocate space for</param>
+        /// <param name="comparer">Specified comparer to use for the <typeparamref name="TKey"/>s</param>
+        /// <param name="collectionFactory">A function to create a new <see cref="ICollection{TValue}"/> to use
+        /// in the internal dictionary store of this <see cref="MultiValueDictionary{TKey, TValue}" />.</param> 
+        /// <returns>A new <see cref="MultiValueDictionary{TKey, TValue}" /> with the specified
+        /// parameters.</returns>
+        /// <exception cref="InvalidOperationException"><paramref name="collectionFactory"/> must create collections with
+        /// IsReadOnly set to true by default.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Capacity must be >= 0</exception>
+        /// <remarks>If <paramref name="comparer"/> is set to null, then the default <see cref="IEqualityComparer" /> for <typeparamref name="TKey"/> is used.</remarks>
+        /// <remarks>
+        /// Note that <typeparamref name="TValueCollection"/> must implement <see cref="ICollection{TValue}"/>
+        /// in addition to being constructable through new(). The collection returned from the constructor
+        /// must also not have IsReadOnly set to True by default.
+        /// </remarks>
+        public static MultiValueDictionary<TKey, TValue> Create<TValueCollection>(int capacity, IEqualityComparer<TKey> comparer, Func<TValueCollection> collectionFactory)
+            where TValueCollection : ICollection<TValue>
+        {
+            if (capacity < 0)
+                throw new ArgumentOutOfRangeException("capacity", SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (collectionFactory().IsReadOnly)
+                throw new InvalidOperationException((SR.Create_TValueCollectionReadOnly));
+
+            var multiValueDictionary = new MultiValueDictionary<TKey, TValue>(capacity, comparer);
+            multiValueDictionary.NewCollectionFactory = (Func<ICollection<TValue>>)(Delegate)collectionFactory;
+            return multiValueDictionary;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> class that contains 
+        /// elements copied from the specified IEnumerable&lt;KeyValuePair&lt;TKey, IReadOnlyCollection&lt;TValue&gt;&gt;&gt;
+        /// and uses the default <see cref="IEqualityComparer{TKey}" /> for the <typeparamref name="TKey"/> type.
+        /// The internal dictionary will use instances of the <typeparamref name="TValueCollection"/>
+        /// class as its collection type.
+        /// </summary>
+        /// <typeparam name="TValueCollection">
+        /// The collection type that this <see cref="MultiValueDictionary{TKey, TValue}" />
+        /// will contain in its internal dictionary.
+        /// </typeparam>
+        /// <param name="enumerable">IEnumerable to copy elements into this from</param>
+        /// <param name="collectionFactory">A function to create a new <see cref="ICollection{TValue}"/> to use
+        /// in the internal dictionary store of this <see cref="MultiValueDictionary{TKey, TValue}" />.</param> 
+        /// <returns>A new <see cref="MultiValueDictionary{TKey, TValue}" /> with the specified
+        /// parameters.</returns>
+        /// <exception cref="InvalidOperationException"><paramref name="collectionFactory"/> must create collections with
+        /// IsReadOnly set to true by default.</exception>
+        /// <exception cref="ArgumentNullException">enumerable must be non-null</exception>
+        /// <remarks>
+        /// Note that <typeparamref name="TValueCollection"/> must implement <see cref="ICollection{TValue}"/>
+        /// in addition to being constructable through new(). The collection returned from the constructor
+        /// must also not have IsReadOnly set to True by default.
+        /// </remarks>
+        public static MultiValueDictionary<TKey, TValue> Create<TValueCollection>(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, Func<TValueCollection> collectionFactory)
+            where TValueCollection : ICollection<TValue>
+        {
+            if (enumerable == null)
+                throw new ArgumentNullException("enumerable");
+            if (collectionFactory().IsReadOnly)
+                throw new InvalidOperationException((SR.Create_TValueCollectionReadOnly));
+
+            var multiValueDictionary = new MultiValueDictionary<TKey, TValue>();
+            multiValueDictionary.NewCollectionFactory = (Func<ICollection<TValue>>)(Delegate)collectionFactory;
+            foreach (var pair in enumerable)
+                multiValueDictionary.AddRange(pair.Key, pair.Value);
+            return multiValueDictionary;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> class that contains 
+        /// elements copied from the specified IEnumerable&lt;KeyValuePair&lt;TKey, IReadOnlyCollection&lt;TValue&gt;&gt;&gt;
+        /// and uses the specified <see cref="IEqualityComparer{TKey}" /> for the <typeparamref name="TKey"/> type.
+        /// The internal dictionary will use instances of the <typeparamref name="TValueCollection"/>
+        /// class as its collection type.
+        /// </summary>
+        /// <typeparam name="TValueCollection">
+        /// The collection type that this <see cref="MultiValueDictionary{TKey, TValue}" />
+        /// will contain in its internal dictionary.
+        /// </typeparam>
+        /// <param name="enumerable">IEnumerable to copy elements into this from</param>
+        /// <param name="comparer">Specified comparer to use for the <typeparamref name="TKey"/>s</param>
+        /// <param name="collectionFactory">A function to create a new <see cref="ICollection{TValue}"/> to use
+        /// in the internal dictionary store of this <see cref="MultiValueDictionary{TKey, TValue}" />.</param> 
+        /// <returns>A new <see cref="MultiValueDictionary{TKey, TValue}" /> with the specified
+        /// parameters.</returns>
+        /// <exception cref="InvalidOperationException"><paramref name="collectionFactory"/> must create collections with
+        /// IsReadOnly set to true by default.</exception>
+        /// <exception cref="ArgumentNullException">enumerable must be non-null</exception>
+        /// <remarks>If <paramref name="comparer"/> is set to null, then the default <see cref="IEqualityComparer" /> for <typeparamref name="TKey"/> is used.</remarks>
+        /// <remarks>
+        /// Note that <typeparamref name="TValueCollection"/> must implement <see cref="ICollection{TValue}"/>
+        /// in addition to being constructable through new(). The collection returned from the constructor
+        /// must also not have IsReadOnly set to True by default.
+        /// </remarks>
+        public static MultiValueDictionary<TKey, TValue> Create<TValueCollection>(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, IEqualityComparer<TKey> comparer, Func<TValueCollection> collectionFactory)
+            where TValueCollection : ICollection<TValue>
+        {
+            if (enumerable == null)
+                throw new ArgumentNullException("enumerable");
+            if (collectionFactory().IsReadOnly)
+                throw new InvalidOperationException((SR.Create_TValueCollectionReadOnly));
+
+            var multiValueDictionary = new MultiValueDictionary<TKey, TValue>(comparer);
+            multiValueDictionary.NewCollectionFactory = (Func<ICollection<TValue>>)(Delegate)collectionFactory;
+            foreach (var pair in enumerable)
+                multiValueDictionary.AddRange(pair.Key, pair.Value);
+            return multiValueDictionary;
+        }
+
+        #endregion
+
+        #region Concrete Methods
+        /*======================================================================
+        ** Concrete Methods
+        ======================================================================*/
+
+        /// <summary>
+        /// Adds the specified <typeparamref name="TKey"/> and <typeparamref name="TValue"/> to the <see cref="MultiValueDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <param name="key">The <typeparamref name="TKey"/> of the element to add.</param>
+        /// <param name="value">The <typeparamref name="TValue"/> of the element to add.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c>.</exception>
+        /// <remarks>
+        /// Unlike the Add for <see cref="IDictionary" />, the <see cref="MultiValueDictionary{TKey,TValue}"/> Add will not
+        /// throw any exceptions. If the given <typeparamref name="TKey"/> is already in the <see cref="MultiValueDictionary{TKey,TValue}"/>,
+        /// then <typeparamref name="TValue"/> will be added to <see cref="IReadOnlyCollection{TValue}"/> associated with <paramref name="key"/>
+        /// </remarks>
+        /// <remarks>
+        /// A call to this Add method will always invalidate any currently running enumeration regardless
+        /// of whether the Add method actually modified the <see cref="MultiValueDictionary{TKey, TValue}" />.
+        /// </remarks>
+        public void Add(TKey key, TValue value)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+            InnerCollectionView collection;
+            if (!dictionary.TryGetValue(key, out collection))
+            {
+                collection = new InnerCollectionView(key, NewCollectionFactory());
+                dictionary.Add(key, collection);
+            }
+            collection.AddValue(value);
+            version++;
+        }
+
+        /// <summary>
+        /// Adds a number of key-value pairs to this <see cref="MultiValueDictionary{TKey,TValue}"/>, where
+        /// the key for each value is <paramref name="key"/>, and the value for a pair
+        /// is an element from <paramref name="values"/>
+        /// </summary>
+        /// <param name="key">The <typeparamref name="TKey"/> of all entries to add</param>
+        /// <param name="values">An <see cref="IEnumerable{TValue}"/> of values to add</param>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> and <paramref name="values"/> must be non-null</exception>
+        /// <remarks>
+        /// A call to this AddRange method will always invalidate any currently running enumeration regardless
+        /// of whether the AddRange method actually modified the <see cref="MultiValueDictionary{TKey,TValue}"/>.
+        /// </remarks>
+        public void AddRange(TKey key, IEnumerable<TValue> values)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+            if (values == null)
+                throw new ArgumentNullException("values");
+
+            InnerCollectionView collection;
+            if (!dictionary.TryGetValue(key, out collection))
+            {
+                collection = new InnerCollectionView(key, NewCollectionFactory());
+                dictionary.Add(key, collection);
+            }
+            foreach (TValue value in values)
+            {
+                collection.AddValue(value);
+            }
+            version++;
+        }
+
+        /// <summary>
+        /// Removes every <typeparamref name="TValue"/> associated with the given <typeparamref name="TKey"/>
+        /// from the <see cref="MultiValueDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <param name="key">The <typeparamref name="TKey"/> of the elements to remove</param>
+        /// <returns><c>true</c> if the removal was successful; otherwise <c>false</c></returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> is <c>null</c>.</exception>
+        public bool Remove(TKey key)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+
+            InnerCollectionView collection;
+            if (dictionary.TryGetValue(key, out collection) && dictionary.Remove(key))
+            {
+                version++;
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Removes the first instance (if any) of the given <typeparamref name="TKey"/>-<typeparamref name="TValue"/> 
+        /// pair from this <see cref="MultiValueDictionary{TKey,TValue}"/>. 
+        /// </summary>
+        /// <param name="key">The <typeparamref name="TKey"/> of the element to remove</param>
+        /// <param name="value">The <typeparamref name="TValue"/> of the element to remove</param>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> must be non-null</exception>
+        /// <returns><c>true</c> if the removal was successful; otherwise <c>false</c></returns>
+        /// <remarks>
+        /// If the <typeparamref name="TValue"/> being removed is the last one associated with its <typeparamref name="TKey"/>, then that 
+        /// <typeparamref name="TKey"/> will be removed from the <see cref="MultiValueDictionary{TKey,TValue}"/> and its 
+        /// associated <see cref="IReadOnlyCollection{TValue}"/> will be freed as if a call to <see cref="Remove(TKey)"/>
+        /// had been made.
+        /// </remarks>
+        public bool Remove(TKey key, TValue value)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+
+            InnerCollectionView collection;
+            if (dictionary.TryGetValue(key, out collection) && collection.RemoveValue(value))
+            {
+                if (collection.Count == 0)
+                    dictionary.Remove(key);
+                version++;
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Determines if the given <typeparamref name="TKey"/>-<typeparamref name="TValue"/> 
+        /// pair exists within this <see cref="MultiValueDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <param name="key">The <typeparamref name="TKey"/> of the element.</param>
+        /// <param name="value">The <typeparamref name="TValue"/> of the element.</param>
+        /// <returns><c>true</c> if found; otherwise <c>false</c></returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> must be non-null</exception>
+        public bool Contains(TKey key, TValue value)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+
+            InnerCollectionView collection;
+            return (dictionary.TryGetValue(key, out collection) && collection.Contains(value));
+        }
+
+        /// <summary>
+        /// Determines if the given <typeparamref name="TValue"/> exists within this <see cref="MultiValueDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <param name="value">A <typeparamref name="TValue"/> to search the <see cref="MultiValueDictionary{TKey,TValue}"/> for</param>
+        /// <returns><c>true</c> if the <see cref="MultiValueDictionary{TKey,TValue}"/> contains the <paramref name="value"/>; otherwise <c>false</c></returns>      
+        public bool ContainsValue(TValue value)
+        {
+            foreach (InnerCollectionView sublist in dictionary.Values)
+                if (sublist.Contains(value))
+                    return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Removes every <typeparamref name="TKey"/> and <typeparamref name="TValue"/> from this 
+        /// <see cref="MultiValueDictionary{TKey,TValue}"/>.
+        /// </summary>
+        public void Clear()
+        {
+            dictionary.Clear();
+            version++;
+        }
+
+        #endregion
+
+        #region Members implemented from IReadOnlyDictionary<TKey, IReadOnlyCollection<TValue>>
+        /*======================================================================
+        ** Members implemented from IReadOnlyDictionary<TKey, IReadOnlyCollection<TValue>>
+        ======================================================================*/
+
+        /// <summary>
+        /// Determines if the given <typeparamref name="TKey"/> exists within this <see cref="MultiValueDictionary{TKey,TValue}"/> and has
+        /// at least one <typeparamref name="TValue"/> associated with it.
+        /// </summary>
+        /// <param name="key">The <typeparamref name="TKey"/> to search the <see cref="MultiValueDictionary{TKey,TValue}"/> for</param>
+        /// <returns><c>true</c> if the <see cref="MultiValueDictionary{TKey,TValue}"/> contains the requested <typeparamref name="TKey"/>;
+        /// otherwise <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> must be non-null</exception>
+        public bool ContainsKey(TKey key)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+            // Since modification to the MultiValueDictionary is only allowed through its own API, we
+            // can ensure that if a collection is in the internal dictionary then it must have at least one
+            // associated TValue, or else it would have been removed whenever its final TValue was removed.
+            return dictionary.ContainsKey(key);
+        }
+
+        /// <summary>
+        /// Gets each <typeparamref name="TKey"/> in this <see cref="MultiValueDictionary{TKey,TValue}"/> that
+        /// has one or more associated <typeparamref name="TValue"/>.
+        /// </summary>
+        /// <value>
+        /// An <see cref="IEnumerable{TKey}"/> containing each <typeparamref name="TKey"/> 
+        /// in this <see cref="MultiValueDictionary{TKey,TValue}"/> that has one or more associated 
+        /// <typeparamref name="TValue"/>.
+        /// </value>
+        public IEnumerable<TKey> Keys
+        {
+            get
+            {
+                return dictionary.Keys;
+            }
+        }
+
+        /// <summary>
+        /// Attempts to get the <typeparamref name="TValue"/> associated with the given
+        /// <typeparamref name="TKey"/> and place it into <paramref name="value"/>.
+        /// </summary>
+        /// <param name="key">The <typeparamref name="TKey"/> of the element to retrieve</param>
+        /// <param name="value">
+        /// When this method returns, contains the <typeparamref name="TValue"/> associated with the specified
+        /// <typeparamref name="TKey"/> if it is found; otherwise contains the default value of <typeparamref name="TValue"/>.
+        /// </param>
+        /// <returns>
+        /// <c>true</c> if the <see cref="MultiValueDictionary{TKey,TValue}"/> contains an element with the specified 
+        /// <typeparamref name="TKey"/>; otherwise, <c>false</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> must be non-null</exception>
+        public bool TryGetValue(TKey key, out IReadOnlyCollection<TValue> value)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+
+            InnerCollectionView collection;
+            var success = dictionary.TryGetValue(key, out collection);
+            value = collection;
+            return success;
+        }
+
+        /// <summary>
+        /// Gets an enumerable of <see cref="IReadOnlyCollection{TValue}"/> from this <see cref="MultiValueDictionary{TKey,TValue}"/>,
+        /// where each <see cref="IReadOnlyCollection{TValue}" /> is the collection of every <typeparamref name="TValue"/> associated
+        /// with a <typeparamref name="TKey"/> present in the <see cref="MultiValueDictionary{TKey,TValue}"/>. 
+        /// </summary>
+        /// <value>An IEnumerable of each <see cref="IReadOnlyCollection{TValue}"/> in this 
+        /// <see cref="MultiValueDictionary{TKey,TValue}"/></value>
+        public IEnumerable<IReadOnlyCollection<TValue>> Values
+        {
+            get
+            {
+                return dictionary.Values;
+            }
+        }
+
+        /// <summary>
+        /// Get every <typeparamref name="TValue"/> associated with the given <typeparamref name="TKey"/>. If 
+        /// <paramref name="key"/> is not found in this <see cref="MultiValueDictionary{TKey,TValue}"/>, will 
+        /// throw a <see cref="KeyNotFoundException"/>.
+        /// </summary>
+        /// <param name="key">The <typeparamref name="TKey"/> of the elements to retrieve.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="key"/> must be non-null</exception>
+        /// <exception cref="KeyNotFoundException"><paramref name="key"/> does not have any associated 
+        /// <typeparamref name="TValue"/>s in this <see cref="MultiValueDictionary{TKey,TValue}"/>.</exception>
+        /// <value>
+        /// An <see cref="IReadOnlyCollection{TValue}"/> containing every <typeparamref name="TValue"/>
+        /// associated with <paramref name="key"/>.
+        /// </value>
+        /// <remarks>
+        /// Note that the <see cref="IReadOnlyCollection{TValue}"/> returned will change alongside any changes 
+        /// to the <see cref="MultiValueDictionary{TKey,TValue}"/> 
+        /// </remarks>
+        public IReadOnlyCollection<TValue> this[TKey key]
+        {
+            get
+            {
+                if (key == null)
+                    throw new ArgumentNullException("key");
+
+                InnerCollectionView collection;
+                if (dictionary.TryGetValue(key, out collection))
+                    return collection;
+                else
+                    throw new KeyNotFoundException();
+            }
+        }
+
+        /// <summary>
+        /// Returns the number of <typeparamref name="TKey"/>s with one or more associated <typeparamref name="TValue"/>
+        /// in this <see cref="MultiValueDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <value>The number of <typeparamref name="TKey"/>s in this <see cref="MultiValueDictionary{TKey,TValue}"/>.</value>
+        public int Count
+        {
+            get
+            {
+                return dictionary.Count;
+            }
+        }
+
+        /// <summary>
+        /// Get an Enumerator over the <typeparamref name="TKey"/>-<see cref="IReadOnlyCollection{TValue}"/>
+        /// pairs in this <see cref="MultiValueDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <returns>an Enumerator over the <typeparamref name="TKey"/>-<see cref="IReadOnlyCollection{TValue}"/>
+        /// pairs in this <see cref="MultiValueDictionary{TKey,TValue}"/>.</returns>
+        public IEnumerator<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// The Enumerator class for a <see cref="MultiValueDictionary{TKey, TValue}"/>
+        /// that iterates over <typeparamref name="TKey"/>-<see cref="IReadOnlyCollection{TValue}"/>
+        /// pairs.
+        /// </summary>
+        private class Enumerator :
+            IEnumerator<KeyValuePair<TKey, IReadOnlyCollection<TValue>>>
+        {
+            private MultiValueDictionary<TKey, TValue> multiValueDictionary;
+            private int version;
+            private KeyValuePair<TKey, IReadOnlyCollection<TValue>> current;
+            private Dictionary<TKey, InnerCollectionView>.Enumerator enumerator;
+            private enum EnumerationState { BeforeFirst, During, AfterLast };
+            private EnumerationState state;
+
+            /// <summary>
+            /// Constructor for the enumerator
+            /// </summary>
+            /// <param name="multiValueDictionary">A MultiValueDictionary to iterate over</param>
+            internal Enumerator(MultiValueDictionary<TKey, TValue> multiValueDictionary)
+            {
+                this.multiValueDictionary = multiValueDictionary;
+                this.version = multiValueDictionary.version;
+                this.current = default(KeyValuePair<TKey, IReadOnlyCollection<TValue>>);
+                this.enumerator = multiValueDictionary.dictionary.GetEnumerator();
+                this.state = EnumerationState.BeforeFirst; ;
+            }
+
+            public KeyValuePair<TKey, IReadOnlyCollection<TValue>> Current
+            {
+                get { return current; }
+            }
+
+            object IEnumerator.Current
+            {
+                get
+                {
+                    switch (state)
+                    {
+                        case EnumerationState.BeforeFirst:
+                            throw new InvalidOperationException((SR.InvalidOperation_EnumNotStarted));
+                        case EnumerationState.AfterLast:
+                            throw new InvalidOperationException((SR.InvalidOperation_EnumEnded));
+                        default:
+                            return current;
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Advances the enumerator to the next element of the collection.
+            /// </summary>
+            /// <returns>
+            /// true if the enumerator was successfully advanced to the next element; false if the enumerator has passed the end of the collection.
+            /// </returns>
+            /// <exception cref="T:System.InvalidOperationException">The collection was modified after the enumerator was created. </exception>
+            public bool MoveNext()
+            {
+                if (version != multiValueDictionary.version)
+                {
+                    throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                }
+                else if (enumerator.MoveNext())
+                {
+                    current = new KeyValuePair<TKey, IReadOnlyCollection<TValue>>(enumerator.Current.Key, (IReadOnlyCollection<TValue>)enumerator.Current.Value);
+                    state = EnumerationState.During;
+                    return true;
+                }
+                else
+                {
+                    current = default(KeyValuePair<TKey, IReadOnlyCollection<TValue>>);
+                    state = EnumerationState.AfterLast;
+                    return false;
+                }
+            }
+
+            /// <summary>
+            /// Sets the enumerator to its initial position, which is before the first element in the collection.
+            /// </summary>
+            /// <exception cref="T:System.InvalidOperationException">The collection was modified after the enumerator was created. </exception>
+            public void Reset()
+            {
+                if (version != multiValueDictionary.version)
+                    throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                enumerator.Dispose();
+                enumerator = multiValueDictionary.dictionary.GetEnumerator();
+                current = default(KeyValuePair<TKey, IReadOnlyCollection<TValue>>);
+                state = EnumerationState.BeforeFirst;
+            }
+
+            /// <summary>
+            /// Frees resources associated with this Enumerator
+            /// </summary>
+            public void Dispose()
+            {
+                enumerator.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// An inner class that functions as a view of an ICollection within a MultiValueDictionary
+        /// </summary>
+        private class InnerCollectionView :
+            ICollection<TValue>,
+            IReadOnlyCollection<TValue>
+        {
+            private TKey key;
+            private ICollection<TValue> collection;
+
+            #region Private Concrete API
+            /*======================================================================
+            ** Private Concrete API
+            ======================================================================*/
+
+            public InnerCollectionView(TKey key, ICollection<TValue> collection)
+            {
+                this.key = key;
+                this.collection = collection;
+            }
+
+            public void AddValue(TValue item)
+            {
+                collection.Add(item);
+            }
+
+            public bool RemoveValue(TValue item)
+            {
+                return collection.Remove(item);
+            }
+
+            #endregion
+
+            #region Shared API
+            /*======================================================================
+            ** Shared API
+            ======================================================================*/
+
+            public bool Contains(TValue item)
+            {
+                return collection.Contains(item);
+            }
+
+            public void CopyTo(TValue[] array, int arrayIndex)
+            {
+                if (array == null)
+                    throw new ArgumentNullException("array");
+                if (arrayIndex < 0)
+                    throw new ArgumentOutOfRangeException("arrayIndex", SR.ArgumentOutOfRange_NeedNonNegNum);
+                if (arrayIndex > array.Length)
+                    throw new ArgumentOutOfRangeException("arrayIndex", SR.ArgumentOutOfRange_Index);
+                if (array.Length - arrayIndex < collection.Count)
+                    throw new ArgumentException("arrayIndex", SR.CopyTo_ArgumentsTooSmall);
+
+                collection.CopyTo(array, arrayIndex);
+            }
+
+            public int Count
+            {
+                get
+                {
+                    return collection.Count;
+                }
+            }
+
+            public bool IsReadOnly
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            public IEnumerator<TValue> GetEnumerator()
+            {
+                return collection.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return this.GetEnumerator();
+            }
+
+            public TKey Key
+            {
+                get { return key; }
+            }
+
+            #endregion
+
+            #region Public-Facing API
+            /*======================================================================
+            ** Public-Facing API
+            ======================================================================*/
+
+            void ICollection<TValue>.Add(TValue item)
+            {
+                throw new NotSupportedException(SR.ReadOnly_Modification);
+            }
+
+            void ICollection<TValue>.Clear()
+            {
+                throw new NotSupportedException(SR.ReadOnly_Modification);
+            }
+
+            bool ICollection<TValue>.Remove(TValue item)
+            {
+                throw new NotSupportedException(SR.ReadOnly_Modification);
+            }
+
+            #endregion
+        }
+    }
+}

--- a/src/System.Collections.Generic.MultiValueDictionary/src/project.json
+++ b/src/System.Collections.Generic.MultiValueDictionary/src/project.json
@@ -1,0 +1,15 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.0", 
+    "System.Diagnostics.Debug": "4.0.0", 
+    "System.Reflection.Primitives": "4.0.0",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Runtime": "4.0.0",
+    "System.Runtime.Extensions": "4.0.0",
+    "System.Runtime.InteropServices": "4.0.0",
+    "System.Threading": "4.0.0"
+    },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Collections.Generic.MultiValueDictionary/src/project.lock.json
+++ b/src/System.Collections.Generic.MultiValueDictionary/src/project.lock.json
@@ -1,0 +1,730 @@
+{
+  "locked": true,
+  "version": -9996,
+  "targets": {
+    "DNXCore,Version=v5.0": {
+      "System.Collections/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Globalization/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        }
+      },
+      "System.IO/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        }
+      },
+      "System.Reflection/4.0.0": {
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Globalization": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.0": {
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.0": {
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Threading/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "System.Collections/4.0.0": {
+      "sha512": "i2vsGDIEbWdHcUSNDPKZP/ZWod6o740el7mGTCy0dqbCxQh74W4QoC+klUwPEtGEFuvzJ7bJgvwJqscosVNyZQ==",
+      "files": [
+        "License.rtf",
+        "System.Collections.4.0.0.nupkg",
+        "System.Collections.4.0.0.nupkg.sha512",
+        "System.Collections.nuspec",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
+        "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
+        "ref/dotnet/fr/System.Collections.xml",
+        "ref/dotnet/it/System.Collections.xml",
+        "ref/dotnet/ja/System.Collections.xml",
+        "ref/dotnet/ko/System.Collections.xml",
+        "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/zh-hans/System.Collections.xml",
+        "ref/dotnet/zh-hant/System.Collections.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/System.Collections.dll",
+        "ref/netcore50/System.Collections.xml",
+        "ref/netcore50/de/System.Collections.xml",
+        "ref/netcore50/es/System.Collections.xml",
+        "ref/netcore50/fr/System.Collections.xml",
+        "ref/netcore50/it/System.Collections.xml",
+        "ref/netcore50/ja/System.Collections.xml",
+        "ref/netcore50/ko/System.Collections.xml",
+        "ref/netcore50/ru/System.Collections.xml",
+        "ref/netcore50/zh-hans/System.Collections.xml",
+        "ref/netcore50/zh-hant/System.Collections.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Diagnostics.Debug/4.0.0": {
+      "sha512": "AYJsLLGDVTC/nyURjgAo7Lpye0+HuSkcQujUf+NgQVdC/C/ky5NyamQHCforHJzgqspitMMtBe8B4UBdGXy1zQ==",
+      "files": [
+        "_rels/.rels",
+        "System.Diagnostics.Debug.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/netcore50/System.Diagnostics.Debug.dll",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/MonoAndroid10/_._",
+        "lib/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "lib/MonoTouch10/_._",
+        "ref/wp80/_._",
+        "lib/wp80/_._",
+        "ref/wpa81/_._",
+        "lib/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "lib/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/netcore50/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/netcore50/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
+        "ref/netcore50/System.Diagnostics.Debug.xml",
+        "ref/dotnet/fr/System.Diagnostics.Debug.xml",
+        "ref/netcore50/fr/System.Diagnostics.Debug.xml",
+        "ref/dotnet/it/System.Diagnostics.Debug.xml",
+        "ref/netcore50/it/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ja/System.Diagnostics.Debug.xml",
+        "ref/netcore50/ja/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ko/System.Diagnostics.Debug.xml",
+        "ref/netcore50/ko/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/netcore50/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/netcore50/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
+        "ref/netcore50/es/System.Diagnostics.Debug.xml",
+        "package/services/metadata/core-properties/9589d3ad95ef4d84a1edf67426c7c00a.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Globalization/4.0.0": {
+      "sha512": "IBJyTo1y7ZtzzoJUA60T1XPvNTyw/wfFmjFoBFtlYfkekIOtD/AzDDIg0YdUa7eNtFEfliED2R7HdppTdU4t5A==",
+      "files": [
+        "_rels/.rels",
+        "System.Globalization.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/netcore50/System.Globalization.dll",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/MonoAndroid10/_._",
+        "lib/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "lib/MonoTouch10/_._",
+        "ref/wp80/_._",
+        "lib/wp80/_._",
+        "ref/wpa81/_._",
+        "lib/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "lib/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "ref/netcore50/zh-hant/System.Globalization.xml",
+        "ref/dotnet/de/System.Globalization.xml",
+        "ref/netcore50/de/System.Globalization.xml",
+        "ref/dotnet/System.Globalization.xml",
+        "ref/netcore50/System.Globalization.xml",
+        "ref/dotnet/fr/System.Globalization.xml",
+        "ref/netcore50/fr/System.Globalization.xml",
+        "ref/dotnet/it/System.Globalization.xml",
+        "ref/netcore50/it/System.Globalization.xml",
+        "ref/dotnet/ja/System.Globalization.xml",
+        "ref/netcore50/ja/System.Globalization.xml",
+        "ref/dotnet/ko/System.Globalization.xml",
+        "ref/netcore50/ko/System.Globalization.xml",
+        "ref/dotnet/ru/System.Globalization.xml",
+        "ref/netcore50/ru/System.Globalization.xml",
+        "ref/dotnet/zh-hans/System.Globalization.xml",
+        "ref/netcore50/zh-hans/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
+        "ref/netcore50/es/System.Globalization.xml",
+        "package/services/metadata/core-properties/7256e6303e10459782eff20c3ec90af5.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.IO/4.0.0": {
+      "sha512": "MoCHQ0u5n0OMwUS8OX4Gl48qKiQziSW5cXvt82d+MmAcsLq9OL90+ihnu/aJ1h6OOYcBswrZAEuApfZha9w2lg==",
+      "files": [
+        "_rels/.rels",
+        "System.IO.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.IO.dll",
+        "ref/netcore50/System.IO.dll",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/MonoAndroid10/_._",
+        "lib/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "lib/MonoTouch10/_._",
+        "ref/wp80/_._",
+        "lib/wp80/_._",
+        "ref/wpa81/_._",
+        "lib/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "lib/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/zh-hant/System.IO.xml",
+        "ref/netcore50/zh-hant/System.IO.xml",
+        "ref/dotnet/de/System.IO.xml",
+        "ref/netcore50/de/System.IO.xml",
+        "ref/dotnet/System.IO.xml",
+        "ref/netcore50/System.IO.xml",
+        "ref/dotnet/fr/System.IO.xml",
+        "ref/netcore50/fr/System.IO.xml",
+        "ref/dotnet/it/System.IO.xml",
+        "ref/netcore50/it/System.IO.xml",
+        "ref/dotnet/ja/System.IO.xml",
+        "ref/netcore50/ja/System.IO.xml",
+        "ref/dotnet/ko/System.IO.xml",
+        "ref/netcore50/ko/System.IO.xml",
+        "ref/dotnet/ru/System.IO.xml",
+        "ref/netcore50/ru/System.IO.xml",
+        "ref/dotnet/zh-hans/System.IO.xml",
+        "ref/netcore50/zh-hans/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
+        "ref/netcore50/es/System.IO.xml",
+        "package/services/metadata/core-properties/93bf03c6f6d24eaf9a358a72856daa5f.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Reflection/4.0.0": {
+      "sha512": "g96Rn8XuG7y4VfxPj/jnXroRJdQ8L3iN3k3zqsuzk4k3Nq4KMXARYiIO4BLW4GwX06uQpuYwRMcAC/aF117knQ==",
+      "files": [
+        "_rels/.rels",
+        "System.Reflection.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/netcore50/System.Reflection.dll",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/MonoAndroid10/_._",
+        "lib/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "lib/MonoTouch10/_._",
+        "ref/wp80/_._",
+        "lib/wp80/_._",
+        "ref/wpa81/_._",
+        "lib/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "lib/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "ref/netcore50/zh-hant/System.Reflection.xml",
+        "ref/dotnet/de/System.Reflection.xml",
+        "ref/netcore50/de/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.xml",
+        "ref/netcore50/System.Reflection.xml",
+        "ref/dotnet/fr/System.Reflection.xml",
+        "ref/netcore50/fr/System.Reflection.xml",
+        "ref/dotnet/it/System.Reflection.xml",
+        "ref/netcore50/it/System.Reflection.xml",
+        "ref/dotnet/ja/System.Reflection.xml",
+        "ref/netcore50/ja/System.Reflection.xml",
+        "ref/dotnet/ko/System.Reflection.xml",
+        "ref/netcore50/ko/System.Reflection.xml",
+        "ref/dotnet/ru/System.Reflection.xml",
+        "ref/netcore50/ru/System.Reflection.xml",
+        "ref/dotnet/zh-hans/System.Reflection.xml",
+        "ref/netcore50/zh-hans/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
+        "ref/netcore50/es/System.Reflection.xml",
+        "package/services/metadata/core-properties/1e935117d401458384a90c2c69f60bd2.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Reflection.Primitives/4.0.0": {
+      "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
+      "files": [
+        "_rels/.rels",
+        "System.Reflection.Primitives.nuspec",
+        "lib/netcore50/System.Reflection.Primitives.dll",
+        "lib/DNXCore50/System.Reflection.Primitives.dll",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/fr/System.Reflection.Primitives.xml",
+        "ref/dotnet/it/System.Reflection.Primitives.xml",
+        "ref/dotnet/ja/System.Reflection.Primitives.xml",
+        "ref/dotnet/ko/System.Reflection.Primitives.xml",
+        "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "ref/net45/_._",
+        "ref/win8/_._",
+        "ref/netcore50/System.Reflection.Primitives.dll",
+        "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Resources.ResourceManager/4.0.0": {
+      "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
+      "files": [
+        "_rels/.rels",
+        "System.Resources.ResourceManager.nuspec",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
+        "lib/DNXCore50/System.Resources.ResourceManager.dll",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/fr/System.Resources.ResourceManager.xml",
+        "ref/dotnet/it/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ja/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ko/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "ref/net45/_._",
+        "ref/win8/_._",
+        "ref/netcore50/System.Resources.ResourceManager.dll",
+        "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Runtime/4.0.0": {
+      "sha512": "Uq9epame8hEqJlj4KaWb67dDJvj4IM37jRFGVeFbugRdPz48bR0voyBhrbf3iSa2tAmlkg4lsa6BUOL9iwlMew==",
+      "files": [
+        "_rels/.rels",
+        "System.Runtime.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/netcore50/System.Runtime.dll",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/MonoAndroid10/_._",
+        "lib/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "lib/MonoTouch10/_._",
+        "ref/wp80/_._",
+        "lib/wp80/_._",
+        "ref/wpa81/_._",
+        "lib/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "lib/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/netcore50/zh-hant/System.Runtime.xml",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/netcore50/de/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/netcore50/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/netcore50/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/netcore50/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/netcore50/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/netcore50/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/netcore50/ru/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/netcore50/zh-hans/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "ref/netcore50/es/System.Runtime.xml",
+        "package/services/metadata/core-properties/c5db97a122ad42aeb8e429022c1d1ab8.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Runtime.Extensions/4.0.0": {
+      "sha512": "zPzwoJcA7qar/b5Ihhzfcdr3vBOR8FIg7u//Qc5mqyAriasXuMFVraBZ5vOQq5asfun9ryNEL8Z2BOlUK5QRqA==",
+      "files": [
+        "_rels/.rels",
+        "System.Runtime.Extensions.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/netcore50/System.Runtime.Extensions.dll",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/MonoAndroid10/_._",
+        "lib/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "lib/MonoTouch10/_._",
+        "ref/wp80/_._",
+        "lib/wp80/_._",
+        "ref/wpa81/_._",
+        "lib/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "lib/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "ref/netcore50/zh-hant/System.Runtime.Extensions.xml",
+        "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/netcore50/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.xml",
+        "ref/netcore50/System.Runtime.Extensions.xml",
+        "ref/dotnet/fr/System.Runtime.Extensions.xml",
+        "ref/netcore50/fr/System.Runtime.Extensions.xml",
+        "ref/dotnet/it/System.Runtime.Extensions.xml",
+        "ref/netcore50/it/System.Runtime.Extensions.xml",
+        "ref/dotnet/ja/System.Runtime.Extensions.xml",
+        "ref/netcore50/ja/System.Runtime.Extensions.xml",
+        "ref/dotnet/ko/System.Runtime.Extensions.xml",
+        "ref/netcore50/ko/System.Runtime.Extensions.xml",
+        "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/netcore50/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
+        "ref/netcore50/zh-hans/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
+        "ref/netcore50/es/System.Runtime.Extensions.xml",
+        "package/services/metadata/core-properties/fb0a27c059094735ba8947d01a5f5660.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Runtime.InteropServices/4.0.0": {
+      "sha512": "J8GBB0OsVuKJXR412x6uZdoyNi4y9OMjjJRHPutRHjqujuvthus6Xdxn/i8J1lL2PK+2jWCLpZp72h8x73hkLg==",
+      "files": [
+        "_rels/.rels",
+        "System.Runtime.InteropServices.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/netcore50/System.Runtime.InteropServices.dll",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/MonoAndroid10/_._",
+        "lib/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "lib/MonoTouch10/_._",
+        "ref/wpa81/_._",
+        "lib/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "lib/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/netcore50/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/netcore50/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
+        "ref/netcore50/System.Runtime.InteropServices.xml",
+        "ref/dotnet/fr/System.Runtime.InteropServices.xml",
+        "ref/netcore50/fr/System.Runtime.InteropServices.xml",
+        "ref/dotnet/it/System.Runtime.InteropServices.xml",
+        "ref/netcore50/it/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ja/System.Runtime.InteropServices.xml",
+        "ref/netcore50/ja/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ko/System.Runtime.InteropServices.xml",
+        "ref/netcore50/ko/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/netcore50/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
+        "ref/netcore50/zh-hans/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
+        "ref/netcore50/es/System.Runtime.InteropServices.xml",
+        "package/services/metadata/core-properties/cb937f04833048a9948507c9ef331a18.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Text.Encoding/4.0.0": {
+      "sha512": "AMxFNOXpA6Ab8swULbXuJmoT2K5w6TnV3ObF5wsmEcIHQUJghoZtDVfVHb08O2wW15mOSI1i9Wg0Dx0pY13o8g==",
+      "files": [
+        "_rels/.rels",
+        "System.Text.Encoding.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/netcore50/System.Text.Encoding.dll",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/MonoAndroid10/_._",
+        "lib/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "lib/MonoTouch10/_._",
+        "ref/wp80/_._",
+        "lib/wp80/_._",
+        "ref/wpa81/_._",
+        "lib/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "lib/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "ref/netcore50/zh-hant/System.Text.Encoding.xml",
+        "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/netcore50/de/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.xml",
+        "ref/netcore50/System.Text.Encoding.xml",
+        "ref/dotnet/fr/System.Text.Encoding.xml",
+        "ref/netcore50/fr/System.Text.Encoding.xml",
+        "ref/dotnet/it/System.Text.Encoding.xml",
+        "ref/netcore50/it/System.Text.Encoding.xml",
+        "ref/dotnet/ja/System.Text.Encoding.xml",
+        "ref/netcore50/ja/System.Text.Encoding.xml",
+        "ref/dotnet/ko/System.Text.Encoding.xml",
+        "ref/netcore50/ko/System.Text.Encoding.xml",
+        "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/netcore50/ru/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.xml",
+        "ref/netcore50/zh-hans/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
+        "ref/netcore50/es/System.Text.Encoding.xml",
+        "package/services/metadata/core-properties/8740abce9d6a472db9f21ed43f2fb149.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Threading/4.0.0": {
+      "sha512": "H6O/9gUrjPDNYanh/7OFGAZHjVXvEuITD0RcnjfvIV04HOGrOPqUBU0kmz9RIX/7YGgCQn1o1S2DX6Cuv8kVGQ==",
+      "files": [
+        "_rels/.rels",
+        "System.Threading.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.Threading.dll",
+        "ref/netcore50/System.Threading.dll",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/MonoAndroid10/_._",
+        "lib/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "lib/MonoTouch10/_._",
+        "ref/wp80/_._",
+        "lib/wp80/_._",
+        "ref/wpa81/_._",
+        "lib/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "lib/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/zh-hant/System.Threading.xml",
+        "ref/netcore50/zh-hant/System.Threading.xml",
+        "ref/dotnet/de/System.Threading.xml",
+        "ref/netcore50/de/System.Threading.xml",
+        "ref/dotnet/System.Threading.xml",
+        "ref/netcore50/System.Threading.xml",
+        "ref/dotnet/fr/System.Threading.xml",
+        "ref/netcore50/fr/System.Threading.xml",
+        "ref/dotnet/it/System.Threading.xml",
+        "ref/netcore50/it/System.Threading.xml",
+        "ref/dotnet/ja/System.Threading.xml",
+        "ref/netcore50/ja/System.Threading.xml",
+        "ref/dotnet/ko/System.Threading.xml",
+        "ref/netcore50/ko/System.Threading.xml",
+        "ref/dotnet/ru/System.Threading.xml",
+        "ref/netcore50/ru/System.Threading.xml",
+        "ref/dotnet/zh-hans/System.Threading.xml",
+        "ref/netcore50/zh-hans/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
+        "ref/netcore50/es/System.Threading.xml",
+        "package/services/metadata/core-properties/bec033e95dbf4d6ba6595d2be7bb7e25.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Threading.Tasks/4.0.0": {
+      "sha512": "dA3y1B6Pc8mNt9obhEWWGGpvEakS51+nafXpmM/Z8IF847GErLXGTjdfA+AYEKszfFbH7SVLWUklXhYeeSQ1lw==",
+      "files": [
+        "_rels/.rels",
+        "System.Threading.Tasks.nuspec",
+        "License.rtf",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/netcore50/System.Threading.Tasks.dll",
+        "ref/win8/_._",
+        "lib/win8/_._",
+        "ref/net45/_._",
+        "lib/net45/_._",
+        "ref/MonoAndroid10/_._",
+        "lib/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "lib/MonoTouch10/_._",
+        "ref/wp80/_._",
+        "lib/wp80/_._",
+        "ref/wpa81/_._",
+        "lib/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "lib/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "ref/netcore50/zh-hant/System.Threading.Tasks.xml",
+        "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/netcore50/de/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.xml",
+        "ref/netcore50/System.Threading.Tasks.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.xml",
+        "ref/netcore50/fr/System.Threading.Tasks.xml",
+        "ref/dotnet/it/System.Threading.Tasks.xml",
+        "ref/netcore50/it/System.Threading.Tasks.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.xml",
+        "ref/netcore50/ja/System.Threading.Tasks.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.xml",
+        "ref/netcore50/ko/System.Threading.Tasks.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/netcore50/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
+        "ref/netcore50/zh-hans/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
+        "ref/netcore50/es/System.Threading.Tasks.xml",
+        "package/services/metadata/core-properties/e45094f04ec149d1ba36afbb03ce2e9e.psmdcp",
+        "[Content_Types].xml"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Collections >= 4.0.0",
+      "System.Diagnostics.Debug >= 4.0.0",
+      "System.Reflection.Primitives >= 4.0.0",
+      "System.Resources.ResourceManager >= 4.0.0",
+      "System.Runtime >= 4.0.0",
+      "System.Runtime.Extensions >= 4.0.0",
+      "System.Runtime.InteropServices >= 4.0.0",
+      "System.Threading >= 4.0.0"
+    ],
+    "DNXCore,Version=v5.0": []
+  }
+}

--- a/src/System.Collections.Generic.MultiValueDictionary/tests/Generic/MultiValueDictionary/MVD.TestBase.cs
+++ b/src/System.Collections.Generic.MultiValueDictionary/tests/Generic/MultiValueDictionary/MVD.TestBase.cs
@@ -1,0 +1,199 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public class MVD_TestBase
+    {
+        private static Random rand = new Random(11231992);
+
+        /// <summary>
+        /// Attempts to create a new instance of the given type parameter
+        /// and return it. Only supports a limited number of types that can 
+        /// be successfully created.
+        /// </summary>
+        /// <typeparam name="T">The type to be instantiated and returned</typeparam>
+        /// <returns>A new object of type <typeparamref name="T"/></returns>
+        protected static object TypeBuilder<T>()
+        {
+            if (typeof(T) == typeof(int))
+            {
+                return rand.Next(2, 50);
+            }
+            else if (typeof(T) == typeof(string))
+            {
+                byte[] bytes = new byte[50];
+                rand.NextBytes(bytes);
+                return Convert.ToBase64String(bytes);
+            }
+            else if (typeof(T) == typeof(char))
+            {
+                return (char)rand.Next(2, 50);
+            }
+
+            throw new ArgumentException();
+        }
+
+        /// <summary>
+        /// Method to create an <see cref="ICollection{T}"/> (where T is 
+        /// created randomly through the TypeBuilder method) with the given
+        /// number of elements inside of it.
+        /// </summary>
+        /// <typeparam name="T">The type that the returned collection will contain</typeparam>
+        /// <typeparam name="TCollection">The type of the collection to return</typeparam>
+        /// <param name="count">The number of elements in the returned collection</param>
+        /// <returns>A new collection containing <paramref name="count"/> elements of type <typeparamref name="T"/></returns>
+        protected ICollection<T> CreateRange<T, TCollection>(int count)
+            where TCollection : ICollection<T>, new()
+        {
+            var ret = new TCollection();
+            for (int i = 0; i < count; i++)
+                ret.Add((T)TypeBuilder<T>());
+            return ret;
+        }
+
+        protected static void CompareEnumerables<TValue>(IEnumerable<TValue> enum1, IEnumerable<TValue> enum2)
+        {
+            CompareEnumerables<TValue>(enum1, enum2, true);
+        }
+
+        /// <summary>
+        /// Performs validation to ensure that the two enumerables are equal or not equal depending on areEqual.
+        /// </summary>
+        protected static void CompareEnumerables<TValue>(IEnumerable<TValue> enum1, IEnumerable<TValue> enum2, bool areEqual)
+        {
+            var multiDictionary1 = new Dictionary<TValue, int>();
+            var multiDictionary2 = new Dictionary<TValue, int>();
+            int multiDictionary1nullcount = 0;
+            int multiDictionary2nullcount = 0;
+            foreach (TValue val in enum1)
+            {
+                if (val == null)
+                    multiDictionary1nullcount++;
+                else if (multiDictionary1.ContainsKey(val))
+                    multiDictionary1[val] += 1;
+                else multiDictionary1.Add(val, 1);
+            }
+            foreach (TValue val in enum2)
+            {
+                if (val == null)
+                    multiDictionary2nullcount++;
+                else if (multiDictionary2.ContainsKey(val))
+                    multiDictionary2[val] += 1;
+                else multiDictionary2.Add(val, 1);
+            }
+            if (areEqual)
+            {
+                Assert.Equal(multiDictionary1.Count, multiDictionary2.Count);
+                Assert.Equal(multiDictionary1nullcount, multiDictionary2nullcount);
+                foreach (TValue key in multiDictionary1.Keys)
+                    Assert.Equal(multiDictionary2[key], multiDictionary1[key]);
+            }
+            else
+            {
+                if (multiDictionary1.Count != multiDictionary2.Count && multiDictionary1nullcount != multiDictionary2nullcount)
+                {
+                    foreach (TValue key in multiDictionary1.Keys)
+                        if (multiDictionary2[key] != multiDictionary1[key])
+                            return;
+                    Assert.True(false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Does validation to determine if the two MVDs contain all of the same elements
+        /// </summary>
+        protected static void CompareMVDs<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd1, MultiValueDictionary<TKey, TValue> mvd2)
+        {
+            Assert.Equal(mvd1.Count, mvd2.Count);
+            Assert.Equal(mvd2.Keys, mvd1.Keys);
+            foreach (var key in mvd1.Keys)
+            {
+                var temp = mvd2[key]; // does not throw
+                var countMap1 = new Dictionary<TValue, int>();
+                var countMap2 = new Dictionary<TValue, int>();
+                foreach (var value in mvd1[key])
+                {
+                    if (countMap1.ContainsKey(value))
+                        countMap1[value] = countMap1[value] + 1;
+                    else
+                        countMap1[value] = 1;
+                }
+                foreach (var value in mvd1[key])
+                {
+                    if (countMap2.ContainsKey(value))
+                        countMap2[value] = countMap2[value] + 1;
+                    else
+                        countMap2[value] = 1;
+                }
+                foreach (var pair in countMap1)
+                    Assert.Equal(pair.Value, countMap2[pair.Key]);
+            }
+        }
+
+        protected class dummyComparer<TKey> : IEqualityComparer<TKey>
+        {
+            public bool Equals(TKey x, TKey y)
+            {
+                throw new InvalidOperationException();
+            }
+
+            public int GetHashCode(TKey obj)
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
+        protected class DummyReadOnlyCollection<TValue> : ICollection<TValue>
+        {
+            public void Add(TValue item)
+            {
+                throw new InvalidOperationException();
+            }
+
+            public void Clear()
+            {
+                throw new InvalidOperationException();
+            }
+
+            public bool Contains(TValue item)
+            {
+                throw new InvalidOperationException();
+            }
+
+            public void CopyTo(TValue[] array, int arrayIndex)
+            {
+                throw new InvalidOperationException();
+            }
+
+            public int Count
+            {
+                get { throw new InvalidOperationException(); }
+            }
+
+            public bool IsReadOnly
+            {
+                get { return true; }
+            }
+
+            public bool Remove(TValue item)
+            {
+                throw new InvalidOperationException();
+            }
+
+            public IEnumerator<TValue> GetEnumerator()
+            {
+                throw new InvalidOperationException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new InvalidOperationException();
+            }
+        }
+    }
+}

--- a/src/System.Collections.Generic.MultiValueDictionary/tests/Generic/MultiValueDictionary/MVD.Tests.cs
+++ b/src/System.Collections.Generic.MultiValueDictionary/tests/Generic/MultiValueDictionary/MVD.Tests.cs
@@ -1,0 +1,1793 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace System.Collections.Tests
+{
+    public class MVD_Tests : MVD_TestBase
+    {
+        #region Helper Methods
+        /*======================================================================
+        ** Helper Methods
+        ======================================================================*/
+        public static MultiValueDictionary<TKey, TValue>[] Multi<TKey, TValue, TValueCollection>()
+            where TValueCollection : ICollection<TValue>, new()
+        {
+            MultiValueDictionary<TKey, TValue>[] ret = new MultiValueDictionary<TKey, TValue>[6];
+
+            //Empty MultiValueDictionary
+            ret[0] = MultiValueDictionary<TKey, TValue>.Create<TValueCollection>();
+
+            //1-element MultiValueDictionary
+            ret[1] = MultiValueDictionary<TKey, TValue>.Create<TValueCollection>();
+            ret[1].Add((TKey)TypeBuilder<TKey>(), (TValue)TypeBuilder<TValue>());
+
+            //2-element MultiValueDictionary
+            ret[2] = MultiValueDictionary<TKey, TValue>.Create<TValueCollection>();
+            ret[2].Add((TKey)TypeBuilder<TKey>(), (TValue)TypeBuilder<TValue>());
+            ret[2].Add((TKey)TypeBuilder<TKey>(), (TValue)TypeBuilder<TValue>());
+
+            //Lightly filled MultiValueDictionary
+            ret[3] = MultiValueDictionary<TKey, TValue>.Create<TValueCollection>();
+            for (int i = 0; i < 20; i++)
+                ret[3].Add((TKey)TypeBuilder<TKey>(), (TValue)TypeBuilder<TValue>());
+
+            //Moderately filled MultiValueDictionary
+            ret[4] = MultiValueDictionary<TKey, TValue>.Create<TValueCollection>();
+            for (int i = 0; i < 200; i++)
+                ret[4].Add((TKey)TypeBuilder<TKey>(), (TValue)TypeBuilder<TValue>());
+
+            //Very filled MultiValueDictionary
+            ret[5] = MultiValueDictionary<TKey, TValue>.Create<TValueCollection>();
+            for (int i = 0; i < 5000; i++)
+                ret[4].Add((TKey)TypeBuilder<TKey>(), (TValue)TypeBuilder<TValue>());
+
+            return ret;
+        }
+
+        private void TestCollectionType<TKey, TValue>(Type type, MultiValueDictionary<TKey, TValue> mvd)
+        {
+            var newCollection = (ICollection<TValue>)Activator.CreateInstance(type);
+            var key = (TKey)TypeBuilder<TKey>();
+            mvd.Remove(key);
+            for (int i = 0; i < (int)TypeBuilder<int>(); i++)
+            {
+                var value = (TValue)TypeBuilder<TValue>();
+                mvd.Add(key, value);
+                newCollection.Add(value);
+            }
+            CompareEnumerables<TValue>(mvd[key], newCollection, true);
+        }
+
+        private int PairsCount<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd)
+        {
+            int count = 0;
+            foreach (var pair in mvd)
+                count += pair.Value.Count;
+            return count;
+        }
+
+        #endregion
+
+        #region Test callers
+        /*======================================================================
+        ** Contains the [Fact] tests that call all actual tests
+        ======================================================================*/
+
+        private void CallTests(string testsPrefix)
+        {
+            var testMethods =
+            from method in this.GetType().GetRuntimeMethods()
+            where method.Name.StartsWith(testsPrefix)
+                && method.IsGenericMethod
+            select method;
+
+            foreach (var test in testMethods)
+            {
+                test.MakeGenericMethod(typeof(char), typeof(int)).Invoke(this, new object[] { });
+                test.MakeGenericMethod(typeof(char), typeof(string)).Invoke(this, new object[] { });
+                test.MakeGenericMethod(typeof(char), typeof(String)).Invoke(this, new object[] { });
+                test.MakeGenericMethod(typeof(int), typeof(int)).Invoke(this, new object[] { });
+                test.MakeGenericMethod(typeof(string), typeof(string)).Invoke(this, new object[] { });
+                test.MakeGenericMethod(typeof(String), typeof(int)).Invoke(this, new object[] { });
+                test.MakeGenericMethod(typeof(int), typeof(string)).Invoke(this, new object[] { });
+            }
+        }
+
+        [Fact]
+        public void MVD_Constructor1() { CallTests("MVD_Constructor1_"); }
+        [Fact]
+        public void MVD_Constructor2() { CallTests("MVD_Constructor2_"); }
+        [Fact]
+        public void MVD_Constructor3() { CallTests("MVD_Constructor3_"); }
+        [Fact]
+        public void MVD_Constructor4() { CallTests("MVD_Constructor4_"); }
+        [Fact]
+        public void MVD_Constructor5() { CallTests("MVD_Constructor5_"); }
+        [Fact]
+        public void MVD_Constructor6() { CallTests("MVD_Constructor6_"); }
+        [Fact]
+        public void MVD_Constructor7() { CallTests("MVD_Constructor7_"); }
+        [Fact]
+        public void MVD_Constructor8() { CallTests("MVD_Constructor8_"); }
+        [Fact]
+        public void MVD_Add() { CallTests("MVD_Add_"); }
+        [Fact]
+        public void MVD_AddRange() { CallTests("MVD_AddRange_"); }
+        [Fact]
+        public void MVD_Clear() { CallTests("MVD_Clear_"); }
+        [Fact]
+        public void MVD_Contains() { CallTests("MVD_Contains_"); }
+        [Fact]
+        public void MVD_ContainsKey() { CallTests("MVD_ContainsKey_"); }
+        [Fact]
+        public void MVD_ContainsValue() { CallTests("MVD_ContainsValue_"); }
+        [Fact]
+        public void MVD_Count() { CallTests("MVD_Count_"); }
+        [Fact]
+        public void MVD_GetEnumerator() { CallTests("MVD_GetEnumerator_"); }
+        [Fact]
+        public void MVD_Item() { CallTests("MVD_Item_"); }
+        [Fact]
+        public void MVD_Keys() { CallTests("MVD_Keys_"); }
+        [Fact]
+        public void MVD_Remove() { CallTests("MVD_Remove_"); }
+        [Fact]
+        public void MVD_RemoveItem() { CallTests("MVD_RemoveItem_"); }
+        [Fact]
+        public void MVD_TryGetValue() { CallTests("MVD_TryGetValue_"); }
+        [Fact]
+        public void MVD_Values() { CallTests("MVD_Values_"); }
+
+        #endregion
+
+        #region Tests for: Constructor1
+        /*======================================================================
+        ** Constructor 1 includes:
+        **     -MultiValueDictionary() 
+        **     -MultiValueDictionary.Create<TValueCollection>()
+        **     -MultiValueDictionary.Create<TValueCollection>(Func<ICollection<TValue>> collectionFactory)
+        ======================================================================*/
+
+        private delegate MultiValueDictionary<TKey, TValue> Constructor1Delegate<TKey, TValue>();
+        private Tuple<Constructor1Delegate<TKey, TValue>, Type>[] Constructor1<TKey, TValue>()
+        {
+            var ret = new Tuple<Constructor1Delegate<TKey, TValue>, Type>[5];
+            ret[0] = Tuple.Create<Constructor1Delegate<TKey, TValue>, Type>(() => new MultiValueDictionary<TKey, TValue>(), typeof(List<TValue>));
+            ret[1] = Tuple.Create<Constructor1Delegate<TKey, TValue>, Type>(() => MultiValueDictionary<TKey, TValue>.Create<List<TValue>>(), typeof(List<TValue>));
+            ret[2] = Tuple.Create<Constructor1Delegate<TKey, TValue>, Type>(() => MultiValueDictionary<TKey, TValue>.Create<HashSet<TValue>>(), typeof(HashSet<TValue>));
+            ret[3] = Tuple.Create<Constructor1Delegate<TKey, TValue>, Type>(() => MultiValueDictionary<TKey, TValue>.Create<List<TValue>>(() => new List<TValue>()), typeof(List<TValue>));
+            ret[4] = Tuple.Create<Constructor1Delegate<TKey, TValue>, Type>(() => MultiValueDictionary<TKey, TValue>.Create<HashSet<TValue>>(() => new HashSet<TValue>()), typeof(HashSet<TValue>));
+            return ret;
+        }
+
+        public void MVD_Constructor1_Valid<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor1<TKey, TValue>())
+            {
+                var mvd = tuple.Item1();
+                TestCollectionType<TKey, TValue>(tuple.Item2, mvd);
+            }
+        }
+
+        public void MVD_Constructor1_InvalidTCollection<TKey, TValue>()
+        {
+            Assert.Throws<InvalidOperationException>(() => MultiValueDictionary<TKey, TValue>.Create<DummyReadOnlyCollection<TValue>>());
+            Assert.Throws<InvalidOperationException>(() => MultiValueDictionary<TKey, TValue>.Create<DummyReadOnlyCollection<TValue>>(() => new DummyReadOnlyCollection<TValue>()));
+        }
+
+        #endregion
+
+        #region Tests for: Constructor2
+        /*======================================================================
+        ** Constructor 2 includes:
+        **     -MultiValueDictionary(int capacity) 
+        **     -MultiValueDictionary.Create<TValueCollection>(int capacity)
+        **     -MultiValueDictionary.Create<TValueCollection>(int capacity, Func<ICollection<TValue>> collectionFactory)
+        ======================================================================*/
+
+        private delegate MultiValueDictionary<TKey, TValue> Constructor2Delegate<TKey, TValue>(int capacity);
+        private Tuple<Constructor2Delegate<TKey, TValue>, Type>[] Constructor2<TKey, TValue>()
+        {
+            var ret = new Tuple<Constructor2Delegate<TKey, TValue>, Type>[5];
+            ret[0] = Tuple.Create<Constructor2Delegate<TKey, TValue>, Type>((int capacity) => new MultiValueDictionary<TKey, TValue>(capacity), typeof(List<TValue>));
+            ret[1] = Tuple.Create<Constructor2Delegate<TKey, TValue>, Type>((int capacity) => MultiValueDictionary<TKey, TValue>.Create<List<TValue>>(capacity), typeof(List<TValue>));
+            ret[2] = Tuple.Create<Constructor2Delegate<TKey, TValue>, Type>((int capacity) => MultiValueDictionary<TKey, TValue>.Create<List<TValue>>(capacity, () => new List<TValue>()), typeof(List<TValue>));
+            ret[3] = Tuple.Create<Constructor2Delegate<TKey, TValue>, Type>((int capacity) => MultiValueDictionary<TKey, TValue>.Create<HashSet<TValue>>(capacity), typeof(HashSet<TValue>));
+            ret[4] = Tuple.Create<Constructor2Delegate<TKey, TValue>, Type>((int capacity) => MultiValueDictionary<TKey, TValue>.Create<HashSet<TValue>>(capacity, () => new HashSet<TValue>()), typeof(HashSet<TValue>));
+            return ret;
+        }
+
+        public void MVD_Constructor2_PositiveCapacity<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor2<TKey, TValue>())
+            {
+                var mvd = tuple.Item1(1);
+                TestCollectionType<TKey, TValue>(tuple.Item2, mvd);
+            }
+        }
+
+        public void MVD_Constructor2_ZeroCapacity<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor2<TKey, TValue>())
+            {
+                var mvd = tuple.Item1(0);
+                TestCollectionType<TKey, TValue>(tuple.Item2, mvd);
+            }
+        }
+
+        public void MVD_Constructor2_NegativeCapacity<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor2<TKey, TValue>())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => tuple.Item1(-1));
+            }
+        }
+
+        public void MVD_Constructor2_InvalidTCollection<TKey, TValue>()
+        {
+            Assert.Throws<InvalidOperationException>(() => MultiValueDictionary<TKey, TValue>.Create<DummyReadOnlyCollection<TValue>>(1));
+            Assert.Throws<InvalidOperationException>(() => MultiValueDictionary<TKey, TValue>.Create<DummyReadOnlyCollection<TValue>>(1, () => new DummyReadOnlyCollection<TValue>()));
+        }
+
+        #endregion
+
+        #region Tests for: Constructor3
+        /*======================================================================
+        ** Constructor 3 includes:
+        **     -MultiValueDictionary(IEqualityComparer<TKey> comparer) 
+        **     -MultiValueDictionary.Create<TValueCollection>(IEqualityComparer<TKey> comparer)
+        **     -MultiValueDictionary.Create<TValueCollection>(IEqualityComparer<TKey> comparer, Func<ICollection<TValue>> collectionFactory)
+        ======================================================================*/
+
+        private delegate MultiValueDictionary<TKey, TValue> Constructor3Delegate<TKey, TValue>(IEqualityComparer<TKey> comparer);
+        private Tuple<Constructor3Delegate<TKey, TValue>, Type>[] Constructor3<TKey, TValue>()
+        {
+            var ret = new Tuple<Constructor3Delegate<TKey, TValue>, Type>[5];
+            ret[0] = Tuple.Create<Constructor3Delegate<TKey, TValue>, Type>((IEqualityComparer<TKey> comparer) => new MultiValueDictionary<TKey, TValue>(comparer), typeof(List<TValue>));
+            ret[1] = Tuple.Create<Constructor3Delegate<TKey, TValue>, Type>((IEqualityComparer<TKey> comparer) => MultiValueDictionary<TKey, TValue>.Create<List<TValue>>(comparer), typeof(List<TValue>));
+            ret[2] = Tuple.Create<Constructor3Delegate<TKey, TValue>, Type>((IEqualityComparer<TKey> comparer) => MultiValueDictionary<TKey, TValue>.Create<HashSet<TValue>>(comparer), typeof(HashSet<TValue>));
+            ret[3] = Tuple.Create<Constructor3Delegate<TKey, TValue>, Type>((IEqualityComparer<TKey> comparer) => MultiValueDictionary<TKey, TValue>.Create<List<TValue>>(comparer, () => new List<TValue>()), typeof(List<TValue>));
+            ret[4] = Tuple.Create<Constructor3Delegate<TKey, TValue>, Type>((IEqualityComparer<TKey> comparer) => MultiValueDictionary<TKey, TValue>.Create<HashSet<TValue>>(comparer, () => new HashSet<TValue>()), typeof(HashSet<TValue>));
+            return ret;
+        }
+
+        public void MVD_Constructor3_DummyComparer<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor3<TKey, TValue>())
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    var mvd = tuple.Item1(new dummyComparer<TKey>());
+                    mvd.Add((TKey)TypeBuilder<TKey>(), (TValue)TypeBuilder<TValue>());
+                });
+            }
+        }
+
+        public void MVD_Constructor3_NullComparer<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor3<TKey, TValue>())
+            {
+                var mvd = tuple.Item1(null);
+                TestCollectionType<TKey, TValue>(tuple.Item2, mvd);
+            }
+        }
+
+        public void MVD_Constructor3_InvalidTCollection<TKey, TValue>()
+        {
+            Assert.Throws<InvalidOperationException>(() => MultiValueDictionary<TKey, TValue>.Create<DummyReadOnlyCollection<TValue>>((IEqualityComparer<TKey>)null));
+            Assert.Throws<InvalidOperationException>(() => MultiValueDictionary<TKey, TValue>.Create<DummyReadOnlyCollection<TValue>>((IEqualityComparer<TKey>)null, () => new DummyReadOnlyCollection<TValue>()));
+        }
+
+        #endregion
+
+        #region Tests for: Constructor4
+        /*======================================================================
+        ** Constructor 4 includes:
+        **     -MultiValueDictionary(int capacity, IEqualityComparer<TKey> comparer) 
+        **     -MultiValueDictionary.Create<TValueCollection>(int capacity, IEqualityComparer<TKey> comparer)
+        **     -MultiValueDictionary.Create<TValueCollection>(int capacity, IEqualityComparer<TKey> comparer, Func<ICollection<TValue>> collectionFactory)
+        ======================================================================*/
+
+        private delegate MultiValueDictionary<TKey, TValue> Constructor4Delegate<TKey, TValue>(int capacity, IEqualityComparer<TKey> comparer);
+        private Tuple<Constructor4Delegate<TKey, TValue>, Type>[] Constructor4<TKey, TValue>()
+        {
+            var ret = new Tuple<Constructor4Delegate<TKey, TValue>, Type>[5];
+            ret[0] = Tuple.Create<Constructor4Delegate<TKey, TValue>, Type>((int capacity, IEqualityComparer<TKey> comparer) => new MultiValueDictionary<TKey, TValue>(capacity, comparer), typeof(List<TValue>));
+            ret[1] = Tuple.Create<Constructor4Delegate<TKey, TValue>, Type>((int capacity, IEqualityComparer<TKey> comparer) => MultiValueDictionary<TKey, TValue>.Create<List<TValue>>(capacity, comparer), typeof(List<TValue>));
+            ret[2] = Tuple.Create<Constructor4Delegate<TKey, TValue>, Type>((int capacity, IEqualityComparer<TKey> comparer) => MultiValueDictionary<TKey, TValue>.Create<HashSet<TValue>>(capacity, comparer, () => new HashSet<TValue>()), typeof(HashSet<TValue>));
+            ret[3] = Tuple.Create<Constructor4Delegate<TKey, TValue>, Type>((int capacity, IEqualityComparer<TKey> comparer) => MultiValueDictionary<TKey, TValue>.Create<List<TValue>>(capacity, comparer, () => new List<TValue>()), typeof(List<TValue>));
+            ret[4] = Tuple.Create<Constructor4Delegate<TKey, TValue>, Type>((int capacity, IEqualityComparer<TKey> comparer) => MultiValueDictionary<TKey, TValue>.Create<HashSet<TValue>>(capacity, comparer), typeof(HashSet<TValue>));
+            return ret;
+        }
+
+        public void MVD_Constructor4_DummyComparerValidCapacity<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor4<TKey, TValue>())
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    var mvd = tuple.Item1(0, new dummyComparer<TKey>());
+                    mvd.Add((TKey)TypeBuilder<TKey>(), (TValue)TypeBuilder<TValue>());
+                });
+            }
+        }
+
+        public void MVD_Constructor4_NullComparerValidCapacity<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor4<TKey, TValue>())
+            {
+                var mvd = tuple.Item1(1, null);
+                TestCollectionType<TKey, TValue>(tuple.Item2, mvd);
+            }
+        }
+
+        public void MVD_Constructor4_DummyComparerInvalidCapacity<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor4<TKey, TValue>())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                {
+                    var mvd = tuple.Item1(-1, new dummyComparer<TKey>());
+                    mvd.Add((TKey)TypeBuilder<TKey>(), (TValue)TypeBuilder<TValue>());
+                });
+            }
+        }
+
+        public void MVD_Constructor4_NullComparerInvalidCapacity<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor4<TKey, TValue>())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() =>
+                {
+                    var mvd = tuple.Item1(-1, null);
+                    mvd.Add((TKey)TypeBuilder<TKey>(), (TValue)TypeBuilder<TValue>());
+                });
+            }
+        }
+
+        public void MVD_Constructor4_InvalidTCollection<TKey, TValue>()
+        {
+            Assert.Throws<InvalidOperationException>(() => MultiValueDictionary<TKey, TValue>.Create<DummyReadOnlyCollection<TValue>>(1, (IEqualityComparer<TKey>)null));
+            Assert.Throws<InvalidOperationException>(() => MultiValueDictionary<TKey, TValue>.Create<DummyReadOnlyCollection<TValue>>(1, (IEqualityComparer<TKey>)null, () => new DummyReadOnlyCollection<TValue>()));
+        }
+
+        #endregion    
+
+        #region Tests for: Constructor5
+        /*======================================================================
+        ** Constructor 5 includes:
+        **     -MultiValueDictionary(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable) 
+        **     -MultiValueDictionary.Create<TValueCollection>(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable)
+        **     -MultiValueDictionary.Create<TValueCollection>(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, Func<ICollection<TValue>> collectionFactory)
+        ======================================================================*/
+
+        private delegate MultiValueDictionary<TKey, TValue> Constructor5Delegate<TKey, TValue>(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable);
+        private Tuple<Constructor5Delegate<TKey, TValue>, Type>[] Constructor5<TKey, TValue>()
+        {
+            var ret = new Tuple<Constructor5Delegate<TKey, TValue>, Type>[5];
+            ret[0] = Tuple.Create<Constructor5Delegate<TKey, TValue>, Type>((IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable) => new MultiValueDictionary<TKey, TValue>(enumerable), typeof(List<TValue>));
+            ret[1] = Tuple.Create<Constructor5Delegate<TKey, TValue>, Type>((IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable) => MultiValueDictionary<TKey, TValue>.Create<List<TValue>>(enumerable), typeof(List<TValue>));
+            ret[2] = Tuple.Create<Constructor5Delegate<TKey, TValue>, Type>((IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable) => MultiValueDictionary<TKey, TValue>.Create<HashSet<TValue>>(enumerable), typeof(HashSet<TValue>));
+            ret[3] = Tuple.Create<Constructor5Delegate<TKey, TValue>, Type>((IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable) => MultiValueDictionary<TKey, TValue>.Create<List<TValue>>(enumerable, () => new List<TValue>()), typeof(List<TValue>));
+            ret[4] = Tuple.Create<Constructor5Delegate<TKey, TValue>, Type>((IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable) => MultiValueDictionary<TKey, TValue>.Create<HashSet<TValue>>(enumerable, () => new HashSet<TValue>()), typeof(HashSet<TValue>));
+            return ret;
+        }
+
+        public void MVD_Constructor5_EmptyIEnumerable<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor5<TKey, TValue>())
+            {
+                var enumerable = new MultiValueDictionary<TKey, TValue>();
+                var mvd = tuple.Item1(enumerable);
+                CompareMVDs<TKey, TValue>(enumerable, mvd);
+
+                var newKey = (TKey)TypeBuilder<TKey>();
+                var newValue = (TValue)TypeBuilder<TValue>();
+                while (mvd.Contains(newKey, newValue))
+                    newKey = (TKey)TypeBuilder<TKey>();
+                mvd.Add(newKey, newValue);
+
+                CompareEnumerables<KeyValuePair<TKey, IReadOnlyCollection<TValue>>>(enumerable, mvd, false);
+                Assert.Equal(PairsCount<TKey, TValue>(enumerable) + 1, PairsCount<TKey, TValue>(mvd));
+            }
+        }
+
+        public void MVD_Constructor5_NullIEnumerable<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor5<TKey, TValue>())
+            {
+                IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable = null;
+                Assert.Throws<ArgumentNullException>(() =>
+                {
+                    var mvd = tuple.Item1(enumerable);
+                });
+            }
+        }
+
+        public void MVD_Constructor5_NonEmptyIEnumerable<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor5<TKey, TValue>())
+            {
+                var enumerable = Multi<TKey, TValue, HashSet<TValue>>()[1];
+                var mvd = tuple.Item1(enumerable);
+                CompareMVDs<TKey, TValue>(enumerable, mvd);
+
+                var newKey = (TKey)TypeBuilder<TKey>();
+                var newValue = (TValue)TypeBuilder<TValue>();
+                while (mvd.Contains(newKey, newValue))
+                    newKey = (TKey)TypeBuilder<TKey>();
+                mvd.Add(newKey, newValue);
+
+                CompareEnumerables<KeyValuePair<TKey, IReadOnlyCollection<TValue>>>(enumerable, mvd, false);
+                Assert.Equal(PairsCount<TKey, TValue>(enumerable) + 1, PairsCount<TKey, TValue>(mvd));
+            }
+        }
+
+        public void MVD_Constructor5_ValueCopyIEnumerable<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor5<TKey, TValue>())
+            {
+                var enumerable = Multi<TKey, TValue, HashSet<TValue>>()[1];
+                var mvd = tuple.Item1(enumerable);
+                CompareMVDs<TKey, TValue>(enumerable, mvd);
+
+                var newKey = (TKey)TypeBuilder<TKey>();
+                var newValue = (TValue)TypeBuilder<TValue>();
+                while (enumerable.Contains(newKey, newValue))
+                    newKey = (TKey)TypeBuilder<TKey>();
+                enumerable.Add(newKey, newValue);
+
+                CompareEnumerables<KeyValuePair<TKey, IReadOnlyCollection<TValue>>>(enumerable, mvd, false);
+                Assert.Equal(PairsCount<TKey, TValue>(mvd) + 1, PairsCount<TKey, TValue>(enumerable));
+            }
+        }
+
+        public void MVD_Constructor5_InvalidTCollection<TKey, TValue>()
+        {
+            Assert.Throws<InvalidOperationException>(() => MultiValueDictionary<TKey, TValue>.Create<DummyReadOnlyCollection<TValue>>(new List<KeyValuePair<TKey, IReadOnlyCollection<TValue>>>(), () => new DummyReadOnlyCollection<TValue>()));
+            Assert.Throws<InvalidOperationException>(() => MultiValueDictionary<TKey, TValue>.Create<DummyReadOnlyCollection<TValue>>(new List<KeyValuePair<TKey, IReadOnlyCollection<TValue>>>()));
+        }
+
+        #endregion
+
+        #region Tests for: Constructor6
+        /*======================================================================
+        ** Constructor 6 includes:
+        **     -MultiValueDictionary(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, IEqualityComparer<TKey> comparer) 
+        **     -MultiValueDictionary.Create<TValueCollection>(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, IEqualityComparer<TKey> comparer)
+        **     -MultiValueDictionary.Create<TValueCollection>(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, IEqualityComparer<TKey> comparer, Func<ICollection<TValue>> collectionFactory)
+        ======================================================================*/
+
+        private delegate MultiValueDictionary<TKey, TValue> Constructor6Delegate<TKey, TValue>(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, IEqualityComparer<TKey> comparer);
+        private Tuple<Constructor6Delegate<TKey, TValue>, Type>[] Constructor6<TKey, TValue>()
+        {
+            var ret = new Tuple<Constructor6Delegate<TKey, TValue>, Type>[5];
+            ret[0] = Tuple.Create<Constructor6Delegate<TKey, TValue>, Type>((IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, IEqualityComparer<TKey> comparer) => new MultiValueDictionary<TKey, TValue>(enumerable, comparer), typeof(List<TValue>));
+            ret[1] = Tuple.Create<Constructor6Delegate<TKey, TValue>, Type>((IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, IEqualityComparer<TKey> comparer) => MultiValueDictionary<TKey, TValue>.Create<List<TValue>>(enumerable, comparer), typeof(List<TValue>));
+            ret[2] = Tuple.Create<Constructor6Delegate<TKey, TValue>, Type>((IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, IEqualityComparer<TKey> comparer) => MultiValueDictionary<TKey, TValue>.Create<HashSet<TValue>>(enumerable, comparer), typeof(HashSet<TValue>));
+            ret[3] = Tuple.Create<Constructor6Delegate<TKey, TValue>, Type>((IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, IEqualityComparer<TKey> comparer) => MultiValueDictionary<TKey, TValue>.Create<List<TValue>>(enumerable, comparer, () => new List<TValue>()), typeof(List<TValue>));
+            ret[4] = Tuple.Create<Constructor6Delegate<TKey, TValue>, Type>((IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable, IEqualityComparer<TKey> comparer) => MultiValueDictionary<TKey, TValue>.Create<HashSet<TValue>>(enumerable, comparer, () => new HashSet<TValue>()), typeof(HashSet<TValue>));
+            return ret;
+        }
+
+        public void MVD_Constructor6_NullIEnumerable<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor6<TKey, TValue>())
+            {
+                IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable = null;
+                Assert.Throws<ArgumentNullException>(() =>
+                {
+                    var mvd = tuple.Item1(enumerable, null);
+                });
+            }
+        }
+
+        public void MVD_Constructor6_EmptyIEnumerable<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor6<TKey, TValue>())
+            {
+                var enumerable = new MultiValueDictionary<TKey, TValue>();
+                var mvd = tuple.Item1(enumerable, null);
+                CompareMVDs<TKey, TValue>(enumerable, mvd);
+
+                var newKey = (TKey)TypeBuilder<TKey>();
+                var newValue = (TValue)TypeBuilder<TValue>();
+                while (mvd.Contains(newKey, newValue))
+                    newKey = (TKey)TypeBuilder<TKey>();
+                mvd.Add(newKey, newValue);
+
+                Assert.Equal(PairsCount<TKey, TValue>(enumerable) + 1, PairsCount<TKey, TValue>(mvd));
+            }
+        }
+
+        public void MVD_Constructor6_NonEmptyIEnumerable<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor6<TKey, TValue>())
+            {
+                var enumerable = Multi<TKey, TValue, HashSet<TValue>>()[1];
+                var mvd = tuple.Item1(enumerable, null);
+                CompareMVDs<TKey, TValue>(enumerable, mvd);
+
+                var newKey = (TKey)TypeBuilder<TKey>();
+                var newValue = (TValue)TypeBuilder<TValue>();
+                while (mvd.Contains(newKey, newValue))
+                    newKey = (TKey)TypeBuilder<TKey>();
+                mvd.Add(newKey, newValue);
+
+                CompareEnumerables<KeyValuePair<TKey, IReadOnlyCollection<TValue>>>(enumerable, mvd, false);
+                Assert.Equal(PairsCount<TKey, TValue>(enumerable) + 1, PairsCount<TKey, TValue>(mvd));
+            }
+        }
+
+        public void MVD_Constructor6_ValueCopyIEnumerable<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor6<TKey, TValue>())
+            {
+                var enumerable = Multi<TKey, TValue, HashSet<TValue>>()[1];
+                var mvd = tuple.Item1(enumerable, null);
+                CompareMVDs<TKey, TValue>(enumerable, mvd);
+
+                var newKey = (TKey)TypeBuilder<TKey>();
+                var newValue = (TValue)TypeBuilder<TValue>();
+                while (enumerable.Contains(newKey, newValue))
+                    newKey = (TKey)TypeBuilder<TKey>();
+                enumerable.Add(newKey, newValue);
+
+                CompareEnumerables<KeyValuePair<TKey, IReadOnlyCollection<TValue>>>(enumerable, mvd, false);
+                Assert.Equal(PairsCount<TKey, TValue>(mvd) + 1, PairsCount<TKey, TValue>(enumerable));
+            }
+        }
+
+        public void MVD_Constructor6_DummyComparer<TKey, TValue>()
+        {
+            foreach (var tuple in Constructor6<TKey, TValue>())
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    var enumerable = new MultiValueDictionary<TKey, TValue>();
+                    var mvd = tuple.Item1(enumerable, new dummyComparer<TKey>());
+                    mvd.Add((TKey)TypeBuilder<TKey>(), (TValue)TypeBuilder<TValue>());
+                });
+            }
+        }
+
+        public void MVD_Constructor6_InvalidTCollection<TKey, TValue>()
+        {
+            Assert.Throws<InvalidOperationException>(() => MultiValueDictionary<TKey, TValue>.Create<DummyReadOnlyCollection<TValue>>(new List<KeyValuePair<TKey, IReadOnlyCollection<TValue>>>(), null, () => new DummyReadOnlyCollection<TValue>()));
+            Assert.Throws<InvalidOperationException>(() => MultiValueDictionary<TKey, TValue>.Create<DummyReadOnlyCollection<TValue>>(new List<KeyValuePair<TKey, IReadOnlyCollection<TValue>>>(), (IEqualityComparer<TKey>)null));
+        }
+
+        #endregion
+
+        #region Tests for: Add
+        /*======================================================================
+        ** Add includes:
+        **     -multiDictionary.Add(TKey key, TValue value)
+        ======================================================================*/
+
+        private delegate void AddDelegate<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd, TKey key, TValue value);
+        private AddDelegate<TKey, TValue>[] Add<TKey, TValue>()
+        {
+            var ret = new AddDelegate<TKey, TValue>[1];
+            ret[0] = (MultiValueDictionary<TKey, TValue> mvd, TKey key, TValue value) => mvd.Add(key, value);
+            return ret;
+        }
+
+        [Fact]
+        public void MVD_Add_NullKey()
+        {
+            foreach (var add in Add<string, int>())
+            {
+                foreach (var mvd in Multi<string, int, List<int>>())
+                {
+                    string newKey = null;
+                    int newValue = (int)TypeBuilder<int>();
+                    Assert.Throws<ArgumentNullException>(() =>
+                    {
+                        add(mvd, newKey, newValue);
+                    });
+                }
+                foreach (var mvd in Multi<string, int, HashSet<int>>())
+                {
+                    string newKey = null;
+                    int newValue = (int)TypeBuilder<int>();
+                    Assert.Throws<ArgumentNullException>(() =>
+                    {
+                        add(mvd, newKey, newValue);
+                    });
+                }
+            }
+        }
+
+        public void MVD_Add_ValidKeyNullValue<TKey, TValue>()
+        {
+            foreach (var add in Add<TKey, String>())
+            {
+                foreach (var mvd in Multi<TKey, String, List<String>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    String newValue = null;
+
+                    mvd.Remove(newKey, newValue);
+                    int oldCount = PairsCount<TKey, String>(mvd);
+                    add(mvd, newKey, newValue);
+                    Assert.Equal(oldCount + 1, PairsCount<TKey, String>(mvd));
+                }
+                foreach (var mvd in Multi<TKey, String, HashSet<String>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    String newValue = null;
+
+                    mvd.Remove(newKey, newValue);
+                    int oldCount = PairsCount<TKey, String>(mvd);
+                    add(mvd, newKey, newValue);
+                    Assert.Equal(oldCount + 1, PairsCount<TKey, String>(mvd));
+                }
+            }
+        }
+
+        public void MVD_Add_ValidKeyValidValue<TKey, TValue>()
+        {
+            foreach (var add in Add<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+
+                    mvd.Remove(newKey, newValue);
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+                    add(mvd, newKey, newValue);
+                    Assert.Equal(oldCount + 1, PairsCount<TKey, TValue>(mvd));
+                }
+                foreach (var mvd in Multi<TKey, TValue, HashSet<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+
+                    mvd.Remove(newKey, newValue);
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+                    add(mvd, newKey, newValue);
+                    Assert.Equal(oldCount + 1, PairsCount<TKey, TValue>(mvd));
+                }
+            }
+        }
+
+        public void MVD_Add_AlreadyPresentPair<TKey, TValue>()
+        {
+            foreach (var add in Add<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+
+                    mvd.Remove(newKey, newValue);
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+                    add(mvd, newKey, newValue);
+                    add(mvd, newKey, newValue);
+                    add(mvd, newKey, newValue);
+                    Assert.Equal(oldCount + 3, PairsCount<TKey, TValue>(mvd));
+                }
+                foreach (var mvd in Multi<TKey, TValue, HashSet<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+
+                    mvd.Remove(newKey, newValue);
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+                    add(mvd, newKey, newValue);
+                    add(mvd, newKey, newValue);
+                    Assert.Equal(oldCount + 1, PairsCount<TKey, TValue>(mvd));
+                }
+            }
+        }
+
+        #endregion
+
+        #region Tests for: AddRange
+        /*======================================================================
+        ** AddRange includes:
+        **     -multiDictionary.AddRange(TKey key, IEnumerable<TValue> values)
+        ======================================================================*/
+
+        private delegate void AddRangeDelegate<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd, TKey key, IEnumerable<TValue> values);
+        private AddRangeDelegate<TKey, TValue>[] AddRange<TKey, TValue>()
+        {
+            var ret = new AddRangeDelegate<TKey, TValue>[1];
+            ret[0] = (MultiValueDictionary<TKey, TValue> mvd, TKey key, IEnumerable<TValue> values) => mvd.AddRange(key, values);
+            return ret;
+        }
+
+        [Fact]
+        public void MVD_AddRange_NullKey()
+        {
+            foreach (var addRange in AddRange<string, int>())
+            {
+                foreach (var mvd in Multi<string, int, List<int>>())
+                {
+                    string newKey = null;
+                    var newValues = CreateRange<int, List<int>>((int)TypeBuilder<int>());
+                    int oldCount = mvd.Count;
+                    Assert.Throws<ArgumentNullException>(() =>
+                    {
+                        addRange(mvd, newKey, newValues);
+                    });
+                    Assert.Equal(oldCount, mvd.Count);
+                }
+                foreach (var mvd in Multi<string, int, HashSet<int>>())
+                {
+                    string newKey = null;
+                    var newValues = CreateRange<int, HashSet<int>>((int)TypeBuilder<int>());
+                    int oldCount = mvd.Count;
+
+                    Assert.Throws<ArgumentNullException>(() =>
+                    {
+                        addRange(mvd, newKey, newValues);
+                    });
+                    Assert.Equal(oldCount, mvd.Count);
+
+                }
+            }
+        }
+
+        public void MVD_AddRange_NullValues<TKey, TValue>()
+        {
+            foreach (var addRange in AddRange<TKey, int>())
+            {
+                foreach (var mvd in Multi<TKey, int, List<int>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    List<int> newValues = null;
+                    int oldCount = mvd.Count;
+
+                    Assert.Throws<ArgumentNullException>(() =>
+                    {
+                        addRange(mvd, newKey, newValues);
+                    });
+
+                    Assert.Equal(oldCount, mvd.Count);
+                }
+                foreach (var mvd in Multi<TKey, int, HashSet<int>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    HashSet<int> newValues = null;
+                    int oldCount = mvd.Count;
+
+                    Assert.Throws<ArgumentNullException>(() =>
+                    {
+                        addRange(mvd, newKey, newValues);
+                    });
+
+                    Assert.Equal(oldCount, mvd.Count);
+
+                }
+            }
+        }
+
+        public void MVD_AddRange_ValidKeyEmptyValues<TKey, TValue>()
+        {
+            foreach (var addRange in AddRange<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    var newValues = new List<TValue>();
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+
+                    addRange(mvd, newKey, newValues);
+
+                    Assert.Equal(oldCount, PairsCount<TKey, TValue>(mvd));
+                }
+                foreach (var mvd in Multi<TKey, TValue, HashSet<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    var newValues = new HashSet<TValue>();
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+
+                    addRange(mvd, newKey, newValues);
+
+                    Assert.Equal(oldCount, PairsCount<TKey, TValue>(mvd));
+                }
+            }
+        }
+
+        public void MVD_AddRange_ValidKeyNonEmptyValues<TKey, TValue>()
+        {
+            foreach (var addRange in AddRange<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    var newValues = CreateRange<TValue, List<TValue>>((int)TypeBuilder<int>());
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+
+                    addRange(mvd, newKey, newValues);
+
+                    Assert.Equal(oldCount + newValues.Count, PairsCount<TKey, TValue>(mvd));
+                }
+                foreach (var mvd in Multi<TKey, TValue, HashSet<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    var newValues = CreateRange<TValue, HashSet<TValue>>((int)TypeBuilder<int>());
+                    mvd.Remove(newKey);
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+
+                    addRange(mvd, newKey, newValues);
+
+                    Assert.Equal(oldCount + newValues.Count, PairsCount<TKey, TValue>(mvd));
+                }
+            }
+        }
+
+        public void MVD_AddRange_ValidKeyDuplicateValues<TKey, TValue>()
+        {
+            foreach (var addRange in AddRange<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+                    var newValues = new List<TValue>();
+                    newValues.Add(newValue);
+                    newValues.Add(newValue);
+                    newValues.Add(newValue);
+                    newValues.Add(newValue);
+                    newValues.Add(newValue);
+
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+
+                    addRange(mvd, newKey, newValues);
+
+                    Assert.Equal(oldCount + newValues.Count, PairsCount<TKey, TValue>(mvd));
+                }
+                foreach (var mvd in Multi<TKey, TValue, HashSet<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+                    while (mvd.Contains(newKey, newValue))
+                        newValue = (TValue)TypeBuilder<TValue>();
+                    var newValues = new List<TValue>();
+                    newValues.Add(newValue);
+                    newValues.Add(newValue);
+                    newValues.Add(newValue);
+                    newValues.Add(newValue);
+                    newValues.Add(newValue);
+
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+
+                    addRange(mvd, newKey, newValues);
+
+                    Assert.Equal(oldCount + 1, PairsCount<TKey, TValue>(mvd));
+                }
+            }
+        }
+
+        public void MVD_AddRange_PreexistingKey<TKey, TValue>()
+        {
+            foreach (var addRange in AddRange<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    mvd.Remove(newKey);
+                    var newValues = CreateRange<TValue, List<TValue>>((int)TypeBuilder<int>());
+                    var preValue = (TValue)TypeBuilder<TValue>();
+                    while (newValues.Contains(preValue))
+                        preValue = (TValue)TypeBuilder<TValue>();
+                    mvd.Add(newKey, preValue);
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+
+                    addRange(mvd, newKey, newValues);
+
+                    Assert.Equal(oldCount + newValues.Count, PairsCount<TKey, TValue>(mvd));
+                    newValues.Add(preValue);
+                    CompareEnumerables<TValue>(mvd[newKey], newValues, true);
+                }
+                foreach (var mvd in Multi<TKey, TValue, HashSet<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    mvd.Remove(newKey);
+                    var newValues = CreateRange<TValue, HashSet<TValue>>((int)TypeBuilder<int>());
+                    var preValue = (TValue)TypeBuilder<TValue>();
+                    while (newValues.Contains(preValue))
+                        preValue = (TValue)TypeBuilder<TValue>();
+                    mvd.Add(newKey, preValue);
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+
+                    addRange(mvd, newKey, newValues);
+
+                    Assert.Equal(oldCount + newValues.Count, PairsCount<TKey, TValue>(mvd));
+                    newValues.Add(preValue);
+                    CompareEnumerables<TValue>(mvd[newKey], newValues, true);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Tests for: Clear
+        /*======================================================================
+        ** Clear includes:
+        **      -multiDictionary.Clear()
+        ======================================================================*/
+
+        private delegate void ClearDelegate<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd);
+        private ClearDelegate<TKey, TValue>[] Clear<TKey, TValue>()
+        {
+            var ret = new ClearDelegate<TKey, TValue>[1];
+            ret[0] = (MultiValueDictionary<TKey, TValue> mvd) => mvd.Clear();
+            return ret;
+        }
+
+        public void MVD_Values_Validity<TKey, TValue>()
+        {
+            foreach (var clear in Clear<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    mvd.Clear();
+                    Assert.Empty(mvd);
+                    Assert.Empty(mvd.Keys);
+                    Assert.Empty(mvd.Values);
+                    Assert.Equal(PairsCount<TKey, TValue>(mvd), 0);
+                    Assert.Equal(mvd.Count, 0);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Tests for: Contains
+        /*======================================================================
+        ** Contains includes:
+        **      -multiDictionary.Contains(TKey key, TValue value)
+        ======================================================================*/
+
+        private delegate bool ContainsDelegate<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd, TKey key, TValue value);
+        private ContainsDelegate<TKey, TValue>[] Contains<TKey, TValue>()
+        {
+            var ret = new ContainsDelegate<TKey, TValue>[1];
+            ret[0] = (MultiValueDictionary<TKey, TValue> mvd, TKey key, TValue value) => mvd.Contains(key, value);
+            return ret;
+        }
+
+        public void MVD_Contains_NullKey<TKey, TValue>()
+        {
+            foreach (var contains in Contains<string, TValue>())
+            {
+                foreach (var mvd in Multi<string, TValue, List<TValue>>())
+                {
+                    string newKey = null;
+
+                    Assert.Throws<ArgumentNullException>(() =>
+                    {
+                        contains(mvd, newKey, (TValue)TypeBuilder<TValue>());
+                    });
+                }
+            }
+        }
+
+        public void MVD_Contains_ValidKeyInvalidValue<TKey, TValue>()
+        {
+            foreach (var contains in Contains<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue1 = (TValue)TypeBuilder<TValue>();
+                    TValue newValue2 = (TValue)TypeBuilder<TValue>();
+                    while (newValue1.Equals(newValue2))
+                        newValue2 = (TValue)TypeBuilder<TValue>();
+                    mvd.Add(newKey, newValue1);
+                    while (mvd.Contains(newKey, newValue2))
+                        mvd.Remove(newKey, newValue2);
+
+                    Assert.True(contains(mvd, newKey, newValue1));
+                    Assert.False(contains(mvd, newKey, newValue2));
+                }
+            }
+        }
+
+        #endregion
+
+        #region Tests for: ContainsKey
+        /*======================================================================
+        ** ContainsKey includes:
+        **      -multiDictionary.ContainsKey(TKey key)
+        ======================================================================*/
+
+        private delegate bool ContainsKeyDelegate<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd, TKey key);
+        private ContainsKeyDelegate<TKey, TValue>[] ContainsKey<TKey, TValue>()
+        {
+            var ret = new ContainsKeyDelegate<TKey, TValue>[1];
+            ret[0] = (MultiValueDictionary<TKey, TValue> mvd, TKey key) => mvd.ContainsKey(key);
+            return ret;
+        }
+
+        public void MVD_ContainsKey_NullKey<TKey, TValue>()
+        {
+            foreach (var contains in ContainsKey<string, TValue>())
+            {
+                foreach (var mvd in Multi<string, TValue, List<TValue>>())
+                {
+                    string newKey = null;
+
+                    Assert.Throws<ArgumentNullException>(() =>
+                    {
+                        contains(mvd, newKey);
+                    });
+                }
+            }
+        }
+
+        public void MVD_ContainsKey_ValidNonEmptyKey<TKey, TValue>()
+        {
+            foreach (var contains in ContainsKey<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+                    mvd.Add(newKey, newValue);
+
+                    Assert.True(contains(mvd, newKey));
+                }
+            }
+        }
+
+        public void MVD_ContainsKey_PreviouslyValidKey<TKey, TValue>()
+        {
+            foreach (var contains in ContainsKey<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+                    mvd.Add(newKey, newValue);
+                    mvd.Remove(newKey);
+                    Assert.False(contains(mvd, newKey));
+
+                    mvd.Add(newKey, newValue);
+                    mvd.Remove(newKey, newValue);
+                    Assert.False(contains(mvd, newKey));
+                }
+            }
+        }
+
+        public void MVD_ContainsKey_EmptyKey<TKey, TValue>()
+        {
+            foreach (var contains in ContainsKey<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    mvd.Remove(newKey);
+                    Assert.False(contains(mvd, newKey));
+                }
+            }
+        }
+
+        #endregion
+
+        #region Tests for: ContainsValue
+        /*======================================================================
+        ** ContainsValue includes:
+        **      -multiDictionary.ContainsValue(TValue value)
+        ======================================================================*/
+
+        private delegate bool ContainsValueDelegate<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd, TValue value);
+        private ContainsValueDelegate<TKey, TValue>[] ContainsValue<TKey, TValue>()
+        {
+            var ret = new ContainsValueDelegate<TKey, TValue>[1];
+            ret[0] = (MultiValueDictionary<TKey, TValue> mvd, TValue value) => mvd.ContainsValue(value);
+            return ret;
+        }
+
+        public void MVD_ContainsValue_NullValidValue<TKey, TValue>()
+        {
+            foreach (var contains in ContainsValue<TKey, string>())
+            {
+                foreach (var mvd in Multi<TKey, string, List<string>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    string newValue = null;
+                    mvd.Add(newKey, newValue);
+                    Assert.True(contains(mvd, null));
+                }
+            }
+        }
+
+        public void MVD_ContainsValue_NonExistentValue<TKey, TValue>()
+        {
+            foreach (var contains in ContainsValue<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TValue newValue1 = (TValue)TypeBuilder<TValue>();
+                    var keys = new List<TKey>(mvd.Keys);
+                    foreach (var key in keys)
+                        while (mvd.Contains(key, newValue1))
+                            mvd.Remove(key, newValue1);
+
+                    Assert.False(contains(mvd, newValue1));
+                }
+            }
+        }
+
+        public void MVD_ContainsValue_ValidValueExists<TKey, TValue>()
+        {
+            foreach (var contains in ContainsValue<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+                    mvd.Add(newKey, newValue);
+                    Assert.True(contains(mvd, newValue));
+                }
+            }
+        }
+
+        public void MVD_ContainsValue_ValidValueExistsMultipleTimes<TKey, TValue>()
+        {
+            foreach (var contains in ContainsValue<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey1 = (TKey)TypeBuilder<TKey>();
+                    TKey newKey2 = (TKey)TypeBuilder<TKey>();
+                    while (newKey1.Equals(newKey2))
+                        newKey2 = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+                    mvd.Add(newKey1, newValue);
+                    mvd.Add(newKey1, newValue);
+                    mvd.Add(newKey2, newValue);
+                    Assert.True(contains(mvd, newValue));
+                }
+            }
+        }
+
+        #endregion
+
+        #region Tests for: Count
+        /*======================================================================
+        ** Count includes:
+        **      -multiDictionary.Count
+        ======================================================================*/
+
+        private delegate int CountDelegate<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd);
+        private CountDelegate<TKey, TValue>[] Count<TKey, TValue>()
+        {
+            var ret = new CountDelegate<TKey, TValue>[1];
+            ret[0] = (MultiValueDictionary<TKey, TValue> mvd) => mvd.Count;
+            return ret;
+        }
+
+        public void MVD_Count_Empty<TKey, TValue>()
+        {
+            foreach (var count in Count<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    mvd.Clear();
+                    Assert.Equal(0, count(mvd));
+                }
+            }
+        }
+
+        public void MVD_Count_NonEmpty<TKey, TValue>()
+        {
+            foreach (var count in Count<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    var key1 = (TKey)TypeBuilder<TKey>();
+                    var key2 = (TKey)TypeBuilder<TKey>();
+                    var key3 = (TKey)TypeBuilder<TKey>();
+                    while (key1.Equals(key2) || key1.Equals(key3) || key2.Equals(key3))
+                    {
+                        key1 = (TKey)TypeBuilder<TKey>();
+                        key2 = (TKey)TypeBuilder<TKey>();
+                        key3 = (TKey)TypeBuilder<TKey>();
+                    }
+
+                    mvd.Clear();
+                    mvd.Add(key1, (TValue)TypeBuilder<TValue>());
+                    mvd.Add(key2, (TValue)TypeBuilder<TValue>());
+                    mvd.Add(key3, (TValue)TypeBuilder<TValue>());
+
+                    Assert.Equal(3, count(mvd));
+                }
+            }
+        }
+
+        #endregion
+
+        #region Tests for: GetEnumerator
+        /*======================================================================
+        ** GetEnumerator includes:
+        **      -multiDictionary.GetEnumerator()
+        ======================================================================*/
+
+        private delegate IEnumerator GetEnumeratorDelegate<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd);
+        private GetEnumeratorDelegate<TKey, TValue>[] GetEnumerator<TKey, TValue>()
+        {
+            var ret = new GetEnumeratorDelegate<TKey, TValue>[1];
+            ret[0] = (MultiValueDictionary<TKey, TValue> mvd) => mvd.GetEnumerator();
+            return ret;
+        }
+
+        public void MVD_GetEnumerator_ValidReset<TKey, TValue>()
+        {
+            foreach (var enu in GetEnumerator<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    var enumerator = enu(mvd);
+                    for (int i = 0; i < mvd.Count; i++)
+                        Assert.True(enumerator.MoveNext());
+                    enumerator.Reset();
+                    for (int i = 0; i < mvd.Count; i++)
+                        Assert.True(enumerator.MoveNext());
+                }
+            }
+        }
+
+        public void MVD_GetEnumerator_ResetAfterModificationToMVD<TKey, TValue>()
+        {
+            foreach (var enu in GetEnumerator<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    var enumerator = enu(mvd);
+                    mvd.Add((TKey)TypeBuilder<TKey>(), (TValue)TypeBuilder<TValue>());
+                    Assert.Throws<InvalidOperationException>(() => enumerator.Reset());
+                }
+            }
+        }
+
+        public void MVD_GetEnumerator_MoveNextAfterModificationToMVD<TKey, TValue>()
+        {
+            foreach (var enu in GetEnumerator<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    var enumerator = enu(mvd);
+                    mvd.Add((TKey)TypeBuilder<TKey>(), (TValue)TypeBuilder<TValue>());
+                    Assert.Throws<InvalidOperationException>(() => enumerator.MoveNext());
+                }
+            }
+        }
+
+        public void MVD_GetEnumerator_Validity<TKey, TValue>()
+        {
+            foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                foreach (var pair in mvd)
+                    CompareEnumerables<TValue>(pair.Value, mvd[pair.Key], true);
+        }
+
+        public void MVD_GetEnumerator_IEnumeratorValidity<TKey, TValue>()
+        {
+            foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+            {
+                IEnumerator enumerator = mvd.GetEnumerator();
+                while (enumerator.MoveNext())
+                {
+                    var current = (KeyValuePair<TKey, IReadOnlyCollection<TValue>>)enumerator.Current;
+                    CompareEnumerables<TValue>(current.Value, mvd[current.Key], true);
+                }
+            }
+        }
+
+        public void MVD_GetEnumerator_IEnumeratorBeforeFirst<TKey, TValue>()
+        {
+            foreach (var enu in GetEnumerator<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    IEnumerator enumerator = enu(mvd);
+                    Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+                }
+            }
+        }
+
+        public void MVD_GetEnumerator_IEnumeratorAfterLast<TKey, TValue>()
+        {
+            foreach (var enu in GetEnumerator<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    IEnumerator enumerator = enu(mvd);
+                    while (enumerator.MoveNext()) ;
+                    Assert.Throws<InvalidOperationException>(() => enumerator.Current);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Tests for: Item
+        /*======================================================================
+        ** Item includes:
+        **      -multiDictionary[TKey key]
+        ======================================================================*/
+
+        private delegate IEnumerable<TValue> ItemDelegate<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd, TKey key);
+        private ItemDelegate<TKey, TValue>[] Item<TKey, TValue>()
+        {
+            var ret = new ItemDelegate<TKey, TValue>[1];
+            ret[0] = (MultiValueDictionary<TKey, TValue> mvd, TKey key) => mvd[key];
+            return ret;
+        }
+
+        public void MVD_Item_NullKey<TKey, TValue>()
+        {
+            foreach (var item in Item<string, TValue>())
+            {
+                foreach (var mvd in Multi<string, TValue, List<TValue>>())
+                {
+                    Assert.Throws<ArgumentNullException>(() =>
+                    {
+                        item(mvd, null);
+                    });
+                }
+            }
+        }
+
+        public void MVD_Item_ExistentKey<TKey, TValue>()
+        {
+            foreach (var item in Item<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+
+                    mvd.Remove(newKey);
+                    mvd.Add(newKey, newValue);
+                    CompareEnumerables<TValue>(item(mvd, newKey), new TValue[] { newValue }, true);
+                }
+            }
+        }
+
+        public void MVD_Item_ActiveView<TKey, TValue>()
+        {
+            foreach (var item in Item<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+
+                    mvd.Remove(newKey);
+                    mvd.Add(newKey, newValue);
+                    var retCol = item(mvd, newKey);
+                    mvd.Add(newKey, (TValue)TypeBuilder<TValue>());
+                    mvd.Add(newKey, (TValue)TypeBuilder<TValue>());
+                    mvd.Add(newKey, (TValue)TypeBuilder<TValue>());
+                    mvd.Add(newKey, (TValue)TypeBuilder<TValue>());
+                    mvd.Add(newKey, (TValue)TypeBuilder<TValue>());
+                    CompareEnumerables(item(mvd, newKey), retCol, true);
+                    Assert.Equal(retCol, item(mvd, newKey));
+                }
+            }
+        }
+
+        public void MVD_Item_NonExistentKey<TKey, TValue>()
+        {
+            ItemDelegate<TKey, TValue> item = (MultiValueDictionary<TKey, TValue> mvd, TKey key) => mvd[key];
+            foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+            {
+                TKey key = (TKey)TypeBuilder<TKey>();
+                mvd.Remove(key);
+                Assert.Throws<KeyNotFoundException>(() =>
+                {
+                    item(mvd, key);
+                });
+            }
+        }
+
+        #endregion
+
+        #region Tests for: Keys
+        /*======================================================================
+        ** Keys includes:
+        **      -multiDictionary.Keys
+        ======================================================================*/
+
+        private delegate IEnumerable<TKey> KeysDelegate<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd);
+        private KeysDelegate<TKey, TValue>[] Keys<TKey, TValue>()
+        {
+            var ret = new KeysDelegate<TKey, TValue>[1];
+            ret[0] = (MultiValueDictionary<TKey, TValue> mvd) => mvd.Keys;
+            return ret;
+        }
+
+        public void MVD_Keys_EmptyMVD<TKey, TValue>()
+        {
+            foreach (var keys in Keys<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    mvd.Clear();
+                    Assert.Empty(keys(mvd));
+                }
+            }
+        }
+
+        public void MVD_Keys_NonEmptyMVD<TKey, TValue>()
+        {
+            foreach (var keys in Keys<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+                    mvd.Add(newKey, newValue);
+
+                    Assert.NotEmpty(keys(mvd));
+                    var keyList = new List<TKey>();
+                    foreach (var pair in mvd)
+                        keyList.Add(pair.Key);
+                    CompareEnumerables<TKey>(keys(mvd), keyList, true);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Tests for: Remove
+        /*======================================================================
+        ** Remove includes:
+        **      -multiDictionary.Remove(TKey key)
+        ======================================================================*/
+
+        private delegate bool RemoveDelegate<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd, TKey key);
+        private RemoveDelegate<TKey, TValue>[] Remove<TKey, TValue>()
+        {
+            var ret = new RemoveDelegate<TKey, TValue>[1];
+            ret[0] = (MultiValueDictionary<TKey, TValue> mvd, TKey key) => mvd.Remove(key);
+            return ret;
+        }
+
+        public void MVD_Remove_NullKey<TKey, TValue>()
+        {
+            foreach (var remove in Remove<string, TValue>())
+            {
+                foreach (var mvd in Multi<string, TValue, List<TValue>>())
+                {
+                    string newKey = null;
+
+                    int oldCount = mvd.Count;
+                    Assert.Throws<ArgumentNullException>(() =>
+                    {
+                        remove(mvd, newKey);
+                    });
+                    Assert.Equal(oldCount, mvd.Count);
+                }
+                foreach (var mvd in Multi<string, TValue, HashSet<TValue>>())
+                {
+                    string newKey = null;
+
+                    int oldCount = mvd.Count;
+                    Assert.Throws<ArgumentNullException>(() =>
+                    {
+                        remove(mvd, newKey);
+                    });
+                    Assert.Equal(oldCount, mvd.Count);
+                }
+            }
+        }
+
+        public void MVD_Remove_NonexistentKey<TKey, TValue>()
+        {
+            foreach (var remove in Remove<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    remove(mvd, newKey);
+                    int oldCount = mvd.Count;
+
+                    Assert.False(remove(mvd, newKey));
+
+                    Assert.Throws<KeyNotFoundException>(() => mvd[newKey]);
+                    Assert.Equal(oldCount, mvd.Count);
+                }
+                foreach (var mvd in Multi<TKey, TValue, HashSet<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    remove(mvd, newKey);
+                    int oldCount = mvd.Count;
+
+                    Assert.False(remove(mvd, newKey));
+
+                    Assert.Equal(oldCount, mvd.Count);
+                    Assert.Throws<KeyNotFoundException>(() => mvd[newKey]);
+                }
+            }
+        }
+
+        public void MVD_Remove_PreExistingKey<TKey, TValue>()
+        {
+            foreach (var remove in Remove<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    mvd.Add(newKey, (TValue)TypeBuilder<TValue>());
+                    mvd.Add(newKey, (TValue)TypeBuilder<TValue>());
+                    mvd.Add(newKey, (TValue)TypeBuilder<TValue>());
+                    int keyCount = mvd[newKey].Count;
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+
+                    Assert.True(remove(mvd, newKey));
+
+                    Assert.Throws<KeyNotFoundException>(() => mvd[newKey]);
+                    Assert.Equal(oldCount - keyCount, PairsCount<TKey, TValue>(mvd));
+                }
+                foreach (var mvd in Multi<TKey, TValue, HashSet<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    mvd.Add(newKey, (TValue)TypeBuilder<TValue>());
+                    int keyCount = mvd[newKey].Count;
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+
+                    Assert.True(remove(mvd, newKey));
+
+                    Assert.Throws<KeyNotFoundException>(() => mvd[newKey]);
+                    Assert.Equal(oldCount - keyCount, PairsCount<TKey, TValue>(mvd));
+                }
+            }
+        }
+
+        #endregion
+
+        #region Tests for: RemoveItem
+        /*======================================================================
+        ** RemoveItem includes:
+        **      -multiDictionary.Remove(TKey key, TValue value)
+        ======================================================================*/
+
+        private delegate bool RemoveItemDelegate<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd, TKey key, TValue value);
+        private RemoveItemDelegate<TKey, TValue>[] RemoveItem<TKey, TValue>()
+        {
+            var ret = new RemoveItemDelegate<TKey, TValue>[1];
+            ret[0] = (MultiValueDictionary<TKey, TValue> mvd, TKey key, TValue value) => mvd.Remove(key, value);
+            return ret;
+        }
+
+        public void MVD_RemoveItem_NullKey<TKey, TValue>()
+        {
+            foreach (var remove in RemoveItem<string, TValue>())
+            {
+                foreach (var mvd in Multi<string, TValue, List<TValue>>())
+                {
+                    string newKey = null;
+
+                    int oldCount = mvd.Count;
+                    Assert.Throws<ArgumentNullException>(() =>
+                    {
+                        remove(mvd, newKey, (TValue)TypeBuilder<TValue>());
+                    });
+                    Assert.Equal(oldCount, mvd.Count);
+                }
+            }
+        }
+
+        public void MVD_RemoveItem_ValidKeyInvalidValue<TKey, TValue>()
+        {
+            foreach (var remove in RemoveItem<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue1 = (TValue)TypeBuilder<TValue>();
+                    TValue newValue2 = (TValue)TypeBuilder<TValue>();
+                    while (newValue1.Equals(newValue2))
+                        newValue2 = (TValue)TypeBuilder<TValue>();
+                    mvd.Add(newKey, newValue1);
+                    while (mvd.Contains(newKey, newValue2))
+                        Assert.True(remove(mvd, newKey, newValue2));
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+                    int keyCount = mvd[newKey].Count;
+
+                    Assert.False(remove(mvd, newKey, newValue2));
+
+                    Assert.Equal(oldCount, PairsCount<TKey, TValue>(mvd));
+                    Assert.Equal(keyCount, mvd[newKey].Count);
+                }
+            }
+        }
+
+        public void MVD_RemoveItem_ValidKeyValidValue<TKey, TValue>()
+        {
+            foreach (var remove in RemoveItem<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue1 = (TValue)TypeBuilder<TValue>();
+                    TValue newValue2 = (TValue)TypeBuilder<TValue>();
+                    while (newValue1.Equals(newValue2))
+                        newValue2 = (TValue)TypeBuilder<TValue>();
+                    mvd.Add(newKey, newValue1);
+                    mvd.Add(newKey, newValue2);
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+                    int keyCount = mvd[newKey].Count;
+
+                    Assert.True(remove(mvd, newKey, newValue2));
+
+                    Assert.Equal(oldCount - 1, PairsCount<TKey, TValue>(mvd));
+                    Assert.Equal(keyCount - 1, mvd[newKey].Count);
+                    Assert.True(mvd[newKey].Count > 0);
+                }
+            }
+        }
+
+        public void MVD_RemoveItem_RemovesOnlyOneInstanceOfValue<TKey, TValue>()
+        {
+            foreach (var remove in RemoveItem<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue1 = (TValue)TypeBuilder<TValue>();
+                    mvd.Add(newKey, newValue1);
+                    mvd.Add(newKey, newValue1);
+                    int oldCount = PairsCount<TKey, TValue>(mvd);
+                    int keyCount = mvd[newKey].Count;
+
+                    Assert.True(remove(mvd, newKey, newValue1));
+
+                    Assert.Equal(oldCount - 1, PairsCount<TKey, TValue>(mvd));
+                    Assert.Equal(keyCount - 1, mvd[newKey].Count);
+                    Assert.True(mvd[newKey].Count > 0);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Tests for: TryGetValue
+        /*======================================================================
+        ** TryGetValue includes:
+        **      -multiDictionary.TryGetValue(TKey key, out IReadOnlyCollection<TValue> value)
+        ======================================================================*/
+
+        private delegate bool TryGetValueDelegate<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd, TKey key, out IReadOnlyCollection<TValue> value);
+        private TryGetValueDelegate<TKey, TValue>[] TryGetValue<TKey, TValue>()
+        {
+            var ret = new TryGetValueDelegate<TKey, TValue>[1];
+            ret[0] = (MultiValueDictionary<TKey, TValue> mvd, TKey key, out IReadOnlyCollection<TValue> value) => mvd.TryGetValue(key, out value);
+            return ret;
+        }
+
+        public void MVD_TryGetValue_NullKey<TKey, TValue>()
+        {
+            foreach (var tgv in TryGetValue<string, TValue>())
+            {
+                foreach (var mvd in Multi<string, TValue, List<TValue>>())
+                {
+                    IReadOnlyCollection<TValue> retCol;
+                    Assert.Throws<ArgumentNullException>(() =>
+                    {
+                        tgv(mvd, null, out retCol);
+                    });
+                }
+            }
+        }
+
+        public void MVD_TryGetValue_EmptyKey<TKey, TValue>()
+        {
+            foreach (var tgv in TryGetValue<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    IReadOnlyCollection<TValue> retCol;
+                    mvd.Remove(newKey);
+
+                    Assert.False(tgv(mvd, newKey, out retCol));
+                }
+            }
+        }
+
+        public void MVD_TryGetValue_NonEmptyKey<TKey, TValue>()
+        {
+            foreach (var tgv in TryGetValue<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+                    IReadOnlyCollection<TValue> retCol;
+                    mvd.Add(newKey, newValue);
+
+                    Assert.True(tgv(mvd, newKey, out retCol));
+                    Assert.True(retCol.Contains(newValue));
+                    CompareEnumerables<TValue>(retCol, mvd[newKey], true);
+                }
+            }
+        }
+
+        public void MVD_TryGetValue_ReturnedCollectionIsAView<TKey, TValue>()
+        {
+            foreach (var tgv in TryGetValue<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey = (TKey)TypeBuilder<TKey>();
+                    IReadOnlyCollection<TValue> retCol;
+                    mvd.Remove(newKey);
+                    mvd.Add(newKey, (TValue)TypeBuilder<TValue>());
+
+                    Assert.True(tgv(mvd, newKey, out retCol));
+                    mvd.Add(newKey, (TValue)TypeBuilder<TValue>());
+                    mvd.Add(newKey, (TValue)TypeBuilder<TValue>());
+                    mvd.Add(newKey, (TValue)TypeBuilder<TValue>());
+                    mvd.Add(newKey, (TValue)TypeBuilder<TValue>());
+
+                    CompareEnumerables<TValue>(retCol, mvd[newKey], true);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Tests for: Values
+        /*======================================================================
+        ** Values includes:
+        **      -multiDictionary.Values
+        ======================================================================*/
+
+        private delegate IEnumerable<IReadOnlyCollection<TValue>> ValuesDelegate<TKey, TValue>(MultiValueDictionary<TKey, TValue> mvd);
+        private ValuesDelegate<TKey, TValue>[] Values<TKey, TValue>()
+        {
+            var ret = new ValuesDelegate<TKey, TValue>[1];
+            ret[0] = (MultiValueDictionary<TKey, TValue> mvd) => mvd.Values;
+            return ret;
+        }
+
+        public void MVD_Values_EmptyMVD<TKey, TValue>()
+        {
+            foreach (var values in Values<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    mvd.Clear();
+                    Assert.Empty(values(mvd));
+                }
+            }
+        }
+
+        public void MVD_Values_NonEmptyMVD<TKey, TValue>()
+        {
+            foreach (var values in Values<TKey, TValue>())
+            {
+                foreach (var mvd in Multi<TKey, TValue, List<TValue>>())
+                {
+                    TKey newKey2 = (TKey)TypeBuilder<TKey>();
+                    TKey newKey1 = (TKey)TypeBuilder<TKey>();
+                    TValue newValue = (TValue)TypeBuilder<TValue>();
+                    mvd.Add(newKey2, newValue);
+                    mvd.Add(newKey1, newValue);
+
+                    Assert.NotEmpty(values(mvd));
+                    var valueList = new List<IReadOnlyCollection<TValue>>();
+                    foreach (var pair in mvd)
+                        valueList.Add(pair.Value);
+                    CompareEnumerables<IReadOnlyCollection<TValue>>(values(mvd), valueList, true);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/System.Collections.Generic.MultiValueDictionary/tests/Performance/Perf.MVD.cs
+++ b/src/System.Collections.Generic.MultiValueDictionary/tests/Performance/Perf.MVD.cs
@@ -1,0 +1,263 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.Collections.Tests
+{
+    public class Perf_MVD
+    {
+        public static MultiValueDictionary<int, int> CreateMVD(int size)
+        {
+            MultiValueDictionary<int, int> mvd = new MultiValueDictionary<int, int>();
+            Random rand = new Random(11231992);
+
+            while (mvd.Count < size)
+                mvd.Add(rand.Next(), rand.Next());
+
+            return mvd;
+        }
+
+        [Benchmark]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void Add(int size)
+        {
+            MultiValueDictionary<int, int> dict = CreateMVD(size);
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                MultiValueDictionary<int, int> copyDict = new MultiValueDictionary<int, int>(dict);
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        copyDict.Add(i * 10 + 1, 0); copyDict.Add(i * 10 + 2, 0); copyDict.Add(i * 10 + 3, 0);
+                        copyDict.Add(i * 10 + 4, 0); copyDict.Add(i * 10 + 5, 0); copyDict.Add(i * 10 + 6, 0);
+                        copyDict.Add(i * 10 + 7, 0); copyDict.Add(i * 10 + 8, 0); copyDict.Add(i * 10 + 9, 0);
+                    }
+            }
+        }
+
+        [Benchmark]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void AddRange(int size)
+        {
+            List<int> values = new List<int>();
+            for (int i = 0; i < size; i++)
+                values.Add(i);
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                MultiValueDictionary<int, int> empty = new MultiValueDictionary<int, int>();
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                        empty.AddRange(i, values);
+            }
+        }
+
+        [Benchmark]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void Remove(int size)
+        {
+            MultiValueDictionary<int, int> dict = new MultiValueDictionary<int, int>();
+            for (int i = 0; i < size; i++)
+                for (int j = 0; j < 100; j++)
+                    dict.Add(i, j);
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                MultiValueDictionary<int, int> copyDict = new MultiValueDictionary<int, int>(dict);
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= size; i++)
+                    {
+                        copyDict.Remove(i);
+                    }
+            }
+        }
+
+        [Benchmark]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void RemoveItem(int size)
+        {
+            MultiValueDictionary<int, int> dict = new MultiValueDictionary<int, int>();
+            for (int i = 0; i < size; i++)
+                for (int j = 0; j < 100; j++)
+                    dict.Add(i, j);
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                MultiValueDictionary<int, int> copyDict = new MultiValueDictionary<int, int>(dict);
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= size; i++)
+                        for (int j = 0; j <= 100; j++)
+                            copyDict.RemoveItem(i, j);
+            }
+        }
+
+        [Benchmark]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void Clear(int size)
+        {
+            MultiValueDictionary<int, int> dict = CreateMVD(size);
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                MultiValueDictionary<int, int> copyDict = new MultiValueDictionary<int, int>(dict);
+                using (iteration.StartMeasurement())
+                    copyDict.Clear();
+            }
+        }
+
+        [Benchmark]
+        public void ctor()
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        new MultiValueDictionary<int, string>(); new MultiValueDictionary<int, string>(); new MultiValueDictionary<int, string>();
+                        new MultiValueDictionary<int, string>(); new MultiValueDictionary<int, string>(); new MultiValueDictionary<int, string>();
+                        new MultiValueDictionary<int, string>(); new MultiValueDictionary<int, string>(); new MultiValueDictionary<int, string>();
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1024)]
+        [InlineData(4096)]
+        [InlineData(16384)]
+        public void ctor_int(int size)
+        {
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 500; i++)
+                    {
+                        new MultiValueDictionary<int, string>(size); new MultiValueDictionary<int, string>(size); new MultiValueDictionary<int, string>(size);
+                        new MultiValueDictionary<int, string>(size); new MultiValueDictionary<int, string>(size); new MultiValueDictionary<int, string>(size);
+                        new MultiValueDictionary<int, string>(size); new MultiValueDictionary<int, string>(size); new MultiValueDictionary<int, string>(size);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void GetItem(int size)
+        {
+            MultiValueDictionary<int, int> dict = CreateMVD(size);
+
+            // Setup
+            IReadOnlyCollection<int> retrieved;
+            for (int i = 1; i <= 9; i++)
+                dict.Add(i, 0);
+
+            // Actual perf testing
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 10000; i++)
+                    {
+                        retrieved = dict[1]; retrieved = dict[2]; retrieved = dict[3];
+                        retrieved = dict[4]; retrieved = dict[5]; retrieved = dict[6];
+                        retrieved = dict[7]; retrieved = dict[8]; retrieved = dict[9];
+                    }
+            }
+        }
+
+        [Benchmark]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void GetKeys(int size)
+        {
+            MultiValueDictionary<int, int> dict = CreateMVD(size);
+            IEnumerable<int> result;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        result = dict.Keys; result = dict.Keys; result = dict.Keys;
+                        result = dict.Keys; result = dict.Keys; result = dict.Keys;
+                        result = dict.Keys; result = dict.Keys; result = dict.Keys;
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void TryGetValue(int size)
+        {
+            MultiValueDictionary<int, int> dict = CreateMVD(size);
+            // Setup
+            IReadOnlyCollection<int> retrieved;
+            Random rand = new Random(837322);
+            int key = rand.Next(0, 400000);
+            dict.Add(key, 12);
+
+            // Actual perf testing
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 1000; i++)
+                    {
+                        dict.TryGetValue(key, out retrieved); dict.TryGetValue(key, out retrieved);
+                        dict.TryGetValue(key, out retrieved); dict.TryGetValue(key, out retrieved);
+                        dict.TryGetValue(key, out retrieved); dict.TryGetValue(key, out retrieved);
+                        dict.TryGetValue(key, out retrieved); dict.TryGetValue(key, out retrieved);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void ContainsKey(int size)
+        {
+            MultiValueDictionary<int, int> dict = CreateMVD(size);
+
+            // Setup
+            Random rand = new Random(837322);
+            int key = rand.Next(0, 400000);
+            dict.Add(key, 12);
+
+            // Actual perf testing
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 10000; i++)
+                    {
+                        dict.ContainsKey(key); dict.ContainsKey(key); dict.ContainsKey(key);
+                        dict.ContainsKey(key); dict.ContainsKey(key); dict.ContainsKey(key);
+                        dict.ContainsKey(key); dict.ContainsKey(key); dict.ContainsKey(key);
+                        dict.ContainsKey(key); dict.ContainsKey(key); dict.ContainsKey(key);
+                    }
+        }
+
+        [Benchmark]
+        [InlineData(1000)]
+        [InlineData(10000)]
+        [InlineData(100000)]
+        public void ContainsValue(int size)
+        {
+            MultiValueDictionary<int, int> dict = CreateMVD(size);
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i <= 20000; i++)
+                    {
+                        dict.ContainsValue(i); dict.ContainsValue(i); dict.ContainsValue(i);
+                        dict.ContainsValue(i); dict.ContainsValue(i); dict.ContainsValue(i);
+                        dict.ContainsValue(i); dict.ContainsValue(i); dict.ContainsValue(i);
+                    }
+            }
+        }
+    }
+}

--- a/src/System.Collections.Generic.MultiValueDictionary/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections.Generic.MultiValueDictionary/tests/System.Collections.Tests.csproj
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Collections.Tests</AssemblyName>
+    <RootNamespace>System.Collections.Tests</RootNamespace>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Collections.csproj">
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- MVD tests -->
+    <Compile Include="Generic\MultiValueDictionary\MVD.TestBase.cs" />
+    <Compile Include="Generic\MultiValueDictionary\MVD.Tests.cs" />
+  </ItemGroup>
+  <!-- Performance Tests -->
+  <ItemGroup Condition="'$(Performance)' == 'true'">
+    <Compile Include="Performance\Perf.MVD.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Collections.Generic.MultiValueDictionary/tests/project.json
+++ b/src/System.Collections.Generic.MultiValueDictionary/tests/project.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore" : "5.0.0-beta-*",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-*",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-*"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Collections.Generic.MultiValueDictionary/tests/project.lock.json
+++ b/src/System.Collections.Generic.MultiValueDictionary/tests/project.lock.json
@@ -1,0 +1,3632 @@
+{
+  "locked": true,
+  "version": -9996,
+  "targets": {
+    "DNXCore,Version=v5.0": {
+      "Microsoft.CSharp/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Dynamic.Runtime": "4.0.0-beta-23127",
+          "System.Linq.Expressions": "4.0.0-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Linq": "4.0.0-beta-23127",
+          "System.Reflection.TypeExtensions": "4.0.0-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127",
+          "System.Reflection.Extensions": "4.0.0-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Reflection": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.ObjectModel": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.CSharp.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.CSharp.dll": {}
+        }
+      },
+      "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0023": {
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "xunit.abstractions": "2.0.0",
+          "xunit.extensibility.core": "2.1.0",
+          "xunit.extensibility.execution": "2.1.0"
+        },
+        "compile": {
+          "lib/dotnet/xunit.performance.core.dll": {},
+          "lib/dotnet/xunit.performance.execution.dotnet.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/xunit.performance.core.dll": {},
+          "lib/dotnet/xunit.performance.execution.dotnet.dll": {}
+        }
+      },
+      "Microsoft.NETCore/5.0.0-beta-23127": {
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.0-beta-23127",
+          "Microsoft.VisualBasic": "10.0.0-beta-23127",
+          "System.AppContext": "4.0.0-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Collections.Concurrent": "4.0.10-beta-23127",
+          "System.Collections.Immutable": "1.1.37-beta-23127",
+          "System.ComponentModel": "4.0.0-beta-23127",
+          "System.ComponentModel.Annotations": "4.0.10-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Diagnostics.Tools": "4.0.0-beta-23127",
+          "System.Diagnostics.Tracing": "4.0.20-beta-23127",
+          "System.Dynamic.Runtime": "4.0.10-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127",
+          "System.Globalization.Calendars": "4.0.0-beta-23127",
+          "System.Globalization.Extensions": "4.0.0-beta-23127",
+          "System.IO": "4.0.10-beta-23127",
+          "System.IO.Compression": "4.0.0-beta-23127",
+          "System.IO.Compression.ZipFile": "4.0.0-beta-23127",
+          "System.IO.FileSystem": "4.0.0-beta-23127",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23127",
+          "System.IO.UnmanagedMemoryStream": "4.0.0-beta-23127",
+          "System.Linq": "4.0.0-beta-23127",
+          "System.Linq.Expressions": "4.0.10-beta-23127",
+          "System.Linq.Parallel": "4.0.0-beta-23127",
+          "System.Linq.Queryable": "4.0.0-beta-23127",
+          "System.Net.NetworkInformation": "4.0.0-beta-23127",
+          "System.Net.Http": "4.0.0-beta-23127",
+          "System.Net.Primitives": "4.0.10-beta-23127",
+          "System.Numerics.Vectors": "4.1.0-beta-23127",
+          "System.ObjectModel": "4.0.10-beta-23127",
+          "System.Reflection": "4.0.10-beta-23127",
+          "System.Reflection.DispatchProxy": "4.0.0-beta-23127",
+          "System.Reflection.Extensions": "4.0.0-beta-23127",
+          "System.Reflection.Metadata": "1.0.22-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127",
+          "System.Reflection.TypeExtensions": "4.0.0-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.Runtime.Handles": "4.0.0-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127",
+          "System.Runtime.Numerics": "4.0.0-beta-23127",
+          "System.Security.Claims": "4.0.0-beta-23127",
+          "System.Security.Principal": "4.0.0-beta-23127",
+          "System.Text.Encoding": "4.0.10-beta-23127",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-23127",
+          "System.Text.RegularExpressions": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127",
+          "System.Threading.Tasks": "4.0.10-beta-23127",
+          "System.Threading.Tasks.Dataflow": "4.5.25-beta-23127",
+          "System.Threading.Tasks.Parallel": "4.0.0-beta-23127",
+          "System.Threading.Timer": "4.0.0-beta-23127",
+          "System.Xml.ReaderWriter": "4.0.10-beta-23127",
+          "System.Xml.XDocument": "4.0.10-beta-23127",
+          "Microsoft.NETCore.Targets": "1.0.0-beta-23127"
+        }
+      },
+      "Microsoft.NETCore.Platforms/1.0.0-beta-23127": {},
+      "Microsoft.NETCore.Targets/1.0.0-beta-23127": {
+        "dependencies": {
+          "Microsoft.NETCore.Targets.DNXCore": "4.9.0-beta-23127",
+          "Microsoft.NETCore.Platforms": "1.0.0-beta-23127"
+        }
+      },
+      "Microsoft.NETCore.Targets.DNXCore/4.9.0-beta-23127": {},
+      "Microsoft.VisualBasic/10.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Reflection.TypeExtensions": "4.0.0-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127",
+          "System.Linq": "4.0.0-beta-23127",
+          "System.Reflection.Extensions": "4.0.0-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Reflection": "4.0.10-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127",
+          "System.Dynamic.Runtime": "4.0.10-beta-23127",
+          "System.Linq.Expressions": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127",
+          "System.ObjectModel": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.VisualBasic.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.VisualBasic.dll": {}
+        }
+      },
+      "Microsoft.Win32.Primitives/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "System.AppContext/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.AppContext.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.AppContext.dll": {}
+        }
+      },
+      "System.Collections/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Collections.dll": {}
+        }
+      },
+      "System.Collections.Concurrent/4.0.10-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Threading.Tasks": "4.0.10-beta-23127",
+          "System.Diagnostics.Tracing": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Concurrent.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Concurrent.dll": {}
+        }
+      },
+      "System.Collections.Immutable/1.1.37-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Diagnostics.Debug": "4.0.0-beta-23127",
+          "System.Collections": "4.0.0-beta-23127",
+          "System.Linq": "4.0.0-beta-23127",
+          "System.Runtime.Extensions": "4.0.0-beta-23127",
+          "System.Globalization": "4.0.0-beta-23127",
+          "System.Threading": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "lib/dotnet/System.Collections.Immutable.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Immutable.dll": {}
+        }
+      },
+      "System.Collections.NonGeneric/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.ComponentModel/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.dll": {}
+        }
+      },
+      "System.ComponentModel.Annotations/4.0.10-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.ComponentModel": "4.0.0-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Reflection.Extensions": "4.0.0-beta-23127",
+          "System.Linq": "4.0.0-beta-23127",
+          "System.Reflection": "4.0.10-beta-23127",
+          "System.Text.RegularExpressions": "4.0.10-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.Annotations.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.Annotations.dll": {}
+        }
+      },
+      "System.ComponentModel.EventBasedAsync/4.0.10-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Threading": "4.0.10-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Threading.Tasks": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.0.20": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "System.Dynamic.Runtime/4.0.10-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127",
+          "System.Reflection.Emit": "4.0.0-beta-23127",
+          "System.Reflection.TypeExtensions": "4.0.0-beta-23127",
+          "System.Linq": "4.0.0-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Reflection": "4.0.10-beta-23127",
+          "System.Linq.Expressions": "4.0.10-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.ObjectModel": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Dynamic.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Dynamic.Runtime.dll": {}
+        }
+      },
+      "System.Globalization/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127",
+          "System.Globalization": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Calendars.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Globalization.Extensions.dll": {}
+        }
+      },
+      "System.IO/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.dll": {}
+        }
+      },
+      "System.IO.Compression/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.IO": "4.0.10-beta-23127",
+          "System.Text.Encoding": "4.0.10-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Runtime.Handles": "4.0.0-beta-23127",
+          "System.Threading": "4.0.0-beta-23127",
+          "System.Threading.Tasks": "4.0.10-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.Compression.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.Compression.dll": {}
+        }
+      },
+      "System.IO.Compression.ZipFile/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.IO.Compression": "4.0.0-beta-23127",
+          "System.Text.Encoding": "4.0.10-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23127",
+          "System.IO.FileSystem": "4.0.0-beta-23127",
+          "System.IO": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.Compression.ZipFile.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.Compression.ZipFile.dll": {}
+        }
+      },
+      "System.IO.FileSystem/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Text.Encoding": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Collections": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.FileSystem.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.IO.UnmanagedMemoryStream/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23127",
+          "System.IO": "4.0.10-beta-23127",
+          "System.Threading.Tasks": "4.0.10-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Threading": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.UnmanagedMemoryStream.dll": {}
+        }
+      },
+      "System.Linq/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Collections": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.dll": {}
+        }
+      },
+      "System.Linq.Expressions/4.0.10-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Reflection.TypeExtensions": "4.0.0-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127",
+          "System.Reflection.Emit": "4.0.0-beta-23127",
+          "System.Linq": "4.0.0-beta-23127",
+          "System.Reflection.Extensions": "4.0.0-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Reflection": "4.0.10-beta-23127",
+          "System.IO": "4.0.10-beta-23127",
+          "System.ObjectModel": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.Expressions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Linq.Expressions.dll": {}
+        }
+      },
+      "System.Linq.Parallel/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Collections.Concurrent": "4.0.10-beta-23127",
+          "System.Linq": "4.0.0-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Threading.Tasks": "4.0.10-beta-23127",
+          "System.Diagnostics.Tracing": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Threading": "4.0.10-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.Parallel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.Parallel.dll": {}
+        }
+      },
+      "System.Linq.Queryable/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Linq.Expressions": "4.0.10-beta-23127",
+          "System.Linq": "4.0.0-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Reflection.Extensions": "4.0.0-beta-23127",
+          "System.Reflection": "4.0.10-beta-23127",
+          "System.Collections": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.Queryable.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.Queryable.dll": {}
+        }
+      },
+      "System.Net.Http/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127",
+          "System.Runtime.Handles": "4.0.0-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "Microsoft.Win32.Primitives": "4.0.0-beta-23127",
+          "System.IO.Compression": "4.0.0-beta-23127",
+          "System.Net.Primitives": "4.0.10-beta-23127",
+          "System.Threading.Tasks": "4.0.10-beta-23127",
+          "System.IO": "4.0.10-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Text.Encoding": "4.0.10-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Http.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Http.dll": {}
+        }
+      },
+      "System.Net.NetworkInformation/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.NetworkInformation.dll": {}
+        }
+      },
+      "System.Net.Primitives/4.0.10-beta-23127": {
+        "dependencies": {
+          "System.Private.Networking": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Primitives.dll": {}
+        }
+      },
+      "System.Numerics.Vectors/4.1.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Numerics.Vectors.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Numerics.Vectors.dll": {}
+        }
+      },
+      "System.ObjectModel/4.0.10-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.ObjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ObjectModel.dll": {}
+        }
+      },
+      "System.Private.Networking/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127",
+          "System.Diagnostics.Tracing": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Runtime.Handles": "4.0.0-beta-23127",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23127",
+          "System.Collections.Concurrent": "4.0.0-beta-23127",
+          "System.Collections.NonGeneric": "4.0.0-beta-23127",
+          "System.Security.SecureString": "4.0.0-beta-23127",
+          "System.Security.Principal.Windows": "4.0.0-beta-23127",
+          "Microsoft.Win32.Primitives": "4.0.0-beta-23127",
+          "System.IO.FileSystem": "4.0.0-beta-23127",
+          "System.Threading.Overlapped": "4.0.0-beta-23127",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23127",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127",
+          "System.Threading.Tasks": "4.0.10-beta-23127",
+          "System.IO": "4.0.10-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Threading.ThreadPool": "4.0.10-beta-23127",
+          "System.ComponentModel.EventBasedAsync": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127"
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Networking.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0": {
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.DispatchProxy/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127",
+          "System.Linq": "4.0.0-beta-23127",
+          "System.Reflection.Extensions": "4.0.0-beta-23127",
+          "System.Reflection": "4.0.10-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.DispatchProxy.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127",
+          "System.Reflection": "4.0.0-beta-23127",
+          "System.Reflection.Emit.ILGeneration": "4.0.0-beta-23127",
+          "System.IO": "4.0.0-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127",
+          "System.Reflection": "4.0.0-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Metadata/1.0.22-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127",
+          "System.IO": "4.0.0-beta-23127",
+          "System.Diagnostics.Debug": "4.0.0-beta-23127",
+          "System.Collections": "4.0.0-beta-23127",
+          "System.Text.Encoding": "4.0.0-beta-23127",
+          "System.Runtime.InteropServices": "4.0.0-beta-23127",
+          "System.Reflection": "4.0.0-beta-23127",
+          "System.Runtime.Extensions": "4.0.0-beta-23127",
+          "System.Threading": "4.0.0-beta-23127",
+          "System.Text.Encoding.Extensions": "4.0.0-beta-23127",
+          "System.Reflection.Extensions": "4.0.0-beta-23127",
+          "System.Collections.Immutable": "1.1.37-beta-23127"
+        },
+        "compile": {
+          "lib/dotnet/System.Reflection.Metadata.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Reflection.Metadata.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127",
+          "System.Reflection": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Globalization": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "dependencies": {
+          "System.Private.Uri": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.20": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Resources.ResourceManager": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+        }
+      },
+      "System.Runtime.Numerics/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Numerics.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.Numerics.dll": {}
+        }
+      },
+      "System.Security.Claims/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Security.Principal": "4.0.0-beta-23127",
+          "System.IO": "4.0.0-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Collections": "4.0.0-beta-23127",
+          "System.Diagnostics.Debug": "4.0.0-beta-23127",
+          "System.Globalization": "4.0.0-beta-23127",
+          "System.Runtime.Extensions": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Claims.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Claims.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23127",
+          "System.Runtime.Handles": "4.0.0-beta-23127",
+          "System.IO": "4.0.0-beta-23127",
+          "System.Text.Encoding.Extensions": "4.0.0-beta-23127",
+          "System.Text.Encoding": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Algorithms.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Csp/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23127",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23127",
+          "System.IO": "4.0.0-beta-23127",
+          "System.Reflection": "4.0.0-beta-23127",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23127",
+          "System.Runtime.Handles": "4.0.0-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Csp.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Csp.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23127",
+          "System.Runtime.Handles": "4.0.0-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Globalization": "4.0.0-beta-23127",
+          "System.IO": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Runtime.Handles": "4.0.0-beta-23127",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23127",
+          "System.Security.Cryptography.Csp": "4.0.0-beta-23127",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23127",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23127",
+          "System.Runtime.Numerics": "4.0.0-beta-23127",
+          "System.Globalization.Calendars": "4.0.0-beta-23127",
+          "System.IO.FileSystem": "4.0.0-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.IO": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.Text.Encoding": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Cryptography.X509Certificates.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Cryptography.X509Certificates.dll": {}
+        }
+      },
+      "System.Security.Principal/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Principal.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Security.Principal.dll": {}
+        }
+      },
+      "System.Security.Principal.Windows/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Collections": "4.0.0-beta-23127",
+          "System.Runtime.InteropServices": "4.0.0-beta-23127",
+          "System.Security.Claims": "4.0.0-beta-23127",
+          "System.Security.Principal": "4.0.0-beta-23127",
+          "System.Diagnostics.Debug": "4.0.0-beta-23127",
+          "System.Reflection": "4.0.0-beta-23127",
+          "System.Runtime.Extensions": "4.0.0-beta-23127",
+          "System.Threading": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.Principal.Windows.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
+        }
+      },
+      "System.Security.SecureString/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Runtime.Handles": "4.0.0-beta-23127",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23127",
+          "System.Threading": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Security.SecureString.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Security.SecureString.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Text.RegularExpressions/4.0.10-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.RegularExpressions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Text.RegularExpressions.dll": {}
+        }
+      },
+      "System.Threading/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Overlapped/4.0.0": {
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Overlapped.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Overlapped.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Tasks.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Dataflow/4.5.25-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Diagnostics.Debug": "4.0.0-beta-23127",
+          "System.Collections.Concurrent": "4.0.0-beta-23127",
+          "System.Collections": "4.0.0-beta-23127",
+          "System.Threading.Tasks": "4.0.0-beta-23127",
+          "System.Dynamic.Runtime": "4.0.0-beta-23127",
+          "System.Diagnostics.Tracing": "4.0.0-beta-23127",
+          "System.Threading": "4.0.0-beta-23127",
+          "System.Linq": "4.0.0-beta-23127",
+          "System.Runtime.Extensions": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Threading.Tasks.Dataflow.dll": {}
+        }
+      },
+      "System.Threading.Tasks.Parallel/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Collections.Concurrent": "4.0.10-beta-23127",
+          "System.Threading.Tasks": "4.0.10-beta-23127",
+          "System.Diagnostics.Tracing": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.Parallel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Threading.Tasks.Parallel.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127",
+          "System.Runtime.InteropServices": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Threading.Timer/4.0.0-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Timer.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Timer.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.10-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.Text.Encoding": "4.0.10-beta-23127",
+          "System.IO": "4.0.10-beta-23127",
+          "System.Threading.Tasks": "4.0.10-beta-23127",
+          "System.Runtime.InteropServices": "4.0.20-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.IO.FileSystem": "4.0.0-beta-23127",
+          "System.IO.FileSystem.Primitives": "4.0.0-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Text.RegularExpressions": "4.0.10-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127",
+          "System.Text.Encoding.Extensions": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.ReaderWriter.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.ReaderWriter.dll": {}
+        }
+      },
+      "System.Xml.XDocument/4.0.10-beta-23127": {
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127",
+          "System.IO": "4.0.10-beta-23127",
+          "System.Xml.ReaderWriter": "4.0.10-beta-23127",
+          "System.Resources.ResourceManager": "4.0.0-beta-23127",
+          "System.Diagnostics.Debug": "4.0.10-beta-23127",
+          "System.Collections": "4.0.10-beta-23127",
+          "System.Globalization": "4.0.10-beta-23127",
+          "System.Threading": "4.0.10-beta-23127",
+          "System.Text.Encoding": "4.0.10-beta-23127",
+          "System.Reflection": "4.0.10-beta-23127",
+          "System.Runtime.Extensions": "4.0.10-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XDocument.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.XDocument.dll": {}
+        }
+      },
+      "xunit/2.1.0": {
+        "dependencies": {
+          "xunit.core": "[2.1.0]",
+          "xunit.assert": "[2.1.0]"
+        }
+      },
+      "xunit.abstractions/2.0.0": {
+        "compile": {
+          "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll": {}
+        },
+        "runtime": {
+          "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll": {}
+        }
+      },
+      "xunit.assert/2.1.0": {
+        "dependencies": {
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.ObjectModel": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Text.RegularExpressions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "lib/dotnet/xunit.assert.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/xunit.assert.dll": {}
+        }
+      },
+      "xunit.core/2.1.0": {
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0]",
+          "xunit.extensibility.execution": "[2.1.0]",
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading.Tasks": "4.0.0",
+          "xunit.abstractions": "2.0.0"
+        }
+      },
+      "xunit.extensibility.core/2.1.0": {
+        "dependencies": {
+          "xunit.abstractions": "[2.0.0]"
+        },
+        "compile": {
+          "lib/dotnet/xunit.core.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/xunit.core.dll": {}
+        }
+      },
+      "xunit.extensibility.execution/2.1.0": {
+        "dependencies": {
+          "xunit.extensibility.core": "[2.1.0]",
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0",
+          "xunit.abstractions": "2.0.0"
+        },
+        "compile": {
+          "lib/dotnet/xunit.execution.dotnet.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/xunit.execution.dotnet.dll": {}
+        }
+      },
+      "xunit.netcore.extensions/1.0.0-prerelease-00112": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23213",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "xunit": "2.1.0"
+        },
+        "compile": {
+          "lib/dotnet/Xunit.NetCore.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Xunit.NetCore.Extensions.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Microsoft.CSharp/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "C65wlRjLwb25yf9XKQiY1g8/dHPA33p6IhynzeNxklc0Kyu5watlY3RSr1uExS3fQ4b/KO05k5CDmJ/IimOUlg==",
+      "files": [
+        "Microsoft.CSharp.4.0.0-beta-23127.nupkg",
+        "Microsoft.CSharp.4.0.0-beta-23127.nupkg.sha512",
+        "Microsoft.CSharp.nuspec",
+        "lib/dotnet/Microsoft.CSharp.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/Microsoft.CSharp.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/Microsoft.CSharp.dll",
+        "ref/dotnet/Microsoft.CSharp.xml",
+        "ref/dotnet/de/Microsoft.CSharp.xml",
+        "ref/dotnet/es/Microsoft.CSharp.xml",
+        "ref/dotnet/fr/Microsoft.CSharp.xml",
+        "ref/dotnet/it/Microsoft.CSharp.xml",
+        "ref/dotnet/ja/Microsoft.CSharp.xml",
+        "ref/dotnet/ko/Microsoft.CSharp.xml",
+        "ref/dotnet/ru/Microsoft.CSharp.xml",
+        "ref/dotnet/zh-hans/Microsoft.CSharp.xml",
+        "ref/dotnet/zh-hant/Microsoft.CSharp.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/Microsoft.CSharp.dll",
+        "ref/netcore50/Microsoft.CSharp.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0023": {
+      "sha512": "7TOhATYXNVMF3HHGuM/WFHLt7r4uvFIUliplzIHsfL/KwxaHUbV6RI1f7EZRAioMbJI5520BGOOZ+9XIqtTQuA==",
+      "files": [
+        "_rels/.rels",
+        "Microsoft.DotNet.xunit.performance.nuspec",
+        "lib/dotnet/xunit.performance.core.dll",
+        "lib/dotnet/xunit.performance.core.pdb",
+        "lib/dotnet/xunit.performance.core.XML",
+        "lib/dotnet/xunit.performance.execution.dotnet.dll",
+        "lib/dotnet/xunit.performance.execution.dotnet.pdb",
+        "lib/net46/xunit.performance.core.dll",
+        "lib/net46/xunit.performance.core.pdb",
+        "lib/net46/xunit.performance.core.XML",
+        "lib/net46/xunit.performance.execution.desktop.dll",
+        "lib/net46/xunit.performance.execution.desktop.pdb",
+        "package/services/metadata/core-properties/b700b008fbc64ae1a3ad112bf6153897.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "Microsoft.NETCore/5.0.0-beta-23127": {
+      "sha512": "Y3ZbW4nQ+0sP0fSOmHOElVDuGeElz2ZGVyj38IvRG6AylNFN02iBw56vYME4d7s5h9Jz/wQwhkVHP5ua4KrqJw==",
+      "files": [
+        "Microsoft.NETCore.5.0.0-beta-23127.nupkg",
+        "Microsoft.NETCore.5.0.0-beta-23127.nupkg.sha512",
+        "Microsoft.NETCore.nuspec",
+        "_._"
+      ]
+    },
+    "Microsoft.NETCore.Platforms/1.0.0-beta-23127": {
+      "sha512": "aiLuM4Cygvn3gFHgWPIIWnmQw8bfRgjC3wHBx4WnKnDuJGLZLX5hGOaDr8AbpKzxY9Pks8EEwehRjsbY6xfSFQ==",
+      "files": [
+        "Microsoft.NETCore.Platforms.1.0.0-beta-23127.nupkg",
+        "Microsoft.NETCore.Platforms.1.0.0-beta-23127.nupkg.sha512",
+        "Microsoft.NETCore.Platforms.nuspec",
+        "runtime.json"
+      ]
+    },
+    "Microsoft.NETCore.Targets/1.0.0-beta-23127": {
+      "sha512": "+LTPS+b1x82WT0af6PfhDKI0W25ASv6qSHKPok02Wck6Y5IxtXPP9R6JecpgiNK+BMPWNvfFCZr+ZwI7igKkNw==",
+      "files": [
+        "Microsoft.NETCore.Targets.1.0.0-beta-23127.nupkg",
+        "Microsoft.NETCore.Targets.1.0.0-beta-23127.nupkg.sha512",
+        "Microsoft.NETCore.Targets.nuspec",
+        "runtime.json"
+      ]
+    },
+    "Microsoft.NETCore.Targets.DNXCore/4.9.0-beta-23127": {
+      "sha512": "J4oVf0JSYOK1wgNsjqCBJp3lnLoLznDknh77crnS5lVEQ/TEk+OOif7a5jxoo+bSNWMuCqO5yYT+vVyGfEY+4A==",
+      "files": [
+        "Microsoft.NETCore.Targets.DNXCore.4.9.0-beta-23127.nupkg",
+        "Microsoft.NETCore.Targets.DNXCore.4.9.0-beta-23127.nupkg.sha512",
+        "Microsoft.NETCore.Targets.DNXCore.nuspec",
+        "runtime.json"
+      ]
+    },
+    "Microsoft.VisualBasic/10.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "JLtNmqSuy6rZ+7x9lw1/gjhv0ER8xZ8fpqrn11k3hqI9zCtToMyjnO/zb3NVDMkcxPx3F3qBIWb/IwKosYwSUw==",
+      "files": [
+        "Microsoft.VisualBasic.10.0.0-beta-23127.nupkg",
+        "Microsoft.VisualBasic.10.0.0-beta-23127.nupkg.sha512",
+        "Microsoft.VisualBasic.nuspec",
+        "lib/dotnet/Microsoft.VisualBasic.dll",
+        "lib/net45/_._",
+        "lib/netcore50/Microsoft.VisualBasic.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/Microsoft.VisualBasic.dll",
+        "ref/dotnet/Microsoft.VisualBasic.xml",
+        "ref/dotnet/de/Microsoft.VisualBasic.xml",
+        "ref/dotnet/es/Microsoft.VisualBasic.xml",
+        "ref/dotnet/fr/Microsoft.VisualBasic.xml",
+        "ref/dotnet/it/Microsoft.VisualBasic.xml",
+        "ref/dotnet/ja/Microsoft.VisualBasic.xml",
+        "ref/dotnet/ko/Microsoft.VisualBasic.xml",
+        "ref/dotnet/ru/Microsoft.VisualBasic.xml",
+        "ref/dotnet/zh-hans/Microsoft.VisualBasic.xml",
+        "ref/dotnet/zh-hant/Microsoft.VisualBasic.xml",
+        "ref/net45/_._",
+        "ref/netcore50/Microsoft.VisualBasic.dll",
+        "ref/netcore50/Microsoft.VisualBasic.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._"
+      ]
+    },
+    "Microsoft.Win32.Primitives/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "RhBDkPQpFEEx6gHmNlge7eG9up6U0lC41Sbgh8ugosNeputVZRzbskXMOPkgNz3I5FMU/E+g0YuJB/T8K0Slhg==",
+      "files": [
+        "Microsoft.Win32.Primitives.4.0.0-beta-23127.nupkg",
+        "Microsoft.Win32.Primitives.4.0.0-beta-23127.nupkg.sha512",
+        "Microsoft.Win32.Primitives.nuspec",
+        "lib/dotnet/Microsoft.Win32.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/Microsoft.Win32.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/Microsoft.Win32.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.AppContext/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "dj/6m1l2oz2hPqkp8SAZJkwnQTnuBBcCfvIm859YvsQwQ1FSAoQraCE9MrYF5m9x4vdxB6I5yBwdhYJqOGKAWw==",
+      "files": [
+        "System.AppContext.4.0.0-beta-23127.nupkg",
+        "System.AppContext.4.0.0-beta-23127.nupkg.sha512",
+        "System.AppContext.nuspec",
+        "lib/DNXCore50/System.AppContext.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.AppContext.dll",
+        "lib/netcore50/System.AppContext.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.AppContext.dll",
+        "ref/dotnet/System.AppContext.xml",
+        "ref/dotnet/de/System.AppContext.xml",
+        "ref/dotnet/es/System.AppContext.xml",
+        "ref/dotnet/fr/System.AppContext.xml",
+        "ref/dotnet/it/System.AppContext.xml",
+        "ref/dotnet/ja/System.AppContext.xml",
+        "ref/dotnet/ko/System.AppContext.xml",
+        "ref/dotnet/ru/System.AppContext.xml",
+        "ref/dotnet/zh-hans/System.AppContext.xml",
+        "ref/dotnet/zh-hant/System.AppContext.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.AppContext.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Collections/4.0.10": {
+      "serviceable": true,
+      "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
+      "files": [
+        "System.Collections.4.0.10.nupkg",
+        "System.Collections.4.0.10.nupkg.sha512",
+        "System.Collections.nuspec",
+        "lib/DNXCore50/System.Collections.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Collections.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
+        "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
+        "ref/dotnet/fr/System.Collections.xml",
+        "ref/dotnet/it/System.Collections.xml",
+        "ref/dotnet/ja/System.Collections.xml",
+        "ref/dotnet/ko/System.Collections.xml",
+        "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/zh-hans/System.Collections.xml",
+        "ref/dotnet/zh-hant/System.Collections.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll"
+      ]
+    },
+    "System.Collections.Concurrent/4.0.10-beta-23127": {
+      "serviceable": true,
+      "sha512": "6ztGCgMpxYIVbHC0KYDDR2UdwzVXT7QB827EkPHntcRJKmcyEYbH3ZS3uWXOoLG8PBTSoJfVP/k2Wpf0CwcKvA==",
+      "files": [
+        "System.Collections.Concurrent.4.0.10-beta-23127.nupkg",
+        "System.Collections.Concurrent.4.0.10-beta-23127.nupkg.sha512",
+        "System.Collections.Concurrent.nuspec",
+        "lib/dotnet/System.Collections.Concurrent.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.Concurrent.dll",
+        "ref/dotnet/System.Collections.Concurrent.xml",
+        "ref/dotnet/de/System.Collections.Concurrent.xml",
+        "ref/dotnet/es/System.Collections.Concurrent.xml",
+        "ref/dotnet/fr/System.Collections.Concurrent.xml",
+        "ref/dotnet/it/System.Collections.Concurrent.xml",
+        "ref/dotnet/ja/System.Collections.Concurrent.xml",
+        "ref/dotnet/ko/System.Collections.Concurrent.xml",
+        "ref/dotnet/ru/System.Collections.Concurrent.xml",
+        "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
+        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Collections.Immutable/1.1.37-beta-23127": {
+      "serviceable": true,
+      "sha512": "7+jfhGSMpTYT9nm4EqlqSShdQl2xA3HeDvl65EYHm3p8PDgJqZYh4pSjh+/rhif8/yox0bBnUI37+US50tZr7w==",
+      "files": [
+        "System.Collections.Immutable.1.1.37-beta-23127.nupkg",
+        "System.Collections.Immutable.1.1.37-beta-23127.nupkg.sha512",
+        "System.Collections.Immutable.nuspec",
+        "lib/dotnet/System.Collections.Immutable.dll",
+        "lib/dotnet/System.Collections.Immutable.xml",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml"
+      ]
+    },
+    "System.Collections.NonGeneric/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "/J9iHpOqRwPRM1WFY+F8pPqD9kJyPQLJRqlK40cncyHqzeNArDfjlVKtP8qTMxydZVWJy9RfSzelTeFUU8+xAQ==",
+      "files": [
+        "System.Collections.NonGeneric.4.0.0-beta-23127.nupkg",
+        "System.Collections.NonGeneric.4.0.0-beta-23127.nupkg.sha512",
+        "System.Collections.NonGeneric.nuspec",
+        "lib/dotnet/System.Collections.NonGeneric.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.NonGeneric.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.NonGeneric.dll",
+        "ref/dotnet/System.Collections.NonGeneric.xml",
+        "ref/dotnet/de/System.Collections.NonGeneric.xml",
+        "ref/dotnet/es/System.Collections.NonGeneric.xml",
+        "ref/dotnet/fr/System.Collections.NonGeneric.xml",
+        "ref/dotnet/it/System.Collections.NonGeneric.xml",
+        "ref/dotnet/ja/System.Collections.NonGeneric.xml",
+        "ref/dotnet/ko/System.Collections.NonGeneric.xml",
+        "ref/dotnet/ru/System.Collections.NonGeneric.xml",
+        "ref/dotnet/zh-hans/System.Collections.NonGeneric.xml",
+        "ref/dotnet/zh-hant/System.Collections.NonGeneric.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Collections.NonGeneric.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.ComponentModel/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "+TKw0cAGEImTZb04kEN0VXNJfHaeKsiJVrQXfEMaKFfhSkcyFzxUJ1GxhW2E6dIywz+mgnFScHGNs6HxP3mFxQ==",
+      "files": [
+        "System.ComponentModel.4.0.0-beta-23127.nupkg",
+        "System.ComponentModel.4.0.0-beta-23127.nupkg.sha512",
+        "System.ComponentModel.nuspec",
+        "lib/dotnet/System.ComponentModel.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.ComponentModel.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.ComponentModel.dll",
+        "ref/dotnet/System.ComponentModel.xml",
+        "ref/dotnet/de/System.ComponentModel.xml",
+        "ref/dotnet/es/System.ComponentModel.xml",
+        "ref/dotnet/fr/System.ComponentModel.xml",
+        "ref/dotnet/it/System.ComponentModel.xml",
+        "ref/dotnet/ja/System.ComponentModel.xml",
+        "ref/dotnet/ko/System.ComponentModel.xml",
+        "ref/dotnet/ru/System.ComponentModel.xml",
+        "ref/dotnet/zh-hans/System.ComponentModel.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.ComponentModel.dll",
+        "ref/netcore50/System.ComponentModel.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._"
+      ]
+    },
+    "System.ComponentModel.Annotations/4.0.10-beta-23127": {
+      "serviceable": true,
+      "sha512": "nM28WsdqAGssA4MWrQHYDA7shPbcJ9DX/wqWQr0wyWlYAn5+LEQG6r9vV9MgkIoXc4kSr9y9rHdUiDguZiMSbw==",
+      "files": [
+        "System.ComponentModel.Annotations.4.0.10-beta-23127.nupkg",
+        "System.ComponentModel.Annotations.4.0.10-beta-23127.nupkg.sha512",
+        "System.ComponentModel.Annotations.nuspec",
+        "lib/dotnet/System.ComponentModel.Annotations.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.ComponentModel.Annotations.dll",
+        "ref/dotnet/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/de/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/es/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/fr/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/it/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/ja/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/ko/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/ru/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/zh-hans/System.ComponentModel.Annotations.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.Annotations.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.ComponentModel.EventBasedAsync/4.0.10-beta-23127": {
+      "serviceable": true,
+      "sha512": "0QNgn7RwPaZxqLajGOGJrhubVIR/03Ruq3NrPZ9fzE6ff7guRafiYCOjjP5N1/UsOAaCqMmukArO7DbPBo3MjQ==",
+      "files": [
+        "System.ComponentModel.EventBasedAsync.4.0.10-beta-23127.nupkg",
+        "System.ComponentModel.EventBasedAsync.4.0.10-beta-23127.nupkg.sha512",
+        "System.ComponentModel.EventBasedAsync.nuspec",
+        "lib/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.dll",
+        "ref/dotnet/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/de/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/es/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/fr/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/it/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/ja/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/ko/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/ru/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/zh-hans/System.ComponentModel.EventBasedAsync.xml",
+        "ref/dotnet/zh-hant/System.ComponentModel.EventBasedAsync.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Diagnostics.Debug/4.0.10": {
+      "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
+      "files": [
+        "_rels/.rels",
+        "System.Diagnostics.Debug.nuspec",
+        "lib/DNXCore50/System.Diagnostics.Debug.dll",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/fr/System.Diagnostics.Debug.xml",
+        "ref/dotnet/it/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ja/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ko/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/bfb05c26051f4a5f9015321db9cb045c.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Diagnostics.Tools/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "XwGB3xujbltZNvijseNclviPyTkSFTJbWUnIK64T8QqBKlmM+vclOfqTq0XFPk+E3f1wQD1Ild5qny/g03rGow==",
+      "files": [
+        "System.Diagnostics.Tools.4.0.0-beta-23127.nupkg",
+        "System.Diagnostics.Tools.4.0.0-beta-23127.nupkg.sha512",
+        "System.Diagnostics.Tools.nuspec",
+        "lib/DNXCore50/System.Diagnostics.Tools.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Tools.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
+        "ref/dotnet/de/System.Diagnostics.Tools.xml",
+        "ref/dotnet/es/System.Diagnostics.Tools.xml",
+        "ref/dotnet/fr/System.Diagnostics.Tools.xml",
+        "ref/dotnet/it/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ja/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ko/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ru/System.Diagnostics.Tools.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Tools.dll",
+        "ref/netcore50/System.Diagnostics.Tools.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll"
+      ]
+    },
+    "System.Diagnostics.Tracing/4.0.20": {
+      "sha512": "gn/wexGHc35Fv++5L1gYHMY5g25COfiZ0PGrL+3PfwzoJd4X2LbTAm/U8d385SI6BKQBI/z4dQfvneS9J27+Tw==",
+      "files": [
+        "_rels/.rels",
+        "System.Diagnostics.Tracing.nuspec",
+        "lib/netcore50/System.Diagnostics.Tracing.dll",
+        "lib/DNXCore50/System.Diagnostics.Tracing.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Diagnostics.Tracing.dll",
+        "ref/dotnet/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/de/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/it/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/13423e75e6344b289b3779b51522737c.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Dynamic.Runtime/4.0.10-beta-23127": {
+      "serviceable": true,
+      "sha512": "CdHP5xdcur8RBwv3Ywmq2MQypHpb4KbGaY1dD2DkNP7cm50tovA/p7oue96wKgm44IYsCJm6Es75ton15WdgwA==",
+      "files": [
+        "runtime.json",
+        "System.Dynamic.Runtime.4.0.10-beta-23127.nupkg",
+        "System.Dynamic.Runtime.4.0.10-beta-23127.nupkg.sha512",
+        "System.Dynamic.Runtime.nuspec",
+        "lib/DNXCore50/System.Dynamic.Runtime.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Dynamic.Runtime.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Dynamic.Runtime.dll",
+        "ref/dotnet/System.Dynamic.Runtime.xml",
+        "ref/dotnet/de/System.Dynamic.Runtime.xml",
+        "ref/dotnet/es/System.Dynamic.Runtime.xml",
+        "ref/dotnet/fr/System.Dynamic.Runtime.xml",
+        "ref/dotnet/it/System.Dynamic.Runtime.xml",
+        "ref/dotnet/ja/System.Dynamic.Runtime.xml",
+        "ref/dotnet/ko/System.Dynamic.Runtime.xml",
+        "ref/dotnet/ru/System.Dynamic.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Dynamic.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Dynamic.Runtime.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll"
+      ]
+    },
+    "System.Globalization/4.0.10": {
+      "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
+      "files": [
+        "_rels/.rels",
+        "System.Globalization.nuspec",
+        "lib/netcore50/System.Globalization.dll",
+        "lib/DNXCore50/System.Globalization.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "ref/dotnet/de/System.Globalization.xml",
+        "ref/dotnet/fr/System.Globalization.xml",
+        "ref/dotnet/it/System.Globalization.xml",
+        "ref/dotnet/ja/System.Globalization.xml",
+        "ref/dotnet/ko/System.Globalization.xml",
+        "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/zh-hans/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/93bcad242a4e4ad7afd0b53244748763.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Globalization.Calendars/4.0.0-beta-23127": {
+      "sha512": "qGG4XuUE9Mj3akqNbZdjmbV32hFBrNEyg9NaVT9kiccEmFN3N7nFcu9fsHg5TgiNrHzyWoqYFCcwjfAF0Qx7nw==",
+      "files": [
+        "System.Globalization.Calendars.4.0.0-beta-23127.nupkg",
+        "System.Globalization.Calendars.4.0.0-beta-23127.nupkg.sha512",
+        "System.Globalization.Calendars.nuspec",
+        "lib/DNXCore50/System.Globalization.Calendars.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Calendars.dll",
+        "lib/netcore50/System.Globalization.Calendars.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Globalization.Calendars.dll",
+        "ref/dotnet/System.Globalization.Calendars.xml",
+        "ref/dotnet/de/System.Globalization.Calendars.xml",
+        "ref/dotnet/es/System.Globalization.Calendars.xml",
+        "ref/dotnet/fr/System.Globalization.Calendars.xml",
+        "ref/dotnet/it/System.Globalization.Calendars.xml",
+        "ref/dotnet/ja/System.Globalization.Calendars.xml",
+        "ref/dotnet/ko/System.Globalization.Calendars.xml",
+        "ref/dotnet/ru/System.Globalization.Calendars.xml",
+        "ref/dotnet/zh-hans/System.Globalization.Calendars.xml",
+        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Calendars.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll"
+      ]
+    },
+    "System.Globalization.Extensions/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "A2VibExYdGYioMGXogrwifUqre2jBuFucVE1ymCnmGwGmOkZKnvWuNVO3FiFlWUwBUlUlkOmzKna5bKl/dt+9A==",
+      "files": [
+        "System.Globalization.Extensions.4.0.0-beta-23127.nupkg",
+        "System.Globalization.Extensions.4.0.0-beta-23127.nupkg.sha512",
+        "System.Globalization.Extensions.nuspec",
+        "lib/dotnet/System.Globalization.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Globalization.Extensions.dll",
+        "ref/dotnet/System.Globalization.Extensions.xml",
+        "ref/dotnet/de/System.Globalization.Extensions.xml",
+        "ref/dotnet/es/System.Globalization.Extensions.xml",
+        "ref/dotnet/fr/System.Globalization.Extensions.xml",
+        "ref/dotnet/it/System.Globalization.Extensions.xml",
+        "ref/dotnet/ja/System.Globalization.Extensions.xml",
+        "ref/dotnet/ko/System.Globalization.Extensions.xml",
+        "ref/dotnet/ru/System.Globalization.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Globalization.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Extensions.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.IO/4.0.10": {
+      "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
+      "files": [
+        "_rels/.rels",
+        "System.IO.nuspec",
+        "lib/netcore50/System.IO.dll",
+        "lib/DNXCore50/System.IO.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
+        "ref/dotnet/zh-hant/System.IO.xml",
+        "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/fr/System.IO.xml",
+        "ref/dotnet/it/System.IO.xml",
+        "ref/dotnet/ja/System.IO.xml",
+        "ref/dotnet/ko/System.IO.xml",
+        "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/zh-hans/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/db72fd58a86b4d13a6d2858ebec46705.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.IO.Compression/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "+1CLNZk+R/TWMYvukDJPKKpKQE9A9f7Qu/ABcd5Lojq9TDA10QNW+uzRuLODYQyVFy4DytDYTQ3+hRF58M3ltw==",
+      "files": [
+        "runtime.json",
+        "System.IO.Compression.4.0.0-beta-23127.nupkg",
+        "System.IO.Compression.4.0.0-beta-23127.nupkg.sha512",
+        "System.IO.Compression.nuspec",
+        "lib/dotnet/System.IO.Compression.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.IO.Compression.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.Compression.dll",
+        "ref/dotnet/System.IO.Compression.xml",
+        "ref/dotnet/de/System.IO.Compression.xml",
+        "ref/dotnet/es/System.IO.Compression.xml",
+        "ref/dotnet/fr/System.IO.Compression.xml",
+        "ref/dotnet/it/System.IO.Compression.xml",
+        "ref/dotnet/ja/System.IO.Compression.xml",
+        "ref/dotnet/ko/System.IO.Compression.xml",
+        "ref/dotnet/ru/System.IO.Compression.xml",
+        "ref/dotnet/zh-hans/System.IO.Compression.xml",
+        "ref/dotnet/zh-hant/System.IO.Compression.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/System.IO.Compression.dll",
+        "ref/netcore50/System.IO.Compression.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.IO.Compression.ZipFile/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "w4oRy4lg/0aJpndY57FuO3xXfb231dYPJo1TM/DWH81v7W1zU7M/aqhlJtUxhX/AcmeTtAGtG2SBuN/U/jazgA==",
+      "files": [
+        "System.IO.Compression.ZipFile.4.0.0-beta-23127.nupkg",
+        "System.IO.Compression.ZipFile.4.0.0-beta-23127.nupkg.sha512",
+        "System.IO.Compression.ZipFile.nuspec",
+        "lib/dotnet/System.IO.Compression.ZipFile.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.Compression.ZipFile.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/de/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/es/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/fr/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/it/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/ja/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/ko/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/ru/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/zh-hans/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet/zh-hant/System.IO.Compression.ZipFile.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.Compression.ZipFile.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.IO.FileSystem/4.0.0": {
+      "sha512": "eo05SPWfG+54UA0wxgRIYOuOslq+2QrJLXZaJDDsfLXG15OLguaItW39NYZTqUb4DeGOkU4R0wpOLOW4ynMUDQ==",
+      "files": [
+        "_rels/.rels",
+        "System.IO.FileSystem.nuspec",
+        "lib/DNXCore50/System.IO.FileSystem.dll",
+        "lib/netcore50/System.IO.FileSystem.dll",
+        "lib/net46/System.IO.FileSystem.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.FileSystem.dll",
+        "ref/dotnet/System.IO.FileSystem.xml",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.xml",
+        "ref/dotnet/de/System.IO.FileSystem.xml",
+        "ref/dotnet/fr/System.IO.FileSystem.xml",
+        "ref/dotnet/it/System.IO.FileSystem.xml",
+        "ref/dotnet/ja/System.IO.FileSystem.xml",
+        "ref/dotnet/ko/System.IO.FileSystem.xml",
+        "ref/dotnet/ru/System.IO.FileSystem.xml",
+        "ref/dotnet/zh-hans/System.IO.FileSystem.xml",
+        "ref/dotnet/es/System.IO.FileSystem.xml",
+        "ref/net46/System.IO.FileSystem.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/0405bad2bcdd403884f42a0a79534bc1.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.IO.FileSystem.Primitives/4.0.0": {
+      "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
+      "files": [
+        "_rels/.rels",
+        "System.IO.FileSystem.Primitives.nuspec",
+        "lib/dotnet/System.IO.FileSystem.Primitives.dll",
+        "lib/net46/System.IO.FileSystem.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/de/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/fr/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/it/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/ja/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/ko/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/ru/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/zh-hans/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
+        "ref/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/2cf3542156f0426483f92b9e37d8d381.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.IO.UnmanagedMemoryStream/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "8bCdV5pmeUxGFhVhARRoR8GB8GLgcecuPQmK/9rN6ouVVlyNeI2Wi22j4AkhSw4i9sp3Coad4nB6k3i93d7veQ==",
+      "files": [
+        "System.IO.UnmanagedMemoryStream.4.0.0-beta-23127.nupkg",
+        "System.IO.UnmanagedMemoryStream.4.0.0-beta-23127.nupkg.sha512",
+        "System.IO.UnmanagedMemoryStream.nuspec",
+        "lib/dotnet/System.IO.UnmanagedMemoryStream.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.UnmanagedMemoryStream.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/de/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/es/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/fr/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/it/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/ja/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/ko/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/ru/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/zh-hans/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet/zh-hant/System.IO.UnmanagedMemoryStream.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.UnmanagedMemoryStream.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Linq/4.0.0": {
+      "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
+      "files": [
+        "_rels/.rels",
+        "System.Linq.nuspec",
+        "lib/dotnet/System.Linq.dll",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/netcore50/System.Linq.dll",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
+        "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/fr/System.Linq.xml",
+        "ref/dotnet/it/System.Linq.xml",
+        "ref/dotnet/ja/System.Linq.xml",
+        "ref/dotnet/ko/System.Linq.xml",
+        "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/zh-hans/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
+        "ref/net45/_._",
+        "ref/win8/_._",
+        "ref/netcore50/System.Linq.dll",
+        "ref/netcore50/System.Linq.xml",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "package/services/metadata/core-properties/6fcde56ce4094f6a8fff4b28267da532.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Linq.Expressions/4.0.10-beta-23127": {
+      "serviceable": true,
+      "sha512": "sTx6tiIJwc9gECz2gv9+2e7hFpRlX0GbRAPowFtD95dcWgm1MlYV+3WF70XismWnPN9k5/ZHTyz4RjEPFY+lBg==",
+      "files": [
+        "runtime.json",
+        "System.Linq.Expressions.4.0.10-beta-23127.nupkg",
+        "System.Linq.Expressions.4.0.10-beta-23127.nupkg.sha512",
+        "System.Linq.Expressions.nuspec",
+        "lib/DNXCore50/System.Linq.Expressions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Linq.Expressions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Linq.Expressions.dll",
+        "ref/dotnet/System.Linq.Expressions.xml",
+        "ref/dotnet/de/System.Linq.Expressions.xml",
+        "ref/dotnet/es/System.Linq.Expressions.xml",
+        "ref/dotnet/fr/System.Linq.Expressions.xml",
+        "ref/dotnet/it/System.Linq.Expressions.xml",
+        "ref/dotnet/ja/System.Linq.Expressions.xml",
+        "ref/dotnet/ko/System.Linq.Expressions.xml",
+        "ref/dotnet/ru/System.Linq.Expressions.xml",
+        "ref/dotnet/zh-hans/System.Linq.Expressions.xml",
+        "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll"
+      ]
+    },
+    "System.Linq.Parallel/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "LY9Im6evr9O4SsgI90BA2gQTp9btpE+7UkRhSddbMARSCqaTSM/XvKfkucmWtkO/66UCWQKPQaH42LXfdKLTJw==",
+      "files": [
+        "System.Linq.Parallel.4.0.0-beta-23127.nupkg",
+        "System.Linq.Parallel.4.0.0-beta-23127.nupkg.sha512",
+        "System.Linq.Parallel.nuspec",
+        "lib/dotnet/System.Linq.Parallel.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.Parallel.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Linq.Parallel.dll",
+        "ref/dotnet/System.Linq.Parallel.xml",
+        "ref/dotnet/de/System.Linq.Parallel.xml",
+        "ref/dotnet/es/System.Linq.Parallel.xml",
+        "ref/dotnet/fr/System.Linq.Parallel.xml",
+        "ref/dotnet/it/System.Linq.Parallel.xml",
+        "ref/dotnet/ja/System.Linq.Parallel.xml",
+        "ref/dotnet/ko/System.Linq.Parallel.xml",
+        "ref/dotnet/ru/System.Linq.Parallel.xml",
+        "ref/dotnet/zh-hans/System.Linq.Parallel.xml",
+        "ref/dotnet/zh-hant/System.Linq.Parallel.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.Parallel.dll",
+        "ref/netcore50/System.Linq.Parallel.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._"
+      ]
+    },
+    "System.Linq.Queryable/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "vBVhVAVLGSvtiJ1i7U8hLWujYwLrcQG+OEottxaf+98J7bNcAnGbmhcFXE1K5etvIA0XIXVDBoagYX1M8bjA6A==",
+      "files": [
+        "System.Linq.Queryable.4.0.0-beta-23127.nupkg",
+        "System.Linq.Queryable.4.0.0-beta-23127.nupkg.sha512",
+        "System.Linq.Queryable.nuspec",
+        "lib/dotnet/System.Linq.Queryable.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.Queryable.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Linq.Queryable.dll",
+        "ref/dotnet/System.Linq.Queryable.xml",
+        "ref/dotnet/de/System.Linq.Queryable.xml",
+        "ref/dotnet/es/System.Linq.Queryable.xml",
+        "ref/dotnet/fr/System.Linq.Queryable.xml",
+        "ref/dotnet/it/System.Linq.Queryable.xml",
+        "ref/dotnet/ja/System.Linq.Queryable.xml",
+        "ref/dotnet/ko/System.Linq.Queryable.xml",
+        "ref/dotnet/ru/System.Linq.Queryable.xml",
+        "ref/dotnet/zh-hans/System.Linq.Queryable.xml",
+        "ref/dotnet/zh-hant/System.Linq.Queryable.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.Queryable.dll",
+        "ref/netcore50/System.Linq.Queryable.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._"
+      ]
+    },
+    "System.Net.Http/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "9EAp6kSDokmuqqvLXcxbhSq2/zqpZDQ7m8Pz8pXHQyAtZUgPob6zKHjb7aV8hocC85C7beveipOTGV0ybCeWFg==",
+      "files": [
+        "System.Net.Http.4.0.0-beta-23127.nupkg",
+        "System.Net.Http.4.0.0-beta-23127.nupkg.sha512",
+        "System.Net.Http.nuspec",
+        "lib/DNXCore50/System.Net.Http.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Net.Http.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Net.Http.dll",
+        "ref/dotnet/System.Net.Http.xml",
+        "ref/dotnet/de/System.Net.Http.xml",
+        "ref/dotnet/es/System.Net.Http.xml",
+        "ref/dotnet/fr/System.Net.Http.xml",
+        "ref/dotnet/it/System.Net.Http.xml",
+        "ref/dotnet/ja/System.Net.Http.xml",
+        "ref/dotnet/ko/System.Net.Http.xml",
+        "ref/dotnet/ru/System.Net.Http.xml",
+        "ref/dotnet/zh-hans/System.Net.Http.xml",
+        "ref/dotnet/zh-hant/System.Net.Http.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Net.Http.dll",
+        "ref/netcore50/System.Net.Http.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._"
+      ]
+    },
+    "System.Net.NetworkInformation/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "Pt5q7INB5+xQMsC5zReJbFAqZkTsbvZVxx4skRTNhRHCKcRny2YOHpavWlnid7JhFNLGmyut/Om6YTqy2DoQsw==",
+      "files": [
+        "System.Net.NetworkInformation.4.0.0-beta-23127.nupkg",
+        "System.Net.NetworkInformation.4.0.0-beta-23127.nupkg.sha512",
+        "System.Net.NetworkInformation.nuspec",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.Net.NetworkInformation.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.NetworkInformation.dll",
+        "ref/dotnet/System.Net.NetworkInformation.xml",
+        "ref/dotnet/de/System.Net.NetworkInformation.xml",
+        "ref/dotnet/es/System.Net.NetworkInformation.xml",
+        "ref/dotnet/fr/System.Net.NetworkInformation.xml",
+        "ref/dotnet/it/System.Net.NetworkInformation.xml",
+        "ref/dotnet/ja/System.Net.NetworkInformation.xml",
+        "ref/dotnet/ko/System.Net.NetworkInformation.xml",
+        "ref/dotnet/ru/System.Net.NetworkInformation.xml",
+        "ref/dotnet/zh-hans/System.Net.NetworkInformation.xml",
+        "ref/dotnet/zh-hant/System.Net.NetworkInformation.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/System.Net.NetworkInformation.dll",
+        "ref/netcore50/System.Net.NetworkInformation.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Net.Primitives/4.0.10-beta-23127": {
+      "serviceable": true,
+      "sha512": "iMopReygV88cUUXWeem9y9vrb1Sn8gOXXaRClKWW1KrRozBklOh6Og+b/gpsVQJpz2ztZLJI3k96ttoie2M2QA==",
+      "files": [
+        "System.Net.Primitives.4.0.10-beta-23127.nupkg",
+        "System.Net.Primitives.4.0.10-beta-23127.nupkg.sha512",
+        "System.Net.Primitives.nuspec",
+        "lib/DNXCore50/System.Net.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Net.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Net.Primitives.dll",
+        "ref/dotnet/System.Net.Primitives.xml",
+        "ref/dotnet/de/System.Net.Primitives.xml",
+        "ref/dotnet/es/System.Net.Primitives.xml",
+        "ref/dotnet/fr/System.Net.Primitives.xml",
+        "ref/dotnet/it/System.Net.Primitives.xml",
+        "ref/dotnet/ja/System.Net.Primitives.xml",
+        "ref/dotnet/ko/System.Net.Primitives.xml",
+        "ref/dotnet/ru/System.Net.Primitives.xml",
+        "ref/dotnet/zh-hans/System.Net.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Net.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Numerics.Vectors/4.1.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "zxz1rpm5uuSw01QszM+L+kqtmLhBUi2AWPJ3CQ2bQz6H6iKlN97MT9ZK4JxowZGwGaz/ETPgVq5Iiz9peJBMzg==",
+      "files": [
+        "System.Numerics.Vectors.4.1.0-beta-23127.nupkg",
+        "System.Numerics.Vectors.4.1.0-beta-23127.nupkg.sha512",
+        "System.Numerics.Vectors.nuspec",
+        "lib/dotnet/System.Numerics.Vectors.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Numerics.Vectors.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Numerics.Vectors.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Numerics.Vectors.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.ObjectModel/4.0.10-beta-23127": {
+      "serviceable": true,
+      "sha512": "WddIdzpJxPz+UI3wlUPNpeZwMQEX6AxxnT/ycTmSdFVUazsb1sRxE92TeYMDKpIlEu6jRvuv8A36yGsQr5CEkQ==",
+      "files": [
+        "System.ObjectModel.4.0.10-beta-23127.nupkg",
+        "System.ObjectModel.4.0.10-beta-23127.nupkg.sha512",
+        "System.ObjectModel.nuspec",
+        "lib/dotnet/System.ObjectModel.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.ObjectModel.dll",
+        "ref/dotnet/System.ObjectModel.xml",
+        "ref/dotnet/de/System.ObjectModel.xml",
+        "ref/dotnet/es/System.ObjectModel.xml",
+        "ref/dotnet/fr/System.ObjectModel.xml",
+        "ref/dotnet/it/System.ObjectModel.xml",
+        "ref/dotnet/ja/System.ObjectModel.xml",
+        "ref/dotnet/ko/System.ObjectModel.xml",
+        "ref/dotnet/ru/System.ObjectModel.xml",
+        "ref/dotnet/zh-hans/System.ObjectModel.xml",
+        "ref/dotnet/zh-hant/System.ObjectModel.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Private.Networking/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "KgVFtvhIvZX36Mat5xGyLwKqmo1syvm8aH+Y8sMbbrKEeMOn6QuyiDSyUy1ahu8WbUQdnRCLB0VqgKUDwzeZ2w==",
+      "files": [
+        "System.Private.Networking.4.0.0-beta-23127.nupkg",
+        "System.Private.Networking.4.0.0-beta-23127.nupkg.sha512",
+        "System.Private.Networking.nuspec",
+        "lib/DNXCore50/System.Private.Networking.dll",
+        "lib/netcore50/System.Private.Networking.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._"
+      ]
+    },
+    "System.Private.Uri/4.0.0": {
+      "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
+      "files": [
+        "_rels/.rels",
+        "System.Private.Uri.nuspec",
+        "lib/netcore50/System.Private.Uri.dll",
+        "lib/DNXCore50/System.Private.Uri.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
+        "package/services/metadata/core-properties/86377e21a22d44bbba860094428d894c.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Reflection/4.0.10": {
+      "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
+      "files": [
+        "_rels/.rels",
+        "System.Reflection.nuspec",
+        "lib/netcore50/System.Reflection.dll",
+        "lib/DNXCore50/System.Reflection.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/fr/System.Reflection.xml",
+        "ref/dotnet/it/System.Reflection.xml",
+        "ref/dotnet/ja/System.Reflection.xml",
+        "ref/dotnet/ko/System.Reflection.xml",
+        "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/zh-hans/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/84d992ce164945bfa10835e447244fb1.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Reflection.DispatchProxy/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "CsvTEk/hh4QdzbYF66xY9QdDcdco5o2y5+FvyHKXZKQm/Z9KuUuuDV3Yy/ggPiOJ+xwWiuvJXtt7tI5HQP/ygA==",
+      "files": [
+        "runtime.json",
+        "System.Reflection.DispatchProxy.4.0.0-beta-23127.nupkg",
+        "System.Reflection.DispatchProxy.4.0.0-beta-23127.nupkg.sha512",
+        "System.Reflection.DispatchProxy.nuspec",
+        "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.DispatchProxy.dll",
+        "lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/de/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/es/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/fr/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/it/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/ja/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/ko/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/ru/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/zh-hans/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet/zh-hant/System.Reflection.DispatchProxy.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll"
+      ]
+    },
+    "System.Reflection.Emit/4.0.0-beta-23127": {
+      "sha512": "v4Fzkc1VvgjK5Y0zqY8a0vFLQvz9XbEDC7wrLi0YLEjgmnUw8gxsWFgFQnOABjUYc28ygwQjz1Zpl+sfnIHgFw==",
+      "files": [
+        "System.Reflection.Emit.4.0.0-beta-23127.nupkg",
+        "System.Reflection.Emit.4.0.0-beta-23127.nupkg.sha512",
+        "System.Reflection.Emit.nuspec",
+        "lib/DNXCore50/System.Reflection.Emit.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.dll",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Reflection.Emit.dll",
+        "ref/dotnet/System.Reflection.Emit.xml",
+        "ref/dotnet/de/System.Reflection.Emit.xml",
+        "ref/dotnet/es/System.Reflection.Emit.xml",
+        "ref/dotnet/fr/System.Reflection.Emit.xml",
+        "ref/dotnet/it/System.Reflection.Emit.xml",
+        "ref/dotnet/ja/System.Reflection.Emit.xml",
+        "ref/dotnet/ko/System.Reflection.Emit.xml",
+        "ref/dotnet/ru/System.Reflection.Emit.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/net45/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Reflection.Emit.ILGeneration/4.0.0-beta-23127": {
+      "sha512": "Z953hng7bseRmyedsWYyRMXm6VlKYaAizg/h1bN3Yol+dKcdU1PPNgtyM5lFf1poMQQWedqFrB6wP+PrV9MNFQ==",
+      "files": [
+        "System.Reflection.Emit.ILGeneration.4.0.0-beta-23127.nupkg",
+        "System.Reflection.Emit.ILGeneration.4.0.0-beta-23127.nupkg.sha512",
+        "System.Reflection.Emit.ILGeneration.nuspec",
+        "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
+        "lib/wp80/_._",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/de/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/fr/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/it/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ja/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ko/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ru/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
+        "ref/net45/_._",
+        "ref/wp80/_._"
+      ]
+    },
+    "System.Reflection.Extensions/4.0.0": {
+      "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
+      "files": [
+        "_rels/.rels",
+        "System.Reflection.Extensions.nuspec",
+        "lib/netcore50/System.Reflection.Extensions.dll",
+        "lib/DNXCore50/System.Reflection.Extensions.dll",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
+        "ref/dotnet/de/System.Reflection.Extensions.xml",
+        "ref/dotnet/fr/System.Reflection.Extensions.xml",
+        "ref/dotnet/it/System.Reflection.Extensions.xml",
+        "ref/dotnet/ja/System.Reflection.Extensions.xml",
+        "ref/dotnet/ko/System.Reflection.Extensions.xml",
+        "ref/dotnet/ru/System.Reflection.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
+        "ref/dotnet/es/System.Reflection.Extensions.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "ref/net45/_._",
+        "ref/win8/_._",
+        "ref/netcore50/System.Reflection.Extensions.dll",
+        "ref/netcore50/System.Reflection.Extensions.xml",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "package/services/metadata/core-properties/0bcc335e1ef540948aef9032aca08bb2.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Reflection.Metadata/1.0.22-beta-23127": {
+      "serviceable": true,
+      "sha512": "6nZwZWZ4NHZeNhMjcfS6WHXhmk0SAlPj7aUQ9kNYqZQntCzx28kC1hPH4kD00vJ/tHQxyLZaKSCCXL6tpRu9ag==",
+      "files": [
+        "System.Reflection.Metadata.1.0.22-beta-23127.nupkg",
+        "System.Reflection.Metadata.1.0.22-beta-23127.nupkg.sha512",
+        "System.Reflection.Metadata.nuspec",
+        "lib/dotnet/System.Reflection.Metadata.dll",
+        "lib/dotnet/System.Reflection.Metadata.xml",
+        "lib/portable-net45+win8/System.Reflection.Metadata.dll",
+        "lib/portable-net45+win8/System.Reflection.Metadata.xml"
+      ]
+    },
+    "System.Reflection.Primitives/4.0.0": {
+      "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
+      "files": [
+        "_rels/.rels",
+        "System.Reflection.Primitives.nuspec",
+        "lib/netcore50/System.Reflection.Primitives.dll",
+        "lib/DNXCore50/System.Reflection.Primitives.dll",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/fr/System.Reflection.Primitives.xml",
+        "ref/dotnet/it/System.Reflection.Primitives.xml",
+        "ref/dotnet/ja/System.Reflection.Primitives.xml",
+        "ref/dotnet/ko/System.Reflection.Primitives.xml",
+        "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "ref/net45/_._",
+        "ref/win8/_._",
+        "ref/netcore50/System.Reflection.Primitives.dll",
+        "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "package/services/metadata/core-properties/7070509f3bfd418d859635361251dab0.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Reflection.TypeExtensions/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "vVc+uhYZh6k4+tDxl0QeP31dq3RUySaiDjSmQ2aOEnVfBs7xtbNaxXLXKd5BBAweNQIZBZ5L1Yv0wC2tCa17KQ==",
+      "files": [
+        "System.Reflection.TypeExtensions.4.0.0-beta-23127.nupkg",
+        "System.Reflection.TypeExtensions.4.0.0-beta-23127.nupkg.sha512",
+        "System.Reflection.TypeExtensions.nuspec",
+        "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.TypeExtensions.dll",
+        "lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/it/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Reflection.TypeExtensions.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll"
+      ]
+    },
+    "System.Resources.ResourceManager/4.0.0": {
+      "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
+      "files": [
+        "_rels/.rels",
+        "System.Resources.ResourceManager.nuspec",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
+        "lib/DNXCore50/System.Resources.ResourceManager.dll",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/fr/System.Resources.ResourceManager.xml",
+        "ref/dotnet/it/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ja/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ko/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "ref/net45/_._",
+        "ref/win8/_._",
+        "ref/netcore50/System.Resources.ResourceManager.dll",
+        "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "package/services/metadata/core-properties/657a73ee3f09479c9fedb9538ade8eac.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Runtime/4.0.20": {
+      "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
+      "files": [
+        "_rels/.rels",
+        "System.Runtime.nuspec",
+        "lib/netcore50/System.Runtime.dll",
+        "lib/DNXCore50/System.Runtime.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/d1ded52f75da4446b1c962f9292aa3ef.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Runtime.Extensions/4.0.10": {
+      "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
+      "files": [
+        "_rels/.rels",
+        "System.Runtime.Extensions.nuspec",
+        "lib/netcore50/System.Runtime.Extensions.dll",
+        "lib/DNXCore50/System.Runtime.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/fr/System.Runtime.Extensions.xml",
+        "ref/dotnet/it/System.Runtime.Extensions.xml",
+        "ref/dotnet/ja/System.Runtime.Extensions.xml",
+        "ref/dotnet/ko/System.Runtime.Extensions.xml",
+        "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/c7fee76a13d04c7ea49fb1a24c184f37.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Runtime.Handles/4.0.0": {
+      "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
+      "files": [
+        "_rels/.rels",
+        "System.Runtime.Handles.nuspec",
+        "lib/DNXCore50/System.Runtime.Handles.dll",
+        "lib/netcore50/System.Runtime.Handles.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
+        "ref/dotnet/de/System.Runtime.Handles.xml",
+        "ref/dotnet/fr/System.Runtime.Handles.xml",
+        "ref/dotnet/it/System.Runtime.Handles.xml",
+        "ref/dotnet/ja/System.Runtime.Handles.xml",
+        "ref/dotnet/ko/System.Runtime.Handles.xml",
+        "ref/dotnet/ru/System.Runtime.Handles.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
+        "ref/dotnet/es/System.Runtime.Handles.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/da57aa32ff2441d1acfe85bee4f101ab.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Runtime.InteropServices/4.0.20": {
+      "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
+      "files": [
+        "_rels/.rels",
+        "System.Runtime.InteropServices.nuspec",
+        "lib/DNXCore50/System.Runtime.InteropServices.dll",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/fr/System.Runtime.InteropServices.xml",
+        "ref/dotnet/it/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ja/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ko/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/78e7f61876374acba2a95834f272d262.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
+      "sha512": "yzVJM7dF6XqnGTkv2IRufKs8AiqDpfdfBvMT5sVgY2fCtUXdkcjxiIWzaVIau8IYrJUlQDmSpeQ8NV6l1vz0Lg==",
+      "files": [
+        "_rels/.rels",
+        "System.Runtime.InteropServices.RuntimeInformation.nuspec",
+        "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/979d708fec824c778c40c2377d8978ca.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Runtime.Numerics/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "qB+XSAhTz7gwZG8XUV+8Z4XgygM2OWiKCwepK1GecRfDT3XBzA+FCU9xgpwyGSpz5zExN0tjsbBG2J1Au6xHKw==",
+      "files": [
+        "System.Runtime.Numerics.4.0.0-beta-23127.nupkg",
+        "System.Runtime.Numerics.4.0.0-beta-23127.nupkg.sha512",
+        "System.Runtime.Numerics.nuspec",
+        "lib/dotnet/System.Runtime.Numerics.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Runtime.Numerics.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Runtime.Numerics.dll",
+        "ref/dotnet/System.Runtime.Numerics.xml",
+        "ref/dotnet/de/System.Runtime.Numerics.xml",
+        "ref/dotnet/es/System.Runtime.Numerics.xml",
+        "ref/dotnet/fr/System.Runtime.Numerics.xml",
+        "ref/dotnet/it/System.Runtime.Numerics.xml",
+        "ref/dotnet/ja/System.Runtime.Numerics.xml",
+        "ref/dotnet/ko/System.Runtime.Numerics.xml",
+        "ref/dotnet/ru/System.Runtime.Numerics.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Numerics.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Numerics.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Runtime.Numerics.dll",
+        "ref/netcore50/System.Runtime.Numerics.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._"
+      ]
+    },
+    "System.Security.Claims/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "WxCXTjY6iqWA+26Oq8NUV8K5zNBc/m2yRfmBGa96+Ch2HSeINwJLio1a6VlD7m16aeqfIDxCkIM9GNl2sYGIww==",
+      "files": [
+        "System.Security.Claims.4.0.0-beta-23127.nupkg",
+        "System.Security.Claims.4.0.0-beta-23127.nupkg.sha512",
+        "System.Security.Claims.nuspec",
+        "lib/dotnet/System.Security.Claims.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Claims.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Claims.dll",
+        "ref/dotnet/System.Security.Claims.xml",
+        "ref/dotnet/de/System.Security.Claims.xml",
+        "ref/dotnet/es/System.Security.Claims.xml",
+        "ref/dotnet/fr/System.Security.Claims.xml",
+        "ref/dotnet/it/System.Security.Claims.xml",
+        "ref/dotnet/ja/System.Security.Claims.xml",
+        "ref/dotnet/ko/System.Security.Claims.xml",
+        "ref/dotnet/ru/System.Security.Claims.xml",
+        "ref/dotnet/zh-hans/System.Security.Claims.xml",
+        "ref/dotnet/zh-hant/System.Security.Claims.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Claims.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "yFHIFZ323kXmA0HE/k2yUnUNitaQYOf+sRxvV29KCUFGOmoWOTKRm9dn+z71xhux5V2i7ZuPhb4KOjskEiTMGA==",
+      "files": [
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23127.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23127.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.nuspec",
+        "lib/DNXCore50/System.Security.Cryptography.Algorithms.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Algorithms.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.Algorithms.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Algorithms.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Security.Cryptography.Csp/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "0heOYE/0HnQU6rcEL2g+OzgAyeVepegmva1/B8cMdYRATREz/mNwrpd7qOoW0SWjq51fUfBd3wTGU78lV7MOEA==",
+      "files": [
+        "System.Security.Cryptography.Csp.4.0.0-beta-23127.nupkg",
+        "System.Security.Cryptography.Csp.4.0.0-beta-23127.nupkg.sha512",
+        "System.Security.Cryptography.Csp.nuspec",
+        "lib/DNXCore50/System.Security.Cryptography.Csp.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Csp.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.Csp.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Csp.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "Asq9e58QLgiZ32YEp5aCJFSgMHM7rotzxexdq+VbBSWD7bBJybUVY9g85LN1FCsv0AeCxayZ6Hscyr0Rwd8R6g==",
+      "files": [
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23127.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23127.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.nuspec",
+        "lib/DNXCore50/System.Security.Cryptography.Encoding.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.Encoding.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Encoding.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "DfVrthXW+V8VnNhbiil7gfVysbkqZD5oRCLL8JiUypE8nuHvQxfFvyxi/PagTTOBin8no8in9Z+Oth66FLWb/w==",
+      "files": [
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23127.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23127.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.nuspec",
+        "lib/DNXCore50/System.Security.Cryptography.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.Primitives.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "Qyr6GUDmYwoX1eN9rRXmolE8V71zf1sLFtYwlVmccPcr8nis5HHW4wmwalXYQKGC2iR0PoVqiVGSLLSnnabBjQ==",
+      "files": [
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23127.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23127.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.nuspec",
+        "lib/DNXCore50/System.Security.Cryptography.X509Certificates.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.Cryptography.X509Certificates.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.dll",
+        "ref/dotnet/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/de/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/es/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/fr/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/it/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ja/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ko/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/ru/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hans/System.Security.Cryptography.X509Certificates.xml",
+        "ref/dotnet/zh-hant/System.Security.Cryptography.X509Certificates.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.Cryptography.X509Certificates.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Security.Principal/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "XiETY0hBbuL6VCgE/jyTiMuZpBRi/iv1irzWVRiXfsyPxD/iww7gCcepot9XD0lKiLq/H4F0dVh0EX7lib1Mxg==",
+      "files": [
+        "System.Security.Principal.4.0.0-beta-23127.nupkg",
+        "System.Security.Principal.4.0.0-beta-23127.nupkg.sha512",
+        "System.Security.Principal.nuspec",
+        "lib/dotnet/System.Security.Principal.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Security.Principal.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Security.Principal.dll",
+        "ref/dotnet/System.Security.Principal.xml",
+        "ref/dotnet/de/System.Security.Principal.xml",
+        "ref/dotnet/es/System.Security.Principal.xml",
+        "ref/dotnet/fr/System.Security.Principal.xml",
+        "ref/dotnet/it/System.Security.Principal.xml",
+        "ref/dotnet/ja/System.Security.Principal.xml",
+        "ref/dotnet/ko/System.Security.Principal.xml",
+        "ref/dotnet/ru/System.Security.Principal.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Security.Principal.dll",
+        "ref/netcore50/System.Security.Principal.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._"
+      ]
+    },
+    "System.Security.Principal.Windows/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "Wwce3jHkchtiKxvCaclE2gkquZbr7ASopk/ppFPnVYwQ9UZcf4e/T5+/5bHqOJMnjGY5ywcnnEM6OKwvsy9zeA==",
+      "files": [
+        "System.Security.Principal.Windows.4.0.0-beta-23127.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23127.nupkg.sha512",
+        "System.Security.Principal.Windows.nuspec",
+        "lib/DNXCore50/System.Security.Principal.Windows.dll",
+        "lib/net46/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.dll",
+        "ref/dotnet/System.Security.Principal.Windows.xml",
+        "ref/dotnet/de/System.Security.Principal.Windows.xml",
+        "ref/dotnet/es/System.Security.Principal.Windows.xml",
+        "ref/dotnet/fr/System.Security.Principal.Windows.xml",
+        "ref/dotnet/it/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ja/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ko/System.Security.Principal.Windows.xml",
+        "ref/dotnet/ru/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hans/System.Security.Principal.Windows.xml",
+        "ref/dotnet/zh-hant/System.Security.Principal.Windows.xml",
+        "ref/net46/System.Security.Principal.Windows.dll"
+      ]
+    },
+    "System.Security.SecureString/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "4gotwKWDrZBpSzxqxSg1iuY44LvyMAcqX3Lb3owSLXi9feEj23cY6QznxVJZEYqPs31jNF4a2G8yEKTC7Jh1CA==",
+      "files": [
+        "System.Security.SecureString.4.0.0-beta-23127.nupkg",
+        "System.Security.SecureString.4.0.0-beta-23127.nupkg.sha512",
+        "System.Security.SecureString.nuspec",
+        "lib/DNXCore50/System.Security.SecureString.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Security.SecureString.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Security.SecureString.dll",
+        "ref/dotnet/System.Security.SecureString.xml",
+        "ref/dotnet/de/System.Security.SecureString.xml",
+        "ref/dotnet/es/System.Security.SecureString.xml",
+        "ref/dotnet/fr/System.Security.SecureString.xml",
+        "ref/dotnet/it/System.Security.SecureString.xml",
+        "ref/dotnet/ja/System.Security.SecureString.xml",
+        "ref/dotnet/ko/System.Security.SecureString.xml",
+        "ref/dotnet/ru/System.Security.SecureString.xml",
+        "ref/dotnet/zh-hans/System.Security.SecureString.xml",
+        "ref/dotnet/zh-hant/System.Security.SecureString.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Security.SecureString.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Text.Encoding/4.0.10": {
+      "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
+      "files": [
+        "_rels/.rels",
+        "System.Text.Encoding.nuspec",
+        "lib/netcore50/System.Text.Encoding.dll",
+        "lib/DNXCore50/System.Text.Encoding.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/fr/System.Text.Encoding.xml",
+        "ref/dotnet/it/System.Text.Encoding.xml",
+        "ref/dotnet/ja/System.Text.Encoding.xml",
+        "ref/dotnet/ko/System.Text.Encoding.xml",
+        "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/829e172aadac4937a5a6a4b386855282.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Text.Encoding.Extensions/4.0.10": {
+      "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
+      "files": [
+        "_rels/.rels",
+        "System.Text.Encoding.Extensions.nuspec",
+        "lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/it/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/894d51cf918c4bca91e81a732d958707.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Text.RegularExpressions/4.0.10-beta-23127": {
+      "serviceable": true,
+      "sha512": "xDh2rudWn0gHbvdZFmXnP+PnCJ1Yq4VsS2R7vcqsIwCqm+oqzuLUXk6R/YNvJ30Z5r6Fdv4keiHPAZbx9UKT7w==",
+      "files": [
+        "System.Text.RegularExpressions.4.0.10-beta-23127.nupkg",
+        "System.Text.RegularExpressions.4.0.10-beta-23127.nupkg.sha512",
+        "System.Text.RegularExpressions.nuspec",
+        "lib/dotnet/System.Text.RegularExpressions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Text.RegularExpressions.dll",
+        "ref/dotnet/System.Text.RegularExpressions.xml",
+        "ref/dotnet/de/System.Text.RegularExpressions.xml",
+        "ref/dotnet/es/System.Text.RegularExpressions.xml",
+        "ref/dotnet/fr/System.Text.RegularExpressions.xml",
+        "ref/dotnet/it/System.Text.RegularExpressions.xml",
+        "ref/dotnet/ja/System.Text.RegularExpressions.xml",
+        "ref/dotnet/ko/System.Text.RegularExpressions.xml",
+        "ref/dotnet/ru/System.Text.RegularExpressions.xml",
+        "ref/dotnet/zh-hans/System.Text.RegularExpressions.xml",
+        "ref/dotnet/zh-hant/System.Text.RegularExpressions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Threading/4.0.10": {
+      "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
+      "files": [
+        "_rels/.rels",
+        "System.Threading.nuspec",
+        "lib/DNXCore50/System.Threading.dll",
+        "lib/netcore50/System.Threading.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
+        "ref/dotnet/zh-hant/System.Threading.xml",
+        "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/fr/System.Threading.xml",
+        "ref/dotnet/it/System.Threading.xml",
+        "ref/dotnet/ja/System.Threading.xml",
+        "ref/dotnet/ko/System.Threading.xml",
+        "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/zh-hans/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/c17c3791d8fa4efbb8aded2ca8c71fbe.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Threading.Overlapped/4.0.0": {
+      "sha512": "X5LuQFhM5FTqaez3eXKJ9CbfSGZ7wj6j4hSVtxct3zmwQXLqG95qoWdvILcgN7xtrDOBIFtpiyDg0vmoI0jE2A==",
+      "files": [
+        "_rels/.rels",
+        "System.Threading.Overlapped.nuspec",
+        "lib/netcore50/System.Threading.Overlapped.dll",
+        "lib/DNXCore50/System.Threading.Overlapped.dll",
+        "lib/net46/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.dll",
+        "ref/dotnet/System.Threading.Overlapped.xml",
+        "ref/dotnet/zh-hant/System.Threading.Overlapped.xml",
+        "ref/dotnet/de/System.Threading.Overlapped.xml",
+        "ref/dotnet/fr/System.Threading.Overlapped.xml",
+        "ref/dotnet/it/System.Threading.Overlapped.xml",
+        "ref/dotnet/ja/System.Threading.Overlapped.xml",
+        "ref/dotnet/ko/System.Threading.Overlapped.xml",
+        "ref/dotnet/ru/System.Threading.Overlapped.xml",
+        "ref/dotnet/zh-hans/System.Threading.Overlapped.xml",
+        "ref/dotnet/es/System.Threading.Overlapped.xml",
+        "ref/net46/System.Threading.Overlapped.dll",
+        "package/services/metadata/core-properties/e9846a81e829434aafa4ae2e8c3517d7.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Threading.Tasks/4.0.10": {
+      "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
+      "files": [
+        "_rels/.rels",
+        "System.Threading.Tasks.nuspec",
+        "lib/netcore50/System.Threading.Tasks.dll",
+        "lib/DNXCore50/System.Threading.Tasks.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.xml",
+        "ref/dotnet/it/System.Threading.Tasks.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "package/services/metadata/core-properties/a4ed35f8764a4b68bb39ec8d13b3e730.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "System.Threading.Tasks.Dataflow/4.5.25-beta-23127": {
+      "serviceable": true,
+      "sha512": "VNIllu3BIfjUVi5O3sQsCpAOvdF/AzyVBfs2BkxCw8o+kOexmMp+WNmMIMdyK+hwH8rVwpPdBl6vgbQmZxVHHg==",
+      "files": [
+        "System.Threading.Tasks.Dataflow.4.5.25-beta-23127.nupkg",
+        "System.Threading.Tasks.Dataflow.4.5.25-beta-23127.nupkg.sha512",
+        "System.Threading.Tasks.Dataflow.nuspec",
+        "lib/dotnet/System.Threading.Tasks.Dataflow.dll",
+        "lib/dotnet/System.Threading.Tasks.Dataflow.XML",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
+        "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML"
+      ]
+    },
+    "System.Threading.Tasks.Parallel/4.0.0-beta-23127": {
+      "serviceable": true,
+      "sha512": "5g9d4gt4QnsE56fPfwROlfv3X6tQ1mmv0gQY5KWQIpGe2EWlaL/zt9QzOqmPnny+isEXs5EzVGuemTs3cwgnUA==",
+      "files": [
+        "System.Threading.Tasks.Parallel.4.0.0-beta-23127.nupkg",
+        "System.Threading.Tasks.Parallel.4.0.0-beta-23127.nupkg.sha512",
+        "System.Threading.Tasks.Parallel.nuspec",
+        "lib/dotnet/System.Threading.Tasks.Parallel.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Threading.Tasks.Parallel.dll",
+        "lib/win8/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Threading.Tasks.Parallel.dll",
+        "ref/dotnet/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/de/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/es/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/it/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.Parallel.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.Parallel.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Threading.Tasks.Parallel.dll",
+        "ref/netcore50/System.Threading.Tasks.Parallel.xml",
+        "ref/win8/_._",
+        "ref/wpa81/_._"
+      ]
+    },
+    "System.Threading.ThreadPool/4.0.10-beta-23127": {
+      "sha512": "Z99U+/mlNrB1+1XL7NkwoqEnUJvDZISG9InPJFmnrNKIHX1TywFK5F8/O+B5QJXB18XCvEMpXbOk0BQ241iYoQ==",
+      "files": [
+        "System.Threading.ThreadPool.4.0.10-beta-23127.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23127.nupkg.sha512",
+        "System.Threading.ThreadPool.nuspec",
+        "lib/DNXCore50/System.Threading.ThreadPool.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.ThreadPool.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.ThreadPool.dll",
+        "ref/dotnet/System.Threading.ThreadPool.xml",
+        "ref/dotnet/de/System.Threading.ThreadPool.xml",
+        "ref/dotnet/es/System.Threading.ThreadPool.xml",
+        "ref/dotnet/fr/System.Threading.ThreadPool.xml",
+        "ref/dotnet/it/System.Threading.ThreadPool.xml",
+        "ref/dotnet/ja/System.Threading.ThreadPool.xml",
+        "ref/dotnet/ko/System.Threading.ThreadPool.xml",
+        "ref/dotnet/ru/System.Threading.ThreadPool.xml",
+        "ref/dotnet/zh-hans/System.Threading.ThreadPool.xml",
+        "ref/dotnet/zh-hant/System.Threading.ThreadPool.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.ThreadPool.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Threading.Timer/4.0.0-beta-23127": {
+      "sha512": "KiGhjDuGS3yGb4OMznFlC5vYmOQxEpj4PleDRnwrxrxyFY6yPs/9R9/X7HRDhgG6Ulp08MvSaPpxD17dDeC4ZQ==",
+      "files": [
+        "System.Threading.Timer.4.0.0-beta-23127.nupkg",
+        "System.Threading.Timer.4.0.0-beta-23127.nupkg.sha512",
+        "System.Threading.Timer.nuspec",
+        "lib/DNXCore50/System.Threading.Timer.dll",
+        "lib/net451/_._",
+        "lib/netcore50/System.Threading.Timer.dll",
+        "lib/win81/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Threading.Timer.dll",
+        "ref/dotnet/System.Threading.Timer.xml",
+        "ref/dotnet/de/System.Threading.Timer.xml",
+        "ref/dotnet/es/System.Threading.Timer.xml",
+        "ref/dotnet/fr/System.Threading.Timer.xml",
+        "ref/dotnet/it/System.Threading.Timer.xml",
+        "ref/dotnet/ja/System.Threading.Timer.xml",
+        "ref/dotnet/ko/System.Threading.Timer.xml",
+        "ref/dotnet/ru/System.Threading.Timer.xml",
+        "ref/dotnet/zh-hans/System.Threading.Timer.xml",
+        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
+        "ref/net451/_._",
+        "ref/netcore50/System.Threading.Timer.dll",
+        "ref/netcore50/System.Threading.Timer.xml",
+        "ref/win81/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll"
+      ]
+    },
+    "System.Xml.ReaderWriter/4.0.10-beta-23127": {
+      "serviceable": true,
+      "sha512": "qDWTA6KSSCpqLlM0ZayuYmtChu5H+v6yciKR5PW12YHxKQuvteR0DnOnk/NThmb3N0K2NIE5ozgnjNdX+ESJ7Q==",
+      "files": [
+        "System.Xml.ReaderWriter.4.0.10-beta-23127.nupkg",
+        "System.Xml.ReaderWriter.4.0.10-beta-23127.nupkg.sha512",
+        "System.Xml.ReaderWriter.nuspec",
+        "lib/dotnet/System.Xml.ReaderWriter.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Xml.ReaderWriter.dll",
+        "ref/dotnet/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/de/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/fr/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/it/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/ja/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/ko/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/ru/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/zh-hans/System.Xml.ReaderWriter.xml",
+        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "System.Xml.XDocument/4.0.10-beta-23127": {
+      "serviceable": true,
+      "sha512": "2Gv6EgKZRV1t3epbXln8mqSjiZiQ1O+Kp+cXTMKnKxfqAJzjntVJMYBG3MTrzRAL/orUlZoIkGMO85gWlnF4Ig==",
+      "files": [
+        "System.Xml.XDocument.4.0.10-beta-23127.nupkg",
+        "System.Xml.XDocument.4.0.10-beta-23127.nupkg.sha512",
+        "System.Xml.XDocument.nuspec",
+        "lib/dotnet/System.Xml.XDocument.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Xml.XDocument.dll",
+        "ref/dotnet/System.Xml.XDocument.xml",
+        "ref/dotnet/de/System.Xml.XDocument.xml",
+        "ref/dotnet/es/System.Xml.XDocument.xml",
+        "ref/dotnet/fr/System.Xml.XDocument.xml",
+        "ref/dotnet/it/System.Xml.XDocument.xml",
+        "ref/dotnet/ja/System.Xml.XDocument.xml",
+        "ref/dotnet/ko/System.Xml.XDocument.xml",
+        "ref/dotnet/ru/System.Xml.XDocument.xml",
+        "ref/dotnet/zh-hans/System.Xml.XDocument.xml",
+        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
+    "xunit/2.1.0": {
+      "sha512": "u/7VQSOSXa7kSG4iK6Lcn7RqKZQ3hk7cnyMNVMpXHSP0RI5VQEtc44hvkG3LyWOVsx1dhUDD3rPAHAxyOUDQJw==",
+      "files": [
+        "_rels/.rels",
+        "xunit.nuspec",
+        "package/services/metadata/core-properties/645916a897f44189a642f33e571d5b90.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "xunit.abstractions/2.0.0": {
+      "sha512": "NAdxKQRzuLnCZ0g++x6i87/8rMBpQoRiRlRNLAqfODm2zJPbteHRoSER3DXfxnqrHXyBJT8rFaZ8uveBeQyaMA==",
+      "files": [
+        "_rels/.rels",
+        "xunit.abstractions.nuspec",
+        "lib/net35/xunit.abstractions.dll",
+        "lib/net35/xunit.abstractions.xml",
+        "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll",
+        "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.xml",
+        "package/services/metadata/core-properties/24083640fee244bf9de77f4c35d40a72.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "xunit.assert/2.1.0": {
+      "sha512": "Hhhw+YaTe+BGhbr57dxVE+6VJk8BfThqFFii1XIsSZ4qx+SSCixprJC10JkiLRVSTfWyT8W/4nAf6NQgIrmBxA==",
+      "files": [
+        "_rels/.rels",
+        "xunit.assert.nuspec",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.assert.dll",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.assert.pdb",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.assert.xml",
+        "lib/dotnet/xunit.assert.dll",
+        "lib/dotnet/xunit.assert.pdb",
+        "lib/dotnet/xunit.assert.xml",
+        "package/services/metadata/core-properties/4f538d979dfc48ed9b4c20e5a69d87b1.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "xunit.core/2.1.0": {
+      "sha512": "jlbYdPbnkPIRwJllcT/tQZCNsSElVDEymdpJfH79uTUrPARkELVYw9o/zhAjKZXmeikGqGK5C2Yny4gTNoEu0Q==",
+      "files": [
+        "_rels/.rels",
+        "xunit.core.nuspec",
+        "build/_desktop/xunit.execution.desktop.dll",
+        "build/dnx451/_._",
+        "build/monoandroid/_._",
+        "build/monotouch/_._",
+        "build/net45/_._",
+        "build/portable-net45+win8+wp8+wpa81/xunit.core.props",
+        "build/win8/_._",
+        "build/win81/xunit.core.props",
+        "build/wp8/_._",
+        "build/wpa81/xunit.core.props",
+        "build/xamarinios/_._",
+        "package/services/metadata/core-properties/cce23a490b7f4272adfe9aa57c4e1ca3.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "xunit.extensibility.core/2.1.0": {
+      "sha512": "ANWM3WxeaeHjACLRlmrv+xOc0WAcr3cvIiJE+gqbdzTv1NCH4p1VDyT+8WmmdCc9db0WFiJLaDy4YTYsL1wWXw==",
+      "files": [
+        "_rels/.rels",
+        "xunit.extensibility.core.nuspec",
+        "lib/dotnet/xunit.core.dll",
+        "lib/dotnet/xunit.core.dll.tdnet",
+        "lib/dotnet/xunit.core.pdb",
+        "lib/dotnet/xunit.core.xml",
+        "lib/dotnet/xunit.runner.tdnet.dll",
+        "lib/dotnet/xunit.runner.utility.desktop.dll",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.core.dll",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.core.dll.tdnet",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.core.pdb",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.core.xml",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.runner.tdnet.dll",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.runner.utility.desktop.dll",
+        "package/services/metadata/core-properties/5218831c5b01422bb82b23cafd6488b3.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "xunit.extensibility.execution/2.1.0": {
+      "sha512": "tAoNafoVknKa3sZJPMvtZRnhOSk3gasEGeceSm7w/gyGwsR/OXFxndWJB1xSHeoy33d3Z6jFqn4A3j+pWCF0Ew==",
+      "files": [
+        "_rels/.rels",
+        "xunit.extensibility.execution.nuspec",
+        "lib/dotnet/xunit.execution.dotnet.dll",
+        "lib/dotnet/xunit.execution.dotnet.pdb",
+        "lib/dotnet/xunit.execution.dotnet.xml",
+        "lib/dnx451/xunit.execution.dotnet.dll",
+        "lib/dnx451/xunit.execution.dotnet.pdb",
+        "lib/dnx451/xunit.execution.dotnet.xml",
+        "lib/monoandroid/xunit.execution.dotnet.dll",
+        "lib/monoandroid/xunit.execution.dotnet.pdb",
+        "lib/monoandroid/xunit.execution.dotnet.xml",
+        "lib/monotouch/xunit.execution.dotnet.dll",
+        "lib/monotouch/xunit.execution.dotnet.pdb",
+        "lib/monotouch/xunit.execution.dotnet.xml",
+        "lib/net45/xunit.execution.desktop.dll",
+        "lib/net45/xunit.execution.desktop.pdb",
+        "lib/net45/xunit.execution.desktop.xml",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.execution.dotnet.dll",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.execution.dotnet.pdb",
+        "lib/portable-net45+win8+wp8+wpa81/xunit.execution.dotnet.xml",
+        "lib/win8/xunit.execution.dotnet.dll",
+        "lib/win8/xunit.execution.dotnet.pdb",
+        "lib/win8/xunit.execution.dotnet.xml",
+        "lib/wp8/xunit.execution.dotnet.dll",
+        "lib/wp8/xunit.execution.dotnet.pdb",
+        "lib/wp8/xunit.execution.dotnet.xml",
+        "lib/wpa81/xunit.execution.dotnet.dll",
+        "lib/wpa81/xunit.execution.dotnet.pdb",
+        "lib/wpa81/xunit.execution.dotnet.xml",
+        "lib/xamarinios/xunit.execution.dotnet.dll",
+        "lib/xamarinios/xunit.execution.dotnet.pdb",
+        "lib/xamarinios/xunit.execution.dotnet.xml",
+        "package/services/metadata/core-properties/9f5f1211ea9a4e748cecce63d1c73e30.psmdcp",
+        "[Content_Types].xml"
+      ]
+    },
+    "xunit.netcore.extensions/1.0.0-prerelease-00112": {
+      "serviceable": true,
+      "sha512": "a/ERxK1fORRE2re8l1n8+SP6TaKT/vF4/hfb//jgMjq0lZAf91ITZELnPNyOnkYtjI2KTlWtIn2nqA9HJVOebg==",
+      "files": [
+        "xunit.netcore.extensions.1.0.0-prerelease-00112.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00112.nupkg.sha512",
+        "xunit.netcore.extensions.nuspec",
+        "lib/dotnet/Xunit.NetCore.Extensions.dll"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "Microsoft.NETCore >= 5.0.0-beta-*",
+      "Microsoft.DotNet.xunit.performance >= 1.0.0-*",
+      "xunit >= 2.1.0",
+      "xunit.netcore.extensions >= 1.0.0-prerelease-*"
+    ],
+    "DNXCore,Version=v5.0": []
+  }
+}


### PR DESCRIPTION
The MultiValueDictionary is an experimental collection that was first released the summer of 2014 as a Nuget package. This commit releases the source code of the MultiValueDictionary tied into .NET Core with the intention of it being considered as an addition to System.Collections.Generic in CoreFX.

- All code is open sourced from the original package with only changes made to get it functioning. As such, some things will need to be changed to better match the style of CoreFX (e.g. the tests).
- I based the csproj, project.json, folder structure, and strings.resx heavily on that of System.Collections.Generic in CoreFX so that they may be easily merged in the future. This is why Strings.resx has some strings that aren't used by the MVD
- Addition of performance tests required an update of BuildTools from 70 to 107.
- The MVD released earlier had tie-in functions to ILookup like ConvertToLookup. I removed those with the intention of adding them as extension functions in ILookup instead of being in MultiValueDictionary. The reason for this is that System.Collections.Generic shouldn't reference System.Linq but System.Linq can reference System.Collections.Generic.
- The design decisions around the MVD were made at point where .NET was very different than it is today. Some things might be worth reconsidering now that .NET Core exists.