### PR TITLE
Add methods ToShortString / ToLongString for invariant culture for System.Time types

### DIFF
--- a/src/System.Time/src/System/Date.cs
+++ b/src/System.Time/src/System/Date.cs
@@ -919,7 +919,7 @@ namespace System
         /// </remarks>
         public string ToLongDateStringInvariant()
         {
-            return ToString(CultureInfo.InvariantCulture.DateTimeFormat.LongDatePattern);
+            return ToString(CultureInfo.InvariantCulture.DateTimeFormat.LongDatePattern, CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -951,7 +951,7 @@ namespace System
         /// </remarks>
         public string ToShortDateStringInvariant()
         {
-            return ToString(CultureInfo.InvariantCulture.DateTimeFormat.ShortDatePattern);
+            return ToString(CultureInfo.InvariantCulture.DateTimeFormat.ShortDatePattern, CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/src/System.Time/src/System/Date.cs
+++ b/src/System.Time/src/System/Date.cs
@@ -907,6 +907,22 @@ namespace System
         }
 
         /// <summary>
+        /// Converts the value of the current <see cref="Date"/> object to its equivalent long date string
+        /// representation.
+        /// </summary>
+        /// <returns>
+        /// A string that contains the long date string representation of the current <see cref="Date"/> object.
+        /// </returns>
+        /// <remarks>
+        /// The value of the current <see cref="Date"/> object is formatted using the pattern defined by the
+        /// <see cref="DateTimeFormatInfo.LongDatePattern" /> property associated with the invariant culture.
+        /// </remarks>
+        public string ToLongDateStringInvariant()
+        {
+            return ToString(CultureInfo.InvariantCulture.DateTimeFormat.LongDatePattern);
+        }
+
+        /// <summary>
         /// Converts the value of the current <see cref="Date"/> object to its equivalent short date string
         /// representation.
         /// </summary>
@@ -920,6 +936,22 @@ namespace System
         public string ToShortDateString()
         {
             return ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="Date"/> object to its equivalent short date string
+        /// representation.
+        /// </summary>
+        /// <returns>
+        /// A string that contains the short date string representation of the current <see cref="Date"/> object.
+        /// </returns>
+        /// <remarks>
+        /// The value of the current <see cref="Date"/> object is formatted using the pattern defined by the
+        /// <see cref="DateTimeFormatInfo.ShortDatePattern" /> property associated with the invariant culture.
+        /// </remarks>
+        public string ToShortDateStringInvariant()
+        {
+            return ToString(CultureInfo.InvariantCulture.DateTimeFormat.ShortDatePattern);
         }
 
         /// <summary>

--- a/src/System.Time/src/System/DateTimeExtensions.cs
+++ b/src/System.Time/src/System/DateTimeExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
+
 namespace System
 {
     /// <summary>
@@ -154,6 +156,70 @@ namespace System
 
             var result = operation.Invoke(dateTime);
             return resolver.Invoke(result, timeZone);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="DateTime"/> object to its equivalent long date string
+        /// representation.
+        /// </summary>
+        /// <param name="dateTime">The <see cref="DateTime"/> instance.</param>
+        /// <returns>
+        /// A string that contains the long date string representation of the current <see cref="DateTime"/> object.
+        /// </returns>
+        /// <remarks>
+        /// The value of the current <see cref="DateTime"/> object is formatted using the pattern defined by the
+        /// <see cref="DateTimeFormatInfo.LongDatePattern" /> property associated with the invariant culture.
+        /// </remarks>
+        public static string ToLongDateStringInvariant(this DateTime dateTime)
+        {
+            return dateTime.ToString(CultureInfo.InvariantCulture.DateTimeFormat.LongDatePattern, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="DateTime"/> object to its equivalent short date string
+        /// representation.
+        /// </summary>
+        /// <param name="dateTime">The <see cref="DateTime"/> instance.</param>
+        /// <returns>
+        /// A string that contains the short date string representation of the current <see cref="DateTime"/> object.
+        /// </returns>
+        /// <remarks>
+        /// The value of the current <see cref="DateTime"/> object is formatted using the pattern defined by the
+        /// <see cref="DateTimeFormatInfo.ShortDatePattern" /> property associated with the invariant culture.
+        /// </remarks>
+        public static string ToShortDateStringInvariant(this DateTime dateTime)
+        {
+            return dateTime.ToString(CultureInfo.InvariantCulture.DateTimeFormat.ShortDatePattern, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="DateTime"/> object to its equivalent
+        /// long time string representation.
+        /// </summary>
+        /// <param name="dateTime">The <see cref="DateTime"/> instance.</param>
+        /// <returns>A string that contains the long time string representation of the
+        /// current <see cref="DateTime"/> object.</returns>
+        /// <remarks>The value of the current <see cref="DateTime"/> object is formatted
+        /// using the pattern defined by the <see cref="DateTimeFormatInfo.LongTimePattern" />
+        /// property associated with the invariant culture.</remarks>
+        public static string ToLongTimeStringInvariant(this DateTime dateTime)
+        {
+            return dateTime.ToString(CultureInfo.InvariantCulture.DateTimeFormat.LongTimePattern, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="DateTime"/> object to its equivalent
+        /// short time string representation.
+        /// </summary>
+        /// <param name="dateTime">The <see cref="DateTime"/> instance.</param>
+        /// <returns>A string that contains the short time string representation of the
+        /// current <see cref="DateTime"/> object.</returns>
+        /// <remarks>The value of the current <see cref="DateTime"/> object is formatted
+        /// using the pattern defined by the <see cref="DateTimeFormatInfo.ShortTimePattern" />
+        /// property associated with the invariant culture.</remarks>
+        public static string ToShortTimeStringInvariant(this DateTime dateTime)
+        {
+            return dateTime.ToString(CultureInfo.InvariantCulture.DateTimeFormat.ShortTimePattern, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/System.Time/src/System/DateTimeOffsetExtensions.cs
+++ b/src/System.Time/src/System/DateTimeOffsetExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Globalization;
+
 namespace System
 {
     /// <summary>
@@ -115,6 +117,132 @@ namespace System
             var dto = TimeZoneInfo.ConvertTime(dateTimeOffset, timeZone);
             var dt = operation.Invoke(dto.DateTime);
             return resolver.Invoke(dt, timeZone);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="DateTimeOffset"/> object to its equivalent long date string
+        /// representation.
+        /// </summary>
+        /// <param name="dateTimeOffset">The <see cref="DateTimeOffset"/> instance.</param>
+        /// <returns>
+        /// A string that contains the long date string representation of the current <see cref="DateTimeOffset"/> object.
+        /// </returns>
+        /// <remarks>
+        /// The value of the current <see cref="DateTimeOffset"/> object is formatted using the pattern defined by the
+        /// <see cref="DateTimeFormatInfo.LongDatePattern" /> property associated with the current thread culture.
+        /// </remarks>
+        public static string ToLongDateString(this DateTimeOffset dateTimeOffset)
+        {
+            return dateTimeOffset.ToString(CultureInfo.CurrentCulture.DateTimeFormat.LongDatePattern);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="DateTimeOffset"/> object to its equivalent long date string
+        /// representation.
+        /// </summary>
+        /// <param name="dateTimeOffset">The <see cref="DateTimeOffset"/> instance.</param>
+        /// <returns>
+        /// A string that contains the long date string representation of the current <see cref="DateTimeOffset"/> object.
+        /// </returns>
+        /// <remarks>
+        /// The value of the current <see cref="DateTimeOffset"/> object is formatted using the pattern defined by the
+        /// <see cref="DateTimeFormatInfo.LongDatePattern" /> property associated with the invariant culture.
+        /// </remarks>
+        public static string ToLongDateStringInvariant(this DateTimeOffset dateTimeOffset)
+        {
+            return dateTimeOffset.ToString(CultureInfo.InvariantCulture.DateTimeFormat.LongDatePattern, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="DateTimeOffset"/> object to its equivalent short date string
+        /// representation.
+        /// </summary>
+        /// <param name="dateTimeOffset">The <see cref="DateTimeOffset"/> instance.</param>
+        /// <returns>
+        /// A string that contains the short date string representation of the current <see cref="DateTimeOffset"/> object.
+        /// </returns>
+        /// <remarks>
+        /// The value of the current <see cref="DateTimeOffset"/> object is formatted using the pattern defined by the
+        /// <see cref="DateTimeFormatInfo.ShortDatePattern" /> property associated with the current thread culture.
+        /// </remarks>
+        public static string ToShortDateString(this DateTimeOffset dateTimeOffset)
+        {
+            return dateTimeOffset.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="DateTimeOffset"/> object to its equivalent short date string
+        /// representation.
+        /// </summary>
+        /// <param name="dateTimeOffset">The <see cref="DateTimeOffset"/> instance.</param>
+        /// <returns>
+        /// A string that contains the short date string representation of the current <see cref="DateTimeOffset"/> object.
+        /// </returns>
+        /// <remarks>
+        /// The value of the current <see cref="DateTimeOffset"/> object is formatted using the pattern defined by the
+        /// <see cref="DateTimeFormatInfo.ShortDatePattern" /> property associated with the invariant culture.
+        /// </remarks>
+        public static string ToShortDateStringInvariant(this DateTimeOffset dateTimeOffset)
+        {
+            return dateTimeOffset.ToString(CultureInfo.InvariantCulture.DateTimeFormat.ShortDatePattern, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="DateTimeOffset"/> object to its equivalent
+        /// long time string representation.
+        /// </summary>
+        /// <returns>A string that contains the long time string representation of the
+        /// current <see cref="DateTimeOffset"/> object.</returns>
+        /// <remarks>The value of the current <see cref="DateTimeOffset"/> object is formatted
+        /// using the pattern defined by the <see cref="DateTimeFormatInfo.LongTimePattern" />
+        /// property associated with the current thread culture.</remarks>
+        public static string ToLongTimeString(this DateTimeOffset dateTimeOffset)
+        {
+            return dateTimeOffset.ToString(CultureInfo.CurrentCulture.DateTimeFormat.LongTimePattern);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="DateTimeOffset"/> object to its equivalent
+        /// long time string representation.
+        /// </summary>
+        /// <param name="dateTimeOffset">The <see cref="DateTimeOffset"/> instance.</param>
+        /// <returns>A string that contains the long time string representation of the
+        /// current <see cref="DateTimeOffset"/> object.</returns>
+        /// <remarks>The value of the current <see cref="DateTimeOffset"/> object is formatted
+        /// using the pattern defined by the <see cref="DateTimeFormatInfo.LongTimePattern" />
+        /// property associated with the invariant culture.</remarks>
+        public static string ToLongTimeStringInvariant(this DateTimeOffset dateTimeOffset)
+        {
+            return dateTimeOffset.ToString(CultureInfo.InvariantCulture.DateTimeFormat.LongTimePattern, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="DateTimeOffset"/> object to its equivalent
+        /// short time string representation.
+        /// </summary>
+        /// <returns>A string that contains the short time string representation of the
+        /// current <see cref="DateTimeOffset"/> object.</returns>
+        /// <remarks>The value of the current <see cref="DateTimeOffset"/> object is formatted
+        /// using the pattern defined by the <see cref="DateTimeFormatInfo.ShortTimePattern" />
+        /// property associated with the current thread culture.</remarks>
+        public static string ToShortTimeString(this DateTimeOffset dateTimeOffset)
+        {
+            return dateTimeOffset.ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="DateTimeOffset"/> object to its equivalent
+        /// short time string representation.
+        /// </summary>
+        /// <param name="dateTimeOffset">The <see cref="DateTimeOffset"/> instance.</param>
+        /// <returns>A string that contains the short time string representation of the
+        /// current <see cref="DateTimeOffset"/> object.</returns>
+        /// <remarks>The value of the current <see cref="DateTimeOffset"/> object is formatted
+        /// using the pattern defined by the <see cref="DateTimeFormatInfo.ShortTimePattern" />
+        /// property associated with the invariant culture.</remarks>
+        public static string ToShortTimeStringInvariant(this DateTimeOffset dateTimeOffset)
+        {
+            return dateTimeOffset.ToString(CultureInfo.InvariantCulture.DateTimeFormat.ShortTimePattern, CultureInfo.InvariantCulture);
         }
     }
 }

--- a/src/System.Time/src/System/TimeOfDay.cs
+++ b/src/System.Time/src/System/TimeOfDay.cs
@@ -1014,7 +1014,7 @@ namespace System
         /// property associated with the invariant culture.</remarks>
         public string ToLongTimeStringInvariant()
         {
-            return ToString(CultureInfo.InvariantCulture.DateTimeFormat.LongTimePattern);
+            return ToString(CultureInfo.InvariantCulture.DateTimeFormat.LongTimePattern, CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -1042,7 +1042,7 @@ namespace System
         /// property associated with the invariant culture.</remarks>
         public string ToShortTimeStringInvariant()
         {
-            return ToString(CultureInfo.InvariantCulture.DateTimeFormat.ShortTimePattern);
+            return ToString(CultureInfo.InvariantCulture.DateTimeFormat.ShortTimePattern, CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/src/System.Time/src/System/TimeOfDay.cs
+++ b/src/System.Time/src/System/TimeOfDay.cs
@@ -1005,6 +1005,20 @@ namespace System
 
         /// <summary>
         /// Converts the value of the current <see cref="TimeOfDay"/> object to its equivalent
+        /// long time string representation.
+        /// </summary>
+        /// <returns>A string that contains the long time string representation of the
+        /// current <see cref="TimeOfDay"/> object.</returns>
+        /// <remarks>The value of the current <see cref="TimeOfDay"/> object is formatted
+        /// using the pattern defined by the <see cref="DateTimeFormatInfo.LongTimePattern" />
+        /// property associated with the invariant culture.</remarks>
+        public string ToLongTimeStringInvariant()
+        {
+            return ToString(CultureInfo.InvariantCulture.DateTimeFormat.LongTimePattern);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="TimeOfDay"/> object to its equivalent
         /// short time string representation.
         /// </summary>
         /// <returns>A string that contains the short time string representation of the
@@ -1015,6 +1029,20 @@ namespace System
         public string ToShortTimeString()
         {
             return ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="TimeOfDay"/> object to its equivalent
+        /// short time string representation.
+        /// </summary>
+        /// <returns>A string that contains the short time string representation of the
+        /// current <see cref="TimeOfDay"/> object.</returns>
+        /// <remarks>The value of the current <see cref="TimeOfDay"/> object is formatted
+        /// using the pattern defined by the <see cref="DateTimeFormatInfo.ShortTimePattern" />
+        /// property associated with the invariant culture.</remarks>
+        public string ToShortTimeStringInvariant()
+        {
+            return ToString(CultureInfo.InvariantCulture.DateTimeFormat.ShortTimePattern);
         }
 
         /// <summary>

--- a/src/System.Time/tests/DateFormattingTests.cs
+++ b/src/System.Time/tests/DateFormattingTests.cs
@@ -23,10 +23,26 @@ namespace System.Time.Tests
         }
 
         [Fact]
+        public void ToLongDateStringInvariant()
+        {
+            var date = new Date(2000, 12, 31);
+            var s = date.ToLongDateStringInvariant();
+            Assert.Equal("Sunday, 31 December 2000", s);
+        }
+
+        [Fact]
         public void ToShortDateString()
         {
             var date = new Date(2000, 12, 31);
             var s = date.ToShortDateString();
+            Assert.Equal("12/31/2000", s);
+        }
+
+        [Fact]
+        public void ToShortDateStringInvariant()
+        {
+            var date = new Date(2000, 12, 31);
+            var s = date.ToShortDateStringInvariant();
             Assert.Equal("12/31/2000", s);
         }
 

--- a/src/System.Time/tests/TimeOfDayFormattingTests.cs
+++ b/src/System.Time/tests/TimeOfDayFormattingTests.cs
@@ -15,7 +15,7 @@ namespace System.Time.Tests
         }
 
         [Fact]
-        public void ToLongDateString()
+        public void ToLongTimeString()
         {
             var time = new TimeOfDay(10, 49, 12, Meridiem.PM);
             var s = time.ToLongTimeString();
@@ -23,10 +23,26 @@ namespace System.Time.Tests
         }
 
         [Fact]
-        public void ToShortDateString()
+        public void ToLongTimeStringInvariant()
+        {
+            var time = new TimeOfDay(10, 49, 12, Meridiem.PM);
+            var s = time.ToLongTimeStringInvariant();
+            Assert.Equal("22:49:12", s);
+        }
+
+        [Fact]
+        public void ToShortTimeString()
         {
             var time = new TimeOfDay(22, 49);
             var s = time.ToShortTimeString();
+            Assert.Equal("22:49", s);
+        }
+
+        [Fact]
+        public void ToShortTimeStringInvariant()
+        {
+            var time = new TimeOfDay(22, 49);
+            var s = time.ToShortTimeStringInvariant();
             Assert.Equal("22:49", s);
         }
 


### PR DESCRIPTION
System.DateTime type doesn't have such methods, but it will more convenient if System.Date and System.TimeOfDay types will have ToShortString / ToLongString methods for invariant culture.