### PR TITLE
Detect and throw for concurrent reads on SpscUnboundedChannel

### DIFF
--- a/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.SpscUnboundedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/src/System/Threading/Tasks/Channels/Channel.SpscUnboundedChannel.cs
@@ -76,6 +76,9 @@ namespace System.Threading.Tasks.Channels
                     if (_doneWriting != null)
                         return Task.FromException<T>(_doneWriting != s_doneWritingSentinel ? _doneWriting : CreateInvalidCompletionException());
 
+                    if (_blockedReader != null)
+                        return Task.FromException<T>(CreateSingleReaderWriterMisuseException());
+
                     Reader<T> reader = Reader<T>.Create(cancellationToken);
                     _blockedReader = reader;
                     return reader.Task;

--- a/src/System.Threading.Tasks.Channels/tests/UnboundedChannelTests.cs
+++ b/src/System.Threading.Tasks.Channels/tests/UnboundedChannelTests.cs
@@ -37,6 +37,15 @@ namespace System.Threading.Tasks.Channels.Tests
         }
 
         [Fact]
+        public async Task MultipleReaders_ThrowsInvalid()
+        {
+            IChannel<int> c = CreateChannel();
+            ValueTask<int> t1 = c.ReadAsync();
+            ValueTask<int> t2 = c.ReadAsync();
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await t2);
+        }
+
+        [Fact]
         public void Stress_TryWrite_TryRead()
         {
             const int NumItems = 3000000;


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefxlab/issues/478