### PR TITLE
Moved Utf8String to ReadOnlySpan

### DIFF
--- a/src/System.Text.Utf8/System/Text/Utf16/Utf16LittleEndianEncoder.cs
+++ b/src/System.Text.Utf8/System/Text/Utf16/Utf16LittleEndianEncoder.cs
@@ -7,7 +7,7 @@ namespace System.Text.Utf16
     {
         const uint MaskLow10Bits = 0x3FF;
 
-        public static bool TryDecodeCodePoint(Span<byte> buffer, out UnicodeCodePoint codePoint, out int encodedBytes)
+        public static bool TryDecodeCodePoint(ReadOnlySpan<byte> buffer, out UnicodeCodePoint codePoint, out int encodedBytes)
         {
             if (buffer.Length < 2)
             {

--- a/src/System.Text.Utf8/System/Text/Utf8/Utf8EncodedCodePoint.cs
+++ b/src/System.Text.Utf8/System/Text/Utf8/Utf8EncodedCodePoint.cs
@@ -23,7 +23,7 @@ namespace System.Text.Utf8
             {
                 fixed (byte* encodedData = &_byte0)
                 {
-                    Span<byte> buffer = new Span<byte>(encodedData, 4);
+                    var buffer = new Span<byte>(encodedData, 4);
                     if (!Utf8Encoder.TryEncodeCodePoint(codePoint, buffer, out _length))
                     {
                         // TODO: Change exception type
@@ -41,7 +41,7 @@ namespace System.Text.Utf8
             {
                 fixed (byte* encodedData = &_byte0)
                 {
-                    Span<byte> buffer = new Span<byte>(encodedData, 4);
+                    var buffer = new Span<byte>(encodedData, 4);
                     if (!Utf8Encoder.TryEncodeCodePoint(codePoint, buffer, out _length))
                     {
                         // TODO: Change exception type

--- a/src/System.Text.Utf8/System/Text/Utf8/Utf8Encoder.cs
+++ b/src/System.Text.Utf8/System/Text/Utf8/Utf8Encoder.cs
@@ -93,7 +93,7 @@ namespace System.Text.Utf8
             return true;
         }
 
-        public static bool TryDecodeCodePoint(Span<byte> buffer, out UnicodeCodePoint codePoint, out int encodedBytes)
+        public static bool TryDecodeCodePoint(ReadOnlySpan<byte> buffer, out UnicodeCodePoint codePoint, out int encodedBytes)
         {
             if (buffer.Length == 0)
             {
@@ -120,10 +120,10 @@ namespace System.Text.Utf8
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool TryFindEncodedCodePointBytesCountGoingBackwards(Span<byte> buffer, out int encodedBytes)
+        private static bool TryFindEncodedCodePointBytesCountGoingBackwards(ReadOnlySpan<byte> buffer, out int encodedBytes)
         {
             encodedBytes = 1;
-            Span<byte> it = buffer;
+            ReadOnlySpan<byte> it = buffer;
             // TODO: Should we have something like: Span<byte>.(Slice from the back)
             for (; encodedBytes <= UnicodeConstants.Utf8MaxCodeUnitsPerCodePoint; encodedBytes++, it = it.Slice(0, it.Length - 1))
             {
@@ -149,7 +149,7 @@ namespace System.Text.Utf8
         // TODO: Name TBD
         // TODO: optimize?
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryDecodeCodePointBackwards(Span<byte> buffer, out UnicodeCodePoint codePoint, out int encodedBytes)
+        public static bool TryDecodeCodePointBackwards(ReadOnlySpan<byte> buffer, out UnicodeCodePoint codePoint, out int encodedBytes)
         {
             if (TryFindEncodedCodePointBytesCountGoingBackwards(buffer, out encodedBytes))
             {

--- a/src/System.Text.Utf8/System/Text/Utf8/Utf8String.CodePointEnumerable.cs
+++ b/src/System.Text.Utf8/System/Text/Utf8/Utf8String.CodePointEnumerable.cs
@@ -10,14 +10,14 @@ namespace System.Text.Utf8
     {
         public struct CodePointEnumerable : IEnumerable<UnicodeCodePoint>, IEnumerable
         {
-            private Span<byte> _buffer;
+            private ReadOnlySpan<byte> _buffer;
 
             public CodePointEnumerable(byte[] bytes, int index, int length)
             {
-                _buffer = new Span<byte>(bytes, index, length);
+                _buffer = new ReadOnlySpan<byte>(bytes, index, length);
             }
 
-            public unsafe CodePointEnumerable(Span<byte> buffer)
+            public unsafe CodePointEnumerable(ReadOnlySpan<byte> buffer)
             {
                 _buffer = buffer;
             }

--- a/src/System.Text.Utf8/System/Text/Utf8/Utf8String.CodePointEnumerator.cs
+++ b/src/System.Text.Utf8/System/Text/Utf8/Utf8String.CodePointEnumerator.cs
@@ -10,12 +10,12 @@ namespace System.Text.Utf8
     {
         public struct CodePointEnumerator : IEnumerator<UnicodeCodePoint>, IEnumerator
         {
-            private Span<byte> _buffer;
+            private ReadOnlySpan<byte> _buffer;
             private int _index;
             private int _currentLenCache;
             private const int ResetIndex = -UnicodeConstants.Utf8MaxCodeUnitsPerCodePoint - 1;
 
-            public unsafe CodePointEnumerator(Span<byte> buffer) : this()
+            public unsafe CodePointEnumerator(ReadOnlySpan<byte> buffer) : this()
             {
                 _buffer = buffer;
 
@@ -52,7 +52,7 @@ namespace System.Text.Utf8
                         throw new InvalidOperationException("Current does not exist");
                     }
 
-                    Span<byte> buffer = _buffer.Slice(_index);
+                    ReadOnlySpan<byte> buffer = _buffer.Slice(_index);
                     UnicodeCodePoint ret;
                     bool succeeded = Utf8Encoder.TryDecodeCodePoint(buffer, out ret, out _currentLenCache);
 

--- a/src/System.Text.Utf8/System/Text/Utf8/Utf8String.CodePointReverseEnumerator.cs
+++ b/src/System.Text.Utf8/System/Text/Utf8/Utf8String.CodePointReverseEnumerator.cs
@@ -11,12 +11,12 @@ namespace System.Text.Utf8
         // TODO: Name TBD
         public struct CodePointReverseEnumerator : IEnumerator<UnicodeCodePoint>, IEnumerator
         {
-            private Span<byte> _buffer;
+            private ReadOnlySpan<byte> _buffer;
             private int _index;
             private int _currentLenCache;
             private const int ResetIndex = -UnicodeConstants.Utf8MaxCodeUnitsPerCodePoint - 1;
 
-            public unsafe CodePointReverseEnumerator(Span<byte> buffer) : this()
+            public unsafe CodePointReverseEnumerator(ReadOnlySpan<byte> buffer) : this()
             {
                 _buffer = buffer;
 
@@ -53,7 +53,7 @@ namespace System.Text.Utf8
                         throw new InvalidOperationException("Current does not exist");
                     }
 
-                    Span<byte> buffer = _buffer.Slice(0, _index);
+                    ReadOnlySpan<byte> buffer = _buffer.Slice(0, _index);
                     UnicodeCodePoint ret;
                     bool succeeded = Utf8Encoder.TryDecodeCodePointBackwards(buffer, out ret, out _currentLenCache);
 

--- a/src/System.Text.Utf8/System/Text/Utf8/Utf8String.Enumerator.cs
+++ b/src/System.Text.Utf8/System/Text/Utf8/Utf8String.Enumerator.cs
@@ -10,9 +10,9 @@ namespace System.Text.Utf8
     {
         public struct Enumerator : IEnumerator<Utf8CodeUnit>, IEnumerator
         {
-            private Span<byte>.Enumerator _enumerator;
+            private ReadOnlySpan<byte>.Enumerator _enumerator;
 
-            public Enumerator(Span<byte> buffer)
+            public Enumerator(ReadOnlySpan<byte> buffer)
             {
                 _enumerator = buffer.GetEnumerator();
             }

--- a/src/System.Text.Utf8/System/Text/Utf8/Utf8String.cs
+++ b/src/System.Text.Utf8/System/Text/Utf8/Utf8String.cs
@@ -13,7 +13,7 @@ namespace System.Text.Utf8
     [DebuggerDisplay("{ToString()}u8")]
     public partial struct Utf8String : IEnumerable<Utf8CodeUnit>, IEquatable<Utf8String>, IComparable<Utf8String> 
     {
-        private Span<byte> _buffer;
+        private ReadOnlySpan<byte> _buffer;
 
         private const int StringNotFound = -1;
 
@@ -21,35 +21,35 @@ namespace System.Text.Utf8
 
         // TODO: Validate constructors, When should we copy? When should we just use the underlying array?
         // TODO: Should we be immutable/readonly?
-        public Utf8String(Span<byte> buffer)
+        public Utf8String(ReadOnlySpan<byte> buffer)
         {
             _buffer = buffer;
         }
 
         public Utf8String(byte[] utf8bytes)
         {
-            _buffer = new Span<byte>(utf8bytes);
+            _buffer = new ReadOnlySpan<byte>(utf8bytes);
         }
 
         public Utf8String(byte[] utf8bytes, int index, int length)
         {
-            _buffer = new Span<byte>(utf8bytes, index, length);
+            _buffer = new ReadOnlySpan<byte>(utf8bytes, index, length);
         }
 
         // TODO: reevaluate implementation
         public Utf8String(IEnumerable<UnicodeCodePoint> codePoints)
         {
             int len = GetUtf8LengthInBytes(codePoints);
-            _buffer = new Span<byte>(new byte[len]);
-            Span<byte> span = _buffer;
+            var newSpan = new Span<byte>(new byte[len]);
+            _buffer = newSpan;
             foreach (UnicodeCodePoint codePoint in codePoints)
             {
                 int encodedBytes;
-                if (!Utf8Encoder.TryEncodeCodePoint(codePoint, span, out encodedBytes))
+                if (!Utf8Encoder.TryEncodeCodePoint(codePoint, newSpan, out encodedBytes))
                 {
                     throw new ArgumentException("Invalid code point", "codePoints");
                 }
-                span = span.Slice(encodedBytes);
+                newSpan = newSpan.Slice(encodedBytes);
             }
         }
 
@@ -62,11 +62,11 @@ namespace System.Text.Utf8
 
             if (s == string.Empty)
             {
-                _buffer = Span<byte>.Empty;
+                _buffer = ReadOnlySpan<byte>.Empty;
             }
             else
             {
-                _buffer = new Span<byte>(GetUtf8BytesFromString(s));
+                _buffer = new ReadOnlySpan<byte>(GetUtf8BytesFromString(s));
             }
         }
 
@@ -643,7 +643,7 @@ namespace System.Text.Utf8
 
             byte[] bytes = new byte[len];
            
-            Span<byte> p = new Span<byte>(bytes);
+            var p = new Span<byte>(bytes);
             for (int i = 0; i < s.Length; /* intentionally no increment */)
             {
                 UnicodeCodePoint codePoint;


### PR DESCRIPTION
Utf8String was created before we had ReadOnlySpan<T> and so it was using Span<T>.
This change moves the implementation to use ReadOnlySpan, as Utf8String is read-only.