### PR TITLE
Support for optional option arguments in System.CommandLine

### DIFF
--- a/src/System.CommandLine/README.md
+++ b/src/System.CommandLine/README.md
@@ -241,6 +241,25 @@ specified. However you can still explicitly pass in `true` or `false`. So this
 Is equivalent to
 
     $ tool -x:true
+    
+Normally, options must supply an argument value (or it's considered an error). However, there may be times when you want to allow a particular option whether it supplies a value or not. To do this, use the overloaded `DefineOption()` methods:
+
+```C#
+int port = 1234;
+var option = syntax.DefineOption("s|server", ref port, false,
+    "Start the server, optionally specifying a port");
+```
+
+Then the value in code will be set regardless of whether the command line option specifies one and an error will not be thrown if the option value is omitted. You can check for whether the option was specified at all by checking the `Argument.IsSpecified` flag. For example, given the above option definition:
+
+    $ tool
+    # port = 1234, option.IsSpecified = false
+    
+    $ tool --server
+    # port = 1234, option.IsSpecified = true
+    
+    $ tool --server 9876
+    # port = 9876, option.IsSpecified = true
 
 The syntax used to define the option supports multiple names by separating them
 using a pipe. All names are aliases for the same option. For diagnostic

--- a/src/System.CommandLine/System/CommandLine/Argument.cs
+++ b/src/System.CommandLine/System/CommandLine/Argument.cs
@@ -9,13 +9,14 @@ namespace System.CommandLine
 {
     public abstract class Argument
     {
-        internal Argument(ArgumentCommand command, IEnumerable<string> names, bool isOption)
+        internal Argument(ArgumentCommand command, IEnumerable<string> names, bool isOption, bool isRequired)
         {
             var nameArray = names.ToArray();
             Command = command;
             Name = nameArray.First();
             Names = new ReadOnlyCollection<string>(nameArray);
             IsOption = isOption;
+            IsRequired = isRequired;
         }
 
         public ArgumentCommand Command { get; private set; }
@@ -37,6 +38,8 @@ namespace System.CommandLine
 
         public bool IsHidden { get; set; }
 
+        public bool IsRequired { get; private set; }
+        
         public virtual bool IsList
         {
             get { return false; }

--- a/src/System.CommandLine/System/CommandLine/ArgumentList_1.cs
+++ b/src/System.CommandLine/System/CommandLine/ArgumentList_1.cs
@@ -8,15 +8,15 @@ namespace System.CommandLine
 {
     public sealed class ArgumentList<T> : Argument
     {
-        internal ArgumentList(ArgumentCommand command, IEnumerable<string> names, IReadOnlyList<T> defaultValue)
-            : base(command, names, true)
+        internal ArgumentList(ArgumentCommand command, IEnumerable<string> names, IReadOnlyList<T> defaultValue, bool isRequired)
+            : base(command, names, true, isRequired)
         {
             Value = defaultValue;
             DefaultValue = defaultValue;
         }
 
         internal ArgumentList(ArgumentCommand command, string name, IReadOnlyList<T> defaultValue)
-            : base(command, new[] { name }, false)
+            : base(command, new[] { name }, false, true)
         {
             Value = defaultValue;
             DefaultValue = defaultValue;

--- a/src/System.CommandLine/System/CommandLine/ArgumentSyntax_Definers.cs
+++ b/src/System.CommandLine/System/CommandLine/ArgumentSyntax_Definers.cs
@@ -53,9 +53,34 @@ namespace System.CommandLine
             return DefineOption(name, defaultValue, s_int32Parser);
         }
 
+        public Argument<string> DefineOption(string name, string defaultValue, bool requireValue)
+        {
+            return DefineOption(name, defaultValue, s_stringParser, requireValue);
+        }
+
+        public Argument<bool> DefineOption(string name, bool defaultValue, bool requireValue)
+        {
+            return DefineOption(name, defaultValue, s_booleanParser, requireValue);
+        }
+
+        public Argument<int> DefineOption(string name, int defaultValue, bool requireValue)
+        {
+            return DefineOption(name, defaultValue, s_int32Parser, requireValue);
+        }
+
+        public Argument<T> DefineOption<T>(string name, T defaultValue, Func<string, T> valueConverter)
+        {
+            return DefineOption(name, defaultValue, valueConverter, true);
+        }
+
         public Argument<T> DefineOption<T>(string name, ref T value, Func<string, T> valueConverter, string help)
         {
-            var option = DefineOption(name, value, valueConverter);
+            return DefineOption(name, ref value, valueConverter, true, help);
+        }
+
+        public Argument<T> DefineOption<T>(string name, ref T value, Func<string, T> valueConverter, bool requireValue, string help)
+        {
+            var option = DefineOption(name, value, valueConverter, requireValue);
             option.Help = help;
 
             value = option.Value;
@@ -77,6 +102,21 @@ namespace System.CommandLine
             return DefineOption(name, ref value, s_int32Parser, help);
         }
 
+        public Argument<string> DefineOption(string name, ref string value, bool requireValue, string help)
+        {
+            return DefineOption(name, ref value, s_stringParser, requireValue, help);
+        }
+
+        public Argument<bool> DefineOption(string name, ref bool value, bool requireValue, string help)
+        {
+            return DefineOption(name, ref value, s_booleanParser, requireValue, help);
+        }
+
+        public Argument<int> DefineOption(string name, ref int value, bool requireValue, string help)
+        {
+            return DefineOption(name, ref value, s_int32Parser, requireValue, help);
+        }
+
         // Option lists
 
         public ArgumentList<string> DefineOptionList(string name, IReadOnlyList<string> defaultValue)
@@ -89,9 +129,29 @@ namespace System.CommandLine
             return DefineOptionList(name, defaultValue, s_int32Parser);
         }
 
+        public ArgumentList<string> DefineOptionList(string name, IReadOnlyList<string> defaultValue, bool requireValue)
+        {
+            return DefineOptionList(name, defaultValue, s_stringParser, requireValue);
+        }
+
+        public ArgumentList<int> DefineOptionList(string name, IReadOnlyList<int> defaultValue, bool requireValue)
+        {
+            return DefineOptionList(name, defaultValue, s_int32Parser, requireValue);
+        }
+
+        public ArgumentList<T> DefineOptionList<T>(string name, IReadOnlyList<T> defaultValue, Func<string, T> valueConverter)
+        {
+            return DefineOptionList(name, defaultValue, valueConverter, true);
+        }
+
         public ArgumentList<T> DefineOptionList<T>(string name, ref IReadOnlyList<T> value, Func<string, T> valueConverter, string help)
         {
-            var optionList = DefineOptionList(name, value, valueConverter);
+            return DefineOptionList(name, ref value, valueConverter, true, help);
+        }
+
+        public ArgumentList<T> DefineOptionList<T>(string name, ref IReadOnlyList<T> value, Func<string, T> valueConverter, bool requireValue, string help)
+        {
+            var optionList = DefineOptionList(name, value, valueConverter, requireValue);
             optionList.Help = help;
 
             value = optionList.Value;
@@ -106,6 +166,16 @@ namespace System.CommandLine
         public ArgumentList<int> DefineOptionList(string name, ref IReadOnlyList<int> value, string help)
         {
             return DefineOptionList(name, ref value, s_int32Parser, help);
+        }
+
+        public ArgumentList<string> DefineOptionList(string name, ref IReadOnlyList<string> value, bool requireValue, string help)
+        {
+            return DefineOptionList(name, ref value, s_stringParser, requireValue, help);
+        }
+
+        public ArgumentList<int> DefineOptionList(string name, ref IReadOnlyList<int> value, bool requireValue, string help)
+        {
+            return DefineOptionList(name, ref value, s_int32Parser, requireValue, help);
         }
 
         // Parameters

--- a/src/System.CommandLine/System/CommandLine/Argument_1.cs
+++ b/src/System.CommandLine/System/CommandLine/Argument_1.cs
@@ -8,15 +8,15 @@ namespace System.CommandLine
 {
     public sealed class Argument<T> : Argument
     {
-        internal Argument(ArgumentCommand command, IEnumerable<string> names, T defaultValue)
-            : base(command, names, true)
+        internal Argument(ArgumentCommand command, IEnumerable<string> names, T defaultValue, bool isRequired)
+            : base(command, names, true, isRequired)
         {
             Value = defaultValue;
             Value = DefaultValue = defaultValue;
         }
 
         internal Argument(ArgumentCommand command, string name, T defaultValue)
-            : base(command, new[] { name }, false)
+            : base(command, new[] { name }, false, true)
         {
             Value = defaultValue;
             DefaultValue = defaultValue;

--- a/src/System.CommandLine/System/CommandLine/HelpTextGenerator.cs
+++ b/src/System.CommandLine/System/CommandLine/HelpTextGenerator.cs
@@ -162,7 +162,7 @@ namespace System.CommandLine
             sb.Append(option.GetDisplayName());
 
             if (!option.IsFlag)
-                sb.Append(@" <arg>");
+                sb.Append(option.IsRequired ? @" <arg>" : @" [arg]");
 
             if (option.IsList)
                 sb.Append(@"...");
@@ -210,7 +210,7 @@ namespace System.CommandLine
             }
 
             if (argument.IsOption && !argument.IsFlag)
-                sb.Append(@" <arg>");
+                sb.Append(argument.IsRequired ? @" <arg>" : @" [arg]");
 
             if (argument.IsList)
                 sb.Append(@"...");

--- a/tests/System.CommandLine.Tests/System/CommandLine/Tests/ArgumentSyntaxTests.cs
+++ b/tests/System.CommandLine.Tests/System/CommandLine/Tests/ArgumentSyntaxTests.cs
@@ -352,6 +352,19 @@ namespace System.CommandLine.Tests
         }
 
         [Fact]
+        public void Option_Definition_HasDefault_IfNoValue()
+        {
+            var o = "standard";
+
+            Parse("-o", syntax =>
+            {
+                syntax.DefineOption("o", ref o, false, string.Empty);
+            });
+
+            Assert.Equal("standard", o);
+        }
+
+        [Fact]
         public void Option_Usage_Error_Invalid()
         {
             var ex = Assert.Throws<ArgumentSyntaxException>(() =>
@@ -450,6 +463,46 @@ namespace System.CommandLine.Tests
             Assert.Equal("option -a requires a value", ex.Message);
         }
 
+        [Theory]
+        [InlineData("-a")]
+        [InlineData("-a:")]
+        [InlineData("-a : ")]
+        [InlineData("-a : -b")]
+        public void Option_Usage_DoesNotRequireValue(string commandLine)
+        {
+            var a = "defaulta";
+            var b = "defaultb";
+            Parse(commandLine, syntax =>
+            {
+                syntax.DefineOption("a", ref a, false, string.Empty);
+                syntax.DefineOption("b", ref b, false, string.Empty);
+            });
+            
+            Assert.Equal("defaulta", a);
+            Assert.Equal("defaultb", b);
+        }
+
+        [Theory]
+        [InlineData("-a", false)]
+        [InlineData("-a:", false)]
+        [InlineData("-a : ", false)]
+        [InlineData("-a : -b", true)]
+        public void Option_Usage_DoesNotRequireValue_SetsSpecified(string commandLine, bool expectedBSpecified)
+        {
+            var a = "defaulta";
+            var b = "defaultb";
+            bool aSpecified = false;
+            bool bSpecified = false;
+            Parse(commandLine, syntax =>
+            {
+                aSpecified = syntax.DefineOption("a", ref a, false, string.Empty).IsSpecified;
+                bSpecified = syntax.DefineOption("b", ref b, false, string.Empty).IsSpecified;
+            });
+            
+            Assert.True(aSpecified);
+            Assert.Equal(expectedBSpecified, bSpecified);
+        }
+
         [Fact]
         public void Option_Usage_Error_Flag_Bundle_ViaDashDash()
         {
@@ -546,6 +599,25 @@ namespace System.CommandLine.Tests
             Assert.True(f1);
             Assert.True(f2);
             Assert.False(f3);
+        }
+
+        [Fact]
+        public void Option_Usage_DoesNotRequireValue_AcceptsValue()
+        {
+            var a1 = "default1";
+            var a2 = "default2";
+            var a3 = "default3";
+
+            Parse("--a1 --a2:value2 --a3 = value3", syntax =>
+            {
+                syntax.DefineOption("a1", ref a1, false, string.Empty);
+                syntax.DefineOption("a2", ref a2, false, string.Empty);
+                syntax.DefineOption("a3", ref a3, false, string.Empty);
+            });
+
+            Assert.Equal("default1", a1);
+            Assert.Equal("value2", a2);
+            Assert.Equal("value3", a3);
         }
 
         [Fact]

--- a/tests/System.CommandLine.Tests/System/CommandLine/Tests/HelpTextGeneratorTests.cs
+++ b/tests/System.CommandLine.Tests/System/CommandLine/Tests/HelpTextGeneratorTests.cs
@@ -74,12 +74,14 @@ namespace System.CommandLine.Tests
         {
             var expectedHelp = @"
                 usage: tool [-s] [--keyword] [-f] [-o <arg>] [--option <arg>]
+                            [--optional [arg]]
 
-                    -s                Single character flag
-                    --keyword         Keyword flag
-                    -f, --flag        A flag with with short and long name
-                    -o <arg>          Single character option with value
-                    --option <arg>    Keyword option with value
+                    -s                  Single character flag
+                    --keyword           Keyword flag
+                    -f, --flag          A flag with with short and long name
+                    -o <arg>            Single character option with value
+                    --option <arg>      Keyword option with value
+                    --optional [arg]    Keyword option with optional value
             ";
 
             var actualHelp = GetHelp(syntax =>
@@ -94,6 +96,7 @@ namespace System.CommandLine.Tests
                 syntax.DefineOption("f|flag", ref flag, "A flag with with short and long name");
                 syntax.DefineOption("o", ref o, "Single character option with value");
                 syntax.DefineOption("option", ref option, "Keyword option with value");
+                syntax.DefineOption("optional", ref option, false, "Keyword option with optional value");
 
                 if (includeHidden)
                 {
@@ -101,7 +104,7 @@ namespace System.CommandLine.Tests
                     h.IsHidden = true;
                 }
             });
-
+            
             AssertMatch(expectedHelp, actualHelp);
         }
 


### PR DESCRIPTION
I decided to go a slightly different route with the API than I originally suggested in #520. Instead of providing a value to use for when the option argument is missing, you just specify whether the option requires a value (the default is `true`). Then you can check `Argument.IsSpecified` to see if the reason you got the default value was because the option wasn't specified, or it was but no value was provided. I updated the readme with a clearer explanation.
