### PR TITLE
Remove debugger break instruction

### DIFF
--- a/src/System.Buffers/src/System/Buffers/ManagedBufferPool.cs
+++ b/src/System.Buffers/src/System/Buffers/ManagedBufferPool.cs
@@ -44,9 +44,6 @@ namespace System.Buffers
             T[] buffer;
             if (size > _maxBufferSize)
             {
-#if DEBUG
-                System.Diagnostics.Debugger.Break();
-#endif
                 buffer = new T[size];
             }
             else


### PR DESCRIPTION
The instruction makes debugging of projects, which relate on System.Buffers, quite inconvenient.