### PR TITLE
make IsHelpRequested public to enable more configurability

### DIFF
--- a/src/System.CommandLine/src/System/CommandLine/ArgumentSyntax.cs
+++ b/src/System.CommandLine/src/System/CommandLine/ArgumentSyntax.cs
@@ -86,7 +86,7 @@ namespace System.CommandLine
             }
         }
 
-        private bool IsHelpRequested()
+        public bool IsHelpRequested()
         {
             return Parser.GetUnreadOptionNames()
                          .Any(a => string.Equals(a, @"-?", StringComparison.Ordinal) ||


### PR DESCRIPTION
Scenario:
You want to print help on standard output or not fail fast after printing it.

For the failfast issue - the only portable workaround I found so far is Process.GetCurrentProcess().Kill()... that causes the process to exit with -1 although doesn't show dialog.

Other workaround would be https://msdn.microsoft.com/en-us/library/windows/desktop/ms686714%28v=vs.85%29.aspx
Third (win specific): https://msdn.microsoft.com/en-us/library/windows/desktop/ms682658%28v=vs.85%29.aspx