### PR TITLE
Making the tests build and work with dotnet test command

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -15,6 +15,8 @@
     <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
     <add key="myget.org dotnet-corefxlab" value="https://www.myget.org/F/dotnet-corefxlab/" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="CI Builds (dotnet-cli)" value="https://www.myget.org/F/dotnet-cli/" />
     <add key="coreclr-xunit" value="https://www.myget.org/F/coreclr-xunit/api/v2" />
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -15,5 +15,6 @@
     <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
     <add key="myget.org dotnet-corefxlab" value="https://www.myget.org/F/dotnet-corefxlab/" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="coreclr-xunit" value="https://www.myget.org/F/coreclr-xunit/api/v2" />
   </packageSources>
 </configuration>

--- a/dir.props
+++ b/dir.props
@@ -53,6 +53,9 @@
     <NuGetSourceList Include="https:%2F%2Fwww.nuget.org/api/v2" />
     <NuGetSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-core" />
     <NuGetSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefxlab" />
+    <NuGetSourceList Include="https:%2F%2Fwww.myget.org/F/coreclr-xunit/api/v2" />
+    <NuGetSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-cli" />
+    <NuGetSourceList Include="https:%2F%2Fwww.myget.org/F/aspnetcidev/api/v3/index.json" />    
   </ItemGroup>
 
   <!-- Common nuget properties -->
@@ -86,6 +89,9 @@
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-buildtools/" />
     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefxlab/" />    
     <DnuSourceList Include="https:%2F%2Fwww.nuget.org/api/v2/" />
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/coreclr-xunit/api/v2/" />
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-cli/" />
+    <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/aspnetcidev/" />   
   </ItemGroup>
 
     <!-- list of directories to perform batch restore -->

--- a/src/System.Buffers/src/System/Buffers/NativeBufferBucket.cs
+++ b/src/System.Buffers/src/System/Buffers/NativeBufferBucket.cs
@@ -26,7 +26,7 @@ namespace System.Buffers
             _lock = new SpinLock();
 
             int bufferLength = numberOfBuffers * _elementsInBuffer;
-            _buffer = Marshal.AllocHGlobal(bufferLength * Marshal.SizeOf<T>());
+            _buffer = Marshal.AllocHGlobal(bufferLength * Marshal.SizeOf(typeof(T)));
             _slices = new Span<T>?[numberOfBuffers];
 
             for (int i = 0; i < bufferLength; i+= _elementsInBuffer)
@@ -72,7 +72,7 @@ namespace System.Buffers
             {
                 // We can safely exit
                 _lock.Exit(false);
-                buffer = new Span<T>(Marshal.AllocHGlobal(_elementsInBuffer * Marshal.SizeOf<T>()).ToPointer(), _elementsInBuffer);
+                buffer = new Span<T>(Marshal.AllocHGlobal(_elementsInBuffer * Marshal.SizeOf(typeof(T))).ToPointer(), _elementsInBuffer);
             }
             else
             {

--- a/src/System.Buffers/src/System/Buffers/NativeBufferPool.cs
+++ b/src/System.Buffers/src/System/Buffers/NativeBufferPool.cs
@@ -76,7 +76,7 @@ namespace System.Buffers
 #if DEBUG
                 System.Diagnostics.Debugger.Break();
 #endif
-                buffer = new Span<T>(Marshal.AllocHGlobal(numberOfElements * Marshal.SizeOf<T>()).ToPointer(), numberOfElements);
+                buffer = new Span<T>(Marshal.AllocHGlobal(numberOfElements * Marshal.SizeOf(typeof(T))).ToPointer(), numberOfElements);
             }
             else
             {

--- a/src/System.Buffers/tests/project.json
+++ b/src/System.Buffers/tests/project.json
@@ -1,17 +1,19 @@
 ﻿{
   "name": "System.Buffers.Tests",
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
           "type": "build",
           "version": "0.1.0-*"
         },
     "System.Slices": "0.1.0-*",
-    "xunit": "2.1.0"
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
+    "dnxcore50": {
         "imports": "portable-net45+win8"
      }
-  }
+  },
+  "testRunner": "xunit"
 }

--- a/src/System.Collections.Generic.MultiValueDictionary/tests/project.json
+++ b/src/System.Collections.Generic.MultiValueDictionary/tests/project.json
@@ -1,17 +1,19 @@
 {
   "name": "System.Collections.Tests",
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
           "type": "build",
           "version": "0.1.0-*"
         },
-    "xunit": "2.1.0"
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
+    "dnxcore50": {
         "imports": "portable-net45+win8"
      }
   },
