### PR TITLE
Fixing #644

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/Multispan.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Multispan.cs
@@ -33,7 +33,7 @@ namespace System.Buffers
             }
         }
 
-        public int CopyTo(byte[] array)
+        public int CopyTo(T[] array)
         {
             Array.Copy(_head.Array, _head.Offset, array, 0, _head.Count);
             int index = _head.Count;

--- a/src/System.Buffers.Experimental/project.json
+++ b/src/System.Buffers.Experimental/project.json
@@ -19,6 +19,7 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
+    "System.Runtime": "4.0.0",
     "System.Buffers": "4.0.0-rc3-23901",
     "System.Diagnostics.Debug": "4.0.0",
     "System.Slices": "0.1.0-*",


### PR DESCRIPTION
Multispan.CopyTo should take a T[], not byte[]