### PR TITLE
A few code cleanups on Channels

### DIFF
--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.AsyncEnumerator.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.AsyncEnumerator.cs
@@ -21,7 +21,7 @@ namespace System.Threading.Tasks.Channels
                 _cancellationToken = cancellationToken;
             }
 
-            public T Current { get { return _current; } }
+            public T Current => _current;
 
             public Task<bool> MoveNextAsync()
             {

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.BoundedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.BoundedChannel.cs
@@ -30,7 +30,7 @@ namespace System.Threading.Tasks.Channels
             /// <summary>Set to non-null once Complete has been called.</summary>
             private Exception _doneWriting;
             /// <summary>Gets an object used to synchronize all state on the instance.</summary>
-            private object SyncObj { get { return _items; } }
+            private object SyncObj => _items;
 
             /// <summary>Initializes the <see cref="BoundedChannel{T}"/>.</summary>
             /// <param name="bufferedCapacity">The positive bounded capacity for the channel.</param>
@@ -40,7 +40,7 @@ namespace System.Threading.Tasks.Channels
                 _bufferedCapacity = bufferedCapacity;
             }
 
-            public Task Completion { get { return _completion.Task; } }
+            public Task Completion => _completion.Task;
             
             [Conditional("DEBUG")]
             private void AssertInvariants()
@@ -347,13 +347,10 @@ namespace System.Threading.Tasks.Channels
             }
 
             /// <summary>Gets the number of items in the channel.  This should only be used by the debugger.</summary>
-            private int ItemsCountForDebugger { get { return _items.Count; } }
+            private int ItemsCountForDebugger => _items.Count;
 
             /// <summary>Gets an enumerator the debugger can use to show the contents of the channel.</summary>
-            IEnumerator<T> IDebugEnumerable<T>.GetEnumerator()
-            {
-                return _items.GetEnumerator();
-            }
+            IEnumerator<T> IDebugEnumerable<T>.GetEnumerator() => _items.GetEnumerator();
         }
     }
 }

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.CaseBuilder.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.CaseBuilder.cs
@@ -31,9 +31,9 @@ namespace System.Threading.Tasks.Channels
             public CaseBuilder CaseRead<T>(IReadableChannel<T> channel, Action<T> action)
             {
                 if (channel == null)
-                    throw new ArgumentNullException("channel");
+                    throw new ArgumentNullException(nameof(channel));
                 if (action == null)
-                    throw new ArgumentNullException("action");
+                    throw new ArgumentNullException(nameof(action));
                 _cases.Add(new SyncReadCase<T>(channel, action));
                 return this;
             }
@@ -50,9 +50,9 @@ namespace System.Threading.Tasks.Channels
             public CaseBuilder CaseRead<T>(IReadableChannel<T> channel, Func<T, Task> func)
             {
                 if (channel == null)
-                    throw new ArgumentNullException("channel");
+                    throw new ArgumentNullException(nameof(channel));
                 if (func == null)
-                    throw new ArgumentNullException("func");
+                    throw new ArgumentNullException(nameof(func));
                 _cases.Add(new AsyncReadCase<T>(channel, func));
                 return this;
             }
@@ -69,9 +69,9 @@ namespace System.Threading.Tasks.Channels
             public CaseBuilder CaseWrite<T>(IWritableChannel<T> channel, T item, Action action)
             {
                 if (channel == null)
-                    throw new ArgumentNullException("channel");
+                    throw new ArgumentNullException(nameof(channel));
                 if (action == null)
-                    throw new ArgumentNullException("action");
+                    throw new ArgumentNullException(nameof(action));
                 _cases.Add(new SyncWriteCase<T>(channel, item, action));
                 return this;
             }
@@ -88,9 +88,9 @@ namespace System.Threading.Tasks.Channels
             public CaseBuilder CaseWrite<T>(IWritableChannel<T> channel, T item, Func<Task> func)
             {
                 if (channel == null)
-                    throw new ArgumentNullException("channel");
+                    throw new ArgumentNullException(nameof(channel));
                 if (func == null)
-                    throw new ArgumentNullException("func");
+                    throw new ArgumentNullException(nameof(func));
                 _cases.Add(new AsyncWriteCase<T>(channel, item, func));
                 return this;
             }
