### PR TITLE
Slices: Reduce complexity of SpanExtensions Read and Write methods

### DIFF
--- a/src/System.Slices/src/System/SpanExtensions.cs
+++ b/src/System.Slices/src/System/SpanExtensions.cs
@@ -147,22 +147,23 @@ namespace System
         /// <summary>
         /// Reads a structure of type T out of a slice of bytes.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T Read<[Primitive]T>(this Span<byte> slice)
             where T : struct
         {
             Contract.Requires(slice.Length >= PtrUtils.SizeOf<T>());
-            return slice.Cast<byte, T>()[0];
+            return PtrUtils.Get<T>(slice.Object, slice.Offset);
         }
 
         /// <summary>
         /// Writes a structure of type T into a slice of bytes.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Write<[Primitive]T>(this Span<byte> slice, T value)
             where T : struct
         {
             Contract.Requires(slice.Length >= PtrUtils.SizeOf<T>());
-            var cast = slice.Cast<byte, T>();
-            cast[0] = value;
+            PtrUtils.Set(slice.Object, slice.Offset, value);
         }
 
         /// <summary>


### PR DESCRIPTION
SpanExtensions.Read doesn't have to create a Span to read by zero index.
I replaced it with direct reinterpret reading from the slice.

Microbenchmarks show 3.5 - 4 times better perf. Difference in amount of the generated code is huge.
```C#
[MethodImpl(MethodImplOptions.NoInlining)]
public static long TestSpan(Span<byte> span)
{
    return span.Read<long>();
}
```
This is  TestSpan method after the change:
```ASM
; Assembly listing for method CoreClrTest.Program:TestSpan(struct):long
; Emitting BLENDED_CODE for X64 CPU with SSE2
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  6,  10  )   byref  ->  rcx        
;* V01 tmp0         [V01    ] (  0,   0  )  struct (24) zero-ref    ld-addr-op
;* V02 tmp1         [V02    ] (  0,   0  )     int  ->  zero-ref   
;* V03 tmp2         [V03    ] (  0,   0  )     ref  ->  zero-ref   
;  V04 tmp3         [V04,T01] (  2,   4  )    bool  ->  rcx        
;  V05 tmp4         [V05,T06] (  3,   0  )     ref  ->  rsi        
;  V06 tmp5         [V06,T02] (  2,   2  )   byref  ->  rax        
;* V07 tmp6         [V07    ] (  0,   0  )    long  ->  zero-ref   
;  V08 tmp7         [V08,T03] (  2,   2  )     ref  ->  rax         V01._object(offs=0x00) P-INDEP
;  V09 tmp8         [V09,T04] (  2,   2  )    long  ->  rdx         V01._offset(offs=0x08) P-INDEP
;  V10 tmp9         [V10,T05] (  2,   2  )     int  ->  rcx         V01.Length(offs=0x10) P-INDEP
;  V11 OutArgs      [V11    ] (  1,   1  )  lclBlk (32) [rsp+0x00]  
;
; Lcl frame size = 32

G_M17568_IG01:
       56                   push     rsi
       4883EC20             sub      rsp, 32

G_M17568_IG02:
       488B01               mov      rax, gword ptr [rcx]
       488B5108             mov      rdx, qword ptr [rcx+8]
       8B4910               mov      ecx, dword ptr [rcx+16]
       83F908               cmp      ecx, 8
       0F9DC1               setge    cl
       0FB6C9               movzx    rcx, cl
       85C9                 test     ecx, ecx
       740A                 je       SHORT G_M17568_IG05

G_M17568_IG03:
       488B0410             mov      rax, qword ptr [rax+rdx]

G_M17568_IG04:
       4883C420             add      rsp, 32
       5E                   pop      rsi
       C3                   ret      

G_M17568_IG05:
       48B900420EB7FD7F0000 mov      rcx, 0x7FFDB70E4200
       E85B133D5F           call     CORINFO_HELP_NEWSFAST
       488BF0               mov      rsi, rax
       488BCE               mov      rcx, rsi
       E8F0BE025E           call     System.ArgumentException:.ctor():this
       488BCE               mov      rcx, rsi
       E8F812D45E           call     CORINFO_HELP_THROW
       CC                   int3     

; Total bytes of code 73, prolog size 5 for method CoreClrTest.Program:TestSpan(struct):long
; ============================================================
```


