### PR TITLE
Change package versioning convention to make upgrades easier

### DIFF
--- a/package.ps1
+++ b/package.ps1
@@ -1,7 +1,7 @@
 ﻿Push-Location $PSScriptRoot
 [Environment]::CurrentDirectory = $PWD
 
-$version = [string]::Format("0.1.0-d{0}-1", (Get-Date).ToString("MMddyy"))
+$version = [string]::Format("0.1.0-e{0}-1", (Get-Date).ToString("yyMMdd"))
 $apiKey = $args[0]
 $nugetPath = ".\packages\NuGet.exe"
 


### PR DESCRIPTION
The dMMddyy version suffix for our packages does not work well with nuget/VS upgrade experiences,
i.e. a suffix is considered to represent a newer version, if it sorts later in the alphabetical order.
This change aligns the suffix sort order with time.