### PR TITLE
Adding a conditional delegate to option

### DIFF
--- a/src/System.CommandLine/src/System/CommandLine/ArgumentSyntax_Definers.cs
+++ b/src/System.CommandLine/src/System/CommandLine/ArgumentSyntax_Definers.cs
@@ -53,28 +53,37 @@ namespace System.CommandLine
             return DefineOption(name, defaultValue, s_int32Parser);
         }
 
-        public Argument<T> DefineOption<T>(string name, ref T value, Func<string, T> valueConverter, string help)
+        public Argument<T> DefineOption<T>(
+            string name, 
+            ref T value, 
+            Func<string, T> valueConverter, 
+            string help, 
+            Func<T, bool> assignConditional = null)
         {
             var option = DefineOption(name, value, valueConverter);
             option.Help = help;
 
-            value = option.Value;
+            if (assignConditional == null || assignConditional(option.Value))
+            {
+                value = option.Value;
+            }
+            
             return option;
         }
 
-        public Argument<string> DefineOption(string name, ref string value, string help)
+        public Argument<string> DefineOption(string name, ref string value, string help, Func<string, bool> assignConditional = null)
         {
-            return DefineOption(name, ref value, s_stringParser, help);
+            return DefineOption(name, ref value, s_stringParser, help, assignConditional);
         }
 
-        public Argument<bool> DefineOption(string name, ref bool value, string help)
+        public Argument<bool> DefineOption(string name, ref bool value, string help, Func<bool, bool> assignConditional = null)
         {
-            return DefineOption(name, ref value, s_booleanParser, help);
+            return DefineOption(name, ref value, s_booleanParser, help, assignConditional);
         }
 
-        public Argument<int> DefineOption(string name, ref int value, string help)
+        public Argument<int> DefineOption(string name, ref int value, string help, Func<int, bool> assignConditional = null)
         {
-            return DefineOption(name, ref value, s_int32Parser, help);
+            return DefineOption(name, ref value, s_int32Parser, help, assignConditional);
         }
 
         // Option lists

--- a/src/System.CommandLine/src/System/CommandLine/ArgumentSyntax_Definers.cs
+++ b/src/System.CommandLine/src/System/CommandLine/ArgumentSyntax_Definers.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
 
@@ -54,6 +53,40 @@ namespace System.CommandLine
         }
 
         public Argument<T> DefineOption<T>(
+            string name,
+            Action<T> assign,
+            T defaultValue,
+            Func<string, T> valueConverter,
+            string help,
+            Func<T, bool> assignConditional = null)
+        {
+            var option = DefineOption(name, defaultValue, valueConverter);
+            option.Help = help;
+
+            if (assignConditional == null || assignConditional(option.Value))
+            {
+                assign(option.Value);
+            }
+
+            return option;
+        }
+
+        public Argument<string> DefineOption(string name, Action<string> assign, string defaultValue, string help, Func<string, bool> assignConditional = null)
+        {
+            return DefineOption(name, assign, defaultValue, s_stringParser, help, assignConditional);
+        }
+
+        public Argument<bool> DefineOption(string name, Action<bool> assign, bool defaultValue, string help, Func<bool, bool> assignConditional = null)
+        {
+            return DefineOption(name, assign, defaultValue, s_booleanParser, help, assignConditional);
+        }
+
+        public Argument<int> DefineOption(string name, Action<int> assign, int defaultValue, string help, Func<int, bool> assignConditional = null)
+        {
+            return DefineOption(name, assign, defaultValue, s_int32Parser, help, assignConditional);
+        }
+
+        public Argument<T> DefineOption<T>(
             string name, 
             ref T value, 
             Func<string, T> valueConverter, 
@@ -84,7 +117,7 @@ namespace System.CommandLine
         public Argument<int> DefineOption(string name, ref int value, string help, Func<int, bool> assignConditional = null)
         {
             return DefineOption(name, ref value, s_int32Parser, help, assignConditional);
-        }
+        }        
 
         // Option lists
 