-  "compileExclude": "Performance/*.cs"
+  "compileExclude": "Performance/*.cs",
+  "testRunner": "xunit"
 }

--- a/src/System.CommandLine/tests/project.json
+++ b/src/System.CommandLine/tests/project.json
@@ -1,17 +1,19 @@
 {
   "name": "System.CommandLine.Tests",
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
           "type": "build",
           "version": "0.1.0-*"
         },
     "System.Linq.Expressions": "4.0.10-*",
     "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
+    "dnxcore50": {
         "imports": "portable-net45+win8"
      }
-  }
+  },
+  "testRunner": "xunit"
 }

--- a/src/System.Drawing.Graphics/src/project.json
+++ b/src/System.Drawing.Graphics/src/project.json
@@ -19,7 +19,7 @@
   },
   "compileExclude": [ "**/*.OSX.cs", "**/*.Linux.cs"],
   "namedResource": {
-    "System.Drawing.Graphics.Resources": "Resources/Strings.resx"
+    "Resources.Strings": "Resources/Strings.resx"
   },
   "dependencies": {
     "System.Diagnostics.Debug": "4.0.10-*",

--- a/src/System.Drawing.Graphics/tests/project.json
+++ b/src/System.Drawing.Graphics/tests/project.json
@@ -1,17 +1,19 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
           "type": "build",
           "version": "0.1.0-*"
         },
     "FluentAssertions": "4.0.0-*",
     "System.IO.FileSystem":  "4.0.0-*",
-    "xunit": "2.1.0"
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
+    "dnxcore50": {
         "imports": "portable-net45+win8"
      }
-  }
+  },
+  "testRunner": "xunit"
 }

--- a/src/System.IO.FileSystem.Watcher.Polling/tests/project.json
+++ b/src/System.IO.FileSystem.Watcher.Polling/tests/project.json
@@ -1,18 +1,20 @@
 {
   "name": "System.IO.FileSystem.Watcher.Polling.Tests",
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
           "type": "build",
           "version": "0.1.0-*"
         },
     "System.IO.FileSystem": "4.0.1-*",
     "System.Threading.Thread": "4.0.0-*",
-    "xunit": "2.1.0"
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
+    "dnxcore50": {
         "imports": "portable-net45+win8"
      }
-  }
+  },
+  "testRunner": "xunit"
 }

--- a/src/System.Net.Libuv/tests/project.json
+++ b/src/System.Net.Libuv/tests/project.json
@@ -1,16 +1,18 @@
 ﻿{
   "name": "System.Net.Libuv.Tests",
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
           "type": "build",
           "version": "0.1.0-*"
         },
-    "xunit": "2.1.0"
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
+    "dnxcore50": {
         "imports": "portable-net45+win8"
      }
-  }
+  },
+  "testRunner": "xunit"
 }

--- a/src/System.Numerics.Matrices/test/project.json
+++ b/src/System.Numerics.Matrices/test/project.json
@@ -1,15 +1,17 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
           "type": "build",
           "version": "0.1.0-*"
         },
-    "xunit": "2.1.0"
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-     "dotnet5.6": {
+     "dnxcore50": {
        "imports": "portable-net45+win8"
    }
-  }
+  },
+  "testRunner": "xunit"
 }

--- a/src/System.Reflection.Metadata.Cil/src/project.json
+++ b/src/System.Reflection.Metadata.Cil/src/project.json
@@ -18,7 +18,7 @@
     "allowUnsafe": true
   },
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "System.IO.FileSystem": "4.0.0",
     "System.Linq": "4.0.0",
     "System.Runtime": "4.0.21-*",

--- a/src/System.Reflection.Metadata.Cil/tests/project.json
+++ b/src/System.Reflection.Metadata.Cil/tests/project.json
@@ -1,7 +1,7 @@
 {
   "name":"System.Reflection.Metadata.Cil.Tests",
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "System.Console": "4.0.0-*",
     "System.IO.FileSystem": "4.0.0",
     "src":  {
@@ -9,14 +9,14 @@
       "version": "0.1.0-*"
     },
     "xunit": "2.1.0",
-    "xunit.console.netcore": "1.0.2-prerelease-00101",
-    "xunit.extensibility.execution": "2.1.0",
-    "System.Linq.Expressions": "4.0.10-*"
+    "System.Linq.Expressions": "4.0.10-*",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
+    "dnxcore50": {
         "imports": "portable-net45+win8"
      }
   },
-  "resource": "Assemblies/demo1.exe"
+  "resource": "Assemblies/demo1.exe",
+  "testRunner": "xunit"
 }

