### PR TITLE
Added an unsafe method to access the array wrapped by Span<T>

### DIFF
--- a/src/System.Slices/System/Span.cs
+++ b/src/System.Slices/System/Span.cs
@@ -142,6 +142,28 @@ namespace System
         }
 
         /// <summary>
+        /// Gets array if the slice is over an array
+        /// </summary>
+        /// <param name="dummy">dummy is just to make the call unsafe; feel free to pass void</param>
+        /// <param name="array"></param>
+        /// <returns>true if it's a span over an array; otherwise false (if over a pointer)</returns>
+        public unsafe bool TryGetArray(void* dummy, out ArraySegment<T> array)
+        {
+            var a = Object as T[];
+            if (a == null)
+            {
+                array = new ArraySegment<T>();
+                return false;
+            }
+
+            var offsetToData = SpanHelpers<T>.OffsetToArrayData;
+
+            var index = (int)((Offset.ToUInt32() - offsetToData) / PtrUtils.SizeOf<T>());
+            array = new ArraySegment<T>(a, index, Length);
+            return true;
+        }
+
+        /// <summary>
         /// Fetches the element at the specified index.
         /// </summary>
         /// <exception cref="System.ArgumentOutOfRangeException">

--- a/tests/System.Slices.Tests/BasicUnitTests.cs
+++ b/tests/System.Slices.Tests/BasicUnitTests.cs
@@ -267,5 +267,39 @@ namespace System.Slices.Tests
                 Assert.Equal(source[i], destination[i]);
             }
         }
+
+        [Fact]
+        public void GetArray()
+        {
+            var original = new int[] { 1, 2, 3 };
+            ArraySegment<int> array;
+            Span<int> slice;
+
+            slice = new Span<int>(original, 1, 2);
+            unsafe
+            {
+                Assert.True(slice.TryGetArray(null, out array));
+            }
+            Assert.Equal(2, array.Array[array.Offset + 0]);
+            Assert.Equal(3, array.Array[array.Offset + 1]);
+
+            slice = new Span<int>(original, 0, 3);
+            unsafe
+            {
+                Assert.True(slice.TryGetArray(null, out array));
+            }
+            Assert.Equal(1, array.Array[array.Offset + 0]);
+            Assert.Equal(2, array.Array[array.Offset + 1]);
+            Assert.Equal(3, array.Array[array.Offset + 2]);
+
+            slice = new Span<int>(original, 0, 0);
+            unsafe
+            {
+                Assert.True(slice.TryGetArray(null, out array));
+            }
+            Assert.Equal(0, array.Offset);
+            Assert.Equal(original, array.Array);
+            Assert.Equal(0, array.Count);
+        }
     }
 }


### PR DESCRIPTION
Once all consuming APIs in the framework support Spans, we won't need this method.
But during prototyping and transition, we need this method to avoid reimplementing the
whole .NET stack.