### PR TITLE
Perf tests for basic Utf8String functionalities

### DIFF
--- a/src/System.Text.Utf8/src/System.Text.Utf8.csproj
+++ b/src/System.Text.Utf8/src/System.Text.Utf8.csproj
@@ -10,11 +10,6 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{C5FD8740-19EA-4BCC-B518-7F16B55D23CA}</ProjectGuid>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
-    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
-    <!-- workaround until we have Dev14 nuget targets -->
-    <NugetTargetFrameworkMoniker>.NETPlatform,Version=v5.0</NugetTargetFrameworkMoniker>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Text.Utf8/src/System.Text.Utf8.csproj
+++ b/src/System.Text.Utf8/src/System.Text.Utf8.csproj
@@ -7,7 +7,6 @@
     <OutputType>Library</OutputType>
     <RootNamespace>System.Text.Utf8</RootNamespace>
     <AssemblyName>System.Text.Utf8</AssemblyName>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ProjectGuid>{C5FD8740-19EA-4BCC-B518-7F16B55D23CA}</ProjectGuid>
   </PropertyGroup>

--- a/src/System.Text.Utf8/src/System/Text/Utf8/Utf8String.cs
+++ b/src/System.Text.Utf8/src/System/Text/Utf8/Utf8String.cs
@@ -440,7 +440,16 @@ namespace System.Text.Utf8
         // TODO: Should this be public?
         public int IndexOf(UnicodeCodePoint codePoint)
         {
-            throw new NotImplementedException();
+            CodePointEnumerator it = GetCodePointEnumerator();
+            while (it.MoveNext())
+            {
+                if (it.Current == codePoint)
+                {
+                    return it.PositionInCodeUnits;
+                }
+            }
+            
+            return StringNotFound;
         }
 
         // TODO: Re-evaluate all Substring family methods and check their parameters name

