### PR TITLE
fix for Span: using prime number in hashing function

### DIFF
--- a/src/System.Slices/src/System/Span.cs
+++ b/src/System.Slices/src/System/Span.cs
@@ -291,10 +291,10 @@ namespace System
             unchecked
             {
                 var hashCode = Offset.GetHashCode();
-                hashCode = hashCode * 33 + Length;
+                hashCode = hashCode * 31 + Length;
                 if (Object != null)
                 {
-                    hashCode = hashCode * 33 + Object.GetHashCode();
+                    hashCode = hashCode * 31 + Object.GetHashCode();
                 }
                 return hashCode;
             }


### PR DESCRIPTION
In my previous PR I have changed the GetHashCode method. As @GSPP noticed [here](https://github.com/dotnet/corefxlab/pull/455#issuecomment-160470516) I have used the wrong number, 33 instead of 31. 33  is not a prime number, hence the fix.