### PR TITLE
Slices: Faster SequenceEqual<T> implemented in IL

### DIFF
--- a/src/System.Slices/System/MemoryUtils.cs
+++ b/src/System.Slices/System/MemoryUtils.cs
@@ -14,6 +14,11 @@ namespace System
         internal static bool MemCmp<[Primitive]T>(Span<T> first, Span<T> second)
             where T : struct
         {
+            if (first.Length != second.Length)
+            {
+                return false;
+            }
+
             unsafe
             {
                 // prevent GC from moving memory
@@ -79,6 +84,11 @@ namespace System
         internal static bool MemCmp<[Primitive]T>(ReadOnlySpan<T> first, ReadOnlySpan<T> second)
             where T : struct
         {
+            if (first.Length != second.Length)
+            {
+                return false;
+            }
+
             unsafe
             {
                 // prevent GC from moving memory

--- a/src/System.Slices/System/SpanEqualsExtensions.cs
+++ b/src/System.Slices/System/SpanEqualsExtensions.cs
@@ -15,39 +15,21 @@ namespace System
         /// <param name="second">A span of bytes T to compare to first.</param>
         public static bool SequenceEqual(this Span<byte> first, Span<byte> second)
         {
-            if (first.Length != second.Length) { return false; }
-
-            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
-            if (first.Length >= 512) { return MemoryUtils.MemCmp(first, second); }
-
-            // for small slices we just use simple loop
-            for (int i = 0; i < first.Length; i++) {
-                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
-                    return false; 
-                }
-            }
-            return true;
+            return first.Length >= 320
+                ? MemoryUtils.MemCmp(first, second)
+                : SequenceEqual<byte>(first, second);
         }
 
-		/// <summary>
+        /// <summary>
         /// Determines whether two read-only spans are equal (byte-wise) by comparing the elements by using memcmp
         /// </summary>
         /// <param name="first">A span of bytes to compare to second.</param>
         /// <param name="second">A span of bytes T to compare to first.</param>
         public static bool SequenceEqual(this ReadOnlySpan<byte> first, ReadOnlySpan<byte> second)
         {
-            if (first.Length != second.Length) { return false; }
-
-            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
-            if (first.Length >= 512) { return MemoryUtils.MemCmp(first, second); }
-
-            // for small slices we just use simple loop
-            for (int i = 0; i < first.Length; i++) {
-                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
-                    return false; 
-                }
-            }
-            return true;
+            return first.Length >= 320
+                ? MemoryUtils.MemCmp(first, second)
+                : SequenceEqual<byte>(first, second);
         }
 
         /// <summary>
@@ -57,39 +39,21 @@ namespace System
         /// <param name="second">A span of characters T to compare to first.</param>
         public static bool SequenceEqual(this Span<char> first, Span<char> second)
         {
-            if (first.Length != second.Length) { return false; }
-
-            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
-            if (first.Length >= 512) { return MemoryUtils.MemCmp(first, second); }
-
-            // for small slices we just use simple loop
-            for (int i = 0; i < first.Length; i++) {
-                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
-                    return false; 
-                }
-            }
-            return true;
+            return first.Length >= 512
+                ? MemoryUtils.MemCmp(first, second)
+                : SequenceEqual<char>(first, second);
         }
 
-		/// <summary>
+        /// <summary>
         /// Determines whether two read-only spans are equal (byte-wise) by comparing the elements by using memcmp
         /// </summary>
         /// <param name="first">A span of characters to compare to second.</param>
         /// <param name="second">A span of characters T to compare to first.</param>
         public static bool SequenceEqual(this ReadOnlySpan<char> first, ReadOnlySpan<char> second)
         {
-            if (first.Length != second.Length) { return false; }
-
-            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
-            if (first.Length >= 512) { return MemoryUtils.MemCmp(first, second); }
-
-            // for small slices we just use simple loop
-            for (int i = 0; i < first.Length; i++) {
-                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
-                    return false; 
-                }
-            }
-            return true;
+            return first.Length >= 512
+                ? MemoryUtils.MemCmp(first, second)
+                : SequenceEqual<char>(first, second);
         }
 
         /// <summary>
@@ -99,39 +63,21 @@ namespace System
         /// <param name="second">A span of shorts T to compare to first.</param>
         public static bool SequenceEqual(this Span<short> first, Span<short> second)
         {
-            if (first.Length != second.Length) { return false; }
-
-            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
-            if (first.Length >= 512) { return MemoryUtils.MemCmp(first, second); }
-
-            // for small slices we just use simple loop
-            for (int i = 0; i < first.Length; i++) {
-                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
-                    return false; 
-                }
-            }
-            return true;
+            return first.Length >= 512
+                ? MemoryUtils.MemCmp(first, second)
+                : SequenceEqual<short>(first, second);
         }
 
