### PR TITLE
Slices: Fix the overflow  when the  address of a Slice elemnt is computed

### DIFF
--- a/src/System.Net.Libuv/src/project.json
+++ b/src/System.Net.Libuv/src/project.json
@@ -17,6 +17,9 @@
     "System.Buffers": "0.1.0-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": { }
+  },
+  "scripts": {
+    "postcompile": "copy \"%project:Directory%\\libuv.dll\" \"%compile:OutputDir%\\libuv.dll\""
   }
 }

--- a/src/System.Slices/src/System/Contract.cs
+++ b/src/System.Slices/src/System/Contract.cs
@@ -41,6 +41,18 @@ namespace System
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresInInclusiveRange(int start, int length, int existingLength)
+        {
+            if ((uint)start > (uint)existingLength
+                || length < 0
+                || (uint)(start + length) > (uint)existingLength)
+            {
+                throw NewArgumentOutOfRangeException();
+            }
+        }
+
+        
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Exception NewArgumentException()
         {

--- a/src/System.Slices/src/System/Contract.cs
+++ b/src/System.Slices/src/System/Contract.cs
@@ -24,29 +24,29 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void RequiresInRange(int start, int length)
+        public static void RequiresInRange(int start, uint length)
         {
-            if ((uint)start >= (uint)length)
+            if ((uint)start >= length)
             {
                 throw NewArgumentOutOfRangeException();
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void RequiresInInclusiveRange(int start, int length)
+        public static void RequiresInInclusiveRange(int start, uint length)
         {
-            if ((uint)start > (uint)length)
+            if ((uint)start > length)
             {
                 throw NewArgumentOutOfRangeException();
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void RequiresInInclusiveRange(int start, int length, int existingLength)
+        public static void RequiresInInclusiveRange(int start, int length, uint existingLength)
         {
-            if ((uint)start > (uint)existingLength
+            if ((uint)start > existingLength
                 || length < 0
-                || (uint)(start + length) > (uint)existingLength)
+                || (uint)(start + length) > existingLength)
             {
                 throw NewArgumentOutOfRangeException();
             }

--- a/src/System.Slices/src/System/MemoryUtils.cs
+++ b/src/System.Slices/src/System/MemoryUtils.cs
@@ -71,5 +71,70 @@ namespace System
                 }
             }
         }
+
+        /// <summary>
+        /// platform independent fast memory comparison
+        /// for x64 it is as fast as memcmp of msvcrt.dll, for x86 it is up to two times faster!!
+        /// </summary>
+        internal static bool MemCmp<[Primitive]T>(ReadOnlySpan<T> first, ReadOnlySpan<T> second)
+            where T : struct
+        {
+            unsafe
+            {
+                // prevent GC from moving memory
+                var firstPinnedHandle = GCHandle.Alloc(first.Object, GCHandleType.Pinned);
+                var secondPinnedHandle = GCHandle.Alloc(second.Object, GCHandleType.Pinned);
+
+                try
+                {
+                    byte* firstPointer = (byte*)PtrUtils.ComputeAddress(first.Object, first.Offset).ToPointer();
+                    byte* secondPointer = (byte*)PtrUtils.ComputeAddress(second.Object, second.Offset).ToPointer();
+
+                    int step = sizeof(void*) * 5;
+                    int totalBytesCount = first.Length * PtrUtils.SizeOf<T>();
+                    byte* firstPointerLimit = firstPointer + (totalBytesCount - step);
+
+                    if (totalBytesCount > step)
+                    {
+                        while (firstPointer < firstPointerLimit)
+                        {   // IMPORTANT: in order to get HUGE benefits of loop unrolling on x86 we use break instead of return
+                            if (*((void**)firstPointer + 0) != *((void**)secondPointer + 0)) break;
+                            if (*((void**)firstPointer + 1) != *((void**)secondPointer + 1)) break;
+                            if (*((void**)firstPointer + 2) != *((void**)secondPointer + 2)) break;
+                            if (*((void**)firstPointer + 3) != *((void**)secondPointer + 3)) break;
+                            if (*((void**)firstPointer + 4) != *((void**)secondPointer + 4)) break;
+
+                            firstPointer += step;
+                            secondPointer += step;
+                        }
+                        if (firstPointer < firstPointerLimit) // the upper loop ended with break;
+                        {
+                            return false;
+                        }
+                    }
+                    firstPointerLimit += step; // lets check the remaining bytes
+                    while (firstPointer < firstPointerLimit)
+                    {
+                        if (*firstPointer != *secondPointer) break;
+
+                        ++firstPointer;
+                        ++secondPointer;
+                    }
+
+                    return firstPointer == firstPointerLimit;
+                }
+                finally
+                {
+                    if (firstPinnedHandle.IsAllocated)
+                    {
+                        firstPinnedHandle.Free();
+                    }
+                    if (secondPinnedHandle.IsAllocated)
+                    {
+                        secondPinnedHandle.Free();
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/System.Slices/src/System/PtrUtils.cs
+++ b/src/System.Slices/src/System/PtrUtils.cs
@@ -32,43 +32,65 @@ namespace System
         // depends on it working... (okay, I still feel a little dirty.)
 
         /// <summary>
-        /// Takes a (possibly null) object reference, plus an offset in bytes,
+        /// Takes a (possibly null) object reference, plus an offset in bytes, plus an index,
         /// adds them, and safetly dereferences the target (untyped!) address in
         /// a way that the GC will be okay with.  It yields a value of type T.
         /// </summary>
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [ILSub(@"
-            .maxstack 2
-            .locals ([0] uint8& addr)
+            .maxstack 3
+            .locals([0] uint8 & addr)
             ldarg.0     // load the object
             stloc.0     // convert the object pointer to a byref
             ldloc.0     // load the object pointer as a byref
             ldarg.1     // load the offset
             add         // add the offset
+            ldarg.2     // load the index
+            sizeof !!T  // load size of T
+            mul         // multiply the index and size of T
+            add         // add the result
             ldobj !!T   // load a T value from the computed address
             ret")]
-        public static T Get<T>(object obj, UIntPtr offset) { return default(T); }
-
+        public static T Get<T>(object obj, UIntPtr offset, UIntPtr index) { return default(T); }
 
         /// <summary>
-        /// Takes a (possibly null) object reference, plus an offset in bytes,
+        /// Takes a (possibly null) object reference, plus an offset in bytes, plus an index,
         /// adds them, and safely stores the value of type T in a way that the
         /// GC will be okay with.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [ILSub(@"
-            .maxstack 2
-            .locals ([0] uint8& addr)
+            .maxstack 3
+            .locals([0] uint8 & addr)
             ldarg.0     // load the object
             stloc.0     // convert the object pointer to a byref
             ldloc.0     // load the object pointer as a byref
             ldarg.1     // load the offset
             add         // add the offset
-            ldarg.2     // load the value to store
+            ldarg.2     // load the index
+            sizeof !!T  // load size of T
+            mul         // multiply the index and size of T
+            add         // add the result
+            ldarg.3     // load the value to store
             stobj !!T   // store a T value to the computed address
             ret")]
-        public static void Set<T>(object obj, UIntPtr offset, T val) { }
+        public static void Set<T>(object obj, UIntPtr offset, UIntPtr index, T val) { }
+
+        [ILSub(@"            
+            .maxstack 3
+            .locals([0] uint8 & addr)
+            ldarg.0     // load the object
+            stloc.0     // convert the object pointer to a byref
+            ldloc.0     // load the object pointer as a byref
+            ldarg.1     // load the offset
+            add         // add the offset
+            ldarg.2     // load the index
+            sizeof !!T  // load size of T
+            mul         // multiply the index and size of T
+            add         // add the result
+            ldarg.3     // load the value to store
+            stobj !!T   // store a T value to the computed address
+            ret")]
+        public static void Set<T>(object obj, UIntPtr offset, UIntPtr index, T val) { }
 
         /// <summary>
         /// Computes the number of bytes offset from an array object reference

--- a/src/System.Slices/src/System/ReadOnlySpan.cs
+++ b/src/System.Slices/src/System/ReadOnlySpan.cs
@@ -1,0 +1,291 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    /// <summary>
+    /// ReadOnlySpan is a read-only view over Span<typeparam name="T"></typeparam>
+    /// </summary>
+    public partial struct ReadOnlySpan<T> : IEnumerable<T>, IEquatable<ReadOnlySpan<T>>
+    {
+        /// <summary>A managed array/string; or null for native ptrs.</summary>
+        internal readonly object Object;
+        /// <summary>An byte-offset into the array/string; or a native ptr.</summary>
+        internal readonly UIntPtr Offset;
+        /// <summary>Fetches the number of elements this Span contains.</summary>
+        public readonly int Length;
+
+        /// <summary>
+        /// Creates a new span over the entirety of the target array.
+        /// </summary>
+        /// <param name="array">The target array.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown if the 'array' parameter is null.
+        /// </exception>
+        public ReadOnlySpan(T[] array)
+        {
+            Contract.Requires(array != null);
+            Object = array;
+            Offset = new UIntPtr((uint)SpanHelpers<T>.OffsetToArrayData);
+            Length = array.Length;
+        }
+
+        /// <summary>
+        /// Creates a new span over the portion of the target array beginning
+        /// at 'start' index.
+        /// </summary>
+        /// <param name="array">The target array.</param>
+        /// <param name="start">The index at which to begin the span.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown if the 'array' parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified start index is not in range (&lt;0 or &gt;&eq;length).
+        /// </exception>
+        // TODO: Should we have this overload? It is really confusing when you also have Span(T* array, int length)
+        //       While with Slice it makes sense it might not in here.
+        internal ReadOnlySpan(T[] array, int start)
+        {
+            Contract.Requires(array != null);
+            Contract.RequiresInInclusiveRange(start, (uint)array.Length);
+            if (start < array.Length)
+            {
+                Object = array;
+                Offset = new UIntPtr(
+                    (uint)(SpanHelpers<T>.OffsetToArrayData + (start * PtrUtils.SizeOf<T>())));
+                Length = array.Length - start;
+            }
+            else
+            {
+                Object = null;
+                Offset = UIntPtr.Zero;
+                Length = 0;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new span over the portion of the target array beginning
+        /// at 'start' index and ending at 'end' index (exclusive).
+        /// </summary>
+        /// <param name="array">The target array.</param>
+        /// <param name="start">The index at which to begin the span.</param>
+        /// <param name="length">The number of items in the span.</param>
+        /// <exception cref="System.ArgumentException">
+        /// Thrown if the 'array' parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified start or end index is not in range (&lt;0 or &gt;&eq;length).
+        /// </exception>
+        public ReadOnlySpan(T[] array, int start, int length)
+        {
+            Contract.Requires(array != null);
+            Contract.RequiresInInclusiveRange(start, (uint)array.Length);
+            Contract.RequiresNonNegative(length);
+            Contract.RequiresInInclusiveRange(start + length, (uint)array.Length);
+            if (start < array.Length)
+            {
+                Object = array;
+                Offset = new UIntPtr(
+                    (uint)(SpanHelpers<T>.OffsetToArrayData + (start * PtrUtils.SizeOf<T>())));
+                Length = length;
+            }
+            else
+            {
+                Object = null;
+                Offset = UIntPtr.Zero;
+                Length = 0;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new span over the target unmanaged buffer.  Clearly this
+        /// is quite dangerous, because we are creating arbitrarily typed T's
+        /// out of a void*-typed block of memory.  And the length is not checked.
+        /// But if this creation is correct, then all subsequent uses are correct.
+        /// </summary>
+        /// <param name="ptr">An unmanaged pointer to memory.</param>
+        /// <param name="length">The number of T elements the memory contains.</param>
+        [CLSCompliant(false)]
+        public unsafe ReadOnlySpan(void* ptr, int length)
+        {
+            Contract.Requires(length >= 0);
+            Contract.Requires(length == 0 || ptr != null);
+            Object = null;
+            Offset = new UIntPtr(ptr);
+            Length = length;
+        }
+
+        /// <summary>
+        /// An internal helper for creating spans. Not for public use.
+        /// </summary>
+        internal ReadOnlySpan(object obj, UIntPtr offset, int length)
+        {
+            Object = obj;
+            Offset = offset;
+            Length = length;
+        }
+
+        public static implicit operator ReadOnlySpan<T>(Span<T> slice)
+        {
+            return new ReadOnlySpan<T>(slice.Object, slice.Offset, slice.Length);
+        }
+
+        public static ReadOnlySpan<T> Empty { get { return default(ReadOnlySpan<T>); } }
+
+        public bool IsEmpty
+        {
+            get { return Length == 0; }
+        }
+
+        [CLSCompliant(false)]
+        public unsafe void* UnsafeReadOnlyPointer
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return Offset.ToPointer(); }
+        }
+
+        /// <summary>
+        /// Fetches the element at the specified index.
+        /// </summary>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified index is not in range (&lt;0 or &gt;&eq;length).
+        /// </exception>
+        public T this[int index]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Contract.RequiresInRange(index, (uint)Length);
+                return PtrUtils.Get<T>(
+                    Object, Offset + (index * PtrUtils.SizeOf<T>()));
+            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private set
+            {
+                Contract.RequiresInRange(index, (uint)Length);
+                PtrUtils.Set<T>(
+                    Object, Offset + (index * PtrUtils.SizeOf<T>()), value);
+            }
+        }
+
+        /// <summary>
+        /// Copies the contents of this span into a new array.  This heap
+        /// allocates, so should generally be avoided, however is sometimes
+        /// necessary to bridge the gap with APIs written in terms of arrays.
+        /// </summary>
+        public T[] CreateArray()
+        {
+            var dest = new T[Length];
+            TryCopyTo(dest.Slice());
+            return dest;
+        }
+
+        /// <summary>
+        /// Copies the contents of this span into another.  The destination
+        /// must be at least as big as the source, and may be bigger.
+        /// </summary>
+        /// <param name="dest">The span to copy items into.</param>
+        public bool TryCopyTo(Span<T> dest)
+        {
+            if (Length > dest.Length)
+            {
+                return false;
+            }
+
+            // TODO(joe): specialize to use a fast memcpy if T is pointerless.
+            for (int i = 0; i < Length; i++)
+            {
+                dest[i] = this[i];
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Forms a slice out of the given span, beginning at 'start'.
+        /// </summary>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified start index is not in range (&lt;0 or &gt;&eq;length).
+        /// </exception>
+        public ReadOnlySpan<T> Slice(int start)
+        {
+            return Slice(start, Length - start);
+        }
+
+        /// <summary>
+        /// Forms a slice out of the given span, beginning at 'start', and
+        /// ending at 'end' (exclusive).
+        /// </summary>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <param name="end">The index at which to end this slice (exclusive).</param>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified start or end index is not in range (&lt;0 or &gt;&eq;length).
+        /// </exception>
+        public ReadOnlySpan<T> Slice(int start, int length)
+        {
+            Contract.Requires(start + length <= Length);
+            return new ReadOnlySpan<T>(
+                Object, Offset + (start * PtrUtils.SizeOf<T>()), length);
+        }
+
+        /// <summary>
+        /// Checks to see if two spans point at the same memory.  Note that
+        /// this does *not* check to see if the *contents* are equal.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool ReferenceEquals(ReadOnlySpan<T> other)
+        {
+            return Object == other.Object &&
+                Offset == other.Offset && Length == other.Length;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Offset.GetHashCode();
+                hashCode = hashCode * 31 + Length;
+                if (Object != null)
+                {
+                    hashCode = hashCode * 31 + Object.GetHashCode();
+                }
+                return hashCode;
+            }
+        }
+
+        /// <summary>
+        /// Checks to see if two spans point at the same memory.  Note that
+        /// this does *not* check to see if the *contents* are equal.
+        /// </summary>
+        public bool Equals(ReadOnlySpan<T> other)
+        {
+            return ReferenceEquals(other);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ReadOnlySpan<T>)
+            {
+                return Equals((ReadOnlySpan<T>)obj);
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Returns item from given index without the boundaries check
+        /// use only in places where moving outside the boundaries is impossible
+        /// gain: performance: no boundaries check (single operation) 
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal T GetItemWithoutBoundariesCheck(int index)
+        {
+            return PtrUtils.Get<T>(
+                    Object, Offset + (index * PtrUtils.SizeOf<T>()));
+        }
+    }
+}
+
+

--- a/src/System.Slices/src/System/ReadOnlySpanEnumerators.cs
+++ b/src/System.Slices/src/System/ReadOnlySpanEnumerators.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace System
+{
+    public partial struct ReadOnlySpan<T>
+    {
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return new EnumeratorObject(this);
+        }
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            return new EnumeratorObject(this);
+        }
+
+        /// <summary>
+        /// A struct-based enumerator, to make fast enumerations possible.
+        /// This isn't designed for direct use, instead see GetEnumerator.
+        /// </summary>
+        public struct Enumerator
+        {
+            ReadOnlySpan<T> _span;    // The slice being enumerated.
+            int _position; // The current position.
+
+            internal Enumerator(ReadOnlySpan<T> span)
+            {
+                _span = span;
+                _position = -1;
+            }
+
+            public T Current
+            {
+                get { return _span[_position]; }
+            }
+
+            public bool MoveNext()
+            {
+                return ++_position < _span.Length;
+            }
+
+            public void Reset()
+            {
+                _position = -1;
+            }
+        }
+
+        /// <summary>
+        /// enumerator that implements <see cref="IEnumerator{T}"/> pattern (including <see cref="IDisposable"/>).
+        /// it is used by LINQ and foreach when Slice is accessed via <see cref="IEnumerable{T}"/>
+        /// it is reference type to avoid boxing when calling interface methods on stuctures
+        /// </summary>
+        private class EnumeratorObject : IEnumerator<T>
+        {
+            ReadOnlySpan<T> _span;    // The slice being enumerated.
+            int _position; // The current position.
+
+            public EnumeratorObject(ReadOnlySpan<T> span)
+            {
+                _span = span;
+                _position = -1;
+            }
+
+            public T Current
+            {
+                get { return _span.GetItemWithoutBoundariesCheck(_position); }
+            }
+
+            object IEnumerator.Current
+            {
+                get { return Current; }
+            }
+
+            public void Dispose()
+            {
+                _span = default(ReadOnlySpan<T>);
+                _position = -1;
+            }
+
+            public bool MoveNext()
+            {
+                int nextItemIndex = _position + 1;
+                if (nextItemIndex < _span.Length)
+                {
+                    _position = nextItemIndex;
+                    return true;
+                }
+                return false;
+            }
+
+            public void Reset()
+            {
+                _position = -1;
+            }
+        }
+    }
+}

--- a/src/System.Slices/src/System/Span.cs
+++ b/src/System.Slices/src/System/Span.cs
@@ -155,15 +155,13 @@ namespace System
             get
             {
                 Contract.RequiresInRange(index, (uint)Length);
-                return PtrUtils.Get<T>(
-                    Object, Offset + (index * PtrUtils.SizeOf<T>()));
+                return PtrUtils.Get<T>(Object, Offset, (UIntPtr)index);
             }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set
             {
                 Contract.RequiresInRange(index, (uint)Length);
-                PtrUtils.Set<T>(
-                    Object, Offset + (index * PtrUtils.SizeOf<T>()), value);
+                PtrUtils.Set<T>(Object, Offset, (UIntPtr)index, value);
             }
         }
 
@@ -310,8 +308,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal T GetItemWithoutBoundariesCheck(int index)
         {
-            return PtrUtils.Get<T>(
-                    Object, Offset + (index * PtrUtils.SizeOf<T>()));
+            return PtrUtils.Get<T>(Object, Offset, (UIntPtr)index);
         }
     }
 }

--- a/src/System.Slices/src/System/Span.cs
+++ b/src/System.Slices/src/System/Span.cs
@@ -53,7 +53,7 @@ namespace System
         internal Span(T[] array, int start)
         {
             Contract.Requires(array != null);
-            Contract.RequiresInInclusiveRange(start, array.Length);
+            Contract.RequiresInInclusiveRange(start, (uint)array.Length);
             if (start < array.Length)
             {
                 Object = array;
@@ -85,9 +85,7 @@ namespace System
         public Span(T[] array, int start, int length)
         {
             Contract.Requires(array != null);
-            Contract.RequiresInInclusiveRange(start, array.Length);
-            Contract.RequiresNonNegative(length);
-            Contract.RequiresInInclusiveRange(start + length, array.Length);
+            Contract.RequiresInInclusiveRange(start, length, (uint)array.Length);
             if (start < array.Length)
             {
                 Object = array;
@@ -156,14 +154,14 @@ namespace System
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                Contract.RequiresInRange(index, Length);
+                Contract.RequiresInRange(index, (uint)Length);
                 return PtrUtils.Get<T>(
                     Object, Offset + (index * PtrUtils.SizeOf<T>()));
             }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set
             {
-                Contract.RequiresInRange(index, Length);
+                Contract.RequiresInRange(index, (uint)Length);
                 PtrUtils.Set<T>(
                     Object, Offset + (index * PtrUtils.SizeOf<T>()), value);
             }
@@ -239,7 +237,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<T> Slice(int start)
         {
-            Contract.RequiresInInclusiveRange(start, Length);
+            Contract.RequiresInInclusiveRange(start, (uint)Length);
             return new Span<T>(
                 Object, Offset + (start * PtrUtils.SizeOf<T>()), Length - start);
         }
@@ -256,8 +254,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<T> Slice(int start, int length)
         {
-            Contract.RequiresInInclusiveRange(start, length, Length);
-
+            Contract.RequiresInInclusiveRange(start, length, (uint)Length);
             return new Span<T>(
                 Object, Offset + (start * PtrUtils.SizeOf<T>()), length);
         }

--- a/src/System.Slices/src/System/Span.cs
+++ b/src/System.Slices/src/System/Span.cs
@@ -236,9 +236,12 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified start index is not in range (&lt;0 or &gt;&eq;length).
         /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<T> Slice(int start)
         {
-            return Slice(start, Length - start);
+            Contract.RequiresInInclusiveRange(start, Length);
+            return new Span<T>(
+                Object, Offset + (start * PtrUtils.SizeOf<T>()), Length - start);
         }
 
         /// <summary>
@@ -250,9 +253,11 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified start or end index is not in range (&lt;0 or &gt;&eq;length).
         /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<T> Slice(int start, int length)
         {
-            Contract.Requires(start + length <= Length);
+            Contract.RequiresInInclusiveRange(start, length, Length);
+
             return new Span<T>(
                 Object, Offset + (start * PtrUtils.SizeOf<T>()), length);
         }

--- a/src/System.Slices/src/System/SpanEqualsExtensions.cs
+++ b/src/System.Slices/src/System/SpanEqualsExtensions.cs
@@ -29,12 +29,54 @@ namespace System
             return true;
         }
 
+		/// <summary>
+        /// Determines whether two read-only spans are equal (byte-wise) by comparing the elements by using memcmp
+        /// </summary>
+        /// <param name="first">A span of bytes to compare to second.</param>
+        /// <param name="second">A span of bytes T to compare to first.</param>
+        public static bool SequenceEqual(this ReadOnlySpan<byte> first, ReadOnlySpan<byte> second)
+        {
+            if (first.Length != second.Length) { return false; }
+
+            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
+            if (first.Length >= 512) { return MemoryUtils.MemCmp(first, second); }
+
+            // for small slices we just use simple loop
+            for (int i = 0; i < first.Length; i++) {
+                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
+                    return false; 
+                }
+            }
+            return true;
+        }
+
         /// <summary>
         /// Determines whether two spans are equal (byte-wise) by comparing the elements by using memcmp
         /// </summary>
         /// <param name="first">A span of characters to compare to second.</param>
         /// <param name="second">A span of characters T to compare to first.</param>
         public static bool SequenceEqual(this Span<char> first, Span<char> second)
+        {
+            if (first.Length != second.Length) { return false; }
+
+            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
+            if (first.Length >= 512) { return MemoryUtils.MemCmp(first, second); }
+
+            // for small slices we just use simple loop
+            for (int i = 0; i < first.Length; i++) {
+                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
+                    return false; 
+                }
+            }
+            return true;
+        }
+
+		/// <summary>
+        /// Determines whether two read-only spans are equal (byte-wise) by comparing the elements by using memcmp
+        /// </summary>
+        /// <param name="first">A span of characters to compare to second.</param>
+        /// <param name="second">A span of characters T to compare to first.</param>
+        public static bool SequenceEqual(this ReadOnlySpan<char> first, ReadOnlySpan<char> second)
         {
             if (first.Length != second.Length) { return false; }
 
@@ -71,6 +113,27 @@ namespace System
             return true;
         }
 
+		/// <summary>
+        /// Determines whether two read-only spans are equal (byte-wise) by comparing the elements by using memcmp
+        /// </summary>
+        /// <param name="first">A span of shorts to compare to second.</param>
+        /// <param name="second">A span of shorts T to compare to first.</param>
+        public static bool SequenceEqual(this ReadOnlySpan<short> first, ReadOnlySpan<short> second)
+        {
+            if (first.Length != second.Length) { return false; }
+
+            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
+            if (first.Length >= 512) { return MemoryUtils.MemCmp(first, second); }
+
+            // for small slices we just use simple loop
+            for (int i = 0; i < first.Length; i++) {
+                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
+                    return false; 
+                }
+            }
+            return true;
+        }
+
         /// <summary>
         /// Determines whether two spans are equal (byte-wise) by comparing the elements by using memcmp
         /// </summary>
@@ -92,12 +155,54 @@ namespace System
             return true;
         }
 
+		/// <summary>
+        /// Determines whether two read-only spans are equal (byte-wise) by comparing the elements by using memcmp
+        /// </summary>
+        /// <param name="first">A span of integers to compare to second.</param>
+        /// <param name="second">A span of integers T to compare to first.</param>
+        public static bool SequenceEqual(this ReadOnlySpan<int> first, ReadOnlySpan<int> second)
+        {
+            if (first.Length != second.Length) { return false; }
+
+            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
+            if (first.Length >= 256) { return MemoryUtils.MemCmp(first, second); }
+
+            // for small slices we just use simple loop
+            for (int i = 0; i < first.Length; i++) {
+                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
+                    return false; 
+                }
+            }
+            return true;
+        }
+
         /// <summary>
         /// Determines whether two spans are equal (byte-wise) by comparing the elements by using memcmp
         /// </summary>
         /// <param name="first">A span of long integers to compare to second.</param>
         /// <param name="second">A span of long integers T to compare to first.</param>
         public static bool SequenceEqual(this Span<long> first, Span<long> second)
+        {
+            if (first.Length != second.Length) { return false; }
+
+            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
+            if (first.Length >= 256) { return MemoryUtils.MemCmp(first, second); }
+
+            // for small slices we just use simple loop
+            for (int i = 0; i < first.Length; i++) {
+                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
+                    return false; 
+                }
+            }
+            return true;
+        }
+
+		/// <summary>
+        /// Determines whether two read-only spans are equal (byte-wise) by comparing the elements by using memcmp
+        /// </summary>
+        /// <param name="first">A span of long integers to compare to second.</param>
+        /// <param name="second">A span of long integers T to compare to first.</param>
+        public static bool SequenceEqual(this ReadOnlySpan<long> first, ReadOnlySpan<long> second)
         {
             if (first.Length != second.Length) { return false; }
 

--- a/src/System.Slices/src/System/SpanExtensions.cs
+++ b/src/System.Slices/src/System/SpanExtensions.cs
@@ -91,7 +91,7 @@ namespace System
         public static Span<char> Slice(this string str, int start)
         {
             Contract.Requires(str != null);
-            Contract.RequiresInInclusiveRange(start, str.Length);
+            Contract.RequiresInInclusiveRange(start, (uint)str.Length);
             return new Span<char>(
                 str,
                 new UIntPtr((uint)(SpanHelpers.OffsetToStringData + (start * sizeof(char)))),

--- a/src/System.Slices/src/System/SpanExtensionsTemplate.tt
+++ b/src/System.Slices/src/System/SpanExtensionsTemplate.tt
@@ -49,5 +49,26 @@ namespace System
             return true;
         }
 
+		/// <summary>
+        /// Determines whether two read-only spans are equal (byte-wise) by comparing the elements by using memcmp
+        /// </summary>
+        /// <param name="first">A span of <#= many #> to compare to second.</param>
+        /// <param name="second">A span of <#= many #> T to compare to first.</param>
+        public static bool SequenceEqual(this ReadOnlySpan<<#= typeName #>> first, ReadOnlySpan<<#= typeName #>> second)
+        {
+            if (first.Length != second.Length) { return false; }
+
+            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
+            if (first.Length >= <#= smallSliceLimit #>) { return MemoryUtils.MemCmp(first, second); }
+
+            // for small slices we just use simple loop
+            for (int i = 0; i < first.Length; i++) {
+                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
+                    return false; 
+                }
+            }
+            return true;
+        }
+
 <#+}
 #>

--- a/src/System.Slices/tests/BasicUnitTests.cs
+++ b/src/System.Slices/tests/BasicUnitTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Xunit;
-
+ 
 namespace System.Slices.Tests
 {
     public class SlicesTests
@@ -93,6 +93,95 @@ namespace System.Slices.Tests
         public void ByteSpanCtorWithRangeThrowsArgumentOutOfRangeException(byte[] bytes, int start, int length)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => { Span<byte> span = new Span<byte>(bytes, start, length); });
+        }
+
+        [CLSCompliant(false)]
+        [Theory]
+        [InlineData(new byte[0], 0, 0)]
+        [InlineData(new byte[1] { 0 }, 0, 0)]
+        [InlineData(new byte[1] { 0 }, 0, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 0, 2)]
+        [InlineData(new byte[2] { 0, 0 }, 0, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 1, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 2, 0)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 0, 3)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 0, 2)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 1, 2)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 1, 1)]
+        public void ByteSpanSliceWithRangeValidCases(byte[] bytes, int start, int length)
+        {
+            Span<byte> span = new Span<byte>(bytes, start, length);
+        }
+
+        [CLSCompliant(false)]
+        [Theory]
+        [InlineData(new byte[0], 1, 0)]
+        [InlineData(new byte[0], 1, -1)]
+        [InlineData(new byte[0], 0, 1)]
+        [InlineData(new byte[0], -1, 0)]
+        [InlineData(new byte[0], 5, 5)]
+        [InlineData(new byte[1] { 0 }, 0, 2)]
+        [InlineData(new byte[1] { 0 }, 1, 1)]
+        [InlineData(new byte[1] { 0 }, -1, 2)]
+        [InlineData(new byte[2] { 0, 0 }, 0, 3)]
+        [InlineData(new byte[2] { 0, 0 }, 1, 2)]
+        [InlineData(new byte[2] { 0, 0 }, 2, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 3, 0)]
+        [InlineData(new byte[2] { 0, 0 }, 1, -1)]
+        [InlineData(new byte[2] { 0, 0 }, 2, int.MaxValue)]
+        [InlineData(new byte[2] { 0, 0 }, int.MinValue, int.MinValue)]
+        [InlineData(new byte[2] { 0, 0 }, int.MaxValue, int.MaxValue)]
+        [InlineData(new byte[2] { 0, 0 }, int.MinValue, int.MaxValue)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 1, 3)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 2, 2)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 15, 0)]
+        public void ByteSpanSliceWithRangeThrowsArgumentOutOfRangeException1(byte[] bytes, int start, int length)
+        {
+            var span = new Span<byte>(bytes);
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                Span<byte> slice = span.Slice(start, length);
+            });
+        }
+
+        [CLSCompliant(false)]
+        [Theory]
+        [InlineData(new byte[0], 0)]
+        [InlineData(new byte[1] { 0 }, 0)]
+        [InlineData(new byte[1] { 0 }, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 0)]
+        [InlineData(new byte[2] { 0, 0 }, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 2)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 0)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 1)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 2)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 3)]
+        public void ByteSpanSliceWithStartRangeValidCases(byte[] bytes, int start)
+        {
+            Span<byte> span = new Span<byte>(bytes).Slice(start);
+        }
+
+        [CLSCompliant(false)]
+        [Theory]
+        [InlineData(new byte[0], int.MinValue)]
+        [InlineData(new byte[0], -1)]
+        [InlineData(new byte[0], 1)]
+        [InlineData(new byte[0], int.MaxValue)]
+        [InlineData(new byte[1] { 0 }, int.MinValue)]
+        [InlineData(new byte[1] { 0 }, -1)]
+        [InlineData(new byte[1] { 0 }, 2)]
+        [InlineData(new byte[1] { 0 }, int.MaxValue)]
+        [InlineData(new byte[2] { 0, 0 }, int.MinValue)]
+        [InlineData(new byte[2] { 0, 0 }, -1)]
+        [InlineData(new byte[2] { 0, 0 }, 3)]
+        [InlineData(new byte[2] { 0, 0 }, int.MaxValue)]
+        public void ByteSpanSliceWithStartRangeThrowsArgumentOutOfRangeException(byte[] bytes, int start)
+        {
+            var span = new Span<byte>(bytes);
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                Span<byte> slice = span.Slice(start);
+            });
         }
     }
 }

