### PR TITLE
Improve extension methods names for DateTime type in System.Time

### DIFF
--- a/src/System.Time/src/System/DateTimeExtensions.cs
+++ b/src/System.Time/src/System/DateTimeExtensions.cs
@@ -14,7 +14,7 @@ namespace System
         /// </summary>
         /// <param name="dateTime">The <see cref="DateTime"/> instance.</param>
         /// <returns>The <see cref="Date"/> value.</returns>
-        public static Date Date(this DateTime dateTime)
+        public static Date GetDate(this DateTime dateTime)
         {
             return new Date((int) (dateTime.Ticks / TimeSpan.TicksPerDay));
         }
@@ -25,7 +25,7 @@ namespace System
         /// </summary>
         /// <param name="dateTime">The <see cref="DateTime"/> instance.</param>
         /// <returns>The <see cref="TimeOfDay"/> value.</returns>
-        public static TimeOfDay TimeOfDay(this DateTime dateTime)
+        public static TimeOfDay GetTimeOfDay(this DateTime dateTime)
         {
             return new TimeOfDay(dateTime.TimeOfDay.Ticks);
         }

--- a/src/System.Time/src/System/DateTimeOffsetExtensions.cs
+++ b/src/System.Time/src/System/DateTimeOffsetExtensions.cs
@@ -14,7 +14,7 @@ namespace System
         /// </summary>
         /// <param name="dateTimeOffset">The <see cref="DateTimeOffset"/> instance.</param>
         /// <returns>The <see cref="Date"/> value.</returns>
-        public static Date Date(this DateTimeOffset dateTimeOffset)
+        public static Date GetDate(this DateTimeOffset dateTimeOffset)
         {
             return new Date((int)(dateTimeOffset.DateTime.Ticks / TimeSpan.TicksPerDay));
         }
@@ -25,7 +25,7 @@ namespace System
         /// </summary>
         /// <param name="dateTimeOffset">The <see cref="DateTimeOffset"/> instance.</param>
         /// <returns>The <see cref="TimeOfDay"/> value.</returns>
-        public static TimeOfDay TimeOfDay(this DateTimeOffset dateTimeOffset)
+        public static TimeOfDay GetTimeOfDay(this DateTimeOffset dateTimeOffset)
         {
             return new TimeOfDay(dateTimeOffset.TimeOfDay.Ticks);
         }


### PR DESCRIPTION
Extension methods names for System.DateTime type, which returns System.Date and System.TimeOfDay types should start with "Get" (or, probably, "To") prefix to highlight that this is an extension method and not a native property. Moreover, Date() extension method name is very similar to Date property name.