-		/// <summary>
+        /// <summary>
         /// Determines whether two read-only spans are equal (byte-wise) by comparing the elements by using memcmp
         /// </summary>
         /// <param name="first">A span of shorts to compare to second.</param>
         /// <param name="second">A span of shorts T to compare to first.</param>
         public static bool SequenceEqual(this ReadOnlySpan<short> first, ReadOnlySpan<short> second)
         {
-            if (first.Length != second.Length) { return false; }
-
-            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
-            if (first.Length >= 512) { return MemoryUtils.MemCmp(first, second); }
-
-            // for small slices we just use simple loop
-            for (int i = 0; i < first.Length; i++) {
-                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
-                    return false; 
-                }
-            }
-            return true;
+            return first.Length >= 512
+                ? MemoryUtils.MemCmp(first, second)
+                : SequenceEqual<short>(first, second);
         }
 
         /// <summary>
@@ -141,39 +87,21 @@ namespace System
         /// <param name="second">A span of integers T to compare to first.</param>
         public static bool SequenceEqual(this Span<int> first, Span<int> second)
         {
-            if (first.Length != second.Length) { return false; }
-
-            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
-            if (first.Length >= 256) { return MemoryUtils.MemCmp(first, second); }
-
-            // for small slices we just use simple loop
-            for (int i = 0; i < first.Length; i++) {
-                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
-                    return false; 
-                }
-            }
-            return true;
+            return first.Length >= 256
+                ? MemoryUtils.MemCmp(first, second)
+                : SequenceEqual<int>(first, second);
         }
 
-		/// <summary>
+        /// <summary>
         /// Determines whether two read-only spans are equal (byte-wise) by comparing the elements by using memcmp
         /// </summary>
         /// <param name="first">A span of integers to compare to second.</param>
         /// <param name="second">A span of integers T to compare to first.</param>
         public static bool SequenceEqual(this ReadOnlySpan<int> first, ReadOnlySpan<int> second)
         {
-            if (first.Length != second.Length) { return false; }
-
-            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
-            if (first.Length >= 256) { return MemoryUtils.MemCmp(first, second); }
-
-            // for small slices we just use simple loop
-            for (int i = 0; i < first.Length; i++) {
-                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
-                    return false; 
-                }
-            }
-            return true;
+            return first.Length >= 256
+                ? MemoryUtils.MemCmp(first, second)
+                : SequenceEqual<int>(first, second);
         }
 
         /// <summary>
@@ -183,39 +111,21 @@ namespace System
         /// <param name="second">A span of long integers T to compare to first.</param>
         public static bool SequenceEqual(this Span<long> first, Span<long> second)
         {
-            if (first.Length != second.Length) { return false; }
-
-            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
-            if (first.Length >= 256) { return MemoryUtils.MemCmp(first, second); }
-
-            // for small slices we just use simple loop
-            for (int i = 0; i < first.Length; i++) {
-                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
-                    return false; 
-                }
-            }
-            return true;
+            return first.Length >= 256
+                ? MemoryUtils.MemCmp(first, second)
+                : SequenceEqual<long>(first, second);
         }
 
-		/// <summary>
+        /// <summary>
         /// Determines whether two read-only spans are equal (byte-wise) by comparing the elements by using memcmp
         /// </summary>
         /// <param name="first">A span of long integers to compare to second.</param>
         /// <param name="second">A span of long integers T to compare to first.</param>
         public static bool SequenceEqual(this ReadOnlySpan<long> first, ReadOnlySpan<long> second)
         {
-            if (first.Length != second.Length) { return false; }
-
-            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
-            if (first.Length >= 256) { return MemoryUtils.MemCmp(first, second); }
-
-            // for small slices we just use simple loop
-            for (int i = 0; i < first.Length; i++) {
-                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
-                    return false; 
-                }
-            }
-            return true;
+            return first.Length >= 256
+                ? MemoryUtils.MemCmp(first, second)
+                : SequenceEqual<long>(first, second);
         }
 
     }

--- a/src/System.Slices/System/SpanExtensions.cs
+++ b/src/System.Slices/System/SpanExtensions.cs
@@ -210,23 +210,80 @@ namespace System
         /// </summary>
         /// <param name="first">A span of type T to compare to second.</param>
         /// <param name="second">A span of type T to compare to first.</param>