--- a/src/System.Slices/tests/BasicUnitTests.cs
+++ b/src/System.Slices/tests/BasicUnitTests.cs
@@ -15,6 +15,14 @@ namespace System.Slices.Tests
         }
 
         [Fact]
+        public void ByteReadOnlySpanEmptyCreateArrayTest()
+        {
+            var empty = ReadOnlySpan<byte>.Empty;
+            var array = empty.CreateArray();
+            Assert.Equal(0, array.Length);
+        }
+
+        [Fact]
         public unsafe void ByteSpanEqualsTestsTwoDifferentInstancesOfBuffersWithOneValueDifferent()
         {
             const int bufferLength = 128;
@@ -32,6 +40,36 @@ namespace System.Slices.Tests
             {
                 Span<byte> b1 = new Span<byte>(buffer1pinned, bufferLength);
                 Span<byte> b2 = new Span<byte>(buffer2pinned, bufferLength);
+
+                for (int i = 0; i < bufferLength; i++)
+                {
+                    for (int diffPosition = i; diffPosition < bufferLength; diffPosition++)
+                    {
+                        buffer1[diffPosition] = unchecked((byte)(buffer1[diffPosition] + 1));
+                        Assert.False(b1.Slice(i).SequenceEqual(b2.Slice(i)));
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public unsafe void ByteReadOnlySpanEqualsTestsTwoDifferentInstancesOfBuffersWithOneValueDifferent()
+        {
+            const int bufferLength = 128;
+            byte[] buffer1 = new byte[bufferLength];
+            byte[] buffer2 = new byte[bufferLength];
+
+            for (int i = 0; i < bufferLength; i++)
+            {
+                buffer1[i] = (byte)(bufferLength + 1 - i);
+                buffer2[i] = (byte)(bufferLength + 1 - i);
+            }
+
+            fixed (byte* buffer1pinned = buffer1)
+            fixed (byte* buffer2pinned = buffer2)
+            {
+                ReadOnlySpan<byte> b1 = new ReadOnlySpan<byte>(buffer1pinned, bufferLength);
+                ReadOnlySpan<byte> b2 = new ReadOnlySpan<byte>(buffer2pinned, bufferLength);
 
                 for (int i = 0; i < bufferLength; i++)
                 {
@@ -62,10 +100,34 @@ namespace System.Slices.Tests
             Span<byte> span = new Span<byte>(bytes, start, length);
         }
 
+        [CLSCompliant(false)]
+        [Theory]
+        [InlineData(new byte[0], 0, 0)]
+        [InlineData(new byte[1] { 0 }, 0, 0)]
+        [InlineData(new byte[1] { 0 }, 0, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 0, 2)]
+        [InlineData(new byte[2] { 0, 0 }, 0, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 1, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 2, 0)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 0, 3)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 0, 2)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 1, 2)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 1, 1)]
+        public void ByteReadOnlySpanCtorWithRangeValidCases(byte[] bytes, int start, int length)
+        {
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(bytes, start, length);
+        }
+
         [Fact]
         public void ByteSpanCtorWithRangeThrowsArgumentExceptionOnNull()
         {
             Assert.Throws<ArgumentException>(() => { Span<byte> span = new Span<byte>(null, 0, 0); });
+        }
+
+        [Fact]
+        public void ByteReadOnlySpanCtorWithRangeThrowsArgumentExceptionOnNull()
+        {
+            Assert.Throws<ArgumentException>(() => { ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(null, 0, 0); });
         }
 
         [CLSCompliant(false)]
@@ -182,6 +244,11 @@ namespace System.Slices.Tests
             {
                 Span<byte> slice = span.Slice(start);
             });
+        }
+
+        public void ByteReadOnlySpanCtorWithRangeThrowsArgumentOutOfRangeException(byte[] bytes, int start, int length)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => { ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(bytes, start, length); });
         }
     }
 }

