### PR TITLE
Moving LibUV code over to use the new Lab's Buffers package

### DIFF
--- a/src/System.Net.Libuv/src/project.json
+++ b/src/System.Net.Libuv/src/project.json
@@ -18,10 +18,10 @@
     "allowUnsafe": true
   },
   "dependencies": {
+    "System.Buffers.Experimental": "0.1.0-*",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-*",
     "System.Runtime.Extensions": "4.0.0",
-    "System.Slices": "0.1.0-*",
-    "System.Buffers": "0.1.0-*"
+    "System.Slices": "0.1.0-*"
   },
   "frameworks": {
     "dotnet5.6": { }


### PR DESCRIPTION
@KrzysztofCwalina  This is the only instance in CoreFxLab of someone using the Native Slice Pool