### PR TITLE
Updating dotnet pack to use -b instead of -t.

### DIFF
--- a/dotnet.targets
+++ b/dotnet.targets
@@ -3,7 +3,7 @@
   <Target Name="Build">
     <!-- This was the only place I could find where this was guaranteed to be executed. The other targets I tried work in some cases (build.cmd) but not others (msbuild). I went with this simple approach for now. -->
     <Exec Command="$(DotnetExe) restore &quot;$(ProjectJson)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
-    <Exec Command="$(DotnetExe) pack &quot;$(ProjectJson)&quot; -o &quot;$(ProjectDir)nuget&quot; -c Release --version-suffix $([System.DateTime]::Now.ToString(&quot;eyyMMdd-1&quot;)) -t &quot;$(OutputPath)temp&quot;" />
+    <Exec Command="$(DotnetExe) pack &quot;$(ProjectJson)&quot; -o &quot;$(ProjectDir)nuget&quot; -c Release --version-suffix $([System.DateTime]::Now.ToString(&quot;eyyMMdd-1&quot;)) -b &quot;$(OutputPath)temp&quot;" />
   </Target>
 
   <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />

--- a/src/System.Buffers.Experimental/System.Buffers.xproj
+++ b/src/System.Buffers.Experimental/System.Buffers.xproj
@@ -15,10 +15,5 @@
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <Target Name="Build">
-    <!-- This was the only place I could find where this was guaranteed to be executed. The other targets I tried work in some cases (build.cmd) but not others (msbuild). I went with this simple approach for now. -->
-    <Exec Command="$(DotnetExe) restore &quot;$(ProjectJson)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
-    <Exec Command="$(DotnetExe) pack &quot;$(ProjectJson)&quot; -o &quot;$(ProjectDir)nuget&quot; -c Release --version-suffix $([System.DateTime]::Now.ToString(&quot;eyyMMdd-1&quot;)) -t &quot;$(OutputPath)temp&quot;" />
-  </Target>  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />    
 </Project>

--- a/src/System.Net.Libuv/copy_libuv.cmd
+++ b/src/System.Net.Libuv/copy_libuv.cmd
@@ -1,0 +1,1 @@
+copy %1\libuv.dll %2\libuv.dll

--- a/src/System.Net.Libuv/project.json
+++ b/src/System.Net.Libuv/project.json
@@ -28,6 +28,6 @@
     "dotnet5.6": { }
   },
   "scripts": {
-    "postcompile": "copy \"%project:Directory%\\libuv.dll\" \"%compile:OutputDir%\\libuv.dll\""
+    "postcompile": "copy_libuv \"%project:Directory%\" \"%compile:OutputDir%\""
   }
 }


### PR DESCRIPTION
Updating dotnet pack to use -b instead of -t. Also fixed buffer project which had the dotnet commands directly in it and fixing the post compile script for libuv, now that we don't support native commands directly in the scripts