### PR TITLE
Slices: Optimize Cast

### DIFF
--- a/src/System.Slices/src/System/SpanExtensions.cs
+++ b/src/System.Slices/src/System/SpanExtensions.cs
@@ -137,11 +137,15 @@ namespace System
             where U : struct
         {
             int countOfU = slice.Length * PtrUtils.SizeOf<T>() / PtrUtils.SizeOf<U>();
-            if (countOfU == 0)
+            object obj = null;
+            UIntPtr offset = default(UIntPtr);
+
+            if (countOfU != 0)
             {
-                return default(Span<U>);
+                obj = slice.Object;
+                offset = slice.Offset;
             }
-            return new Span<U>(slice.Object, slice.Offset, countOfU);
+            return new Span<U>(obj, offset, countOfU);
         }
 
         /// <summary>


### PR DESCRIPTION
For the JIT Span is a not primitive type (it contains a reference) and the generated code  is sometimes suboptimal. The change  is a workaround for one such case.

```C#
[MethodImpl(MethodImplOptions.NoInlining)]
public static void TestSpanCast(Span<byte> span)
{
    var spanLong = span.Cast<byte, long>();
}
```

After the change:
```ASM
; Assembly listing for method CoreClrTest.Program:TestSpanCast(struct)
; Lcl frame size = 24

G_M62531_IG01:
       57                   push     rdi
       56                   push     rsi
       4883EC18             sub      rsp, 24
       488BF1               mov      rsi, rcx
       488D3C24             lea      rdi, [rsp]
       B906000000           mov      ecx, 6
       33C0                 xor      rax, rax
       F3AB                 rep stosd 
       488BCE               mov      rcx, rsi

G_M62531_IG02:
       4C8B01               mov      r8, gword ptr [rcx]
       4C8B4908             mov      r9, qword ptr [rcx+8]
       8B4110               mov      eax, dword ptr [rcx+16]
       99                   cdq      
       83E207               and      edx, 7
       03C2                 add      eax, edx
       C1F803               sar      eax, 3
       33D2                 xor      rdx, rdx
       33C9                 xor      rcx, rcx
       85C0                 test     eax, eax
       7406                 je       SHORT G_M62531_IG03
       498BD0               mov      rdx, r8
       498BC9               mov      rcx, r9

G_M62531_IG03:
       4C8D0424             lea      r8, bword ptr [rsp]
       498910               mov      gword ptr [r8], rdx
       49894808             mov      qword ptr [r8+8], rcx
       41894010             mov      dword ptr [r8+16], eax

G_M62531_IG04:
       4883C418             add      rsp, 24
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret      

; Total bytes of code 80, prolog size 25 for method CoreClrTest.Program:TestSpanCast(struct)
; ============================================================
``` 

Before
```ASM
; Assembly listing for method CoreClrTest.Program:TestSpanCast(struct)
; Lcl frame size = 72

G_M62531_IG01:
       57                   push     rdi
       56                   push     rsi
       4883EC48             sub      rsp, 72
       488BF1               mov      rsi, rcx
       488D3C24             lea      rdi, [rsp]
       B912000000           mov      ecx, 18
       33C0                 xor      rax, rax
       F3AB                 rep stosd 
       488BCE               mov      rcx, rsi

G_M62531_IG02:
       4C8B01               mov      r8, gword ptr [rcx]
       4C8B4908             mov      r9, qword ptr [rcx+8]
       8B4110               mov      eax, dword ptr [rcx+16]
       99                   cdq      
       83E207               and      edx, 7
       03C2                 add      eax, edx
       C1F803               sar      eax, 3
       85C0                 test     eax, eax
       752B                 jne      SHORT G_M62531_IG05
       4533C0               xor      r8, r8
       4C8D0C24             lea      r9, bword ptr [rsp]
       660F57C0             xorpd    xmm0, xmm0
       F3410F7F01           movdqu   qword ptr [r9], xmm0
       4D894110             mov      qword ptr [r9+16], r8

G_M62531_IG03:
       F30F6F0424           movdqu   xmm0, qword ptr [rsp]
       F30F7F442418         movdqu   qword ptr [rsp+18H], xmm0
       488B442410           mov      rax, qword ptr [rsp+10H]
       4889442428           mov      qword ptr [rsp+28H], rax

G_M62531_IG04:
       EB0F                 jmp      SHORT G_M62531_IG06

G_M62531_IG05:
       488D542418           lea      rdx, bword ptr [rsp+18H]
       4C8902               mov      gword ptr [rdx], r8
       4C894A08             mov      qword ptr [rdx+8], r9
       894210               mov      dword ptr [rdx+16], eax

G_M62531_IG06:
       F30F6F442418         movdqu   xmm0, qword ptr [rsp+18H]
       F30F7F442430         movdqu   qword ptr [rsp+30H], xmm0
       488B442428           mov      rax, qword ptr [rsp+28H]
       4889442440           mov      qword ptr [rsp+40H], rax

G_M62531_IG07:
       4883C448             add      rsp, 72
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret      

; Total bytes of code 135, prolog size 25 for method CoreClrTest.Program:TestSpanCast(struct)
; ============================================================
```