@@ -104,7 +104,7 @@ namespace System.Threading.Tasks.Channels
             public CaseBuilder CaseDefault(Action action)
             {
                 if (action == null)
-                    throw new ArgumentNullException("action");
+                    throw new ArgumentNullException(nameof(action));
                 if (_default != null)
                     throw new InvalidOperationException(Properties.Resources.InvalidOperationException_DefaultCaseAlreadyExists);
                 _default = new SyncDefaultCase(action);
@@ -120,7 +120,7 @@ namespace System.Threading.Tasks.Channels
             public CaseBuilder CaseDefault(Func<Task> func)
             {
                 if (func == null)
-                    throw new ArgumentNullException("func");
+                    throw new ArgumentNullException(nameof(func));
                 if (_default != null)
                     throw new InvalidOperationException(Properties.Resources.InvalidOperationException_DefaultCaseAlreadyExists);
                 _default = new AsyncDefaultCase(func);
@@ -144,7 +144,7 @@ namespace System.Threading.Tasks.Channels
             public Task<int> SelectUntilAsync(Func<int, bool> conditionFunc, CancellationToken cancellationToken = default(CancellationToken))
             {
                 if (conditionFunc == null)
-                    throw new ArgumentNullException("conditionFunc");
+                    throw new ArgumentNullException(nameof(conditionFunc));
                 return SelectUntilAsyncCore(conditionFunc, cancellationToken);
             }
 

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.EnumerableChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.EnumerableChannel.cs
@@ -18,7 +18,7 @@ namespace System.Threading.Tasks.Channels
             private bool _currentIsNext;
 
             /// <summary>The object used to synchronize access to state in the channel.</summary>
-            private object SyncObj { get { return _completion; } }
+            private object SyncObj => _completion;
 
             /// <summary>Initializes the channel, getting an enumerator from the enumerable.</summary>
             internal EnumerableChannel(IEnumerable<T> source)
@@ -26,7 +26,7 @@ namespace System.Threading.Tasks.Channels
                 _source = source.GetEnumerator();
             }
 
-            public Task Completion { get { return _completion.Task; } }
+            public Task Completion => _completion.Task;
 
             public ValueTask<T> ReadAsync(CancellationToken cancellationToken)
             {

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.Observable.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.Observable.cs
@@ -19,20 +19,11 @@ namespace System.Threading.Tasks.Channels
                 _channel = channel;
             }
 
-            public void OnCompleted()
-            {
-                _channel.Complete();
-            }
+            public void OnCompleted() => _channel.Complete();
 
-            public void OnError(Exception error)
-            {
-                _channel.Complete(error);
-            }
+            public void OnError(Exception error) => _channel.Complete(error);
 
-            public void OnNext(T value)
-            {
-                _channel.WriteAsync(value).GetAwaiter().GetResult();
-            }
+            public void OnNext(T value) => _channel.WriteAsync(value).GetAwaiter().GetResult();
         }
 
         /// <summary>Provides an observable for a readable channel.</summary>
@@ -51,7 +42,7 @@ namespace System.Threading.Tasks.Channels
             public IDisposable Subscribe(IObserver<T> observer)
             {
                 if (observer == null)
-                    throw new ArgumentNullException("observer");
+                    throw new ArgumentNullException(nameof(observer));
 
                 lock (_observers)
                 {

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.ReaderWriter.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.ReaderWriter.cs
@@ -34,12 +34,10 @@ namespace System.Threading.Tasks.Channels
 
         private class Reader<T> : Interactor<T>
         {
-            internal static Reader<T> Create(CancellationToken cancellationToken)
-            {
-                return cancellationToken.CanBeCanceled ?
+            internal static Reader<T> Create(CancellationToken cancellationToken) =>
+                cancellationToken.CanBeCanceled ?
                     new CancelableReader<T>(cancellationToken) :
                     new Reader<T>();
-            }
         }
 
         private class Writer<T> : Interactor<VoidResult>
@@ -70,7 +68,7 @@ namespace System.Threading.Tasks.Channels
                 }, this);
             }
 
-            protected override void Dispose() { _registration.Dispose(); }
+            protected override void Dispose() => _registration.Dispose();
         }
 
         private sealed class CancelableWriter<T> : Writer<T>
@@ -87,7 +85,7 @@ namespace System.Threading.Tasks.Channels
                 }, this);
             }
 
-            protected override void Dispose() { _registration.Dispose(); }
+            protected override void Dispose() => _registration.Dispose();
         }
 
     }

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.SerializationChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.SerializationChannel.cs
@@ -119,14 +119,14 @@ namespace System.Threading.Tasks.Channels
             private Task<KeyValuePair<bool, T>> _nextAvailable;
 
             /// <summary>The object to use to synchronize all state on this channel.</summary>
-            private object SyncObj { get { return _source; } }
+            private object SyncObj => _source;
 
             internal DeserializationChannel(Stream source)
             {
                 _source = new BinaryReader(source);
             }
 