TestSpan method before the fix - Read is not inlined:
```ASM
G_M17562_IG01:
       4883EC28             sub      rsp, 40
G_M17562_IG02:
       E82FFCFFFF           call     System.SpanExtensions:Read(struct):long
       90                   nop      
G_M17562_IG03:
       4883C428             add      rsp, 40
       C3                   ret      
```

SpanExtensions.Read method
```ASM
(  2,   4  )    bool  ->  rax        
;  V04 tmp2         [V04,T18] (  3,   0  )     ref  ->  rsi        
;  V05 tmp3         [V05    ] (  3,   1.5)  struct (24) [rsp+0x40]   do-not-enreg[XSB] must-init addr-exposed
;* V06 tmp4         [V06    ] (  0,   0  )  struct (24) zero-ref    ld-addr-op
;* V07 tmp5         [V07    ] (  0,   0  )     int  ->  zero-ref   
;* V08 tmp6         [V08    ] (  0,   0  )     int  ->  zero-ref   
;  V09 tmp7         [V09,T05] (  3,   2.5)     int  ->  rax        
;* V10 tmp8         [V10    ] (  0,   0  )     ref  ->  zero-ref   
;* V11 tmp9         [V11    ] (  0,   0  )  struct (24) zero-ref   
;  V12 tmp10        [V12,T14] (  2,   1  )  struct (24) [rsp+0x28]   do-not-enreg[SB] must-init ld-addr-op
;* V13 tmp11        [V13    ] (  0,   0  )    long  ->  zero-ref   
;* V14 tmp12        [V14    ] (  0,   0  )     ref  ->  zero-ref   
;* V15 tmp13        [V15    ] (  0,   0  )    long  ->  zero-ref   
;  V16 tmp14        [V16,T07] (  2,   2  )     int  ->  rax         ld-addr-op
;  V17 tmp15        [V17,T19] (  3,   0  )     ref  ->  rsi        
;* V18 tmp16        [V18    ] (  0,   0  )    long  ->  zero-ref    ld-addr-op
;* V19 tmp17        [V19    ] (  0,   0  )     int  ->  zero-ref   
;* V20 tmp18        [V20    ] (  0,   0  )    long  ->  zero-ref   
;* V21 tmp19        [V21    ] (  0,   0  )    long  ->  zero-ref   
;  V22 tmp20        [V22,T06] (  2,   2  )   byref  ->  rcx        
;* V23 tmp21        [V23    ] (  0,   0  )    long  ->  zero-ref   
;  V24 tmp22        [V24,T09] (  2,   1.5)     ref  ->  rcx         V01._object(offs=0x00) P-INDEP
;  V25 tmp23        [V25,T11] (  2,   1.5)    long  ->  rdx         V01._offset(offs=0x08) P-INDEP
;  V26 tmp24        [V26,T15] (  2,   1  )     int  ->  rax         V01.Length(offs=0x10) P-INDEP
;  V27 tmp25        [V27,T10] (  2,   1.5)     ref  ->   r8         V06._object(offs=0x00) P-INDEP
;  V28 tmp26        [V28,T12] (  2,   1.5)    long  ->   r9         V06._offset(offs=0x08) P-INDEP
;  V29 tmp27        [V29,T08] (  2,   2  )     int  ->  rax         V06.Length(offs=0x10) P-INDEP
;  V30 tmp28        [V30,T13] (  2,   1  )     ref  ->   r8         V11._object(offs=0x00) P-INDEP
;  V31 tmp29        [V31,T16] (  2,   1  )    long  ->   r9         V11._offset(offs=0x08) P-INDEP
;  V32 tmp30        [V32,T17] (  2,   1  )     int  ->  rax         V11.Length(offs=0x10) P-INDEP
;  V33 tmp31        [V33,T01] (  4,   4  )   byref  ->  rcx         stack-byref
;  V34 tmp32        [V34,T02] (  4,   4  )   byref  ->  rax        
;  V35 OutArgs      [V35    ] (  1,   1  )  lclBlk (32) [rsp+0x00]  
;
; Lcl frame size = 88

G_M45729_IG01:
       57                   push     rdi
       56                   push     rsi
       4883EC58             sub      rsp, 88
       488BF1               mov      rsi, rcx
       488D7C2428           lea      rdi, [rsp+28H]
       B90C000000           mov      ecx, 12
       33C0                 xor      rax, rax
       F3AB                 rep stosd 
       488BCE               mov      rcx, rsi

G_M45729_IG02:
       8B4110               mov      eax, dword ptr [rcx+16]
       83F808               cmp      eax, 8
       0F9DC0               setge    al
       0FB6C0               movzx    rax, al
       85C0                 test     eax, eax
       7471                 je       SHORT G_M45729_IG10

G_M45729_IG03:
       4C8B01               mov      r8, gword ptr [rcx]
       4C8B4908             mov      r9, qword ptr [rcx+8]
       8B4110               mov      eax, dword ptr [rcx+16]
       99                   cdq      
       83E207               and      edx, 7
       03C2                 add      eax, edx
       C1F803               sar      eax, 3
       85C0                 test     eax, eax
       752D                 jne      SHORT G_M45729_IG06
       4533C0               xor      r8, r8
       4C8D4C2428           lea      r9, bword ptr [rsp+28H]
       660F57C0             xorpd    xmm0, xmm0
       F3410F7F01           movdqu   qword ptr [r9], xmm0
       4D894110             mov      qword ptr [r9+16], r8

G_M45729_IG04:
       F30F6F442428         movdqu   xmm0, qword ptr [rsp+28H]
       F30F7F442440         movdqu   qword ptr [rsp+40H], xmm0
       488B442438           mov      rax, qword ptr [rsp+38H]
       4889442450           mov      qword ptr [rsp+50H], rax

G_M45729_IG05:
       EB0F                 jmp      SHORT G_M45729_IG07

G_M45729_IG06:
       488D4C2440           lea      rcx, bword ptr [rsp+40H]
       4C8901               mov      gword ptr [rcx], r8
       4C894908             mov      qword ptr [rcx+8], r9
       894110               mov      dword ptr [rcx+16], eax

G_M45729_IG07:
       488D442440           lea      rax, bword ptr [rsp+40H]
       488B08               mov      rcx, gword ptr [rax]
       488B5008             mov      rdx, qword ptr [rax+8]
       8B4010               mov      eax, dword ptr [rax+16]
       85C0                 test     eax, eax
       7E2D                 jle      SHORT G_M45729_IG11

G_M45729_IG08:
       488B0411             mov      rax, qword ptr [rcx+rdx]

G_M45729_IG09:
       4883C458             add      rsp, 88
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret      

G_M45729_IG10:
       48B9004244C2FD7F0000 mov      rcx, 0x7FFDC2444200
       E8B6083B5F           call     CORINFO_HELP_NEWSFAST
       488BF0               mov      rsi, rax
       488BCE               mov      rcx, rsi
       E84BB46368           call     System.ArgumentException:.ctor():this
       488BCE               mov      rcx, rsi
       E85308D25E           call     CORINFO_HELP_THROW

G_M45729_IG11:
       48B9A04444C2FD7F0000 mov      rcx, 0x7FFDC24444A0
       E894083B5F           call     CORINFO_HELP_NEWSFAST
       488BF0               mov      rsi, rax
       488BCE               mov      rcx, rsi
       E8C9709468           call     System.ArgumentOutOfRangeException:.ctor():this
       488BCE               mov      rcx, rsi
       E83108D25E           call     CORINFO_HELP_THROW
       CC                   int3     

; Total bytes of code 224, prolog size 26 for method System.SpanExtensions:Read(struct):long
; ============================================================

```