### PR TITLE
Update SpanExtensions.cs

### DIFF
--- a/src/System.Slices/src/System/SpanExtensions.cs
+++ b/src/System.Slices/src/System/SpanExtensions.cs
@@ -243,7 +243,7 @@ namespace System
                 return false;
             }
 
-            int j = str.Length - value.Length - 1;
+            int j = str.Length - value.Length;
             foreach (var c in value)
             {
                 if (str[j] != c)


### PR DESCRIPTION
it appears that there is an errornous -1 on the j index, as a foreach loop is used (no <=) this seems to be wrong.

e.g. if we have a needle of "abc" and a haystack of "test.abc" then "test.abc".Length - "abc".Length -1 will equal 4, which would place the start of the search at '.' as opposed to 'a'
 patch-2 (#8) https://github.com/xenocons/slice.net/commit/f5d1a01b1ae44c55734b7f965f7bdcff12401bc5