### PR TITLE
Adding a lazy-loading Shared buffer to both the Managed and Native pools

### DIFF
--- a/src/System.Buffers/src/System/Buffers/ManagedBufferPool.cs
+++ b/src/System.Buffers/src/System/Buffers/ManagedBufferPool.cs
@@ -14,6 +14,21 @@ namespace System.Buffers
         private int _maxBufferSize;
         private ManagedBufferBucket<T>[] _buckets;
 
+        private static ManagedBufferPool<byte> _sharedInstance = null;
+
+        public static ManagedBufferPool<byte> SharedByteBufferPool
+        {
+            get
+            {
+                if (Volatile.Read(ref _sharedInstance) == null)
+                {
+                    Interlocked.CompareExchange(ref _sharedInstance, new ManagedBufferPool<byte>(), null);
+                }
+
+                return _sharedInstance;
+            }
+        }
+
         // 2MB taken as the default since the average HTTP page is 1.9MB
         // per http://httparchive.org/interesting.php, as of October 2015
         public ManagedBufferPool(int maxBufferSizeInBytes = 2048000)

--- a/src/System.Buffers/src/System/Buffers/NativeBufferBucket.cs
+++ b/src/System.Buffers/src/System/Buffers/NativeBufferBucket.cs
@@ -9,13 +9,14 @@ using System.Threading;
 
 namespace System.Buffers
 {
-    internal unsafe sealed class NativeBufferBucket<T> where T : struct
+    internal unsafe sealed class NativeBufferBucket<T> : IDisposable where T : struct
     {
         private volatile int _index;
         private IntPtr _buffer;
         private Span<T>?[] _slices;
         private int _elementsInBuffer;
         private SpinLock _lock;
+        private bool _disposed;
 
         internal NativeBufferBucket(int elementsInBuffer, int numberOfBuffers)
         {
@@ -35,11 +36,29 @@ namespace System.Buffers
 
         ~NativeBufferBucket()
         {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
             Marshal.FreeHGlobal(_buffer);
+            if (disposing)
+            {
+                _disposed = true; // don't touch in the finalizer
+            }
         }
 
         internal Span<T> Rent()
         {
+            if (_disposed)
+                throw new ObjectDisposedException("NativeBufferBucket");
+
             Span<T> buffer;
 
             // Use a lightweight spinlock for our super-short lock
@@ -67,6 +86,9 @@ namespace System.Buffers
 
         internal void Return(ref Span<T> buffer)
         {
+            if (_disposed)
+                throw new ObjectDisposedException("NativeBufferBucket");
+
             // Use a lightweight spinlock for our super short lock
             bool taken = false;
             _lock.Enter(ref taken);

--- a/src/System.Buffers/src/System/Buffers/NativeBufferPool.cs
+++ b/src/System.Buffers/src/System/Buffers/NativeBufferPool.cs
@@ -8,11 +8,31 @@ using System.Threading;
 
 namespace System.Buffers
 {
-    public unsafe sealed class NativeBufferPool<T> where T : struct
+    public unsafe sealed class NativeBufferPool<T> : IDisposable where T : struct
     {
         private const int NUMBER_OF_BUFFERS_IN_BUCKET = 50;
         private int _maxElements;
         private NativeBufferBucket<T>[] _buckets;
+        private bool _disposed;
+
+        private static NativeBufferPool<byte> _sharedInstance = null;
+
+        public static NativeBufferPool<byte> SharedByteBufferPool
+        {
+            get
+            {
+                if (Volatile.Read(ref _sharedInstance) == null)
+                {
+                    // 2MB taken as the default since the average HTTP page is 1.9MB
+                    // per http://httparchive.org/interesting.php, as of October 2015
+                    NativeBufferPool<byte> newPool = new NativeBufferPool<byte>(2048000);
+                    if (Interlocked.CompareExchange(ref _sharedInstance, newPool, null) != null)
+                        newPool.Dispose();
+                }
+
+                return _sharedInstance;
+            }
+        }
 
         public NativeBufferPool(int maxElementsInBuffer)
         {
@@ -21,8 +41,34 @@ namespace System.Buffers
             _buckets = new NativeBufferBucket<T>[maxBuckets + 1];
         }
 
+        ~NativeBufferPool()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                foreach (NativeBufferBucket<T> bucket in _buckets)
+                    if (bucket != null)
+                        bucket.Dispose();
+
+                _disposed = true;
+            }
+        }
+
         public Span<T> RentBuffer(int numberOfElements, bool clearBuffer = false)
         {
+            if (_disposed)
+                throw new ObjectDisposedException("NativeBufferPool");
+
             Span<T> buffer;
             if (numberOfElements > _maxElements)
             {
@@ -37,7 +83,10 @@ namespace System.Buffers
                 NativeBufferBucket<T> bucket = Volatile.Read(ref _buckets[index]);
                 if (bucket == null)
                 {
-                    Interlocked.CompareExchange(ref _buckets[index], new NativeBufferBucket<T>(BufferUtilities.GetMaxSizeForBucket(index), NUMBER_OF_BUFFERS_IN_BUCKET), null);
+                    NativeBufferBucket<T> newBucket = new NativeBufferBucket<T>(BufferUtilities.GetMaxSizeForBucket(index), NUMBER_OF_BUFFERS_IN_BUCKET);
+                    if (Interlocked.CompareExchange(ref _buckets[index], newBucket, null) != null)
+                        newBucket.Dispose();
+
                     bucket = _buckets[index];
                 }
 
@@ -50,6 +99,9 @@ namespace System.Buffers
 
         public void EnlargeBuffer(ref Span<T> buffer, int newSize, bool clearFreeSpace = false)
         {
+            if (_disposed)
+                throw new ObjectDisposedException("NativeBufferPool");
+
             // Still need to figure out how to handle the resizing without allocating more
             // spans to put into the resized-span's original bucket
             throw new NotImplementedException();
@@ -57,6 +109,9 @@ namespace System.Buffers
 
         public void ReturnBuffer(ref Span<T> buffer, bool clearBuffer = false)
         {
+            if (_disposed)
+                throw new ObjectDisposedException("NativeBufferPool");
+
             if (clearBuffer) BufferUtilities.ClearSpan<T>(buffer);
 
             if (buffer.Length > _maxElements)


### PR DESCRIPTION
Adding a lazy-loading Shared buffer to both the Managed and Native buffer pools to reduce the boilerplate needed to use the pools if desired.

/cc @KrzysztofCwalina 

#356 