### PR TITLE
Slices: Implement IndexOf for Span<T>

### DIFF
--- a/src/System.Slices/System/SpanExtensions.cs
+++ b/src/System.Slices/System/SpanExtensions.cs
@@ -317,6 +317,66 @@ namespace System
             return SequenceEqual(Cast<T, byte>(first), Cast<U, byte>(second));
         }
 
+        /// <summary>Searches for the specified value and returns the index of the first occurrence within the entire <see cref="T:System.Span" />.</summary>
+        /// <returns>The zero-based index of the first occurrence of <paramref name="value" /> within the entire <paramref name="slice" />, if found; otherwise, –1.</returns>
+        /// <param name="slice">The <see cref="T:System.Span" /> to search.</param>
+        /// <param name="value">The value to locate in <paramref name="slice" />.</param>
+        /// <typeparam name="T">The type of the elements of the slice.</typeparam>
+        [ILSub(@"   
+            .maxstack 3
+            .locals([0] uint8 & addr,
+                    [1] native uint i,
+                    [2] native uint length)
+            ldarg.0
+            ldfld      int32 valuetype System.ReadOnlySpan`1<!!T>::Length
+            dup
+            stloc.2
+            brfalse.s  EMPTY_SPAN
+ 
+            ldarg.0
+            ldfld      object valuetype System.ReadOnlySpan`1<!!T>::Object
+            stloc.0     
+            ldloc.0     
+            ldarg.0
+            ldfld      native uint valuetype System.ReadOnlySpan`1<!!T>::Offset
+
+            add         
+            stloc.0 
+
+            ldc.i4.0    
+            stloc.1
+            
+        LOOP_START:
+            ldloc.0
+            ldloc.1     
+            sizeof !!T  
+            conv.u  
+            mul         
+            add         
+            ldarg.1
+            constrained. !!T
+            callvirt   instance bool class [System.Runtime]System.IEquatable`1<!!T>::Equals(!0)
+            brfalse.s   NOT_EQUAL
+            ldloc.1     
+            ret 
+     
+        NOT_EQUAL:  
+            ldloc.1     
+            ldc.i4.1    
+            add         
+            stloc.1    
+            ldloc.1     
+            ldloc.2     
+            blt.s       LOOP_START
+        EMPTY_SPAN:
+            ldc.i4.m1 
+            ret")]
+        public static int IndexOf<T>(this ReadOnlySpan<T> slice, T value)
+           where T : struct, IEquatable<T>
+        {
+            return 0;
+        }
+
         // Helper methods similar to System.ArrayExtension:
 
         // String helper methods, offering methods like String on Slice<char>:
@@ -350,11 +410,6 @@ namespace System
             }
 
             return true;
-        }
-
-        public static int IndexOf(this ReadOnlySpan<char> str, char value)
-        {
-            throw new NotImplementedException();
         }
 
         public static int IndexOf(this ReadOnlySpan<char> str, string value)

