### PR TITLE
Added Bytes property to Utf8String

### DIFF
--- a/src/System.Text.Utf8/System/Text/Utf8/Utf8String.cs
+++ b/src/System.Text.Utf8/System/Text/Utf8/Utf8String.cs
@@ -141,6 +141,10 @@ namespace System.Text.Utf8
             return s.ToString();
         }
 
+        public ReadOnlySpan<byte> Bytes
+        {
+            get { return _buffer; }
+        }
         public override string ToString()
         {
             // get length first


### PR DESCRIPTION
Now that we have ReadOnlySpan<T>, there is no reason to expose the bytes,
and it allows to avoid copies in many scenarios.