### PR TITLE
Slices: Fix overflow in Cast<T,U>() which happens when  T is larger than U

### DIFF
--- a/src/System.Slices/System/Contract.cs
+++ b/src/System.Slices/System/Contract.cs
@@ -7,6 +7,7 @@ namespace System
 {
     static class Contract
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Requires(bool condition)
         {
             if (!condition)

--- a/src/System.Slices/System/PtrUtils.cs
+++ b/src/System.Slices/System/PtrUtils.cs
@@ -120,5 +120,18 @@ namespace System
             add         // add the offset
             ret")]
         public static UIntPtr ComputeAddress(object obj, UIntPtr offset) { return UIntPtr.Zero; }
+               
+        [ILSub(@"
+            .maxstack 2
+            ldarg.0
+            conv.i
+            sizeof !!T
+            mul  
+            sizeof !!U
+            div
+            ret")]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IntPtr CountOfU<T, U>(uint countOfT) { return default(IntPtr); }
+
     }
 }

--- a/src/System.Slices/System/SpanExtensions.cs
+++ b/src/System.Slices/System/SpanExtensions.cs
@@ -137,15 +137,34 @@ namespace System
             where T : struct
             where U : struct
         {
-            int countOfU = slice.Length * PtrUtils.SizeOf<T>() / PtrUtils.SizeOf<U>();
-            object obj = null;
-            UIntPtr offset = default(UIntPtr);
+            int countOfU;
 
-            if (countOfU != 0)
+            /// This comparison is a jittime constant
+            if (PtrUtils.SizeOf<T>() > PtrUtils.SizeOf<U>())
             {
-                obj = slice.Object;
-                offset = slice.Offset;
+                IntPtr count = PtrUtils.CountOfU<T, U>((uint)slice.Length);
+                unsafe
+                {
+                    // We can't compare IntPtrs, so have to resort to pointer comparison
+                    bool fits = (byte*)count <= (byte*)int.MaxValue;
+                    Contract.Requires(fits);
+                    countOfU = (int)count.ToPointer();
+                }
             }
+            else
+            {
+                countOfU = slice.Length * PtrUtils.SizeOf<T>() / PtrUtils.SizeOf<U>();
+            }
+            
+            object obj = slice.Object;
+            UIntPtr offset = slice.Offset; 
+
+            if (countOfU == 0)
+            {
+                obj = null;
+                offset = (UIntPtr)0;
+            }
+
             return new Span<U>(obj, offset, countOfU);
         }
 
@@ -160,15 +179,34 @@ namespace System
             where T : struct
             where U : struct
         {
-            int countOfU = slice.Length * PtrUtils.SizeOf<T>() / PtrUtils.SizeOf<U>();
-            object obj = null;
-            UIntPtr offset = default(UIntPtr);
+            int countOfU;
 
-            if (countOfU != 0)
+            /// This comparison is a jittime constant
+            if (PtrUtils.SizeOf<T>() > PtrUtils.SizeOf<U>())
             {
-                obj = slice.Object;
-                offset = slice.Offset;
+                IntPtr count = PtrUtils.CountOfU<T, U>((uint)slice.Length);
+                unsafe
+                {
+                    // We can't compare IntPtrs, so have to resort to pointer comparison
+                    bool fits = (byte*)count <= (byte*)int.MaxValue;
+                    Contract.Requires(fits);
+                    countOfU = (int)count.ToPointer();
+                }
             }
+            else
+            {
+                countOfU = slice.Length * PtrUtils.SizeOf<T>() / PtrUtils.SizeOf<U>();
+            }
+
+            object obj = slice.Object;
+            UIntPtr offset = slice.Offset;
+
+            if (countOfU == 0)
+            {
+                obj = null;
+                offset = (UIntPtr)0;
+            }
+
             return new ReadOnlySpan<U>(obj, offset, countOfU);
         }
 

--- a/tests/System.Slices.Tests/CastTests.cs
+++ b/tests/System.Slices.Tests/CastTests.cs
@@ -1,0 +1,102 @@
+﻿using Xunit;
+
+namespace System.Slices.Tests
+{
+    public class CastTests
+    {
+        [Fact]
+        public void IntArraySpanCastedToByteArraySpanHasSameBytesAsOriginalArray()
+        {
+            var ints = new int[100000];
+            Random r = new Random(42324232);
+            for (int i = 0; i < ints.Length; i++) { ints[i] = r.Next(); }
+            var bytes = ints.Slice().Cast<int, byte>();
+            Assert.Equal(bytes.Length, ints.Length * sizeof(int));
+            for (int i = 0; i < ints.Length; i++)
+            {
+                Assert.Equal(bytes[i * 4], (ints[i] & 0xff));
+                Assert.Equal(bytes[i * 4 + 1], (ints[i] >> 8 & 0xff));
+                Assert.Equal(bytes[i * 4 + 2], (ints[i] >> 16 & 0xff));
+                Assert.Equal(bytes[i * 4 + 3], (ints[i] >> 24 & 0xff));
+            }
+        }
+
+        [Fact]
+        public void ByteArraySpanCastedToIntArraySpanHasSameBytesAsOriginalArray()
+        {
+            var bytes = new byte[100000];
+            Random r = new Random(541345);
+            for (int i = 0; i < bytes.Length; i++) { bytes[i] = (byte)r.Next(256); }
+            var ints = bytes.Slice().Cast<byte, int>();
+            Assert.Equal(ints.Length, bytes.Length / sizeof(int));
+            for (int i = 0; i < ints.Length; i++)
+            {
+                Assert.Equal(BitConverter.ToInt32(bytes, i * 4), ints[i]);
+            }
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        public void SourceTypeLargerThanTargetOneCorrectlyCalcsTargetsLength(int sourceLength)
+        {
+            var sourceSlice = new SevenBytesStruct[sourceLength].Slice();
+
+            var targetSlice = sourceSlice.Cast<SevenBytesStruct, short>();
+
+            Assert.Equal((sourceLength * 7) / sizeof(short), targetSlice.Length);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void WhenSourceDoesntFitIntoTargetLengthIsZero(int sourceLength)
+        {
+            var sourceSlice = new short[sourceLength].Slice();
+
+            var targetSlice = sourceSlice.Cast<short, SevenBytesStruct>();
+
+            Assert.Equal(0, targetSlice.Length);
+        }
+
+        [Theory]
+        [InlineData(4)]
+        [InlineData(6)]
+        public void WhenSourceFitsIntoTargetOnceLengthIsOne(int sourceLength)
+        {
+            var sourceSlice = new short[sourceLength].Slice();
+
+            var targetSlice = sourceSlice.Cast<short, SevenBytesStruct>();
+
+            Assert.Equal(1, targetSlice.Length);
+        }
+
+        [Fact]
+        public void WhenSourceTypeLargerThaTargetAndOverflowsInt32ThrowsException()
+        {
+            unsafe
+            {
+                byte dummy;
+                int sourceLength = 620000000;
+                var sourceSlice = new Span<SevenBytesStruct>(&dummy, sourceLength);
+
+                Assert.Throws<ArgumentException>(() =>
+                {
+                    var targetSlice = sourceSlice.Cast<SevenBytesStruct, short>();
+                });
+            }
+        }
+    }
+
+    struct SevenBytesStruct
+    {
+#pragma warning disable CS0169
+        byte b1, b2, b3, b4, b5, b6, b7;
+#pragma warning restore CS0169
+    }
+}

--- a/tests/System.Slices.Tests/Tests.cs
+++ b/tests/System.Slices.Tests/Tests.cs
@@ -217,23 +217,6 @@ public class Tests
     }
 
     [Fact]
-    public void IntArraySpanCastedToByteArraySpanHasSameBytesAsOriginalArray()
-    {
-        var ints = new int[100000];
-        Random r = new Random(42324232);
-        for (int i = 0; i < ints.Length; i++) { ints[i] = r.Next(); }
-        var bytes = ints.Slice().Cast<int, byte>();
-        Assert.Equal(bytes.Length, ints.Length * sizeof(int));
-        for (int i = 0; i < ints.Length; i++)
-        {
-            Assert.Equal(bytes[i * 4], (ints[i] & 0xff));
-            Assert.Equal(bytes[i * 4 + 1], (ints[i] >> 8 & 0xff));
-            Assert.Equal(bytes[i * 4 + 2], (ints[i] >> 16 & 0xff));
-            Assert.Equal(bytes[i * 4 + 3], (ints[i] >> 24 & 0xff));
-        }
-    }
-
-    [Fact]
     public bool TestPerfLoop()
     {
         var ints = new int[10000];


### PR DESCRIPTION
When T  <= U we don't pay the cost:
```C#
        [MethodImpl(MethodImplOptions.NoInlining)]
        public static void TestSpanCast(Span<byte> span)
        {
            var l = span.Cast<byte, long>();
        }
```
```ASM
; Assembly listing for method CoreClrTest.Program:TestSpanCast(struct)
; Lcl frame size = 56
       57                   push     rdi
       56                   push     rsi
       4883EC38             sub      rsp, 56
       488BF1               mov      rsi, rcx
       488D7C2420           lea      rdi, [rsp+20H]
       B906000000           mov      ecx, 6
       33C0                 xor      rax, rax
       F3AB                 rep stosd 
	   	   
       488BCE               mov      rcx, rsi
       4C8B01               mov      r8, gword ptr [rcx]
       4C8B4908             mov      r9, qword ptr [rcx+8]
       8B4110               mov      eax, dword ptr [rcx+16]
       99                   cdq      
       83E207               and      edx, 7
       03C2                 add      eax, edx
       C1F803               sar      eax, 3
       85C0                 test     eax, eax
       7506                 jne      SHORT G_M62539_IG03
       4533C0               xor      r8, r8
       4533C9               xor      r9, r9
G_M62539_IG03:
       488D542420           lea      rdx, bword ptr [rsp+20H]
       4C8902               mov      gword ptr [rdx], r8
       4C894A08             mov      qword ptr [rdx+8], r9
       894210               mov      dword ptr [rdx+16], eax
       4883C438             add      rsp, 56
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret      

; Total bytes of code 77, prolog size 26 
```

Otherwise we check if it overflows:
```C#
        [MethodImpl(MethodImplOptions.NoInlining)]
        public static void TestSpanCast(Span<long> span)
        {
            var l = span.Cast<long, byte>();
        }
```
```ASM
; Assembly listing for method CoreClrTest.Program:TestSpanCast(struct)
; Lcl frame size = 56
       57                   push     rdi
       56                   push     rsi
       4883EC38             sub      rsp, 56
       488BF1               mov      rsi, rcx
       488D7C2420           lea      rdi, [rsp+20H]
       B906000000           mov      ecx, 6
       33C0                 xor      rax, rax
       F3AB                 rep stosd 

       488BCE               mov      rcx, rsi
       488B01               mov      rax, gword ptr [rcx]
       488B5108             mov      rdx, qword ptr [rcx+8]
       8B4910               mov      ecx, dword ptr [rcx+16]
       4863C9               movsxd   rcx, ecx
       48C1E103             shl      rcx, 3
       4881F9FFFFFF7F       cmp      rcx, 0x7FFFFFFF
       410F96C0             setbe    r8b
       450FB6C0             movzx    r8, r8b
       4585C0               test     r8d, r8d
       741F                 je       SHORT G_M62539_IG06
       85C9                 test     ecx, ecx
       7504                 jne      SHORT G_M62539_IG04
       33C0                 xor      rax, rax
       33D2                 xor      rdx, rdx
G_M62539_IG04:
       4C8D442420           lea      r8, bword ptr [rsp+20H]
       498900               mov      gword ptr [r8], rax
       49895008             mov      qword ptr [r8+8], rdx
       41894810             mov      dword ptr [r8+16], ecx
       4883C438             add      rsp, 56
       5E                   pop      rsi
       5F                   pop      rdi
       C3                   ret      
G_M62539_IG06:
       E88DE4FFFF           call     System.Contract:NewArgumentException():ref
       488BC8               mov      rcx, rax
       E88534D45E           call     CORINFO_HELP_THROW
       CC                   int3     

; Total bytes of code 108, prolog size 26
```