### PR TITLE
Slice/Span performance improvements

### DIFF
--- a/src/System.Slices/src/System.Slices.csproj
+++ b/src/System.Slices/src/System.Slices.csproj
@@ -24,6 +24,7 @@
     <Compile Include="System\PrimitiveAttribute.cs" />
     <Compile Include="System\PtrUtils.cs" />
     <Compile Include="System\Span.cs" />
+    <Compile Include="System\SpanEnumerators.cs" />
     <Compile Include="System\SpanExtensions.cs" />
     <Compile Include="System\SpanHelpers.cs" />
   </ItemGroup>
@@ -33,7 +34,6 @@
     <ILDasm Condition="'$(ILDasm)' == '' AND Exists('$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6 Tools\ildasm.exe')">$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.6 Tools\ildasm.exe</ILDasm>
     <ILAsm Condition="'$(ILAsm)' == '' AND Exists('ilasm.exe')">ilasm.exe</ILAsm>
     <ILAsm Condition="'$(ILAsm)' == '' AND Exists('$(WinDir)\Microsoft.NET\Framework\v4.0.30319\ilasm.exe')">$(WinDir)\Microsoft.NET\Framework\v4.0.30319\ilasm.exe</ILAsm>
-    
     <DecompileToILCommand>"$(ILDasm)" /linenum /out:"$(TargetDir)$(TargetName).beforerewrite.il" /nobar "$(TargetPath)"</DecompileToILCommand>
     <RewriteILCommand>"$([System.IO.Path]::GetFullPath('$(SourceDir)System.Slices\tools\ILSub\ILSub.exe'))" "$(TargetDir)$(TargetName).beforerewrite.il" "$(TargetDir)$(TargetName).rewritten.il"</RewriteILCommand>
     <RecompileILCommand>"$(ILAsm)" /pdb /quiet /dll /out:$(TargetPath) /nologo $(TargetDir)$(TargetName).rewritten.il</RecompileILCommand>

--- a/src/System.Slices/src/System/Span.cs
+++ b/src/System.Slices/src/System/Span.cs
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace System
 {
@@ -13,14 +12,14 @@ namespace System
     /// to regular accesses and is a struct so that creation and subslicing do
     /// not require additional allocations.  It is type- and memory-safe.
     /// </summary>
-    public struct Span<T> : IEnumerable<T>, IEquatable<Span<T>>
+    public partial struct Span<T> : IEnumerable<T>, IEquatable<Span<T>>
     {
         /// <summary>A managed array/string; or null for native ptrs.</summary>
         readonly object _object;
         /// <summary>An byte-offset into the array/string; or a native ptr.</summary>
         readonly UIntPtr _offset;
         /// <summary>Fetches the number of elements this Span contains.</summary>
-        public int Length { get; private set; }
+        public readonly int Length;
 
         /// <summary>
         /// Creates a new span over the entirety of the target array.
@@ -162,6 +161,7 @@ namespace System
         /// </exception>
         public T this[int index]
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
                 Contract.RequiresInRange(index, Length);
@@ -299,27 +299,17 @@ namespace System
                 return false;
             }
 
-            Enumerator thisIt = this.GetEnumerator();
-            Enumerator otherIt = other.GetEnumerator();
-            while (true)
+            var nonBoxingComparer = EqualityComparer<T>.Default;
+            for (int i = 0; i < Length; i++)
             {
-                bool hasNext = thisIt.MoveNext();
-                if (hasNext != otherIt.MoveNext())
-                {
-                    return false;
-                }
-
-                if (!hasNext)
-                {
-                    return true;
-                }
-
-                // TODO: Fix it so it doesn't box (memcmp)
-                if (!thisIt.Current.Equals(otherIt.Current))
+                if (!nonBoxingComparer.Equals(
+                    this.GetItemWithoutBoundariesCheck(i), other.GetItemWithoutBoundariesCheck(i)))
                 {
                     return false;
                 }
             }
+
+            return true;
         }
 
         public override bool Equals(object obj)
@@ -333,63 +323,15 @@ namespace System
         }
 
         /// <summary>
-        /// Returns an enumerator over the span's entire contents.
+        /// Returns item from given index without the boundaries check
+        /// use only in places where moving outside the boundaries is impossible
+        /// gain: performance: no boundaries check (single operation) 
         /// </summary>