@@ -96,6 +129,25 @@ namespace System.CommandLine
         public ArgumentList<int> DefineOptionList(string name, IReadOnlyList<int> defaultValue)
         {
             return DefineOptionList(name, defaultValue, s_int32Parser);
+        }
+
+        public ArgumentList<T> DefineOptionList<T>(string name, Action<IReadOnlyList<T>> assign, Func<string, T> valueConverter, string help)
+        {
+            var optionList = DefineOptionList(name, Array.Empty<T>(), valueConverter);
+            optionList.Help = help;
+
+            assign(optionList.Value);
+            return optionList;
+        }
+
+        public ArgumentList<string> DefineOptionList(string name, Action<IReadOnlyList<string>> assign, string help)
+        {
+            return DefineOptionList(name, assign, s_stringParser, help);
+        }
+
+        public ArgumentList<int> DefineOptionList(string name, Action<IReadOnlyList<int>> assign, string help)
+        {
+            return DefineOptionList(name, assign, s_int32Parser, help);
         }
 
         public ArgumentList<T> DefineOptionList<T>(string name, ref IReadOnlyList<T> value, Func<string, T> valueConverter, string help)
@@ -134,6 +186,30 @@ namespace System.CommandLine
             return DefineParameter(name, defaultValue, s_int32Parser);
         }
 