--- a/src/System.Slices/tests/Tests.cs
+++ b/src/System.Slices/tests/Tests.cs
@@ -47,12 +47,47 @@ public class Tests
             }
         }
     }
+
+    [Fact]
+    public void TwoReadOnlySpansCreatedOverSameIntArrayAreEqual()
+    {
+        for (int i = 0; i < 2; i++)
+        {
+            var ints = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+            // Try out two ways of creating a slice:
+            ReadOnlySpan<int> slice;
+            if (i == 0)
+            {
+                slice = new ReadOnlySpan<int>(ints);
+            }
+            else
+            {
+                slice = ints.Slice();
+            }
+            Assert.Equal(ints.Length, slice.Length);
+            // Now try out two ways of walking the slice's contents:
+            for (int j = 0; j < ints.Length; j++)
+            {
+                Assert.Equal(ints[j], slice[j]);
+            }
+            {
+                int j = 0;
+                foreach (var x in slice)
+                {
+                    Assert.Equal(ints[j], x);
+                    j++;
+                }
+            }
+        }
+    }
+
     [Fact]
     public void TestEndsWith() {
         
         var str = "Hello, Slice!";
-        Span<char> slice = str.Slice();
-        Span<char> slice2 = "Slice!".Slice();
+        ReadOnlySpan<char> slice = str.Slice();
+        ReadOnlySpan<char> slice2 = "Slice!".Slice();
         
         slice.EndsWith(slice2);
     }
