### PR TITLE
Update exit from help output and app name

### DIFF
--- a/src/System.CommandLine/System/CommandLine/ArgumentSyntax.cs
+++ b/src/System.CommandLine/System/CommandLine/ArgumentSyntax.cs
@@ -51,13 +51,7 @@ namespace System.CommandLine
             {
                 var helpText = GetHelpText();
                 Console.Error.Write(helpText);
-
-                // TODO: This should use Environment.Exit(0) but this API isn't available yet.
-#if NET_FX
                 Environment.Exit(0);
-#else
-                Environment.FailFast(string.Empty);
-#endif
             }
 
             // Check for invalid or missing command
@@ -99,13 +93,7 @@ namespace System.CommandLine
             if (HandleErrors)
             {
                 Console.Error.WriteLine(Strings.ErrorWithMessageFmt, message);
-
-                // TODO: This should use Environment.Exit(1) but this API isn't available yet.
-#if NET_FX
                 Environment.Exit(1);
-#else
-                Environment.FailFast(string.Empty);
-#endif
             }
 
             throw new ArgumentSyntaxException(message);
@@ -333,14 +321,9 @@ namespace System.CommandLine
 
         private static string GetApplicationName()
         {
-            // TODO: This should use Environment.GetCommandLineArgs() but this API isn't available yet.
-#if NET_FX
             var processPath = Environment.GetCommandLineArgs()[0];
             var processName = Path.GetFileNameWithoutExtension(processPath);
             return processName;
-#else
-            return string.Empty;
-#endif
         }
 
         public string ApplicationName { get; set; }

--- a/src/System.CommandLine/project.json
+++ b/src/System.CommandLine/project.json
@@ -18,11 +18,7 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "System.Collections": "4.0.10-*",
-    "System.Console": "4.0.0-rc3-23823",
-    "System.Diagnostics.Tools": "4.0.1-rc3-23823",
-    "System.IO.FileSystem": "4.0.0",
-    "System.Linq": "4.0.0-*"
+    "NETStandard.Library": "1.0.0-rc2-23728"
   },
   "frameworks": {
         "netstandard1.3": {


### PR DESCRIPTION
After printing the help screen System.CommandLine was calling fastfail which tears down the process with an exception.  This caused a popup and looked like an exceptional exit.  Switched the code to use Environment.Exit(), which is now available.  At the same time I also include the code to call Environment.GetCommandLineArgs() to allow the help code to find the app name.