### PR TITLE
Slices: Fix overflow in PtrUtils.Get/Set

### DIFF
--- a/src/System.Slices/src/System/PtrUtils.cs
+++ b/src/System.Slices/src/System/PtrUtils.cs
@@ -37,38 +37,49 @@ namespace System
         /// a way that the GC will be okay with.  It yields a value of type T.
         /// </summary>
 
+        /// <summary>
+        /// Takes a (possibly null) object reference, plus an offset in bytes, plus an index,
+        /// adds them, and safetly dereferences the target (untyped!) address in
+        /// a way that the GC will be okay with.  It yields a value of type T.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [ILSub(@"
-            .maxstack 2
-            .locals ([0] uint8& addr)
+        [ILSub(@"            
+            .maxstack 3
+            .locals([0] uint8 & addr)
             ldarg.0     // load the object
             stloc.0     // convert the object pointer to a byref
             ldloc.0     // load the object pointer as a byref
             ldarg.1     // load the offset
             add         // add the offset
+            ldarg.2     // load the index
+            sizeof !!T  // load size of T
+            mul         // multiply the index and size of T
+            add         // add the result
             ldobj !!T   // load a T value from the computed address
             ret")]
-        public static T Get<T>(object obj, UIntPtr offset) { return default(T); }
-
+        public static T Get<T>(object obj, UIntPtr offset, UIntPtr index) { return default(T); }
 
         /// <summary>
-        /// Takes a (possibly null) object reference, plus an offset in bytes,
+        /// Takes a (possibly null) object reference, plus an offset in bytes, plus an index,
         /// adds them, and safely stores the value of type T in a way that the
         /// GC will be okay with.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [ILSub(@"
-            .maxstack 2
-            .locals ([0] uint8& addr)
+        [ILSub(@"            
+            .maxstack 3
+            .locals([0] uint8 & addr)
             ldarg.0     // load the object
             stloc.0     // convert the object pointer to a byref
             ldloc.0     // load the object pointer as a byref
             ldarg.1     // load the offset
             add         // add the offset
-            ldarg.2     // load the value to store
+            ldarg.2     // load the index
+            sizeof !!T  // load size of T
+            mul         // multiply the index and size of T
+            add         // add the result
+            ldarg.3     // load the value to store
             stobj !!T   // store a T value to the computed address
             ret")]
-        public static void Set<T>(object obj, UIntPtr offset, T val) { }
+        public static void Set<T>(object obj, UIntPtr offset, UIntPtr index, T val) { }
 
         /// <summary>
         /// Computes the number of bytes offset from an array object reference

--- a/src/System.Slices/src/System/ReadOnlySpan.cs
+++ b/src/System.Slices/src/System/ReadOnlySpan.cs
@@ -159,15 +159,13 @@ namespace System
             get
             {
                 Contract.RequiresInRange(index, (uint)Length);
-                return PtrUtils.Get<T>(
-                    Object, Offset + (index * PtrUtils.SizeOf<T>()));
+                return PtrUtils.Get<T>(Object, Offset, (UIntPtr)index);
             }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private set
             {
                 Contract.RequiresInRange(index, (uint)Length);
-                PtrUtils.Set<T>(
-                    Object, Offset + (index * PtrUtils.SizeOf<T>()), value);
+                PtrUtils.Set(Object, Offset, (UIntPtr)index, value);
             }
         }
 
@@ -282,8 +280,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal T GetItemWithoutBoundariesCheck(int index)
         {
-            return PtrUtils.Get<T>(
-                    Object, Offset + (index * PtrUtils.SizeOf<T>()));
+            return PtrUtils.Get<T>(Object, Offset, (UIntPtr)index);
         }
     }
 }

--- a/src/System.Slices/src/System/Span.cs
+++ b/src/System.Slices/src/System/Span.cs
@@ -155,15 +155,13 @@ namespace System
             get
             {
                 Contract.RequiresInRange(index, (uint)Length);
-                return PtrUtils.Get<T>(
-                    Object, Offset + (index * PtrUtils.SizeOf<T>()));
+                return PtrUtils.Get<T>(Object, Offset, (UIntPtr)index);
             }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             set
             {
                 Contract.RequiresInRange(index, (uint)Length);
-                PtrUtils.Set<T>(
-                    Object, Offset + (index * PtrUtils.SizeOf<T>()), value);
+                PtrUtils.Set(Object, Offset, (UIntPtr)index, value);
             }
         }
 
@@ -310,8 +308,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal T GetItemWithoutBoundariesCheck(int index)
         {
-            return PtrUtils.Get<T>(
-                    Object, Offset + (index * PtrUtils.SizeOf<T>()));
+            return PtrUtils.Get<T>(Object, Offset, (UIntPtr)index);
         }
     }
 }

--- a/src/System.Slices/src/System/SpanExtensions.cs
+++ b/src/System.Slices/src/System/SpanExtensions.cs
@@ -180,7 +180,7 @@ namespace System
             where T : struct
         {
             Contract.Requires(slice.Length >= PtrUtils.SizeOf<T>());
-            return PtrUtils.Get<T>(slice.Object, slice.Offset);
+            return PtrUtils.Get<T>(slice.Object, slice.Offset, (UIntPtr)0);
         }
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace System
             where T : struct
         {
             Contract.Requires(slice.Length >= PtrUtils.SizeOf<T>());
-            return PtrUtils.Get<T>(slice.Object, slice.Offset);
+            return PtrUtils.Get<T>(slice.Object, slice.Offset, (UIntPtr)0);
         }
 
         /// <summary>
@@ -202,7 +202,7 @@ namespace System
             where T : struct
         {
             Contract.Requires(slice.Length >= PtrUtils.SizeOf<T>());
-            PtrUtils.Set(slice.Object, slice.Offset, value);
+            PtrUtils.Set(slice.Object, slice.Offset, (UIntPtr)0, value);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes [Span indexer computes the element offset using Int32 which can overflow](https://github.com/dotnet/corefxlab/issues/516)

*I created this PR instead of [another one](https://github.com/dotnet/corefxlab/pull/528) which I closed because had messed up its commits.*