-            public Task Completion { get { return _completion.Task; } }
+            public Task Completion => _completion.Task;
 
             public ValueTask<T> ReadAsync(CancellationToken cancellationToken)
             {

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.SimpleQueue.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.SimpleQueue.cs
@@ -16,7 +16,7 @@ namespace System.Threading.Tasks.Channels
             private int _tail; // Last valid element in the queue
             private int _size; // Number of elements.
 
-            public int Count { get { return _size; } }
+            public int Count => _size;
 
             public void Enqueue(T item)
             {

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.SpscUnboundedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.SpscUnboundedChannel.cs
@@ -22,9 +22,9 @@ namespace System.Threading.Tasks.Channels
             private Reader<T> _blockedReader;
             private Reader<bool> _waitingReader;
 
-            private object SyncObj { get { return _items; } }
+            private object SyncObj => _items;
 
-            public Task Completion { get { return _completion.Task; } }
+            public Task Completion => _completion.Task;
 
             public bool TryComplete(Exception error = null)
             {
@@ -196,13 +196,10 @@ namespace System.Threading.Tasks.Channels
             }
 
             /// <summary>Gets the number of items in the channel.  This should only be used by the debugger.</summary>
-            private int ItemsCountForDebugger { get { return _items.Count; } }
+            private int ItemsCountForDebugger => _items.Count;
 
             /// <summary>Gets an enumerator the debugger can use to show the contents of the channel.</summary>
-            IEnumerator<T> IDebugEnumerable<T>.GetEnumerator()
-            {
-                return _items.GetEnumerator();
-            }
+            IEnumerator<T> IDebugEnumerable<T>.GetEnumerator() => _items.GetEnumerator();
         }
     }
 }

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.TaskChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.TaskChannel.cs
@@ -43,7 +43,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            public Task Completion { get { return _completion.Task; } }
+            public Task Completion => _completion.Task;
 
             public ValueTask<T> ReadAsync(CancellationToken cancellationToken)
             {
@@ -113,10 +113,7 @@ namespace System.Threading.Tasks.Channels
                 }
             }
 
-            private bool TransitionRead()
-            {
-                return _completion.TrySetResult(default(VoidResult));
-            }
+            private bool TransitionRead() => _completion.TrySetResult(default(VoidResult));
         }
     }
 }

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.UnboundedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.UnboundedChannel.cs
@@ -25,9 +25,9 @@ namespace System.Threading.Tasks.Channels
             private Exception _doneWriting;
 
             /// <summary>Gets the object used to synchronize access to all state on this instance.</summary>
-            private object SyncObj { get { return _items; } }
+            private object SyncObj => _items;
 
-            public Task Completion { get { return _completion.Task; } }
+            public Task Completion => _completion.Task;
 
             [Conditional("DEBUG")]
             private void AssertInvariants()
@@ -237,13 +237,10 @@ namespace System.Threading.Tasks.Channels
             }
 
             /// <summary>Gets the number of items in the channel.  This should only be used by the debugger.</summary>
-            private int ItemsCountForDebugger { get { return _items.Count; } }
+            private int ItemsCountForDebugger => _items.Count;
 
             /// <summary>Gets an enumerator the debugger can use to show the contents of the channel.</summary>
-            IEnumerator<T> IDebugEnumerable<T>.GetEnumerator()
-            {
-                return _items.GetEnumerator();
-            }
+            IEnumerator<T> IDebugEnumerable<T>.GetEnumerator() => _items.GetEnumerator();
         }
     }
 }

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.UnbufferedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.UnbufferedChannel.cs
@@ -25,9 +25,9 @@ namespace System.Threading.Tasks.Channels
             private readonly SimpleQueue<Reader<bool>> _waitingWriters = new SimpleQueue<Reader<bool>>();
 
             /// <summary>Gets an object used to synchronize all state on the instance.</summary>
-            private object SyncObj { get { return _completion; } }
+            private object SyncObj => _completion;
 
-            public Task Completion { get { return _completion.Task; } }
+            public Task Completion => _completion.Task;
 
             [Conditional("DEBUG")]
             private void AssertInvariants()
@@ -258,10 +258,10 @@ namespace System.Threading.Tasks.Channels
             }
 
             /// <summary>Gets the number of writers waiting on the channel.  This should only be used by the debugger.</summary>
-            private int WaitingWritersCountForDebugger { get { return _waitingWriters.Count; } }
+            private int WaitingWritersCountForDebugger => _waitingWriters.Count;
 
             /// <summary>Gets the number of readers waiting on the channel.  This should only be used by the debugger.</summary>
