### PR TITLE
Fix dependency on time format of test environment

### DIFF
--- a/src/System.Text.Formatting/tests/CompositeFormattingTests.cs
+++ b/src/System.Text.Formatting/tests/CompositeFormattingTests.cs
@@ -1,13 +1,22 @@
-﻿using System;
-using System.Buffers;
-using System.Text.Formatting;
-using System.IO;
+﻿using System.Buffers;
+using System.Globalization;
 using Xunit;
 
 namespace System.Text.Formatting.Tests
 {
     public class CompositeFormattingTests
     {
+        public CompositeFormattingTests()
+        {
+            var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+
+            culture.DateTimeFormat.LongTimePattern = "hh:mm:ss tt";
+            culture.DateTimeFormat.ShortTimePattern = "hh:mm tt";
+
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
+        }
+
         [Fact]
         public void CompositeFormattingBasics()
         {

--- a/src/System.Text.Formatting/tests/PrimitiveFormattingTests.cs
+++ b/src/System.Text.Formatting/tests/PrimitiveFormattingTests.cs
@@ -12,6 +12,17 @@ namespace System.Text.Formatting.Tests
     {
         ManagedBufferPool<byte> pool = new ManagedBufferPool<byte>(2048);
 
+        public SystemTextFormattingTests()
+        {
+            var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+
+            culture.DateTimeFormat.LongTimePattern = "hh:mm:ss tt";
+            culture.DateTimeFormat.ShortTimePattern = "hh:mm tt";
+
+            CultureInfo.CurrentCulture = culture;
+            CultureInfo.CurrentUICulture = culture;
+        }
+
         private void CheckByte(byte value, string format, string expected)
         {
             var formatter = new StringFormatter(pool);


### PR DESCRIPTION
Tests should rely on invariant culture or its derivative, because they are dependent on test environment customizations and can fail.