### PR TITLE
Slices: Fix oveflows in Span<T>.Slice methods

### DIFF
--- a/src/System.Slices/src/System/Contract.cs
+++ b/src/System.Slices/src/System/Contract.cs
@@ -41,6 +41,18 @@ namespace System
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresInInclusiveRange(int start, int length, int existingLength)
+        {
+            if ((uint)start > (uint)existingLength
+                || length < 0
+                || (uint)(start + length) > (uint)existingLength)
+            {
+                throw NewArgumentOutOfRangeException();
+            }
+        }
+
+        
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static Exception NewArgumentException()
         {

--- a/src/System.Slices/src/System/Contract.cs
+++ b/src/System.Slices/src/System/Contract.cs
@@ -24,29 +24,29 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void RequiresInRange(int start, int length)
+        public static void RequiresInRange(int start, uint length)
         {
-            if ((uint)start >= (uint)length)
+            if ((uint)start >= length)
             {
                 throw NewArgumentOutOfRangeException();
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void RequiresInInclusiveRange(int start, int length)
+        public static void RequiresInInclusiveRange(int start, uint length)
         {
-            if ((uint)start > (uint)length)
+            if ((uint)start > length)
             {
                 throw NewArgumentOutOfRangeException();
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void RequiresInInclusiveRange(int start, int length, int existingLength)
+        public static void RequiresInInclusiveRange(int start, int length, uint existingLength)
         {
-            if ((uint)start > (uint)existingLength
+            if ((uint)start > existingLength
                 || length < 0
-                || (uint)(start + length) > (uint)existingLength)
+                || (uint)(start + length) > existingLength)
             {
                 throw NewArgumentOutOfRangeException();
             }

--- a/src/System.Slices/src/System/Span.cs
+++ b/src/System.Slices/src/System/Span.cs
@@ -53,7 +53,7 @@ namespace System
         internal Span(T[] array, int start)
         {
             Contract.Requires(array != null);
-            Contract.RequiresInInclusiveRange(start, array.Length);
+            Contract.RequiresInInclusiveRange(start, (uint)array.Length);
             if (start < array.Length)
             {
                 Object = array;
@@ -85,9 +85,7 @@ namespace System
         public Span(T[] array, int start, int length)
         {
             Contract.Requires(array != null);
-            Contract.RequiresInInclusiveRange(start, array.Length);
-            Contract.RequiresNonNegative(length);
-            Contract.RequiresInInclusiveRange(start + length, array.Length);
+            Contract.RequiresInInclusiveRange(start, length, (uint)array.Length);
             if (start < array.Length)
             {
                 Object = array;
@@ -156,14 +154,14 @@ namespace System
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                Contract.RequiresInRange(index, Length);
+                Contract.RequiresInRange(index, (uint)Length);
                 return PtrUtils.Get<T>(
                     Object, Offset + (index * PtrUtils.SizeOf<T>()));
             }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set
             {
-                Contract.RequiresInRange(index, Length);
+                Contract.RequiresInRange(index, (uint)Length);
                 PtrUtils.Set<T>(
                     Object, Offset + (index * PtrUtils.SizeOf<T>()), value);
             }
@@ -239,7 +237,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<T> Slice(int start)
         {
-            Contract.RequiresInInclusiveRange(start, Length);
+            Contract.RequiresInInclusiveRange(start, (uint)Length);
             return new Span<T>(
                 Object, Offset + (start * PtrUtils.SizeOf<T>()), Length - start);
         }
@@ -256,8 +254,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<T> Slice(int start, int length)
         {
-            Contract.RequiresInInclusiveRange(start, length, Length);
-
+            Contract.RequiresInInclusiveRange(start, length, (uint)Length);
             return new Span<T>(
                 Object, Offset + (start * PtrUtils.SizeOf<T>()), length);
         }

--- a/src/System.Slices/src/System/Span.cs
+++ b/src/System.Slices/src/System/Span.cs
@@ -236,9 +236,12 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified start index is not in range (&lt;0 or &gt;&eq;length).
         /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<T> Slice(int start)
         {
-            return Slice(start, Length - start);
+            Contract.RequiresInInclusiveRange(start, Length);
+            return new Span<T>(
+                Object, Offset + (start * PtrUtils.SizeOf<T>()), Length - start);
         }
 
         /// <summary>
@@ -250,9 +253,11 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified start or end index is not in range (&lt;0 or &gt;&eq;length).
         /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<T> Slice(int start, int length)
         {
-            Contract.Requires(start + length <= Length);
+            Contract.RequiresInInclusiveRange(start, length, Length);
+
             return new Span<T>(
                 Object, Offset + (start * PtrUtils.SizeOf<T>()), length);
         }

--- a/src/System.Slices/src/System/SpanExtensions.cs
+++ b/src/System.Slices/src/System/SpanExtensions.cs
@@ -91,7 +91,7 @@ namespace System
         public static Span<char> Slice(this string str, int start)
         {
             Contract.Requires(str != null);
-            Contract.RequiresInInclusiveRange(start, str.Length);
+            Contract.RequiresInInclusiveRange(start, (uint)str.Length);
             return new Span<char>(
                 str,
                 new UIntPtr((uint)(SpanHelpers.OffsetToStringData + (start * sizeof(char)))),

--- a/src/System.Slices/tests/BasicUnitTests.cs
+++ b/src/System.Slices/tests/BasicUnitTests.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Xunit;
-
+ 
 namespace System.Slices.Tests
 {
     public class SlicesTests
@@ -93,6 +93,95 @@ namespace System.Slices.Tests
         public void ByteSpanCtorWithRangeThrowsArgumentOutOfRangeException(byte[] bytes, int start, int length)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => { Span<byte> span = new Span<byte>(bytes, start, length); });
+        }
+
+        [CLSCompliant(false)]
+        [Theory]
+        [InlineData(new byte[0], 0, 0)]
+        [InlineData(new byte[1] { 0 }, 0, 0)]
+        [InlineData(new byte[1] { 0 }, 0, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 0, 2)]
+        [InlineData(new byte[2] { 0, 0 }, 0, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 1, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 2, 0)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 0, 3)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 0, 2)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 1, 2)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 1, 1)]
+        public void ByteSpanSliceWithRangeValidCases(byte[] bytes, int start, int length)
+        {
+            Span<byte> span = new Span<byte>(bytes, start, length);
+        }
+
+        [CLSCompliant(false)]
+        [Theory]
+        [InlineData(new byte[0], 1, 0)]
+        [InlineData(new byte[0], 1, -1)]
+        [InlineData(new byte[0], 0, 1)]
+        [InlineData(new byte[0], -1, 0)]
+        [InlineData(new byte[0], 5, 5)]
+        [InlineData(new byte[1] { 0 }, 0, 2)]
+        [InlineData(new byte[1] { 0 }, 1, 1)]
+        [InlineData(new byte[1] { 0 }, -1, 2)]
+        [InlineData(new byte[2] { 0, 0 }, 0, 3)]
+        [InlineData(new byte[2] { 0, 0 }, 1, 2)]
+        [InlineData(new byte[2] { 0, 0 }, 2, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 3, 0)]
+        [InlineData(new byte[2] { 0, 0 }, 1, -1)]
+        [InlineData(new byte[2] { 0, 0 }, 2, int.MaxValue)]
+        [InlineData(new byte[2] { 0, 0 }, int.MinValue, int.MinValue)]
+        [InlineData(new byte[2] { 0, 0 }, int.MaxValue, int.MaxValue)]
+        [InlineData(new byte[2] { 0, 0 }, int.MinValue, int.MaxValue)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 1, 3)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 2, 2)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 15, 0)]
+        public void ByteSpanSliceWithRangeThrowsArgumentOutOfRangeException1(byte[] bytes, int start, int length)
+        {
+            var span = new Span<byte>(bytes);
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                Span<byte> slice = span.Slice(start, length);
+            });
+        }
+
+        [CLSCompliant(false)]
+        [Theory]
+        [InlineData(new byte[0], 0)]
+        [InlineData(new byte[1] { 0 }, 0)]
+        [InlineData(new byte[1] { 0 }, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 0)]
+        [InlineData(new byte[2] { 0, 0 }, 1)]
+        [InlineData(new byte[2] { 0, 0 }, 2)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 0)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 1)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 2)]
+        [InlineData(new byte[3] { 0, 0, 0 }, 3)]
+        public void ByteSpanSliceWithStartRangeValidCases(byte[] bytes, int start)
+        {
+            Span<byte> span = new Span<byte>(bytes).Slice(start);
+        }
+
+        [CLSCompliant(false)]
+        [Theory]
+        [InlineData(new byte[0], int.MinValue)]
+        [InlineData(new byte[0], -1)]
+        [InlineData(new byte[0], 1)]
+        [InlineData(new byte[0], int.MaxValue)]
+        [InlineData(new byte[1] { 0 }, int.MinValue)]
+        [InlineData(new byte[1] { 0 }, -1)]
+        [InlineData(new byte[1] { 0 }, 2)]
+        [InlineData(new byte[1] { 0 }, int.MaxValue)]
+        [InlineData(new byte[2] { 0, 0 }, int.MinValue)]
+        [InlineData(new byte[2] { 0, 0 }, -1)]
+        [InlineData(new byte[2] { 0, 0 }, 3)]
+        [InlineData(new byte[2] { 0, 0 }, int.MaxValue)]
+        public void ByteSpanSliceWithStartRangeThrowsArgumentOutOfRangeException(byte[] bytes, int start)
+        {
+            var span = new Span<byte>(bytes);
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                Span<byte> slice = span.Slice(start);
+            });
         }
     }
 }