--- a/src/System.Text.Utf8/src/project.lock.json
+++ b/src/System.Text.Utf8/src/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": true,
+  "locked": false,
   "version": 2,
   "targets": {
     "DNXCore,Version=v5.0": {

--- a/src/System.Text.Utf8/tests/PerformanceTests.cs
+++ b/src/System.Text.Utf8/tests/PerformanceTests.cs
@@ -1,0 +1,343 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text.Utf8;
+using System.Text.Utf16;
+using Xunit.Abstractions;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+
+namespace System.Text.Utf8.Tests
+{
+    [Trait("category", "performance")]
+    public class Utf8StringPerformanceTests
+    {
+        private readonly Stopwatch _timer = new Stopwatch();
+        ITestOutputHelper _output;
+
+        public Utf8StringPerformanceTests(ITestOutputHelper output)
+        {
+            _output = output;
+
+            _timer.Start();
+            _timer.Restart();
+            _timer.Stop();
+            _timer.Reset();
+            PrintTime(new StringWithDescription("", "ignore this", -1));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void PrintTime(StringWithDescription str, [CallerMemberName] string memberName = "")
+        {
+            _output.WriteLine(string.Format("{0} : {1} : Elapsed {2}ms ({3} iterations)", memberName, str.Description, _timer.ElapsedMilliseconds, str.Iterations));
+        }
+
+        private string GetRandomString(int length, int minCodePoint, int maxCodePoint)
+        {
+            Random r = new Random(42);
+            StringBuilder sb = new StringBuilder(length);
+            while (length-- != 0)
+            {
+                sb.Append((char)r.Next(minCodePoint, maxCodePoint));
+            }
+            return sb.ToString();
+        }
+
+        public struct StringWithDescription
+        {
+            string _s;
+            string _description;
+            int _iterations;
+
+            public string String { get { return _s; } }
+            public string Description { get { return _description;  } }
+            public int Iterations { get { return _iterations;  } }
+            public StringWithDescription(string s, string description, int iterations)
+            {
+                _s = s;
+                _description = description;
+                _iterations = iterations;
+            }
+        }
+
+        private IEnumerable<StringWithDescription> StringsWithDescription()
+        {
+            int iterationsMultiplier = 10;
+            yield return new StringWithDescription(GetRandomString(5, 32, 126), "Short ASCII string", 50000 * iterationsMultiplier);
+            yield return new StringWithDescription(GetRandomString(5, 32, 0xD7FF), "Short string", 50000 * iterationsMultiplier);
+            yield return new StringWithDescription(GetRandomString(50000, 32, 126), "Long ASCII string", 5 * iterationsMultiplier);
+            yield return new StringWithDescription(GetRandomString(50000, 32, 0xD7FF), "Long string", 5 * iterationsMultiplier);
+        }
+
+        [Fact]
+        public void ConstructFromString()
+        {
+            foreach (StringWithDescription testData in StringsWithDescription())
+            {
+                string s = testData.String;
+                int iterations = testData.Iterations;
+                _timer.Restart();
+                while (iterations-- != 0)
+                {
+                    Utf8String utf8s = new Utf8String(s);
+                }
+                PrintTime(testData);
+            }
+        }
+
+        [Fact]
+        public void EnumerateCodeUnitsConstructFromByteArray()
+        {
+            foreach (StringWithDescription testData in StringsWithDescription())
+            {
+                string s = testData.String;
+                Utf8String utf8s = new Utf8String(s);
+                utf8s = new Utf8String(utf8s.CopyBytes());
+                int iterations = testData.Iterations;
+                _timer.Restart();
+                while (iterations-- != 0)
+                {
+                    foreach (Utf8CodeUnit codeUnit in utf8s)
+                    {
+                    }
+                }
+                PrintTime(testData);
+            }
+        }
+
+        [Fact]
+        public unsafe void EnumerateCodeUnitsConstructFromSpan()
+        {
+            foreach (StringWithDescription testData in StringsWithDescription())
+            {
+                string s = testData.String;
+                Utf8String utf8s = new Utf8String(s);
+                fixed (byte* bytes = utf8s.CopyBytes())
+                {
+                    utf8s = new Utf8String(new ByteSpan(bytes, utf8s.Length));
+                    int iterations = testData.Iterations;
+                    _timer.Restart();
+                    while (iterations-- != 0)
+                    {
+                        foreach (Utf8CodeUnit codeUnit in utf8s)
+                        {
+                        }
+                    }
+                    PrintTime(testData);
+                }
+            }
+        }
+
+        [Fact]
+        public void EnumerateCodePointsConstructFromByteArray()
+        {
+            foreach (StringWithDescription testData in StringsWithDescription())
+            {
+                string s = testData.String;
+                Utf8String utf8s = new Utf8String(s);
+                utf8s = new Utf8String(utf8s.CopyBytes());
+                int iterations = testData.Iterations;
+                _timer.Restart();
+                while (iterations-- != 0)
+                {
+                    foreach (UnicodeCodePoint codePoint in utf8s.CodePoints)
+                    {
+                    }
+                }
+                PrintTime(testData);
+            }
+        }
+
+        [Fact]
+        public unsafe void EnumerateCodePointsConstructFromSpan()
+        {
+            foreach (StringWithDescription testData in StringsWithDescription())
+            {
+                string s = testData.String;
+                Utf8String utf8s = new Utf8String(s);
+                fixed (byte* bytes = utf8s.CopyBytes())
+                {
+                    utf8s = new Utf8String(new ByteSpan(bytes, utf8s.Length));
+                    int iterations = testData.Iterations;
+                    _timer.Restart();
+                    while (iterations-- != 0)
+                    {
+                        foreach (UnicodeCodePoint codePoint in utf8s.CodePoints)
+                        {
+                        }
+                    }
+                    PrintTime(testData);
+                }
+            }
+        }
+
+        [Fact]
+        public void ReverseEnumerateCodePointsConstructFromByteArray()
+        {
+            foreach (StringWithDescription testData in StringsWithDescription())
+            {
+                string s = testData.String;
+                Utf8String utf8s = new Utf8String(s);
+                utf8s = new Utf8String(utf8s.CopyBytes());
+                int iterations = testData.Iterations;
+                _timer.Restart();
+                while (iterations-- != 0)
+                {
+                    Utf8String.CodePointReverseEnumerator it = utf8s.CodePoints.GetReverseEnumerator();
+                    while (it.MoveNext())
+                    {
+                        UnicodeCodePoint codePoint = it.Current;
+                    }
+                }
+                PrintTime(testData);
+            }
+        }
+
+        [Fact]
+        public unsafe void ReverseEnumerateCodePointsConstructFromSpan()
+        {
+            foreach (StringWithDescription testData in StringsWithDescription())
+            {
+                string s = testData.String;
+                Utf8String utf8s = new Utf8String(s);
+                fixed (byte* bytes = utf8s.CopyBytes())
+                {
+                    utf8s = new Utf8String(new ByteSpan(bytes, utf8s.Length));
+                    int iterations = testData.Iterations;
+                    _timer.Restart();
+                    while (iterations-- != 0)
+                    {
+                        Utf8String.CodePointReverseEnumerator it = utf8s.CodePoints.GetReverseEnumerator();
+                        while (it.MoveNext())
+                        {
+                            UnicodeCodePoint codePoint = it.Current;
+                        }
+                    }
+                    PrintTime(testData);
+                }
+            }
+        }
+
+        [Fact]
+        public void SubstringTrimOneCharacterOnEachSideConstructFromByteArray()
+        {
+            foreach (StringWithDescription testData in StringsWithDescription())
+            {
+                string s = testData.String;
+                Utf8String utf8s = new Utf8String(s);
+                utf8s = new Utf8String(utf8s.CopyBytes());
+                int iterations = testData.Iterations;
+                _timer.Restart();
+                while (iterations-- != 0)
+                {
+                    Utf8String result = utf8s.Substring(1, utf8s.Length - 2);
+                }
+                PrintTime(testData);
+            }
+        }
+
+        [Fact]
+        public unsafe void SubstringTrimOneCharacterOnEachSideConstructFromSpan()
+        {
+            foreach (StringWithDescription testData in StringsWithDescription())
+            {
+                string s = testData.String;
+                Utf8String utf8s = new Utf8String(s);
+                fixed (byte* bytes = utf8s.CopyBytes())
+                {
+                    utf8s = new Utf8String(new ByteSpan(bytes, utf8s.Length));
+                    int iterations = testData.Iterations;
+                    _timer.Restart();
+                    while (iterations-- != 0)
+                    {
+                        Utf8String result = utf8s.Substring(1, utf8s.Length - 2);
+                    }
+                    PrintTime(testData);
+                }
+            }
+        }
+
+        [Fact]
+        public void IndexOfNonOccuringSingleCodeUnitConstructFromByteArray()
+        {
+            foreach (StringWithDescription testData in StringsWithDescription())
+            {
+                string s = testData.String;
+                Utf8String utf8s = new Utf8String(s);
+                utf8s = new Utf8String(utf8s.CopyBytes());
+                int iterations = testData.Iterations;
+                _timer.Restart();
+                while (iterations-- != 0)
+                {
+                    int p = utf8s.IndexOf((Utf8CodeUnit)31);
+                }
+                PrintTime(testData);
+            }
+        }
+
+        [Fact]
+        public unsafe void IndexOfNonOccuringSingleCodeUnitConstructFromSpan()
+        {
+            foreach (StringWithDescription testData in StringsWithDescription())
+            {
+                string s = testData.String;
+                Utf8String utf8s = new Utf8String(s);
+                fixed (byte* bytes = utf8s.CopyBytes())
+                {
+                    utf8s = new Utf8String(new ByteSpan(bytes, utf8s.Length));
+                    int iterations = testData.Iterations;
+                    _timer.Restart();
+                    while (iterations-- != 0)
+                    {
+                        int p = utf8s.IndexOf((Utf8CodeUnit)31);
+                    }
+                    PrintTime(testData);
+                }
+            }
+        }
+
+        [Fact]
+        public void IndexOfNonOccuringSingleCodePointConstructFromByteArray()
+        {
+            foreach (StringWithDescription testData in StringsWithDescription())
+            {
+                string s = testData.String;
+                Utf8String utf8s = new Utf8String(s);
+                utf8s = new Utf8String(utf8s.CopyBytes());
+                int iterations = testData.Iterations;
+                _timer.Restart();
+                while (iterations-- != 0)
+                {
+                    int p = utf8s.IndexOf((UnicodeCodePoint)31);
+                }
+                PrintTime(testData);
+            }
+        }
+
+        [Fact]
+        public unsafe void IndexOfNonOccuringSingleCodePointConstructFromSpan()
+        {
+            foreach (StringWithDescription testData in StringsWithDescription())
+            {
+                string s = testData.String;
+                Utf8String utf8s = new Utf8String(s);
+                fixed (byte* bytes = utf8s.CopyBytes())
+                {
+                    utf8s = new Utf8String(new ByteSpan(bytes, utf8s.Length));
+                    int iterations = testData.Iterations;
+                    _timer.Restart();
+                    while (iterations-- != 0)
+                    {
+                        int p = utf8s.IndexOf((UnicodeCodePoint)31);
+                    }
+                    PrintTime(testData);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Text.Utf8/tests/RandomTests.cs
+++ b/src/System.Text.Utf8/tests/RandomTests.cs
@@ -779,5 +779,30 @@ namespace System.Text.Utf8.Tests
             Utf8String u8substring = new Utf8String(substring);
             Assert.Equal(expected, u8s.IsSubstringAt(position, u8substring));
         }
+
+        [Theory]
+        [InlineData(-1, "", 0)]
+        [InlineData(0, "a", (uint)'a')]
+        [InlineData(-1, "a", (uint)'b')]
+        [InlineData(0, "\uABCD", 0xABCD)]
+        [InlineData(-1, "\uABCD", 0xABCE)]
+        [InlineData(0, "abc", (uint)'a')]
+        [InlineData(1, "abc", (uint)'b')]
+        [InlineData(2, "abc", (uint)'c')]
+        [InlineData(-1, "abc", (uint)'d')]
+        [InlineData(0, "\uABC0\uABC1\uABC2", 0xABC0)]
+        [InlineData(3, "\uABC0\uABC1\uABC2", 0xABC1)]
+        [InlineData(6, "\uABC0\uABC1\uABC2", 0xABC2)]
+        [InlineData(-1, "\uABC0\uABC1\uABC2", 0xABC3)]
+        [InlineData(0, "\uABC0bc", 0xABC0)]
+        [InlineData(1, "a\uABC1c", 0xABC1)]
+        [InlineData(2, "ab\uABC2", 0xABC2)]
+        [InlineData(-1, "\uABC0\uABC1\uABC2", (uint)'d')]
+        public void IndexOfUnicodeCodePoint(int expected, string s, uint codePointValue)
+        {
+            Utf8String u8s = new Utf8String(s);
+            UnicodeCodePoint codePoint = (UnicodeCodePoint)codePointValue;
+            Assert.Equal(expected, u8s.IndexOf(codePoint));
+        }
     }
 }

--- a/src/System.Text.Utf8/tests/System.Text.Utf8.Tests.csproj
+++ b/src/System.Text.Utf8/tests/System.Text.Utf8.Tests.csproj
@@ -16,11 +16,6 @@
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
-    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
-    <!-- workaround until we have Dev14 nuget targets -->
-    <NugetTargetFrameworkMoniker>.NETPlatform,Version=v5.0</NugetTargetFrameworkMoniker>
     <ProjectGuid>{DD942FDB-184A-4D9F-8A1E-3D531858A4B1}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Text.Utf8/tests/System.Text.Utf8.Tests.csproj
+++ b/src/System.Text.Utf8/tests/System.Text.Utf8.Tests.csproj
@@ -9,7 +9,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>System.Text.Utf8</RootNamespace>
+    <RootNamespace>System.Text.Utf8.Tests</RootNamespace>
     <FileAlignment>512</FileAlignment>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
@@ -19,12 +19,17 @@
     <ProjectGuid>{DD942FDB-184A-4D9F-8A1E-3D531858A4B1}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
       <Visible>False</Visible>
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PerformanceTests.cs" />
     <Compile Include="RandomTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Text.Utf8/tests/project.json
+++ b/src/System.Text.Utf8/tests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore" : "5.0.0-beta-*",
-    "System.Console":  "4.0.0-beta-*",
+    "System.Console": "4.0.0-beta-*",
     "xunit": "2.0.0-beta5-build2785"
   },
   "frameworks": {

--- a/src/System.Text.Utf8/tests/project.lock.json
+++ b/src/System.Text.Utf8/tests/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": true,
+  "locked": false,
   "version": 2,
   "targets": {
     "DNXCore,Version=v5.0": {
@@ -6608,9 +6608,8 @@
       "type": "package",
       "sha512": "bNycxZe/83M7o7j0IbGp3/daiPLi17hZgYZB6xttgCVDnxgAuw/TP1zetiUTW1yVUPASnAjlkBeJayv/G2Crsw==",
       "files": [
-        "[Content_Types].xml",
-        "_rels/.rels",
-        "package/services/metadata/core-properties/6c890516e9584d3ab4031ef8a539ff70.psmdcp",
+        "xunit.2.0.0-beta5-build2785.nupkg",
+        "xunit.2.0.0-beta5-build2785.nupkg.sha512",
         "xunit.nuspec"
       ]
     },
@@ -6618,13 +6617,12 @@
       "type": "package",
       "sha512": "b2RCnV2/wilCH1dsh7bAF82Ou+Vs+WfYLEItzRUUbD3YHNODx0ncpQwLz1JYjL/voBFc5mQh77hxIbgCGmyxKA==",
       "files": [
-        "[Content_Types].xml",
-        "_rels/.rels",
         "lib/net35/xunit.abstractions.dll",
         "lib/net35/xunit.abstractions.xml",
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.abstractions.dll",
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.abstractions.xml",
-        "package/services/metadata/core-properties/399f3731609f4d74afacd3835adec3ef.psmdcp",
+        "xunit.abstractions.2.0.0-beta5-build2785.nupkg",
+        "xunit.abstractions.2.0.0-beta5-build2785.nupkg.sha512",
         "xunit.abstractions.nuspec"
       ]
     },
@@ -6632,12 +6630,11 @@
       "type": "package",
       "sha512": "1PTLrP+jLzSIhqO3JzzgPcMPmSyBlFadpFH6v3d2Vm08x/bIYHnF78h20qt6wk/t3wMu7smOsyoNcUFeP2ZnGg==",
       "files": [
-        "[Content_Types].xml",
-        "_rels/.rels",
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch10/xunit.assert.dll",
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch10/xunit.assert.pdb",
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monoandroid+monotouch10/xunit.assert.xml",
-        "package/services/metadata/core-properties/9744844535724f06a45b33a9b7fe9d6b.psmdcp",
+        "xunit.assert.2.0.0-beta5-build2785.nupkg",
+        "xunit.assert.2.0.0-beta5-build2785.nupkg.sha512",
         "xunit.assert.nuspec"
       ]
     },
@@ -6645,8 +6642,6 @@
       "type": "package",
       "sha512": "3rDhbyvCS1iA20A7uXxYvw3LLa4MtyXUX9Y6i3QjY/dRhIHEZcSxBjBfGP3MjPm900WnsBx2H0ryQo2RWABhhg==",
       "files": [
-        "[Content_Types].xml",
-        "_rels/.rels",
         "build/monoandroid/xunit.core.props",
         "build/monoandroid/xunit.execution.dll",
         "build/monotouch/xunit.core.props",
@@ -6672,7 +6667,8 @@
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.core.xml",
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.runner.tdnet.dll",
         "lib/portable-net45+aspnetcore50+win+wpa81+wp80+monotouch+monoandroid/xunit.runner.utility.dll",
-        "package/services/metadata/core-properties/7e3ae190162d4ceaa2151619ccd704ef.psmdcp",
+        "xunit.core.2.0.0-beta5-build2785.nupkg",
+        "xunit.core.2.0.0-beta5-build2785.nupkg.sha512",
         "xunit.core.nuspec"
       ]
     }


### PR DESCRIPTION
This will measure Utf8String implemented on ByteSpan.

Perf tested functionalities (IMO sufficient baseline):
-	Construct from string (convert from string to Utf8String)
-	Enumerate CodeUnits forward
-	Enumerate CodePoints forward
-	Enumerate CodePoints backward
-	IndexOf(Utf8CodeUnit) - searching for non-existing character (to make it as long as possible)
-	IndexOf(Utf8CodePoint) - searching for non-existing character (to make it as long as possible)

Each case tested for:
-	String constructed from byte[], string constructed from ByteSpan
-	4 different types of strings: [short (5 characters), ASCII], [short (5 chars), any 16bit Unicode codepoint], [long (50k chars), ASCII], [long (50k chars), any 16bit Unicode codepoint]