@@ -62,7 +97,7 @@ public class Tests
     public void TwoSpansCreatedOverSameStringsAreEqual()
     {
         var str = "Hello, Slice!";
-        Span<char> slice = str.Slice();
+        ReadOnlySpan<char> slice = str.Slice();
         Assert.Equal(str.Length, slice.Length);
 
         // Now try out two ways of walking the slice's contents:
@@ -88,6 +123,32 @@ public class Tests
             byte* buffer = stackalloc byte[256];
             for (int i = 0; i < 256; i++) { buffer[i] = (byte)i; }
             Span<byte> slice = new Span<byte>(buffer, 256);
+            Assert.Equal(256, slice.Length);
+
+            // Now try out two ways of walking the slice's contents:
+            for (int j = 0; j < slice.Length; j++)
+            {
+                Assert.Equal(buffer[j], slice[j]);
+            }
+            {
+                int j = 0;
+                foreach (var x in slice)
+                {
+                    Assert.Equal(buffer[j], x);
+                    j++;
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public void TwoReadOnlySpansCreatedOverSameByteArayAreEqual()
+    {
+        unsafe
+        {
+            byte* buffer = stackalloc byte[256];
+            for (int i = 0; i < 256; i++) { buffer[i] = (byte)i; }
+            ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(buffer, 256);
             Assert.Equal(256, slice.Length);
 
             // Now try out two ways of walking the slice's contents:

--- a/src/dirs.proj
+++ b/src/dirs.proj
@@ -8,7 +8,7 @@
     <Project Include="*\src\*.xproj" Exclude="@(ExcludeProjects)" />
     <Project Include="*\test*\**\*.csproj" Exclude="@(ExcludeProjects)" />
     <Project Include="*\test*\**\*.vbproj" Condition="'$(IncludeVbProjects)'!='false'" Exclude="@(ExcludeProjects)" />
-    <Project Include="*\test*\**\*.xproj" Exclude="@(ExcludeProjects)" />
+    <Project Include="*\test*\**\*.xproj" Exclude="@(ExcludeProjects);System.Text.Json\Tests\System.Text.Json.Tests.xproj;System.Text.Formatting\Tests\System.Text.Formatting.Tests.xproj" />
   </ItemGroup>
 
   <Import Project="..\dir.targets" />


### PR DESCRIPTION
Fixes [Span indexer computes the element offset using Int32 which can overflow](https://github.com/dotnet/corefxlab/issues/516)
Improves the generated  code a bit in terms of size and quality.

```C#
[MethodImpl(MethodImplOptions.NoInlining)]
public static void TestSpan(Span<long> span, int index)
{
    span[index] = 33;
}
```

Before the fix
```ASM
; Assembly listing for method CoreClrTest.Program:TestSpan(struct,int)
; Emitting BLENDED_CODE for X64 CPU with SSE2
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  8,  10  )   byref  ->  rcx         ld-addr-op
;  V01 arg1         [V01,T01] (  5,   4.5)     int  ->  rdx        
;  V02 tmp0         [V02,T02] (  2,   4  )     ref  ->  rax        
;  V03 tmp1         [V03,T03] (  2,   4  )    long  ->  rcx        
;* V04 tmp2         [V04    ] (  0,   0  )    long  ->  zero-ref   
;  V05 tmp3         [V05,T08] (  3,   0  )     ref  ->  rsi        
;  V06 tmp4         [V06,T06] (  2,   3  )     int  ->  rax         ld-addr-op
;* V07 tmp5         [V07    ] (  0,   0  )    long  ->  zero-ref    ld-addr-op
;  V08 tmp6         [V08,T04] (  2,   4  )     int  ->  rdx        
;* V09 tmp7         [V09    ] (  0,   0  )    long  ->  zero-ref   
;  V10 tmp8         [V10,T05] (  2,   4  )    long  ->  rcx        
;  V11 tmp9         [V11,T07] (  2,   2  )   byref  ->  rax        
;* V12 tmp10        [V12    ] (  0,   0  )    long  ->  zero-ref   
;* V13 tmp11        [V13    ] (  0,   0  )    long  ->  zero-ref   
;  V14 OutArgs      [V14    ] (  1,   1  )  lclBlk (32) [rsp+0x00]  
;
; Lcl frame size = 32

G_M17569_IG01:
       56                   push     rsi
       4883EC20             sub      rsp, 32

G_M17569_IG02:
       8B4110               mov      eax, dword ptr [rcx+16]
       85D2                 test     edx, edx
       7C22                 jl       SHORT G_M17569_IG05
       3BD0                 cmp      edx, eax
       7D1E                 jge      SHORT G_M17569_IG05

G_M17569_IG03:
       488B01               mov      rax, gword ptr [rcx]
       488B4908             mov      rcx, qword ptr [rcx+8]
       C1E203               shl      edx, 3
       4863D2               movsxd   edx, edx
       4803CA               add      rcx, rdx
       48C7040821000000     mov      qword ptr [rax+rcx], 33

G_M17569_IG04:
       4883C420             add      rsp, 32
       5E                   pop      rsi
       C3                   ret      

G_M17569_IG05:
       48B9A044FCB7FD7F0000 mov      rcx, 0x7FFDB7FC44A0
       E8630C3E5F           call     CORINFO_HELP_NEWSFAST
       488BF0               mov      rsi, rax
       488BCE               mov      rcx, rsi
       E898747162           call     System.ArgumentOutOfRangeException:.ctor():this
       488BCE               mov      rcx, rsi
       E8000CD55E           call     CORINFO_HELP_THROW
       CC                   int3     

; Total bytes of code 81, prolog size 5 for method CoreClrTest.Program:TestSpan(struct,int)
; ============================================================
```

After
```ASM
; Assembly listing for method CoreClrTest.Program:TestSpan(struct,int)
; Emitting BLENDED_CODE for X64 CPU with SSE2
; optimized code
; rsp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  8,  10  )   byref  ->  rcx         ld-addr-op
;  V01 arg1         [V01,T01] (  5,   4.5)     int  ->  rdx        
;* V02 tmp0         [V02    ] (  0,   0  )    long  ->  zero-ref   
;  V03 tmp1         [V03,T06] (  3,   0  )     ref  ->  rsi        
;  V04 tmp2         [V04,T04] (  2,   3  )     int  ->  rax         ld-addr-op
;  V05 tmp3         [V05,T02] (  2,   4  )     ref  ->  rax         ld-addr-op
;  V06 tmp4         [V06,T05] (  2,   2  )   byref  ->  rax        
;  V07 tmp5         [V07,T03] (  2,   4  )    long  ->  rcx         ld-addr-op
;* V08 tmp6         [V08    ] (  0,   0  )    long  ->  zero-ref   
;* V09 tmp7         [V09    ] (  0,   0  )    long  ->  zero-ref   
;  V10 OutArgs      [V10    ] (  1,   1  )  lclBlk (32) [rsp+0x00]  
;
; Lcl frame size = 32

G_M17565_IG01:
       56                   push     rsi
       4883EC20             sub      rsp, 32

G_M17565_IG02:
       8B4110               mov      eax, dword ptr [rcx+16]
       85D2                 test     edx, edx
       7C1F                 jl       SHORT G_M17565_IG05
       3BD0                 cmp      edx, eax
       7D1B                 jge      SHORT G_M17565_IG05

G_M17565_IG03:
       488B01               mov      rax, gword ptr [rcx]
       488B4908             mov      rcx, qword ptr [rcx+8]
       4803C1               add      rax, rcx
       4863CA               movsxd   ecx, edx
       48C704C821000000     mov      qword ptr [rax+8*rcx], 33

G_M17565_IG04:
       4883C420             add      rsp, 32
       5E                   pop      rsi
       C3                   ret      

G_M17565_IG05:
       48B9A044FCB7FD7F0000 mov      rcx, 0x7FFDB7FC44A0
       E8660C3C5F           call     CORINFO_HELP_NEWSFAST
       488BF0               mov      rsi, rax
       488BCE               mov      rcx, rsi
       E89B746F62           call     System.ArgumentOutOfRangeException:.ctor():this
       488BCE               mov      rcx, rsi
       E8030CD35E           call     CORINFO_HELP_THROW
       CC                   int3     

; Total bytes of code 78, prolog size 5 for method CoreClrTest.Program:TestSpan(struct,int)
; ============================================================
```