-        public Enumerator GetEnumerator()
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private T GetItemWithoutBoundariesCheck(int index)
         {
-            return new Enumerator(this);
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-
-        IEnumerator<T> IEnumerable<T>.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-
-        /// <summary>
-        /// A struct-based enumerator, to make fast enumerations possible.
-        /// This isn't designed for direct use, instead see GetEnumerator.
-        /// </summary>
-        public struct Enumerator : IEnumerator<T>
-        {
-            Span<T> _slice;    // The slice being enumerated.
-            int _position; // The current position.
-
-            public Enumerator(Span<T> slice)
-            {
-                _slice = slice;
-                _position = -1;
-            }
-
-            public T Current
-            {
-                get { return _slice[_position]; }
-            }
-
-            object IEnumerator.Current
-            {
-                get { return Current; }
-            }
-
-            public void Dispose()
-            {
-                _slice = default(Span<T>);
-                _position = -1;
-            }
-
-            public bool MoveNext()
-            {
-                return ++_position < _slice.Length;
-            }
-
-            public void Reset()
-            {
-                _position = -1;
-            }
+            return PtrUtils.Get<T>(
+                    _object, _offset + (index * PtrUtils.SizeOf<T>()));
         }
     }
 }

--- a/src/System.Slices/src/System/SpanEnumerators.cs
+++ b/src/System.Slices/src/System/SpanEnumerators.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace System
+{
+    public partial struct Span<T>
+    {
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return new EnumeratorObject(this);
+        }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            return new EnumeratorObject(this);
+        }
+
+        /// <summary>
+        /// A struct-based enumerator, to make fast enumerations possible.
+        /// This isn't designed for direct use, instead see GetEnumerator.
+        /// </summary>
+        public struct Enumerator
+        {
+            Span<T> _span;    // The slice being enumerated.
+            int _position; // The current position.
+
+            internal Enumerator(Span<T> span)
+            {
+                _span = span;
+                _position = -1;
+            }
+
+            public T Current
+            {
+                get { return _span[_position]; }
+            }
+
+            public bool MoveNext()
+            {
+                return ++_position < _span.Length;
+            }
+
+            public void Reset()
+            {
+                _position = -1;
+            }
+        }
+
+        /// <summary>
+        /// enumerator that implements <see cref="IEnumerator{T}"/> pattern (including <see cref="IDisposable"/>).
+        /// it is used by LINQ and foreach when Slice is accessed via <see cref="IEnumerable{T}"/>
+        /// it is reference type to avoid boxing when calling interface methods on stuctures
+        /// </summary>
+        private class EnumeratorObject : IEnumerator<T>
+        {
+            Span<T> _span;    // The slice being enumerated.
+            int _position; // The current position.
+
+            public EnumeratorObject(Span<T> span)
+            {
+                _span = span;
+                _position = -1;
+            }
+
+            public T Current
+            {
+                get { return _span.GetItemWithoutBoundariesCheck(_position); }
+            }
+
+            object IEnumerator.Current
+            {
+                get { return Current; }
+            }
+
+            public void Dispose()
+            {
+                _span = default(Span<T>);
+                _position = -1;
+            }
+
+            public bool MoveNext()
+            {
+                int nextItemIndex = _position + 1;
+                if (nextItemIndex < _span.Length)
+                {
+                    _position = nextItemIndex;
+                    return true;
+                }
+                return false;
+            }
+
+            public void Reset()
+            {
+                _position = -1;
+            }
+        }
+    }
+}

--- a/src/System.Slices/src/project.json
+++ b/src/System.Slices/src/project.json
@@ -6,7 +6,8 @@
     "System.Runtime": "4.0.0",
     "System.Runtime.Extensions": "4.0.0",
     "System.Runtime.InteropServices": "4.0.0",