--- a/tests/System.Slices.Tests/IndexOfTests.cs
+++ b/tests/System.Slices.Tests/IndexOfTests.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Xunit;
+
+namespace System.Slices.Tests
+{
+    public class IndexOfTests
+    {
+        [Fact]
+        public void FindInUniqueValues()
+        {
+            var range = Enumerable.Range(0, 10).ToArray();
+
+            UniqueValuesSuccess(range);
+            UniqueValuesSuccess(range.Select(i => Guid.NewGuid()).ToArray());
+        }
+
+        [Fact]
+        public void FindInNonUniqueValues()
+        {
+            var range = Enumerable.Range(0, 10).ToArray();
+
+            NonUniqueValuesSuccess(range.Concat(range).ToArray());
+
+            var guids = range.Select(i => Guid.NewGuid()).ToArray();
+            NonUniqueValuesSuccess(guids.Concat(guids).ToArray());
+        }
+
+        [Fact]
+        public void DontFindNonExisting()
+        {
+            var range = Enumerable.Range(0, 10).ToArray();
+
+            NonExistingValuesFailure(
+                range.Take(5).ToArray(),
+                range.Skip(5).ToArray());
+
+            var guids = range.Select(i => Guid.NewGuid()).ToArray();
+            NonExistingValuesFailure(
+                guids.Take(5).ToArray(),
+                guids.Skip(5).ToArray());
+        }
+
+        private void UniqueValuesSuccess<T>(T[] values)
+            where T : struct, IEquatable<T>
+        {
+            Debug.Assert(values.Distinct().Count() == values.Length);
+
+            ReadOnlySpan<T> slice = values.Slice();
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                T value = values[i];
+                int indexInArray = Array.IndexOf(values, value);
+
+                int index = slice.IndexOf(value);
+
+                Assert.True(index >= 0);
+                Assert.Equal(indexInArray, index);
+                
+            }
+        }
+
+        private void NonUniqueValuesSuccess<T>(T[] values)
+            where T : struct, IEquatable<T>
+        {
+            Debug.Assert(values.Distinct().Count() < values.Length);
+
+            ReadOnlySpan<T> slice = values.Slice();
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                T value = values[i];
+                int indexInArray = Array.IndexOf(values, value);
+
+                int index = slice.IndexOf(value);
+
+                Assert.True(index >= 0);
+                Assert.Equal(indexInArray, index);
+            }
+        }
+
+        private void NonExistingValuesFailure<T>(T[] values, T[] nonExistingValues)
+            where T : struct, IEquatable<T>
+        {
+            Debug.Assert(!values.Intersect(nonExistingValues).Any());
+
+            ReadOnlySpan<T> slice = values.Slice();
+
+            for (int i = 0; i < nonExistingValues.Length; i++)
+            {
+                T value = nonExistingValues[i];
+                int indexInArray = Array.IndexOf(values, value);
+
+                int index = slice.IndexOf(value);
+
+                Assert.True(index == -1);
+                Assert.Equal(indexInArray, index);
+            }
+        }
+    }
+}


### PR DESCRIPTION
It is an implementation of IndexOf method with range check eliminated.
For Span of chars it serves as ordinal IndexOf.

```C#
[MethodImpl(MethodImplOptions.NoInlining)]
public static int TestSpanIndexOf(Span<long> span, longvalue)
{
    return span.IndexOf(value);
}
```
The generated code for different element types.

**long**:
```ASM
; Assembly listing for method System.SpanExtensions:IndexOf(struct,long):int
; Lcl frame size = 0

       8B4110               mov      eax, dword ptr [rcx+16]
       4C63C0               movsxd   r8d, eax
       4D85C0               test     r8, r8
       741C                 je       SHORT G_M9848_IG06
       4C8B09               mov      r9, gword ptr [rcx]
       488B4108             mov      rax, qword ptr [rcx+8]
       4C03C8               add      r9, rax
       33C0                 xor      rax, rax
G_M9848_IG03:
       493914C1             cmp      qword ptr [r9+8*rax], rdx
       7501                 jne      SHORT G_M9848_IG05
       C3                   ret      
G_M9848_IG05:
       48FFC0               inc      rax
       493BC0               cmp      rax, r8
       7CF1                 jl       SHORT G_M9848_IG03
G_M9848_IG06:
       B8FFFFFFFF           mov      eax, -1
       C3                   ret      

; Total bytes of code 44, prolog size 0 for method System.SpanExtensions:IndexOf(struct,long):int
```
**char**
```ASM
; Assembly listing for method System.SpanExtensions:IndexOf(struct,char):int
; Lcl frame size = 0
       8B4110               mov      eax, dword ptr [rcx+16]
       4C63C0               movsxd   r8d, eax
       4D85C0               test     r8, r8
       7425                 je       SHORT G_M64671_IG06
       4C8B09               mov      r9, gword ptr [rcx]
       488B4108             mov      rax, qword ptr [rcx+8]
       4C03C8               add      r9, rax
       33C0                 xor      rax, rax
       81E2FFFF0000         and      edx, 0xFFFF
G_M64671_IG03:
       410FB70C41           movzx    rcx, word  ptr [r9+2*rax]
       3BCA                 cmp      ecx, edx
       7501                 jne      SHORT G_M64671_IG05
       C3                   ret      
G_M64671_IG05:
       48FFC0               inc      rax
       493BC0               cmp      rax, r8
       7CEE                 jl       SHORT G_M64671_IG03
G_M64671_IG06:
       B8FFFFFFFF           mov      eax, -1
       C3                   ret      
; Total bytes of code 53, prolog size 0 for method System.SpanExtensions:IndexOf(struct,char):int
```