### PR DESCRIPTION
Issue #537  
Both overloads of Span.Slice method allow to read at negative offsets.
Besides that they lack AggressiveInlining attribute what makes them slow.

I used the following benchmark code:
```C#
    public class BenchmarkSlice
    {
        Span<char> slice;

        public BenchmarkSlice()
        {
            string str = new string('c', 256);
            slice = str.Slice();
        }

        [Benchmark]
        public void Slice()
        {
            var copy = slice;
            
            do
            {
                copy = copy.Slice(1);
            }
            while (copy.Length != 0);
        }

        [Benchmark]
        public void SliceWithLength()
        {
            var copy = slice;
            do
            {
                copy = copy.Slice(1, copy.Length - 1);
            }
            while (copy.Length != 0);
        }
    }
```

**Original results (before the change)**

BenchmarkDotNet=v0.8.0.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-3537U CPU @ 2.00GHz, ProcessorCount=4
HostCLR=MS.NET 4.0.30319.42000, Arch=64-bit  [RyuJIT]
Type=BenchmarkSlice  Mode=Throughput  Platform=HostPlatform  Jit=HostJit  .NET=HostFramework  toolchain=Classic  Runtime=Clr  Warmup=5  Target=10

          Method |   AvrTime |    StdDev |       op/s |
---------------- |---------- |---------- |----------- |
           Slice | 1.6296 us | 0.1791 us | 620,547.63 |
 SliceWithLength | 1.8450 us | 0.1283 us | 544,803.54 |

**The results just after adding AggressiveInlining:**

          Method |     AvrTime |     StdDev |         op/s |
---------------- |------------ |----------- |------------- |
           Slice | 269.2951 ns |  1.3123 ns | 3,713,482.96 |
 SliceWithLength | 273.1879 ns | 17.6509 ns | 3,671,898.16 |

**The end result (after the fix):**

          Method |     AvrTime |    StdDev |         op/s |
---------------- |------------ |---------- |------------- |
           Slice | 192.6039 ns | 2.5312 ns | 5,192,833.50 |
 SliceWithLength | 357.4231 ns | 1.4362 ns | 2,797,847.44 |



