### PR TITLE
Update dotnet pack command to not use -b option

### DIFF
--- a/dotnet.targets
+++ b/dotnet.targets
@@ -3,7 +3,7 @@
   <Target Name="Build">
     <!-- This was the only place I could find where this was guaranteed to be executed. The other targets I tried work in some cases (build.cmd) but not others (msbuild). I went with this simple approach for now. -->
     <Exec Command="$(DotnetExe) restore &quot;$(ProjectJson)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="^Unable to locate .*" />
-    <Exec Command="$(DotnetExe) pack &quot;$(ProjectJson)&quot; -o &quot;$(ProjectDir)nuget&quot; -c Release --version-suffix $([System.DateTime]::Now.ToString(&quot;eyyMMdd-1&quot;)) -b &quot;$(OutputPath)temp&quot;" />
+    <Exec Command="$(DotnetExe) pack &quot;$(ProjectJson)&quot; -o &quot;$(ProjectDir)nuget&quot; -c Release --version-suffix $([System.DateTime]::Now.ToString(&quot;eyyMMdd-1&quot;))" />
   </Target>
 
   <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />


### PR DESCRIPTION
We had a regression on dotnet pack where -o and -b together cause pack to not compile the project. Removed the -b option for now to have the project build.

CLI issue: https://github.com/dotnet/cli/issues/1525