### PR TITLE
Enabling back DateTime formatting test

### DIFF
--- a/src/System.Text.Formatting/src/System/Text/Formatting/BufferFormatter.cs
+++ b/src/System.Text.Formatting/src/System/Text/Formatting/BufferFormatter.cs
@@ -56,6 +56,7 @@ namespace System.Text.Formatting
         {
             var temp = _buffer;
             _buffer = _pool.Rent(_buffer.Length * 2);
+            Array.Copy(temp, 0, _buffer, 0, _count);
             _pool.Return(temp);
         }
 

--- a/src/System.Text.Formatting/src/System/Text/Formatting/StringFormatter.cs
+++ b/src/System.Text.Formatting/src/System/Text/Formatting/StringFormatter.cs
@@ -84,6 +84,7 @@ namespace System.Text.Formatting
         {
             var temp = _buffer;
             _buffer = _pool.Rent(_buffer.Length * 2);
+            Array.Copy(temp, 0, _buffer, 0, _count);
             _pool.Return(temp);
         }
         void IFormatter.CommitBytes(int bytes)

--- a/src/System.Text.Formatting/tests/CompositeFormattingTests.cs
+++ b/src/System.Text.Formatting/tests/CompositeFormattingTests.cs
@@ -21,14 +21,14 @@ namespace System.Text.Formatting.Tests
             CultureInfo.CurrentUICulture = culture;
         }
 
-        [Fact(Skip = "Issue https://github.com/dotnet/corefxlab/issues/599")]
+        [Fact]
         public void CompositeFormattingBasics()
         {
-            var time = DateTime.UtcNow;
+            var time = new DateTime(2016, 2, 9, 4, 1, 59, DateTimeKind.Utc);
             using (var formatter = new StringFormatter(pool))
             {
-                formatter.Format("{2} - Error {0}. File {1} not found.", 404, "index.html", time);
-                Assert.Equal(time.ToString("G") + " - Error 404. File index.html not found.", formatter.ToString());
+                formatter.Format("{2:G} - Error {0}. File {1} not found.", 404, "index.html", time);
+                Assert.Equal("2/9/2016 4:01:59 AM - Error 404. File index.html not found.", formatter.ToString());
             }
         }
 


### PR DESCRIPTION
Fixes #599

The test got broken when we ported from BufferPool.Resize to Rent/Return.