### PR TITLE
Add libuv.dll to the output folder when building libuv wrapper

### DIFF
--- a/src/System.Net.Libuv/src/project.json
+++ b/src/System.Net.Libuv/src/project.json
@@ -17,6 +17,9 @@
     "System.Buffers": "0.1.0-*"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": { }
+  },
+  "scripts": {
+    "postcompile": "copy \"%project:Directory%\\libuv.dll\" \"%compile:OutputDir%\\libuv.dll\""
   }
 }


### PR DESCRIPTION
When we moved to xproj, we stopped copying the native dll.
This change fixes the issue.