### PR TITLE
Renaming System.Buffers nuget package to System.Buffers.Experimental

### DIFF
--- a/src/System.Buffers/src/System.Buffers.xproj
+++ b/src/System.Buffers/src/System.Buffers.xproj
@@ -8,7 +8,7 @@
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>C5FD8740-19EA-4BCC-B518-7F16B55D23CA</ProjectGuid>
-    <RootNamespace>System.Buffers</RootNamespace>
+    <RootNamespace>System.Buffers.Experimental</RootNamespace>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/System.Buffers/src/project.json
+++ b/src/System.Buffers/src/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "System.Buffers",
+  "name": "System.Buffers.Experimental",
   "version": "0.1.0-*",
   "description": "Pool of unmanaged Span<byte> values",
   "authors": [


### PR DESCRIPTION
Renaming System.Buffers nuget package to System.Buffers.Experimental to avoid conflicts with the CoreFX version

This does not update any dependency packages yet; that must be done after this has been merged and a NuGet package uploaded 

@KrzysztofCwalina 