### PR TITLE
Simplify scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,6 @@ tools/
 
 # Nuget.exe
 nuget.exe
+
+# VS Code Files
+.vscode

--- a/build.cmd
+++ b/build.cmd
@@ -1,17 +1,3 @@
 @echo off
 setlocal
-
-:: Invoke VS Developer Command Prompt batch file.
-:: This sets up some environment variables needed to use ILDasm and ILAsm.
-if not defined VisualStudioVersion (
-    if defined VS140COMNTOOLS (
-        call "%VS140COMNTOOLS%\VsDevCmd.bat"
-        goto :Build
-    )
-
-    echo Error: build.cmd requires Visual Studio 2015.
-    exit /b 1
-)
-
-:Build
 powershell -NoProfile %~dp0scripts\build.ps1 %*

--- a/package.cmd
+++ b/package.cmd
@@ -1,17 +1,3 @@
 @echo off
 setlocal
-
-:: Invoke VS Developer Command Prompt batch file.
-:: This sets up some environment variables needed to use ILDasm and ILAsm.
-if not defined VisualStudioVersion (
-    if defined VS140COMNTOOLS (
-        call "%VS140COMNTOOLS%\VsDevCmd.bat"
-        goto :Package
-    )
-
-    echo Error: package.cmd requires Visual Studio 2015.
-    exit /b 1
-)
-
-:Package
 powershell -NoProfile %~dp0scripts\package.ps1 %*

--- a/src/System.Slices/re_write_il.cmd
+++ b/src/System.Slices/re_write_il.cmd
@@ -1,3 +1,20 @@
+@echo off
+setlocal
+
+:: Invoke VS Developer Command Prompt batch file.
+:: This sets up some environment variables needed to use ILDasm and ILAsm.
+if not defined VisualStudioVersion (
+    if defined VS140COMNTOOLS (
+        call "%VS140COMNTOOLS%\VsDevCmd.bat"
+        goto :Rewrite
+    )
+
+    echo Error: re_write_il.cmd requires Visual Studio 2015.
+    exit /b 1
+)
+
+:Rewrite
+@echo on
 tools\ildasm.exe /caverbal /linenum /out:%1\system.slices.beforerewrite.il /nobar %2
 tools\ILSub\ILSub.exe %1\system.slices.beforerewrite.il %1\system.slices.rewritten.il
 tools\ilasm.exe /quiet /pdb /dll /out:%2 /nologo %1\system.slices.rewritten.il


### PR DESCRIPTION
Instead of forcing VsDevCmd.bat to be called up-front in the build scripts, I've made it part of re_write_il.cmd, which is where is is actually required. This means you can build the project regardless of your environment and the postcompile script will automatically correct it before running the tools. This also fixes things like VS (full) and VS Code. Right now you can't build System.Slices successfully in them unless you explicitly start them from a VS dev command prompt (undesirable).

I've also ignored the .vscode folder, it auto-generates some things that I'm not sure we want to check in yet.