### PR TITLE
Make System.CommandLine not depend on generic virtual methods

### DIFF
--- a/src/System.CommandLine/System/CommandLine/Argument.cs
+++ b/src/System.CommandLine/System/CommandLine/Argument.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 
 namespace System.CommandLine
 {

--- a/src/System.CommandLine/System/CommandLine/ArgumentParser.cs
+++ b/src/System.CommandLine/System/CommandLine/ArgumentParser.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace System.CommandLine
 {

--- a/src/System.CommandLine/System/CommandLine/ArgumentSyntax.cs
+++ b/src/System.CommandLine/System/CommandLine/ArgumentSyntax.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace System.CommandLine
 {

--- a/src/System.CommandLine/System/CommandLine/Enumerable.cs
+++ b/src/System.CommandLine/System/CommandLine/Enumerable.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.CommandLine
+{
+    // Low level replacement of LINQ Enumerable class. In particular, this implementation
+    // doesn't use generic virtual methods.
+    // System.CommandLine needs to be usable for small .NET Native apps that don't carry the
+    // overhead of expensive runtime features such as the generic virtual methods.
+    internal static class Enumerable
+    {
+        public static IEnumerable<T> Empty<T>()
+        {
+            return Linq.Enumerable.Empty<T>();
+        }
+
+        public static IEnumerable<U> Select<T, U>(this IEnumerable<T> values, Func<T, U> func)
+        {
+            Debug.Assert(values != null);
+
+            foreach (T value in values)
+            {
+                yield return func(value);
+            }
+        }
+
+        public static IEnumerable<T> Where<T>(this IEnumerable<T> values, Func<T, bool> func)
+        {
+            Debug.Assert(values != null);
+
+            foreach (T value in values)
+            {
+                if (func(value))
+                    yield return value;
+            }
+        }
+
+        public static IEnumerable<T> Concat<T>(this IEnumerable<T> first, IEnumerable<T> second)
+        {
+            return Linq.Enumerable.Concat(first, second);
+        }
+
+        public static bool All<T>(this IEnumerable<T> source, Func<T, bool> predicate)
+        {
+            return Linq.Enumerable.All(source, predicate);
+        }
+
+        public static bool Any<T>(this IEnumerable<T> source, Func<T, bool> predicate)
+        {
+            return Linq.Enumerable.Any(source, predicate);
+        }
+
+        public static bool Any<T>(this IEnumerable<T> source)
+        {
+            return Linq.Enumerable.Any(source);
+        }
+
+        public static T[] ToArray<T>(this IEnumerable<T> source)
+        {
+            return Linq.Enumerable.ToArray(source);
+        }
+
+        public static T Last<T>(this IEnumerable<T> source)
+        {
+            return Linq.Enumerable.Last(source);
+        }
+
+        public static T FirstOrDefault<T>(this IEnumerable<T> source)
+        {
+            return Linq.Enumerable.FirstOrDefault(source);
+        }
+
+        public static T First<T>(this IEnumerable<T> source)
+        {
+            return Linq.Enumerable.First(source);
+        }
+
+        public static int Max(this IEnumerable<int> source)
+        {
+            return Linq.Enumerable.Max(source);
+        }
+    }
+}

--- a/src/System.CommandLine/System/CommandLine/HelpTextGenerator.cs
+++ b/src/System.CommandLine/System/CommandLine/HelpTextGenerator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace System.CommandLine


### PR DESCRIPTION
Generic virtual methods are pretty expensive for native compilation
scenarios (such as .NET Native). System.CommandLine should be a low
level component and not depend on expensive features so that it can be
used for small command line apps.

Generic virtual methods were used indirectly through LINQ Where and
Select operators.