-            private int WaitingReadersCountForDebugger { get { return _waitingReaders.Count; } }
+            private int WaitingReadersCountForDebugger => _waitingReaders.Count;
 
             private sealed class DebugView
             {
@@ -272,9 +272,9 @@ namespace System.Threading.Tasks.Channels
                     _channel = channel;
                 }
 
-                public int WaitingReaders { get { return _channel._waitingReaders.Count; } }
-                public int WaitingWriters { get { return _channel._waitingWriters.Count; } }
-                public int BlockedReaders { get { return _channel._blockedReaders.Count; } }
+                public int WaitingReaders => _channel._waitingReaders.Count;
+                public int WaitingWriters => _channel._waitingWriters.Count;
+                public int BlockedReaders => _channel._blockedReaders.Count;
                 public T[] BlockedWriters
                 {
                     get

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/IDebugEnumerator.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/IDebugEnumerator.cs
@@ -24,6 +24,6 @@ namespace System.Threading.Tasks.Channels
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        public T[] Items { get; private set; }
+        public T[] Items { get; }
     }
 }

--- a/tests/System.Threading.Tasks.Channels.Tests/ChannelTests.cs
+++ b/tests/System.Threading.Tasks.Channels.Tests/ChannelTests.cs
@@ -89,7 +89,7 @@ namespace System.Threading.Tasks.Channels.Tests
         [Fact]
         public void GetAwaiter_InvalidSource_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentNullException>("channel", () => Channel.GetAwaiter<int>(null));
+            Assert.Throws<NullReferenceException>(() => Channel.GetAwaiter<int>(null));
         }
 
         [Fact]

--- a/tests/System.Threading.Tasks.Channels.Tests/SingleProducerSingleConsumerTests.cs
+++ b/tests/System.Threading.Tasks.Channels.Tests/SingleProducerSingleConsumerTests.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Threading.Tasks.Channels.Tests;
+using Xunit;
+
+namespace System.Collections.Concurrent.Tests
+{
+    public class SingleProducerSingleConsumertests : TestBase
+    {
+        [Fact]
+        public void Enqueue_Dequeue_IsEmpty()
+        {
+            var spscq = new SingleProducerSingleConsumerQueue<int>();
+            Assert.True(spscq.IsEmpty);
+
+            for (int i = 0; i < 10; i++)
+            {
+                spscq.Enqueue(i);
+                Assert.False(spscq.IsEmpty);
+
+                int j;
+                Assert.True(spscq.TryDequeue(out j));
+                Assert.Equal(i, j);
+                Assert.True(spscq.IsEmpty);
+            }
+
+            const int Count = 100000;
+
+            for (int i = 0; i < Count; i++)
+            {
+                spscq.Enqueue(i);
+                Assert.False(spscq.IsEmpty);
+            }
+
+            for (int i = 0; i < Count; i++)
+            {
+                Assert.False(spscq.IsEmpty);
+                int j;
+                Assert.True(spscq.TryDequeue(out j));
+                Assert.Equal(i, j);
+            }
+
+            Assert.True(spscq.IsEmpty);
+        }
+
+        [Fact]
+        public void GetEnumerator()
+        {
+            var spscq = new SingleProducerSingleConsumerQueue<int>();
+
+            const int Count = 100000;
+            for (int i = 1; i <= Count; i++)
+            {
+                spscq.Enqueue(i);
+            }
+
+            int j = 1;
+            foreach (int item in spscq)
+            {
+                Assert.Equal(j++, item);
+            }
+        }
+
+        [Fact]
+        public void ValidateDebuggerAttributes()
+        {
+            var spscq = new SingleProducerSingleConsumerQueue<int>();
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(spscq);
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(spscq);
+
+            for (int i = 0; i < 10; i++)
+            {
+                spscq.Enqueue(i);
+            }
+            DebuggerAttributes.ValidateDebuggerDisplayReferences(spscq);
+            DebuggerAttributes.ValidateDebuggerTypeProxyProperties(spscq);
+        }
+    }
+}

--- a/tests/System.Threading.Tasks.Channels.Tests/TestBase.cs
+++ b/tests/System.Threading.Tasks.Channels.Tests/TestBase.cs
@@ -5,6 +5,8 @@ using System.Collections;
 using System.Collections.Generic;
 using Xunit;
 
+#pragma warning disable 0649 // unused fields there for future testing needs
+
 namespace System.Threading.Tasks.Channels.Tests
 {
     public abstract class TestBase


### PR DESCRIPTION
- Use nameof throughout
- Use expression-bodied members in a few places
- Change a few names
- Make SingleProducerSingleConsumerQueue public