**Guid**

```ASM
; Assembly listing for method System.SpanExtensions:IndexOf(struct,struct):int
; Lcl frame size = 56
       57                   push     rdi
       56                   push     rsi
       55                   push     rbp
       53                   push     rbx
       4883EC38             sub      rsp, 56
       488BF2               mov      rsi, rdx

       8B5110               mov      edx, dword ptr [rcx+16]
       4863FA               movsxd   edi, edx
       4885FF               test     rdi, rdi
       7441                 je       SHORT G_M17753_IG06
       488B19               mov      rbx, gword ptr [rcx]
       488B4908             mov      rcx, qword ptr [rcx+8]
       4803D9               add      rbx, rcx
       33ED                 xor      rbp, rbp
G_M17753_IG03:
       488BCD               mov      rcx, rbp
       48C1E104             shl      rcx, 4
       4803CB               add      rcx, rbx
       F30F6F06             movdqu   xmm0, qword ptr [rsi]
       F30F7F442428         movdqu   qword ptr [rsp+28H], xmm0
       488D542428           lea      rdx, bword ptr [rsp+28H]
       E8400E435E           call     System.Guid:Equals(struct):bool:this
       85C0                 test     eax, eax
       740B                 je       SHORT G_M17753_IG05
       8BC5                 mov      eax, ebp
       4883C438             add      rsp, 56
       5B                   pop      rbx
       5D                   pop      rbp
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret      
G_M17753_IG05:
       48FFC5               inc      rbp
       483BEF               cmp      rbp, rdi
       7CCB                 jl       SHORT G_M17753_IG03
G_M17753_IG06:
       B8FFFFFFFF           mov      eax, -1
       4883C438             add      rsp, 56
       5B                   pop      rbx
       5D                   pop      rbp
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret      

; Total bytes of code 101, prolog size 8 for method System.SpanExtensions:IndexOf(struct,struct):int
```


For comparison this is what we get for for **a  simple iteration over an array**:
```C#
        [MethodImpl(MethodImplOptions.NoInlining)]
        public static int TestSpanIndexOf(long[] array, long value)
        {
            for (int i = 0; i < array.Length; i++)
            {
                if (array[i] == value)
                    return i;
            }

            return -1;
        }
```

```ASM
; Lcl frame size = 0
       33C0                 xor      eax, eax
       448B4108             mov      r8d, dword ptr [rcx+8]
       4585C0               test     r8d, r8d
       7E13                 jle      SHORT G_M39245_IG06
G_M39245_IG03:
       4C63C8               movsxd   r9d, eax
       4A3954C910           cmp      qword ptr [rcx+8*r9+16], rdx
       7502                 jne      SHORT G_M39245_IG05
       C3                   ret      
G_M39245_IG05:
       FFC0                 inc      eax
       443BC0               cmp      r8d, eax
       7FEE                 jg       SHORT G_M39245_IG03
G_M39245_IG06:
       B8FFFFFFFF           mov      eax, -1
       C3                   ret      

; Total bytes of code 35, prolog size 0 for method CoreClrTest.Program:TestSpanIndexOf(ref,long):int
```


Benchmarked it with [BenchmarkDotNet](https://github.com/PerfDotNet/BenchmarkDotNet)
The code is [here](https://gist.github.com/omariom/e2806c35507550ce3153) - searching for the last symbol in a string of  223 chars length.

BenchmarkDotNet=v0.8.0.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-3537U CPU @ 2.00GHz, ProcessorCount=4
HostCLR=MS.NET 4.0.30319.42000, Arch=64-bit  [RyuJIT]
Type=Benchmarks  Mode=Throughput  Platform=HostPlatform  Jit=HostJit  .NET=HostFramework  toolchain=Classic  Runtime=Clr  Warmup=5  Target=10  

           Method |              op/s |
----------------- |--------------- |
 CharArrayIndexOf | 5,782,149.16 |
     SliceIndexOf  | 5,694,112.95 |
    StringIndexOf  | 5,521,419.05 | 

Actually on short distance and when it is in a local var Span is faster than string and char[] though not by much. 