### PR TITLE
Added the ability to explicit reference dlls

### DIFF
--- a/demos/dotnet/dotnet/CscAction.cs
+++ b/demos/dotnet/dotnet/CscAction.cs
@@ -62,7 +62,7 @@ namespace dotnet
                 {
                     first = false;
                 }
-                builder.Append(Path.Combine(project.PackagesDirectory, reference));
+                builder.Append(reference);
             }
             builder.Append(" ");
             return builder.ToString();

--- a/demos/dotnet/dotnet/ProjectPropertiesHelpers.cs
+++ b/demos/dotnet/dotnet/ProjectPropertiesHelpers.cs
@@ -60,6 +60,9 @@ namespace dotnet
             properties.Packages.Add(GetConsoleHost(platformOptionSpecicifcation));
             properties.Packages.Add(GetRuntimeCoreClr(platformOptionSpecicifcation));
 
+            // add explicit references
+            properties.References.AddRange(settings.References);
+
             // CSC OPTIONS
             properties.CscOptions.Add("/nostdlib");
             properties.CscOptions.Add("/noconfig");

--- a/demos/dotnet/dotnet/Settings.cs
+++ b/demos/dotnet/dotnet/Settings.cs
@@ -40,7 +40,8 @@ namespace dotnet
             "/target",
             "/recurse",
             "/debug",
-            "/platform"
+            "/platform",
+            "/reference"
         };
 
         private static readonly List<string> TargetSpecifications = new List<string>
@@ -74,7 +75,8 @@ namespace dotnet
 
         public string ProjectFile;
 
-        public List<string> SourceFiles; 
+        public List<string> SourceFiles;
+        public List<string> References;
 
         public bool SetTargetSpecification(string specification)
         {
@@ -87,6 +89,12 @@ namespace dotnet
         {
             if (!PlatformSpecifications.Contains(specification)) return false;
             Platform = specification;
+            return true;
+        }
+
+        public bool SetReferenceSpecification(string specification)
+        {
+            References = new List<string>(specification.Split(','));
             return true;
         }
 

--- a/demos/dotnet/dotnet/dotnet.cs
+++ b/demos/dotnet/dotnet/dotnet.cs
@@ -16,6 +16,11 @@ namespace dotnet
 
         private static void Main(string[] args)
         {
+            if(args.Length == 0)
+            {
+                args = new string[] { "/log", "/reference:System.Slices.dll,System.Buffers.dll", "main.cs" };
+            }
+
             if (Array.Exists(args, element => element == "/new"))
             {
                 OtherActions.CreateNewProject();
@@ -72,6 +77,8 @@ namespace dotnet
                        Settings.SetPlatformSpecification) &&
                    ValidateAndSetOptionSpecifications(Array.Find(args, element => element.StartsWith("/debug")),
                        Settings.SetDebugSpecification) &&
+                   ValidateAndSetOptionSpecifications(Array.Find(args, element => element.StartsWith("/reference")),
+                       Settings.SetReferenceSpecification) &&
                    ValidateAndSetOptionSpecifications(Array.Find(args, element => element.StartsWith("/recurse")),
                        Settings.SetRecurseSpecification);
         }
@@ -252,7 +259,7 @@ namespace dotnet
 
             foreach (var reference in references)
             {
-                properties.References.Add(reference);
+                properties.References.Add(Path.Combine(properties.PackagesDirectory, reference));
             }
             foreach (var outputAssembly in dependencies)
             {


### PR DESCRIPTION
They can be referenced as follows:
dotnet.exe /reference:A.dll,B.dll,C.dll