-    "System.Threading": "4.0.0"
+    "System.Threading": "4.0.0",
+    "System.Collections": "4.0.0"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Slices/src/project.lock.json
+++ b/src/System.Slices/src/project.lock.json
@@ -3,6 +3,15 @@
   "version": 2,
   "targets": {
     "DNXCore,Version=v5.0": {
+      "System.Collections/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        }
+      },
       "System.Diagnostics.Debug/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -125,6 +134,15 @@
       }
     },
     "DNXCore,Version=v5.0/win7-x86": {
+      "System.Collections/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        }
+      },
       "System.Diagnostics.Debug/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -247,6 +265,15 @@
       }
     },
     "DNXCore,Version=v5.0/win7-x64": {
+      "System.Collections/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        }
+      },
       "System.Diagnostics.Debug/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -370,6 +397,54 @@
     }
   },
   "libraries": {
+    "System.Collections/4.0.0": {
+      "type": "package",
+      "sha512": "i2vsGDIEbWdHcUSNDPKZP/ZWod6o740el7mGTCy0dqbCxQh74W4QoC+klUwPEtGEFuvzJ7bJgvwJqscosVNyZQ==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
+        "ref/dotnet/fr/System.Collections.xml",
+        "ref/dotnet/it/System.Collections.xml",
+        "ref/dotnet/ja/System.Collections.xml",
+        "ref/dotnet/ko/System.Collections.xml",
+        "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
+        "ref/dotnet/zh-hans/System.Collections.xml",
+        "ref/dotnet/zh-hant/System.Collections.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Collections.xml",
+        "ref/netcore50/es/System.Collections.xml",
+        "ref/netcore50/fr/System.Collections.xml",
+        "ref/netcore50/it/System.Collections.xml",
+        "ref/netcore50/ja/System.Collections.xml",
+        "ref/netcore50/ko/System.Collections.xml",
+        "ref/netcore50/ru/System.Collections.xml",
+        "ref/netcore50/System.Collections.dll",
+        "ref/netcore50/System.Collections.xml",
+        "ref/netcore50/zh-hans/System.Collections.xml",
+        "ref/netcore50/zh-hant/System.Collections.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Collections.4.0.0.nupkg",
+        "System.Collections.4.0.0.nupkg.sha512",
+        "System.Collections.nuspec"
+      ]
+    },
     "System.Diagnostics.Debug/4.0.0": {
       "type": "package",
       "sha512": "AYJsLLGDVTC/nyURjgAo7Lpye0+HuSkcQujUf+NgQVdC/C/ky5NyamQHCforHJzgqspitMMtBe8B4UBdGXy1zQ==",
@@ -925,7 +1000,8 @@
       "System.Runtime >= 4.0.0",
       "System.Runtime.Extensions >= 4.0.0",
       "System.Runtime.InteropServices >= 4.0.0",
-      "System.Threading >= 4.0.0"
+      "System.Threading >= 4.0.0",
+      "System.Collections >= 4.0.0"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/src/System.Text.Utf8/src/System/Text/Utf8/Utf8String.Enumerator.cs
+++ b/src/System.Text.Utf8/src/System/Text/Utf8/Utf8String.Enumerator.cs
@@ -29,7 +29,6 @@ namespace System.Text.Utf8
 
             void IDisposable.Dispose()
             {
-                _enumerator.Dispose();
             }
 
             public bool MoveNext()


### PR DESCRIPTION
The optimizations I have introduced:
1. Making Length a readonly field instead of property. It gives a lot for the "for loop"
2. Simpler range check by casting index and length to unsigned integers to eliminate index >= 0 check
3. Removing Dispose from struct Enumerator to avoid compiler from putting foreach in try+finally block
4. Introducing new EnumeratorObject class that is created when the collection is being enumerated via the IEnumerable interface. Since IEnumerable.GetEnumerator() returns IEnumerator (interface) it would be costly if this was struct because invoking interface method on structures is expensive
5. Added inlining of indexer getter, which makes the EnumeratorObject inline the indexer method.
6. Added GetItemWithoutBoundariesCheck method, which is used in safe EnumeratorObject, where Improved MoveNext ensures that it is impossible to move outside boundaries. It eliminates single range check (stadard indexer)
7. Equals based on for loop which reduces number of method calls (enumerating via Enumerator calls to MoveNext and Current, looping just to indexer) and added generic Comparer to avoid boxing (but I had to add dependency to System.Collections to use EqualityComparer<T>.Default)

I have tested all these changes a long time ago when I added them to the original Slice repo of Joe Duffy