### PR TITLE
Fixing JSON project build break

### DIFF
--- a/src/System.Text.Json/src/project.json
+++ b/src/System.Text.Json/src/project.json
@@ -16,6 +16,7 @@
   "requireLicenseAcceptance": true,
   "dependencies": {
     "System.Buffers": "4.0.0-*",
+    "System.Runtime.Extensions": "4.0.0-*",
     "System.Text.Formatting": "0.1.0-*"
   },
   "frameworks": {


### PR DESCRIPTION
For some reason CI built passed but one of the dependencies was missing.
Fixing it now.