### PR TITLE
Update sample

### DIFF
--- a/samples/NetCoreSample/CoreApp.sln
+++ b/samples/NetCoreSample/CoreApp.sln
@@ -17,16 +17,14 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{5E37EDEB-4E0A-4599-815E-7D0DEE966FCD}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{5E37EDEB-4E0A-4599-815E-7D0DEE966FCD}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{5E37EDEB-4E0A-4599-815E-7D0DEE966FCD}.Debug|x64.ActiveCfg = Debug|x64
 		{5E37EDEB-4E0A-4599-815E-7D0DEE966FCD}.Debug|x64.Build.0 = Debug|x64
-		{5E37EDEB-4E0A-4599-815E-7D0DEE966FCD}.Debug|x86.ActiveCfg = Debug|x86
-		{5E37EDEB-4E0A-4599-815E-7D0DEE966FCD}.Debug|x86.Build.0 = Debug|x86
-		{5E37EDEB-4E0A-4599-815E-7D0DEE966FCD}.Release|Any CPU.ActiveCfg = Release|x86
+		{5E37EDEB-4E0A-4599-815E-7D0DEE966FCD}.Debug|x86.ActiveCfg = Debug|x64
+		{5E37EDEB-4E0A-4599-815E-7D0DEE966FCD}.Release|Any CPU.ActiveCfg = Release|x64
 		{5E37EDEB-4E0A-4599-815E-7D0DEE966FCD}.Release|x64.ActiveCfg = Release|x64
 		{5E37EDEB-4E0A-4599-815E-7D0DEE966FCD}.Release|x64.Build.0 = Release|x64
-		{5E37EDEB-4E0A-4599-815E-7D0DEE966FCD}.Release|x86.ActiveCfg = Release|x86
-		{5E37EDEB-4E0A-4599-815E-7D0DEE966FCD}.Release|x86.Build.0 = Release|x86
+		{5E37EDEB-4E0A-4599-815E-7D0DEE966FCD}.Release|x86.ActiveCfg = Release|x64
 		{E5ED1D08-3AE9-4C05-8CA4-9E2981A0F9CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E5ED1D08-3AE9-4C05-8CA4-9E2981A0F9CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E5ED1D08-3AE9-4C05-8CA4-9E2981A0F9CF}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/samples/NetCoreSample/CoreApp/CoreApp.csproj
+++ b/samples/NetCoreSample/CoreApp/CoreApp.csproj
@@ -17,33 +17,11 @@
     <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
     <NuGetTargetMoniker>DNXCore,Version=v5.0</NuGetTargetMoniker>
     <BaseNuGetRuntimeIdentifier>win7</BaseNuGetRuntimeIdentifier>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <NoStdLib>true</NoStdLib>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <NoStdLib>true</NoStdLib>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
+    <HostExe>CoreConsole.exe</HostExe>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
+    <OutputPath>bin\x64.Debug.Win</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <NoStdLib>true</NoStdLib>
     <DebugType>full</DebugType>
@@ -54,7 +32,7 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>bin\x64\Release\</OutputPath>
+    <OutputPath>bin\x64.Release.Win</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
     <NoStdLib>true</NoStdLib>
@@ -63,6 +41,60 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Ubuntu_Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64.Debug.Ubuntu</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+    <BaseNuGetRuntimeIdentifier>ubuntu.14.04</BaseNuGetRuntimeIdentifier>
+    <HostExe>coreconsole</HostExe>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Ubuntu_Release|x64'">
+    <OutputPath>bin\x64.Release.ubuntu</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+    <BaseNuGetRuntimeIdentifier>ubuntu.14.04</BaseNuGetRuntimeIdentifier>
+    <HostExe>coreconsole</HostExe>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Osx_Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64.Debug.osx</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+    <BaseNuGetRuntimeIdentifier>osx.10.10</BaseNuGetRuntimeIdentifier>
+    <HostExe>coreconsole</HostExe>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Osx_Release|x64'">
+    <OutputPath>bin\x64.Release.osx</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <NoStdLib>true</NoStdLib>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+    <BaseNuGetRuntimeIdentifier>osx.10.10</BaseNuGetRuntimeIdentifier>
+    <HostExe>coreconsole</HostExe>
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />
@@ -105,6 +137,6 @@
   </PropertyGroup>
   <Target Name="AfterBuild">
     <Move SourceFiles="$(TargetPath)" DestinationFiles="$(TargetDir)\$(AssemblyName).dll" />
-    <Move SourceFiles="$(TargetDir)\CoreConsole.exe" DestinationFiles="$(TargetPath)" />
+    <Move SourceFiles="$(TargetDir)\$(HostExe)" DestinationFiles="$(TargetPath)" />
   </Target>
 </Project>

--- a/samples/NetCoreSample/CoreApp/project.json
+++ b/samples/NetCoreSample/CoreApp/project.json
@@ -1,10 +1,11 @@
 ﻿{
   "dependencies": {
-    "Microsoft.NETCore.Console": "1.0.0-beta-23504"
+    "Microsoft.NETCore.Console": "1.0.0-beta-23511"
   },
   "runtimes": {
-    "win7-x86": { },
-    "win7-x64": { }
+    "win7-x64": { },
+    "ubuntu.14.04-x64": { },
+    "osx.10.10-x64": { }
   },
   "frameworks": {
     "dnxcore50": { }

--- a/samples/NetCoreSample/NetCoreLibrary/project.json
+++ b/samples/NetCoreSample/NetCoreLibrary/project.json
@@ -4,8 +4,8 @@
     "dnxcore50.app": {}
   },
   "dependencies": {
-    "Microsoft.NETCore": "5.0.1-beta-23504",
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.1-beta-23504"
+    "Microsoft.NETCore": "5.0.1-beta-23511",
+    "Microsoft.NETCore.Portable.Compatibility": "1.0.1-beta-23511"
   },
   "frameworks": {
     "dotnet5.4": {


### PR DESCRIPTION
This updates the NetCoreSample to allow targeting ubuntu, osx, and windows. The default is to set to windows still but people can pick another target in the configuration manager.