--- a/src/System.Slices/tests/project.json
+++ b/src/System.Slices/tests/project.json
@@ -4,17 +4,19 @@
     "allowUnsafe": true
   },
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
-          "type": "build",
-          "version": "0.1.0-*"
-        },
+      "type": "build",
+      "version": "0.1.0-*"
+    },
     "System.Linq": "4.0.1-*",
-    "xunit": "2.0.0-*"
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
-        "imports": "portable-net45+win8"
-     }
-  }
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
+  },
+  "testRunner": "xunit"
 }

--- a/src/System.Text.Formatting.Globalization/tests/project.json
+++ b/src/System.Text.Formatting.Globalization/tests/project.json
@@ -1,16 +1,18 @@
 {
   "name": "System.Text.Formatting.Globalization.Tests",
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
           "type": "build",
           "version": "0.1.0-*"
         },
-    "xunit": "2.1.0"
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
+    "dnxcore50": {
         "imports": "portable-net45+win8"
      }
-  }
+  },
+  "testRunner": "xunit"
 }

--- a/src/System.Text.Formatting/tests/project.json
+++ b/src/System.Text.Formatting/tests/project.json
@@ -4,16 +4,18 @@
     "allowUnsafe": true
   },
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
           "type": "build",
           "version": "0.1.0-*"
         },
-    "xunit": "2.1.0"
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
+    "dnxcore50": {
         "imports": "portable-net45+win8"
      }
-  }
+  },
+  "testRunner": "xunit"
 }

--- a/src/System.Text.Http/tests/project.json
+++ b/src/System.Text.Http/tests/project.json
@@ -4,17 +4,19 @@
     "allowUnsafe": true
   },
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
           "type": "build",
           "version": "0.1.0-*"
         },
     "FluentAssertions": "4.0.1",
-    "xunit": "2.1.0"
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
+    "dnxcore50": {
         "imports": "portable-net45+win8"
      }
-  }
+  },
+  "testRunner": "xunit"
 }

--- a/src/System.Text.Json/tests/project.json
+++ b/src/System.Text.Json/tests/project.json
@@ -7,18 +7,20 @@
     "allowUnsafe": true
   },
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
           "type": "build",
           "version": "0.1.0-*"
         },
     "System.Console": "4.0.0-*",
     "xunit": "2.1.0",
-    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+    "xunit.netcore.extensions": "1.0.0-prerelease-*",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
+    "dnxcore50": {
         "imports": "portable-net45+win8"
      }
-  }
+  },
+  "testRunner": "xunit"
 }

--- a/src/System.Text.Utf8/tests/project.json
+++ b/src/System.Text.Utf8/tests/project.json
@@ -3,16 +3,18 @@
     "allowUnsafe": true
   },
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
           "type": "build",
           "version": "0.1.0-*"
         },
-    "xunit": "2.1.0"
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
+    "dnxcore50": {
         "imports": "portable-net45+win8"
      }
-  }
+  },
+  "testRunner": "xunit"
 }

--- a/src/System.Threading.Tasks.Channels/tests/project.json
+++ b/src/System.Threading.Tasks.Channels/tests/project.json
@@ -1,17 +1,19 @@
 {
   "name": "System.Threading.Tasks.Channels.Tests",
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
           "type": "build",
           "version": "0.1.0-*"
         },
     "System.IO.Pipes": "4.0.0-*",
-    "xunit": "2.1.0"
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
+    "dnxcore50": {
         "imports": "portable-net45+win8"
      }
-  }
+  },
+  "testRunner": "xunit"
 }

--- a/src/System.Time/tests/project.json
+++ b/src/System.Time/tests/project.json
@@ -1,7 +1,7 @@
 {
   "name": "System.Time.Tests",
   "dependencies": {
-    "Microsoft.NETCore.Platforms": "1.0.1-*",
+    "NETStandard.Library": "1.0.0-rc2-23728",
     "src": {
           "type": "build",
           "version": "0.1.0-*"
@@ -9,11 +9,13 @@
     "System.Globalization.Calendars": "4.0.0-*",
     "System.Runtime.Serialization.Xml": "4.0.10-*",
     "System.Xml.XmlSerializer": "4.0.11-*",
-    "xunit": "2.1.0"
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-dev-45337-57"
   },
   "frameworks": {
-    "dotnet5.6": {
+    "dnxcore50": {
         "imports": "portable-net45+win8"
      }
-  }
+  },
+  "testRunner": "xunit"
 }


### PR DESCRIPTION
Making the test projects build and work with dotnet test. I am not adding them back to the build just yet, but a developer can simply run dotnet test from a test folder and the tests are going to be executed. Everything that depends on System.Slices is failing right now, which is why the tests haven't been re-enabled.