+        public Argument<T> DefineParameter<T>(string name, Action<T> assign, T defaultValue, Func<string, T> valueConverter, string help)
+        {
+            var parameter = DefineParameter(name, defaultValue, valueConverter);
+            parameter.Help = help;
+
+            assign(parameter.Value);
+            return parameter;
+        }
+
+        public Argument<string> DefineParameter(string name, Action<string> assign, string defaultValue, string help)
+        {
+            return DefineParameter(name, assign, defaultValue, s_stringParser, help);
+        }
+
+        public Argument<bool> DefineParameter(string name, Action<bool> assign, bool defaultValue, string help)
+        {
+            return DefineParameter(name, assign, defaultValue, s_booleanParser, help);
+        }
+
+        public Argument<int> DefineParameter(string name, Action<int> assign, int defaultValue, string help)
+        {
+            return DefineParameter(name, assign, defaultValue, s_int32Parser, help);
+        }
+
         public Argument<T> DefineParameter<T>(string name, ref T value, Func<string, T> valueConverter, string help)
         {
             var parameter = DefineParameter(name, value, valueConverter);
@@ -168,6 +244,25 @@ namespace System.CommandLine
         public ArgumentList<int> DefineParameterList(string name, IReadOnlyList<int> defaultValue)
         {
             return DefineParameterList(name, defaultValue, s_int32Parser);
+        }
+
+        public ArgumentList<T> DefineParameterList<T>(string name, Action<IReadOnlyList<T>> assign, Func<string, T> valueConverter, string help)
+        {
+            var parameterList = DefineParameterList(name, Array.Empty<T>(), valueConverter);
+            parameterList.Help = help;
+
+            assign(parameterList.Value);
+            return parameterList;
+        }
+
+        public ArgumentList<string> DefineParameterList(string name, Action<IReadOnlyList<string>> assign, string help)
+        {
+            return DefineParameterList(name, assign, s_stringParser, help);
+        }
+
+        public ArgumentList<int> DefineParameterList(string name, Action<IReadOnlyList<int>> assign, string help)
+        {
+            return DefineParameterList(name, assign, s_int32Parser, help);
         }
 
         public ArgumentList<T> DefineParameterList<T>(string name, ref IReadOnlyList<T> value, Func<string, T> valueConverter, string help)

--- a/src/System.CommandLine/src/project.lock.json
+++ b/src/System.CommandLine/src/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": true,
+  "locked": false,
   "version": 2,
   "targets": {
     "DNXCore,Version=v5.0": {
@@ -15,7 +15,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Console/4.0.0-rc2-23519": {
+      "System.Console/4.0.0-rc2-23530": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -37,7 +37,7 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-rc2-23519": {
+      "System.Diagnostics.Tools/4.0.1-rc2-23530": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -286,7 +286,7 @@
       }
     },
     "DNXCore,Version=v5.0/win7-x86": {
-      "runtime.win7.System.Console/4.0.0-rc2-23519": {
+      "runtime.win7.System.Console/4.0.0-rc2-23530": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -318,7 +318,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Console/4.0.0-rc2-23519": {
+      "System.Console/4.0.0-rc2-23530": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -340,7 +340,7 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-rc2-23519": {
+      "System.Diagnostics.Tools/4.0.1-rc2-23530": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -589,7 +589,7 @@
       }
     },
     "DNXCore,Version=v5.0/win7-x64": {
-      "runtime.win7.System.Console/4.0.0-rc2-23519": {
+      "runtime.win7.System.Console/4.0.0-rc2-23530": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -621,7 +621,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Console/4.0.0-rc2-23519": {
+      "System.Console/4.0.0-rc2-23530": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -643,7 +643,7 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-rc2-23519": {
+      "System.Diagnostics.Tools/4.0.1-rc2-23530": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -893,14 +893,14 @@
     }
   },
   "libraries": {
-    "runtime.win7.System.Console/4.0.0-rc2-23519": {
+    "runtime.win7.System.Console/4.0.0-rc2-23530": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HdUziKdEDxQxVltxCqy3zBw98bXfL3vv1OjX79dTej2nO6NCAo4t1WgNW2iYH+nH8FgnfaTkcZ3kWmnFiO2FeQ==",
+      "sha512": "sM2Rdl6t86fjWWhCmw9IrCdoS5EtUw4V8m2WUfN52pBOCTfzErdDPtEovA3jkT+X5XnejkxYaK9ncDKTPj8wOA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Console.4.0.0-rc2-23519.nupkg",
-        "runtime.win7.System.Console.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Console.4.0.0-rc2-23530.nupkg",
+        "runtime.win7.System.Console.4.0.0-rc2-23530.nupkg.sha512",
         "runtime.win7.System.Console.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Console.dll",
         "runtimes/win7/lib/net/_._"
@@ -908,7 +908,6 @@
     },
     "System.Collections/4.0.10": {
       "type": "package",
-      "serviceable": true,
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
       "files": [
         "lib/DNXCore50/System.Collections.dll",
@@ -940,10 +939,10 @@
         "System.Collections.nuspec"
       ]
     },
-    "System.Console/4.0.0-rc2-23519": {
+    "System.Console/4.0.0-rc2-23530": {
       "type": "package",
       "serviceable": true,
-      "sha512": "kcV3vk5iNVYL5Bj2cHjeC2ySZIHkARUaPdkkW4Vg93BWmK31p2XjsTMNEsZASthda7gRJF7yrSASjmoYSt7syg==",
+      "sha512": "WB4ELCb9+/h0YnWRsYKlplsHJTHQKt7m/+51w4/91362VNGAZfgdV2m/Jrz9nrVbcnXURFG3BQ2lQfnJ1BsCSw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -967,14 +966,13 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Console.4.0.0-rc2-23519.nupkg",
-        "System.Console.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Console.4.0.0-rc2-23530.nupkg",
+        "System.Console.4.0.0-rc2-23530.nupkg.sha512",
         "System.Console.nuspec"
       ]
     },
     "System.Diagnostics.Debug/4.0.10": {
       "type": "package",
-      "serviceable": true,
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
       "files": [
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
@@ -1006,10 +1004,10 @@
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.Tools/4.0.1-rc2-23519": {
+    "System.Diagnostics.Tools/4.0.1-rc2-23530": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Z7L/VIQCtYt4P/Evv4wmp44D+kyxlcNK8QJByfhBwICCqUZY2CMJf5KXhDoatoHos3ZACOG6a9CywZK99qKVcA==",
+      "sha512": "bhWqZoMoOVayDRdXgOwSE/cJYYfzUcEsi1VNtuMWuB9wzVrfazRuEtTYkF/LBgt7wd6JB427FamfDQeic9dmFA==",
       "files": [
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
         "lib/net45/_._",
@@ -1044,8 +1042,8 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
-        "System.Diagnostics.Tools.4.0.1-rc2-23519.nupkg",
-        "System.Diagnostics.Tools.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Diagnostics.Tools.4.0.1-rc2-23530.nupkg",
+        "System.Diagnostics.Tools.4.0.1-rc2-23530.nupkg.sha512",
         "System.Diagnostics.Tools.nuspec"
       ]
     },
@@ -1099,7 +1097,6 @@
     },
     "System.IO/4.0.10": {
       "type": "package",
-      "serviceable": true,
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
       "files": [
         "lib/DNXCore50/System.IO.dll",
@@ -1133,7 +1130,6 @@
     },
     "System.IO.FileSystem/4.0.0": {
       "type": "package",
-      "serviceable": true,
       "sha512": "eo05SPWfG+54UA0wxgRIYOuOslq+2QrJLXZaJDDsfLXG15OLguaItW39NYZTqUb4DeGOkU4R0wpOLOW4ynMUDQ==",
       "files": [
         "lib/DNXCore50/System.IO.FileSystem.dll",
@@ -1166,7 +1162,6 @@
     },
     "System.IO.FileSystem.Primitives/4.0.0": {
       "type": "package",
-      "serviceable": true,
       "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
       "files": [
         "lib/dotnet/System.IO.FileSystem.Primitives.dll",
@@ -1198,7 +1193,6 @@
     },
     "System.Linq/4.0.0": {
       "type": "package",
-      "serviceable": true,
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
       "files": [
         "lib/dotnet/System.Linq.dll",
@@ -1231,7 +1225,6 @@
     },
     "System.Private.Uri/4.0.0": {
       "type": "package",
-      "serviceable": true,
       "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "files": [
         "lib/DNXCore50/System.Private.Uri.dll",
@@ -1294,7 +1287,6 @@
     },
     "System.Reflection.Primitives/4.0.0": {
       "type": "package",
-      "serviceable": true,
       "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
       "files": [
         "lib/DNXCore50/System.Reflection.Primitives.dll",
@@ -1328,7 +1320,6 @@
     },
     "System.Resources.ResourceManager/4.0.0": {
       "type": "package",
-      "serviceable": true,
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
       "files": [
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
@@ -1362,7 +1353,6 @@
     },
     "System.Runtime/4.0.20": {
       "type": "package",
-      "serviceable": true,
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "files": [
         "lib/DNXCore50/System.Runtime.dll",
@@ -1396,7 +1386,6 @@
     },
     "System.Runtime.Extensions/4.0.10": {
       "type": "package",
-      "serviceable": true,
       "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "files": [
         "lib/DNXCore50/System.Runtime.Extensions.dll",
@@ -1430,7 +1419,6 @@
     },
     "System.Runtime.Handles/4.0.0": {
       "type": "package",
-      "serviceable": true,
       "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
       "files": [
         "lib/DNXCore50/System.Runtime.Handles.dll",
@@ -1464,7 +1452,6 @@
     },
     "System.Runtime.InteropServices/4.0.20": {
       "type": "package",
-      "serviceable": true,
       "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
       "files": [
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
@@ -1564,7 +1551,6 @@
     },
     "System.Threading/4.0.10": {
       "type": "package",
-      "serviceable": true,
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
       "files": [
         "lib/DNXCore50/System.Threading.dll",
@@ -1598,7 +1584,6 @@
     },
     "System.Threading.Overlapped/4.0.0": {
       "type": "package",
-      "serviceable": true,
       "sha512": "X5LuQFhM5FTqaez3eXKJ9CbfSGZ7wj6j4hSVtxct3zmwQXLqG95qoWdvILcgN7xtrDOBIFtpiyDg0vmoI0jE2A==",
       "files": [
         "lib/DNXCore50/System.Threading.Overlapped.dll",
@@ -1623,7 +1608,6 @@
     },
     "System.Threading.Tasks/4.0.10": {
       "type": "package",
-      "serviceable": true,
       "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
       "files": [
         "lib/DNXCore50/System.Threading.Tasks.dll",

--- a/src/System.CommandLine/src/project.lock.json
+++ b/src/System.CommandLine/src/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": false,
+  "locked": true,
   "version": 2,
   "targets": {
     "DNXCore,Version=v5.0": {
@@ -15,7 +15,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Console/4.0.0-rc2-23530": {
+      "System.Console/4.0.0-rc2-23601": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -37,7 +37,7 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-rc2-23530": {
+      "System.Diagnostics.Tools/4.0.1-rc2-23601": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -286,7 +286,7 @@
       }
     },
     "DNXCore,Version=v5.0/win7-x86": {
-      "runtime.win7.System.Console/4.0.0-rc2-23530": {
+      "runtime.win7.System.Console/4.0.0-rc2-23601": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -318,7 +318,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Console/4.0.0-rc2-23530": {
+      "System.Console/4.0.0-rc2-23601": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -340,7 +340,7 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-rc2-23530": {
+      "System.Diagnostics.Tools/4.0.1-rc2-23601": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -589,7 +589,7 @@
       }
     },
     "DNXCore,Version=v5.0/win7-x64": {
-      "runtime.win7.System.Console/4.0.0-rc2-23530": {
+      "runtime.win7.System.Console/4.0.0-rc2-23601": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -621,7 +621,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Console/4.0.0-rc2-23530": {
+      "System.Console/4.0.0-rc2-23601": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -643,7 +643,7 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-rc2-23530": {
+      "System.Diagnostics.Tools/4.0.1-rc2-23601": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -893,14 +893,14 @@
     }
   },
   "libraries": {
-    "runtime.win7.System.Console/4.0.0-rc2-23530": {
+    "runtime.win7.System.Console/4.0.0-rc2-23601": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sM2Rdl6t86fjWWhCmw9IrCdoS5EtUw4V8m2WUfN52pBOCTfzErdDPtEovA3jkT+X5XnejkxYaK9ncDKTPj8wOA==",
+      "sha512": "BP93EhDm764GiGj4GLa4tpI1y8WVRXARtpSkcIoqEqrwTuj/+yb4NcvuGMU8qXVm4PCqNBkg0n4gFIQy0/gvbg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Console.4.0.0-rc2-23530.nupkg",
-        "runtime.win7.System.Console.4.0.0-rc2-23530.nupkg.sha512",
+        "runtime.win7.System.Console.4.0.0-rc2-23601.nupkg",
+        "runtime.win7.System.Console.4.0.0-rc2-23601.nupkg.sha512",
         "runtime.win7.System.Console.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Console.dll",
         "runtimes/win7/lib/net/_._"
@@ -939,10 +939,10 @@
         "System.Collections.nuspec"
       ]
     },
-    "System.Console/4.0.0-rc2-23530": {
+    "System.Console/4.0.0-rc2-23601": {
       "type": "package",
       "serviceable": true,
-      "sha512": "WB4ELCb9+/h0YnWRsYKlplsHJTHQKt7m/+51w4/91362VNGAZfgdV2m/Jrz9nrVbcnXURFG3BQ2lQfnJ1BsCSw==",
+      "sha512": "hDAx1n3VV+89HvapnW+dNQjJteqacKnJDv1uPVeZx/8qhuZcZvg2xsSIuf5F5fc6J6Z+KnXAyTyoeDQgzsgcXQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -966,8 +966,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Console.4.0.0-rc2-23530.nupkg",
-        "System.Console.4.0.0-rc2-23530.nupkg.sha512",
+        "System.Console.4.0.0-rc2-23601.nupkg",
+        "System.Console.4.0.0-rc2-23601.nupkg.sha512",
         "System.Console.nuspec"
       ]
     },
@@ -1004,17 +1004,21 @@
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.Tools/4.0.1-rc2-23530": {
+    "System.Diagnostics.Tools/4.0.1-rc2-23601": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bhWqZoMoOVayDRdXgOwSE/cJYYfzUcEsi1VNtuMWuB9wzVrfazRuEtTYkF/LBgt7wd6JB427FamfDQeic9dmFA==",
+      "sha512": "ca0aZGPFtBDuyOabtDz6WJZl2WiN4imtUmXYDXaxcMP8Uv7Z4Jl5LOW13IXrMzIAFsO8fabw5NsAVN3u8MZ4Vw==",
       "files": [
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
         "lib/net45/_._",
         "lib/netcore50/System.Diagnostics.Tools.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
         "ref/dotnet5.1/de/System.Diagnostics.Tools.xml",
         "ref/dotnet5.1/es/System.Diagnostics.Tools.xml",
         "ref/dotnet5.1/fr/System.Diagnostics.Tools.xml",
@@ -1026,6 +1030,8 @@
         "ref/dotnet5.1/System.Diagnostics.Tools.xml",
         "ref/dotnet5.1/zh-hans/System.Diagnostics.Tools.xml",
         "ref/dotnet5.1/zh-hant/System.Diagnostics.Tools.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
         "ref/net45/_._",
         "ref/netcore50/de/System.Diagnostics.Tools.xml",
         "ref/netcore50/es/System.Diagnostics.Tools.xml",
@@ -1041,9 +1047,11 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
-        "System.Diagnostics.Tools.4.0.1-rc2-23530.nupkg",
-        "System.Diagnostics.Tools.4.0.1-rc2-23530.nupkg.sha512",
+        "System.Diagnostics.Tools.4.0.1-rc2-23601.nupkg",
+        "System.Diagnostics.Tools.4.0.1-rc2-23601.nupkg.sha512",
         "System.Diagnostics.Tools.nuspec"
       ]
     },

--- a/src/System.CommandLine/tests/System/CommandLine/Tests/ArgumentSyntaxTests.cs
+++ b/src/System.CommandLine/tests/System/CommandLine/Tests/ArgumentSyntaxTests.cs
@@ -413,6 +413,171 @@ namespace System.CommandLine.Tests
             Assert.Equal("value 'abc' isn't valid for -o: invalid format", ex.Message);
         }
 
+        [Fact]
+        public void Option_Value_Gets_Assigned_When_No_Conditional_Is_Passed()
+        {
+            const string valueA = "valueA";
+            var optionAValue = "option A";
+
+            Parse($"--option-a {valueA}", syntax =>
+            {
+                syntax.DefineOption("option-a", ref optionAValue, s => s, string.Empty, null);
+            });
+
+            Assert.Equal(valueA, optionAValue);
+        }
+
+        [Fact]
+        public void Option_Value_Does_Not_Get_Assigned_When_The_Conditional_Returns_False()
+        {
+            const string valueA = "valueA";
+            var optionAValue = "option A";
+
+            Parse($"--option-a {valueA}", syntax =>
+            {
+                syntax.DefineOption("option-a", ref optionAValue, s => s, string.Empty, s => false);
+            });
+
+            Assert.Equal("option A", optionAValue);
+        }
+
+        [Fact]
+        public void Option_Value_Gets_Assigned_When_The_Conditional_Returns_True()
+        {
+            const string valueA = "valueA";
+            var optionAValue = "option A";
+
+            Parse($"--option-a {valueA}", syntax =>
+            {
+                syntax.DefineOption("option-a", ref optionAValue, s => s, string.Empty, s => true);
+            });
+
+            Assert.Equal(valueA, optionAValue);
+        }
+
+        [Fact]
+        public void String_Option_Value_Gets_Assigned_When_No_Conditional_Is_Passed()
+        {
+            const string valueA = "valueA";
+            var optionAValue = "option A";
+
+            Parse($"--option-a {valueA}", syntax =>
+            {
+                syntax.DefineOption("option-a", ref optionAValue, string.Empty, null);
+            });
+
+            Assert.Equal(valueA, optionAValue);
+        }
+
+        [Fact]
+        public void String_Option_Value_Does_Not_Get_Assigned_When_The_Conditional_Returns_False()
+        {
+            const string valueA = "valueA";
+            var optionAValue = "option A";
+
+            Parse($"--option-a {valueA}", syntax =>
+            {
+                syntax.DefineOption("option-a", ref optionAValue, string.Empty, s => false);
+            });
+
+            Assert.Equal("option A", optionAValue);
+        }
+
+        [Fact]
+        public void String_Option_Value_Gets_Assigned_When_The_Conditional_Returns_True()
+        {
+            const string valueA = "valueA";
+            var optionAValue = "option A";
+
+            Parse($"--option-a {valueA}", syntax =>
+            {
+                syntax.DefineOption("option-a", ref optionAValue, string.Empty, s => true);
+            });
+
+            Assert.Equal(valueA, optionAValue);
+        }
+
+        [Fact]
+        public void Int_Option_Value_Gets_Assigned_When_No_Conditional_Is_Passed()
+        {
+            const int valueA = 1;
+            var optionAValue = 99;
+
+            Parse($"--option-a {valueA}", syntax =>
+            {
+                syntax.DefineOption("option-a", ref optionAValue, string.Empty, null);
+            });
+
+            Assert.Equal(valueA, optionAValue);
+        }
+
+        [Fact]
+        public void Int_Option_Value_Does_Not_Get_Assigned_When_The_Conditional_Returns_False()
+        {
+            const int valueA = 1;
+            var optionAValue = 99;
+
+            Parse($"--option-a {valueA}", syntax =>
+            {
+                syntax.DefineOption("option-a", ref optionAValue, string.Empty, s => false);
+            });
+
+            Assert.Equal(99, optionAValue);
+        }
+
+        [Fact]
+        public void Int_Option_Value_Gets_Assigned_When_The_Conditional_Returns_True()
+        {
+            const int valueA = 1;
+            var optionAValue = 99;
+
+            Parse($"--option-a {valueA}", syntax =>
+            {
+                syntax.DefineOption("option-a", ref optionAValue, string.Empty, s => true);
+            });
+
+            Assert.Equal(valueA, optionAValue);
+        }
+
+        [Fact]
+        public void Bool_Option_Value_Gets_Assigned_When_No_Conditional_Is_Passed()
+        {
+            var optionAValue = false;
+
+            Parse("--option-a", syntax =>
+            {
+                syntax.DefineOption("option-a", ref optionAValue, string.Empty, null);
+            });
+
+            Assert.True(optionAValue);
+        }
+
+        [Fact]
+        public void Bool_Option_Value_Does_Not_Get_Assigned_When_The_Conditional_Returns_False()
+        {
+            var optionAValue = false;
+
+            Parse("--option-a", syntax =>
+            {
+                syntax.DefineOption("option-a", ref optionAValue, string.Empty, s => false);
+            });
+
+            Assert.False(optionAValue);
+        }
+
+        [Fact]
+        public void Bool_Option_Value_Gets_Assigned_When_The_Conditional_Returns_True()
+        {
+            var optionAValue = false;
+
+            Parse("--option-a", syntax =>
+            {
+                syntax.DefineOption("option-a", ref optionAValue, string.Empty, s => true);
+            });
+
+            Assert.True(optionAValue);
+        }
+
         [Theory]
         [InlineData("-a")]
         [InlineData("-a:")]

--- a/src/System.CommandLine/tests/System/CommandLine/Tests/ArgumentSyntaxTests.cs
+++ b/src/System.CommandLine/tests/System/CommandLine/Tests/ArgumentSyntaxTests.cs
@@ -456,6 +456,89 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
+        public void Option_Value_Gets_Assigned_Through_Delegate_When_No_Conditional_Is_Passed()
+        {
+            const string valueA = "valueA";
+            var optionAValue = "option A";
+
+            Parse($"--option-a {valueA}", syntax =>
+            {
+                syntax.DefineOption("option-a", s => optionAValue = s, null, s => s, string.Empty, null);
+            });
+
+            Assert.Equal(valueA, optionAValue);
+        }
+
+        [Fact]
+        public void Option_Value_Does_Not_Get_Assigned_Through_Delegate_When_The_Conditional_Returns_False()
+        {
+            const string valueA = "valueA";
+            var optionAValue = "option A";
+
+            Parse($"--option-a {valueA}", syntax =>
+            {
+                syntax.DefineOption("option-a", s => optionAValue = s, null, s => s, string.Empty, s => false);
+            });
+
+            Assert.Equal("option A", optionAValue);
+        }
+
+        [Fact]
+        public void Option_Value_Gets_Assigned_Through_Delegate_When_The_Conditional_Returns_True()
+        {
+            const string valueA = "valueA";
+            var optionAValue = "option A";
+
+            Parse($"--option-a {valueA}", syntax =>
+            {
+                syntax.DefineOption("option-a", s => optionAValue = s, null, s => s, string.Empty, s => true);
+            });
+
+            Assert.Equal(valueA, optionAValue);
+        }
+
+        [Fact]
+        public void String_Option_Value_Gets_Assigned_Through_Delegate()
+        {
+            const string valueA = "valueA";
+            var optionAValue = "option A";
+
+            Parse($"--option-a {valueA}", syntax =>
+            {
+                syntax.DefineOption("option-a", s => optionAValue = s, null, string.Empty);
+            });
+
+            Assert.Equal(valueA, optionAValue);
+        }
+
+        [Fact]
+        public void Int_Option_Value_Gets_Assigned_Through_Delegate()
+        {
+            const int valueA = 1;
+            var optionAValue = 99;
+
+            Parse($"--option-a {valueA}", syntax =>
+            {
+                syntax.DefineOption("option-a", s => optionAValue = s, -1, string.Empty);
+            });
+
+            Assert.Equal(valueA, optionAValue);
+        }
+
+        [Fact]
+        public void Bool_Option_Value_Gets_Assigned_Through_Delegate()
+        {
+            var optionAValue = false;
+
+            Parse("--option-a", syntax =>
+            {
+                syntax.DefineOption("option-a", s => optionAValue = s, false, string.Empty);
+            });
+
+            Assert.True(optionAValue);
+        }
+
+        [Fact]
         public void String_Option_Value_Gets_Assigned_When_No_Conditional_Is_Passed()
         {
             const string valueA = "valueA";
@@ -820,6 +903,45 @@ namespace System.CommandLine.Tests
             Assert.True(arg2);
         }
 
+        [Fact]
+        public void Option_List_Gets_Assigned_Through_Delegate()
+        {
+            var arg1 = (IReadOnlyList<double>)Array.Empty<double>();
+
+            Parse("-a 1 -a 2", syntax =>
+            {
+                syntax.DefineOptionList<double>("a", s => arg1 = s, Double.Parse, string.Empty);
+            });
+
+            Assert.Equal(new double[] { 1, 2 }, arg1);
+        }
+
+        [Fact]
+        public void String_Option_List_Gets_Assigned_Through_Delegate()
+        {
+            var arg1 = (IReadOnlyList<string>)Array.Empty<string>();
+
+            Parse("-a x -a y", syntax =>
+            {
+                syntax.DefineOptionList("a", s => arg1 = s, string.Empty);
+            });
+
+            Assert.Equal(new[] { "x", "y" }, arg1);
+        }
+
+        [Fact]
+        public void Int_Option_List_Gets_Assigned_Through_Delegate()
+        {
+            var arg1 = (IReadOnlyList<int>)Array.Empty<int>();
+
+            Parse("-a 1 -a 2", syntax =>
+            {
+                syntax.DefineOptionList("a", s => arg1 = s, string.Empty);
+            });
+
+            Assert.Equal(new[] { 1, 2 }, arg1);
+        }
+
         [Theory]
         [InlineData("")]
         [InlineData(null)]
@@ -899,6 +1021,58 @@ namespace System.CommandLine.Tests
                 Assert.Equal("x", o1);
                 Assert.Equal("y", o2);
             });
+        }
+
+        [Fact]
+        public void Parameter_Definition_Assigned_Through_Delegate()
+        {
+            var o2 = (double)2;
+
+            Parse("1", syntax =>
+            {
+                syntax.DefineParameter<double>("o", s => o2 = s, -1, Double.Parse, string.Empty);
+            });
+
+            Assert.Equal(1, o2);
+        }
+
+        [Fact]
+        public void String_Parameter_Definition_Assigned_Through_Delegate()
+        {
+            var o2 = "o2";
+
+            Parse("y", syntax =>
+            {
+                syntax.DefineParameter("o", s => o2 = s, null, string.Empty);                
+            });
+
+            Assert.Equal("y", o2);
+        }
+
+        [Fact]
+        public void Int_Parameter_Definition_Assigned_Through_Delegate()
+        {
+            var o2 = 2;
+
+            Parse("1", syntax =>
+            {
+                syntax.DefineParameter("o", s => o2 = s, -1, string.Empty);
+            });
+
+            Assert.Equal(1, o2);
+        }
+
+        [Fact]
+        public void Bool_Parameter_Definition_Assigned_Through_Delegate()
+        {
+            var o2 = false;
+
+            Parse("true", syntax =>
+            {
+                syntax.DefineParameter("o", s => o2 = s, false, string.Empty);
+            });
+
+            Assert.True(o2);
         }
 
         [Fact]
@@ -1051,6 +1225,45 @@ namespace System.CommandLine.Tests
             var expected = new[] { "source1.cs", "source2.cs" };
             var actual = sources;
             Assert.Equal(expected.AsEnumerable(), actual);
+        }
+
+        [Fact]
+        public void Parameter_List_Definition_Assigned_Through_Delegate()
+        {
+            var actual = (IReadOnlyList<double>)Array.Empty<double>();
+
+            Parse("1 2", syntax =>
+            {
+                syntax.DefineParameterList<double>("o", s => actual = s, Double.Parse, string.Empty);
+            });
+
+            Assert.Equal(new double[] { 1, 2 }, actual);
+        }
+
+        [Fact]
+        public void String_Parameter_List_Definition_Assigned_Through_Delegate()
+        {
+            var actual = (IReadOnlyList<string>)Array.Empty<string>();
+
+            Parse("source1.cs source2.cs", syntax =>
+            {
+                syntax.DefineParameterList("sources", s => actual = s, string.Empty);
+            });
+
+            Assert.Equal(new[] { "source1.cs", "source2.cs" }, actual);
+        }
+
+        [Fact]
+        public void Int_Parameter_List_Definition_Assigned_Through_Delegate()
+        {
+            var actual = (IReadOnlyList<int>)Array.Empty<int>();
+
+            Parse("1 2", syntax =>
+            {
+                syntax.DefineParameterList("o", s => actual = s, string.Empty);
+            });
+
+            Assert.Equal(new[] { 1, 2 }, actual);
         }
 
         [Fact]


### PR DESCRIPTION
Adding a conditional delegate to option that will only assign the option value to the passed ref param if the conditional delegate returns true or is null. This will allow us to have to use intermediate objects to check which values were set and will prevent us from having to write a bunch of it/elses in the code. If this gets in, I will update the README.