### PR TITLE
Slices: Reduce size of code generated for Contract methods.

### DIFF
--- a/src/System.Slices/src/System/Contract.cs
+++ b/src/System.Slices/src/System/Contract.cs
@@ -11,7 +11,7 @@ namespace System
         {
             if (!condition)
             {
-                throw new ArgumentException();
+                throw NewArgumentException();
             }
         }
 
@@ -19,35 +19,38 @@ namespace System
         {
             if (n < 0)
             {
-                throw new ArgumentOutOfRangeException();
+                throw NewArgumentOutOfRangeException();
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void RequiresInRange(int start, int length)
         {
-            if (!(start >= 0 && start < length))
+            if ((uint)start >= (uint)length)
             {
-                throw new ArgumentOutOfRangeException();
+                throw NewArgumentOutOfRangeException();
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void RequiresInInclusiveRange(int start, int length)
         {
-            if (!(start >= 0 && start <= length))
+            if ((uint)start > (uint)length)
             {
-                throw new ArgumentOutOfRangeException();
+                throw NewArgumentOutOfRangeException();
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void RequiresInInclusiveRange(int start, int end, int length)
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Exception NewArgumentException()
         {
-            if (!(start >= 0 && start <= end && end >= 0 && end <= length))
-            {
-                throw new ArgumentOutOfRangeException();
-            }
+            return new ArgumentException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Exception NewArgumentOutOfRangeException()
+        {
+            return new ArgumentOutOfRangeException();
         }
     }
 }


### PR DESCRIPTION
Issue: https://github.com/dotnet/corefxlab/issues/510 

Two changes reduce size of machine code generated in **each** call site of Span's indexer by 27 bytes and eliminates one comparison and branch:
1. The trick used by array bounds checking
2. Wrapping creation of exception instance in a separate non-inlinable method.

Here is an example:
```C#
[MethodImpl(MethodImplOptions.NoInlining)]
public static long TestSpan(Span<long> span, int index)
{
    return span[index];
}
```
Before:
```asm
00007FF81D260C70  push        rsi  
00007FF81D260C71  sub         rsp,20h  
00007FF81D260C75  mov         eax,dword ptr [rcx+10h]  
00007FF81D260C78  test        edx,edx  
00007FF81D260C7A  jl          00007FF81D260C9A  
00007FF81D260C7C  cmp         edx,eax  
00007FF81D260C7E  jge         00007FF81D260C9A  
00007FF81D260C80  mov         rax,qword ptr [rcx]  
00007FF81D260C83  mov         rcx,qword ptr [rcx+8]  
00007FF81D260C87  shl         edx,3  
00007FF81D260C8A  movsxd      rdx,edx  
00007FF81D260C8D  add         rcx,rdx  
00007FF81D260C90  mov         rax,qword ptr [rax+rcx]  
00007FF81D260C94  add         rsp,20h  
00007FF81D260C98  pop         rsi  
00007FF81D260C99  ret  
00007FF81D260C9A  mov         rcx,7FF85F62C658h  
00007FF81D260CA4  call        00007FF87C8D4BB0  
00007FF81D260CA9  mov         rsi,rax  
00007FF81D260CAC  mov         rcx,rsi  
00007FF81D260CAF  call        00007FF85FC4DB90  
00007FF81D260CB4  mov         rcx,rsi  
00007FF81D260CB7  call        00007FF87CA035F0  
00007FF81D260CBC  int         3 
```
After the change:
```asm
00007FF81D280C70  sub         rsp,28h  
00007FF81D280C74  mov         eax,dword ptr [rcx+10h]  
00007FF81D280C77  cmp         edx,eax  
00007FF81D280C79  jae         00007FF81D280C94  
00007FF81D280C7B  mov         rax,qword ptr [rcx]  
00007FF81D280C7E  mov         rcx,qword ptr [rcx+8]  
00007FF81D280C82  shl         edx,3  
00007FF81D280C85  movsxd      rdx,edx  
00007FF81D280C88  add         rdx,rcx  
00007FF81D280C8B  mov         rax,qword ptr [rax+rdx]  
00007FF81D280C8F  add         rsp,28h  
00007FF81D280C93  ret  
00007FF81D280C94  call        00007FF81D280780  
00007FF81D280C99  mov         rcx,rax  
00007FF81D280C9C  call        00007FF87CA035F0  
00007FF81D280CA1  int         3  
```