+        [ILSub(@"
+            .maxstack 4
+            .locals([0] uint8 & baseAddr1,
+                    [1] uint8 & baseAddr2,
+                    [2] native uint i,
+                    [3] native uint length)
+            ldarg.0
+            ldfld      int32 valuetype System.Span`1<!!T>::Length
+            dup
+            stloc.3
+            ldarg.1
+            ldfld      int32 valuetype System.Span`1<!!T>::Length
+            ceq
+            brfalse.s  NOT_EQUAL
+
+            ldloc.3
+            brzero.s  EQUAL
+ 
+            ldarg.0
+            ldfld      object valuetype System.Span`1<!!T>::Object
+            stloc.0     
+            ldloc.0     
+            ldarg.0
+            ldfld      native uint valuetype System.Span`1<!!T>::Offset
+            add         
+            stloc.0 
+
+            ldarg.1
+            ldfld      object valuetype System.Span`1<!!T>::Object
+            stloc.1     
+            ldloc.1    
+            ldarg.1
+            ldfld      native uint valuetype System.Span`1<!!T>::Offset
+            add         
+            stloc.1 
+
+            ldc.i4.0    
+            stloc.2
+
+        LOOP_START:
+            ldloc.0
+            ldloc.2     
+            sizeof !!T  
+            mul         
+            add  
+
+            ldloc.1
+            ldloc.2     
+            sizeof !!T  
+            mul         
+            add 
+            ldobj  !!T  
+      
+            constrained. !!T
+            callvirt   instance bool class [System.Runtime]System.IEquatable`1<!!T>::Equals(!0)
+            brfalse.s  NOT_EQUAL
+            ldloc.2     
+            ldc.i4.1    
+            add         
+            stloc.2    
+            ldloc.2     
+            ldloc.3     
+            blt.s      LOOP_START
+
+        EQUAL:
+            ldc.i4.1 
+            ret
+        NOT_EQUAL:
+            ldc.i4.0   
+            ret ")]
         public static bool SequenceEqual<T>(this Span<T> first, Span<T> second)
             where T : struct, IEquatable<T>
-        {
-            if (first.Length != second.Length)
-            {
-                return false;
-            }
-
-            // we can not call memcmp here because structures might have nontrivial Equals implementation
-            for (int i = 0; i < first.Length; i++)
-            {
-                if (!first.GetItemWithoutBoundariesCheck(i).Equals(second.GetItemWithoutBoundariesCheck(i)))
-                {
-                    return false;
-                }
-            }
-            return true;
+        { 
+            return false;
         }
 
         /// <summary>
@@ -234,25 +291,92 @@ namespace System
         /// </summary>
         /// <param name="first">A span of type T to compare to second.</param>
         /// <param name="second">A span of type T to compare to first.</param>
+        [ILSub(@"
+            .maxstack 4
+            .locals([0] uint8 & baseAddr1,
+                    [1] uint8 & baseAddr2,
+                    [2] native uint i,
+                    [3] native uint length)
+            ldarg.0
+            ldfld      int32 valuetype System.ReadOnlySpan`1<!!T>::Length
+            dup
+            stloc.3
+            ldarg.1
+            ldfld      int32 valuetype System.ReadOnlySpan`1<!!T>::Length
+            ceq
+            brfalse.s  NOT_EQUAL
+
+            ldloc.3
+            brzero.s  EQUAL
+ 
+            ldarg.0
+            ldfld      object valuetype System.ReadOnlySpan`1<!!T>::Object
+            stloc.0     
+            ldloc.0     
+            ldarg.0
+            ldfld      native uint valuetype System.ReadOnlySpan`1<!!T>::Offset
+            add         
+            stloc.0 
+
+            ldarg.1
+            ldfld      object valuetype System.ReadOnlySpan`1<!!T>::Object
+            stloc.1     
+            ldloc.1    
+            ldarg.1
+            ldfld      native uint valuetype System.ReadOnlySpan`1<!!T>::Offset
+            add         
+            stloc.1 
+
+            ldc.i4.0    
+            stloc.2
+
+        LOOP_START:
+            ldloc.0
+            ldloc.2     
+            sizeof !!T  
+            mul         
+            add  
+
+            ldloc.1
+            ldloc.2     
+            sizeof !!T  
+            mul         
+            add 
+            ldobj  !!T  
+      
+            constrained. !!T
+            callvirt   instance bool class [System.Runtime]System.IEquatable`1<!!T>::Equals(!0)
+            brfalse.s  NOT_EQUAL
+            ldloc.2     
+            ldc.i4.1    
+            add         
+            stloc.2    
+            ldloc.2     
+            ldloc.3     
+            blt.s      LOOP_START
+
+        EQUAL:
+            ldc.i4.1 
+            ret
+        NOT_EQUAL:
+            ldc.i4.0   
+            ret ")]
         public static bool SequenceEqual<T>(this ReadOnlySpan<T> first, ReadOnlySpan<T> second)
             where T : struct, IEquatable<T>
         {
-            if (first.Length != second.Length)
-            {
-                return false;
-            }
-
-            // we can not call memcmp here because structures might have nontrivial Equals implementation
-            for (int i = 0; i < first.Length; i++)
-            {
-                if (!first.GetItemWithoutBoundariesCheck(i).Equals(second.GetItemWithoutBoundariesCheck(i)))
-                {
-                    return false;
-                }
-            }
-            return true;
+            return false;
         }
 
+        /// <summary>
+        /// Determines whether two spans are equal by comparing the elements by using generic Equals method
+        /// </summary>
+        /// <param name="first">A span of type T to compare to second.</param>
+        /// <param name="second">A span of type T to compare to first.</param>
+        public static bool SequenceEqual<T>(this Span<T> first, ReadOnlySpan<T> second)
+            where T : struct, IEquatable<T>
+        {
+            return SequenceEqual((ReadOnlySpan<T>)first, second);
+        }
         /// <summary>
         /// Determines whether two spans are structurally (byte-wise) equal by comparing the elements by using memcmp
         /// </summary>

--- a/src/System.Slices/System/SpanExtensionsTemplate.tt
+++ b/src/System.Slices/System/SpanExtensionsTemplate.tt
@@ -14,7 +14,7 @@ namespace System
     public static partial class SpanExtensions
     {
 <# 
-    GenerateSequenceEqualMethod(typeName: "byte", many: "bytes", smallSliceLimit: 512);
+    GenerateSequenceEqualMethod(typeName: "byte", many: "bytes", smallSliceLimit: 320);
     GenerateSequenceEqualMethod(typeName: "char", many: "characters", smallSliceLimit: 512);
     GenerateSequenceEqualMethod(typeName: "short", many: "shorts", smallSliceLimit: 512);
     GenerateSequenceEqualMethod(typeName: "int", many: "integers", smallSliceLimit: 512 / 2);
@@ -35,18 +35,9 @@ namespace System
         /// <param name="second">A span of <#= many #> T to compare to first.</param>
         public static bool SequenceEqual(this Span<<#= typeName #>> first, Span<<#= typeName #>> second)
         {
-            if (first.Length != second.Length) { return false; }
-
-            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
-            if (first.Length >= <#= smallSliceLimit #>) { return MemoryUtils.MemCmp(first, second); }
-
-            // for small slices we just use simple loop
-            for (int i = 0; i < first.Length; i++) {
-                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
-                    return false; 
-                }
-            }
-            return true;
+            return first.Length >= <#= smallSliceLimit #>
+                ? MemoryUtils.MemCmp(first, second)
+                : SequenceEqual<<#= typeName #>>(first, second);
         }
 
 		/// <summary>
@@ -56,18 +47,9 @@ namespace System
         /// <param name="second">A span of <#= many #> T to compare to first.</param>
         public static bool SequenceEqual(this ReadOnlySpan<<#= typeName #>> first, ReadOnlySpan<<#= typeName #>> second)
         {
-            if (first.Length != second.Length) { return false; }
-
-            // pinvoke calls are expensive (mostly due to memory pinning) so we call memcmp only for big slices
-            if (first.Length >= <#= smallSliceLimit #>) { return MemoryUtils.MemCmp(first, second); }
-
-            // for small slices we just use simple loop
-            for (int i = 0; i < first.Length; i++) {
-                if (first.GetItemWithoutBoundariesCheck(i) != second.GetItemWithoutBoundariesCheck(i)) { 
-                    return false; 
-                }
-            }
-            return true;
+            return first.Length >= <#= smallSliceLimit #>
+                ? MemoryUtils.MemCmp(first, second)
+                : SequenceEqual<<#= typeName #>>(first, second);
         }
 
 <#+}


### PR DESCRIPTION
It is similar to IndexOf impl. The same benefits - shorter code, tighter loop.

Assembly for the long and char instantiations.
```ASM
; Assembly listing for method System.SpanExtensions:SequenceEqual(struct,struct):bool
; Lcl frame size = 0
       8B4110               mov      eax, dword ptr [rcx+16]
       3B4210               cmp      eax, dword ptr [rdx+16]
       7539                 jne      SHORT G_M39316_IG06
       8B4110               mov      eax, dword ptr [rcx+16]
       4863C0               movsxd   eax, eax
       4885C0               test     rax, rax
       7428                 je       SHORT G_M39316_IG04
       4C8B01               mov      r8, gword ptr [rcx]
       488B4908             mov      rcx, qword ptr [rcx+8]
       4C03C1               add      r8, rcx
       488B0A               mov      rcx, gword ptr [rdx]
       488B5208             mov      rdx, qword ptr [rdx+8]
       4803CA               add      rcx, rdx
       33D2                 xor      rdx, rdx
G_M39316_IG03:
       4C8B0CD1             mov      r9, qword ptr [rcx+8*rdx]
       4D390CD0             cmp      qword ptr [r8+8*rdx], r9
       750E                 jne      SHORT G_M39316_IG06
       48FFC2               inc      rdx
       483BD0               cmp      rdx, rax
       7CEE                 jl       SHORT G_M39316_IG03
G_M39316_IG04:
       B801000000           mov      eax, 1
       C3                   ret      
G_M39316_IG06:
       33C0                 xor      eax, eax
       C3                   ret      

; Total bytes of code 68, prolog size 0 for method System.SpanExtensions:SequenceEqual(struct,struct):bool
; ============================================================

; Assembly listing for method System.SpanExtensions:SequenceEqual(struct,struct):bool
; Lcl frame size = 0
       8B4110               mov      eax, dword ptr [rcx+16]
       3B4210               cmp      eax, dword ptr [rdx+16]
       753E                 jne      SHORT G_M17275_IG06
       8B4110               mov      eax, dword ptr [rcx+16]
       4863C0               movsxd   eax, eax
       4885C0               test     rax, rax
       742D                 je       SHORT G_M17275_IG04
       4C8B01               mov      r8, gword ptr [rcx]
       488B4908             mov      rcx, qword ptr [rcx+8]
       4C03C1               add      r8, rcx
       488B0A               mov      rcx, gword ptr [rdx]
       488B5208             mov      rdx, qword ptr [rdx+8]
       4803CA               add      rcx, rdx
       33D2                 xor      rdx, rdx
G_M17275_IG03:
       440FB70C51           movzx    r9, word  ptr [rcx+2*rdx]
       450FB71450           movzx    r10, word  ptr [r8+2*rdx]
       453BD1               cmp      r10d, r9d
       750E                 jne      SHORT G_M17275_IG06
       48FFC2               inc      rdx
       483BD0               cmp      rdx, rax
       7CE9                 jl       SHORT G_M17275_IG03
G_M17275_IG04:
       B801000000           mov      eax, 1
       C3                   ret      
G_M17275_IG06:
       33C0                 xor      eax, eax
       C3                   ret      

; Total bytes of code 73, prolog size 0 for method System.SpanExtensions:SequenceEqual(struct,struct):bool
```

The results of the [benchmark](https://gist.github.com/omariom/5ac39f97747f96cfe941) for lengths of 1, 2, 4, 8, 16, 32, 64, 128, 512, 1024 and types **byte**, **char** and **int**. For comparison I added string.Equals and looping through two char arrays.
Meaning of the labels for chars:
**char** - calls to SequenceEquals specialized for Span[char]
**char array** - loop through char arrays
**char gen** - current generic SequenceEquals[T]
**char gen 2** - current SequenceEquals[T] but with Span params copied to local vars (JIT enregisters them)
**char gen new** - the new SequenceEquals[T] implemented in IL

 I ran the benchmark on my ultrabook  - Windows 10 and NET 4.6 (BenchmarkDotNet doesn't yet support .NET Core).

BenchmarkDotNet-Dev=v0.8.1.0+
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-3537U CPU @ 2.00GHz, ProcessorCount=4
HostCLR=MS.NET 4.0.30319.42000, Arch=64-bit  [RyuJIT]
Type=BenchmarkSeqEqual  Mode=Throughput  Jit=HostJit  .NET=HostFramework  toolchain=Classic  Runtime=Clr  Warmup=2  Target=3 

<img width="960" alt="seqequals" src="https://cloud.githubusercontent.com/assets/1781701/12380303/076f561c-bd81-11e5-87ee-69479078ce6d.png">
