### PR TITLE
Add minor improvements for System.Time types

### DIFF
--- a/src/System.Time/src/System/Date.cs
+++ b/src/System.Time/src/System/Date.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Text.RegularExpressions;
@@ -15,8 +14,7 @@ namespace System
     /// Represents a whole date, having a year, month and day component.
     /// All values are in the proleptic Gregorian (ISO 8601) calendar system unless otherwise specified.
     /// </summary>
-    [DebuggerDisplay("{ToString()}")]
-    [XmlSchemaProvider("GetSchema")]
+    [XmlSchemaProvider(nameof(GetSchema))]
     public struct Date : IEquatable<Date>, IComparable<Date>, IComparable, IFormattable, IXmlSerializable
     {
         private const int MinDayNumber = 0;

--- a/src/System.Time/src/System/TimeOfDay.cs
+++ b/src/System.Time/src/System/TimeOfDay.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Text.RegularExpressions;
@@ -15,8 +14,7 @@ namespace System
     /// Represents a time of day, as would be read from a clock, within the range 00:00:00 to 23:59:59.9999999
     /// Has properties for working with both 12-hour and 24-hour time values.
     /// </summary>
-    [DebuggerDisplay("{ToString()}")]
-    [XmlSchemaProvider("GetSchema")]
+    [XmlSchemaProvider(nameof(GetSchema))]
     public struct TimeOfDay : IEquatable<TimeOfDay>, IComparable<TimeOfDay>, IComparable, IFormattable, IXmlSerializable
     {
         private const long TicksPerMillisecond = 10000;

--- a/src/System.Time/src/project.json
+++ b/src/System.Time/src/project.json
@@ -1,7 +1,6 @@
 ﻿{
   "dependencies": {
     "System.Diagnostics.Contracts": "4.0.0-*",
-    "System.Diagnostics.Debug": "4.0.10-*",
     "System.Globalization": "4.0.10",
     "System.Text.RegularExpressions": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10"

--- a/src/System.Time/src/project.lock.json
+++ b/src/System.Time/src/project.lock.json
@@ -1637,7 +1637,6 @@
   "projectFileDependencyGroups": {
     "": [
       "System.Diagnostics.Contracts >= 4.0.0-*",
-      "System.Diagnostics.Debug >= 4.0.10-*",
       "System.Globalization >= 4.0.10",
       "System.Text.RegularExpressions >= 4.0.10",
       "System.Xml.ReaderWriter >= 4.0.10"


### PR DESCRIPTION
1. Remove useless DebuggerDisplay attribute and dependency on System.Diagnostics.Debug package.
2. Use nameof expression to reference method for XmlSchemaProvider atribute.