### PR TITLE
Update to released RC2 packages

### DIFF
--- a/scripts/install-dotnet.ps1
+++ b/scripts/install-dotnet.ps1
@@ -48,7 +48,7 @@
 [cmdletbinding()]
 param(
    [string]$Channel="preview",
-   [string]$Version="1.0.0-rc2-002611",
+   [string]$Version="1.0.0-preview1-002702",
    [string]$InstallDir="dotnet",
    [string]$Architecture="<auto>",
    [switch]$DebugSymbols, # TODO: Switch does not work yet. Symbols zip is not being uploaded yet.

--- a/src/System.Drawing.Graphics/project.json
+++ b/src/System.Drawing.Graphics/project.json
@@ -22,11 +22,17 @@
   "buildOptions": {
     "allowUnsafe": true,
     "keyFile": "../../tools/Key.snk",
-    "compile": [
-      "Properties/*.cs",
-      "System/Drawing/Graphics/*.cs",
-      "System/Drawing/Graphics/Interop/Windows/*.cs"
-    ],
+    "compile": {
+      "include": [
+        "Properties/*.cs",
+        "System/Drawing/Graphics/*.cs",
+        "System/Drawing/Graphics/Interop/Windows/*.cs"
+      ],
+      "exclude": [
+        "System/Drawing/graphics/Interop/Linux/*.cs",
+        "System/Drawing/graphics/Interop/OSX/*.cs",
+      ]
+    },
     "embed": {
       "Resources.Strings": "Properties/Strings.resx"
     },

--- a/src/System.Slices/project.json
+++ b/src/System.Slices/project.json
@@ -19,7 +19,10 @@
   "buildOptions": {
     "allowUnsafe": true,
     "keyFile": "../../tools/Key.snk",
-    "compile": [ "System/*.cs"]
+    "compile": {
+        "include": [ "System/*.cs" ],
+        "exclude": [ "tools/**/*.cs" ]
+     }
   },
   "dependencies": {
     "System.Runtime": "4.0.0",

--- a/src/System.Text.Formatting/project.json
+++ b/src/System.Text.Formatting/project.json
@@ -19,7 +19,10 @@
   "buildOptions": {
     "allowUnsafe": true,
     "keyFile": "../../tools/Key.snk",
-    "compile": ["System/**/*.cs", "Properties/**/*.cs"],
+    "compile": { 
+        "include": [ "System/**/*.cs", "Properties/**/*.cs" ],
+        "exclude": [ "GenerateCompatibilityTests/**/*.cs" ]
+    },
     "embed": {
       "include": "Properties/Resources.resx",
       "mappings": {

--- a/src/System.Text.Json/project.json
+++ b/src/System.Text.Json/project.json
@@ -18,7 +18,10 @@
   },
   "buildOptions": {
     "keyFile": "../../tools/Key.snk",
-    "compile": ["System/**/*.cs"]
+    "compile": {
+        "include": [ "System/**/*.cs" ],
+        "exclude": [ "experiments/**/*.cs" ]
+    }
   },
   "dependencies": {
     "System.Buffers": "4.0.0-rc3-23901",

--- a/tests/System.Binary.Tests/project.json
+++ b/tests/System.Binary.Tests/project.json
@@ -6,13 +6,13 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.Binary": {
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/tests/System.Buffers.Experimental.Tests/project.json
+++ b/tests/System.Buffers.Experimental.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.Buffers.Experimental": {
       "target": "project"
@@ -12,7 +12,7 @@
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/tests/System.Collections.Generic.MultiValueDictionary.Tests/project.json
+++ b/tests/System.Collections.Generic.MultiValueDictionary.Tests/project.json
@@ -3,13 +3,13 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.Collections.Generic.MultiValueDictionary": {
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
     "netcoreapp1.0": {
@@ -21,7 +21,10 @@
     }
   },
   "buildOptions": {
-    "compile": "Generic/**/*.cs"
+    "compile": { 
+      "include": [ "Generic/**/*.cs" ],
+      "exclude": [ "Performance/**/*.cs" ]
+    }
   },
   "testRunner": "xunit"
 }

--- a/tests/System.CommandLine.Tests/project.json
+++ b/tests/System.CommandLine.Tests/project.json
@@ -3,14 +3,14 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.CommandLine": {
       "target": "project"
     },
     "System.Linq.Expressions": "4.0.11-rc3-24011-00",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "buildOptions": {
     "keyFile": "../../tools/test_key.snk"

--- a/tests/System.IO.FileSystem.Watcher.Polling.Tests/project.json
+++ b/tests/System.IO.FileSystem.Watcher.Polling.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.IO.FileSystem.Watcher.Polling": {
       "target": "project"
@@ -12,7 +12,7 @@
     "System.IO.FileSystem": "4.0.1-rc3-24011-00",
     "System.Threading.Thread": "4.0.0-rc3-24011-00",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/tests/System.Net.Libuv.Tests/project.json
+++ b/tests/System.Net.Libuv.Tests/project.json
@@ -3,14 +3,14 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.IO.Compression" : "4.1.0-rc3-23902",
     "System.Net.Libuv": {
           "target": "project"
         },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
 "netcoreapp1.0": {

--- a/tests/System.Numerics.Matrices.Tests/project.json
+++ b/tests/System.Numerics.Matrices.Tests/project.json
@@ -3,13 +3,13 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.Numerics.Matrices": {
           "target": "project"
         },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/tests/System.Reflection.Metadata.Cil.Tests/project.json
+++ b/tests/System.Reflection.Metadata.Cil.Tests/project.json
@@ -3,13 +3,13 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.Reflection.Metadata.Cil":  {
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/tests/System.Slices.Tests/project.json
+++ b/tests/System.Slices.Tests/project.json
@@ -6,13 +6,13 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.Slices": {
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/tests/System.Text.Formatting.Globalization.Tests/project.json
+++ b/tests/System.Text.Formatting.Globalization.Tests/project.json
@@ -3,13 +3,13 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.Text.Formatting.Globalization": {
           "target": "project"
         },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/tests/System.Text.Formatting.Tests/project.json
+++ b/tests/System.Text.Formatting.Tests/project.json
@@ -7,13 +7,13 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.Text.Formatting": {
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/tests/System.Text.Http.Tests/project.json
+++ b/tests/System.Text.Http.Tests/project.json
@@ -6,14 +6,14 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.Text.Http": {
           "target": "project"
         },
     "FluentAssertions": "4.0.1",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/tests/System.Text.Json.Tests/project.json
+++ b/tests/System.Text.Json.Tests/project.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.Text.Json": {
       "target": "project"
@@ -20,7 +20,7 @@
     "System.Console": "4.0.0-rc3-24011-00",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/tests/System.Text.Utf8.Tests/project.json
+++ b/tests/System.Text.Utf8.Tests/project.json
@@ -5,13 +5,13 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.Text.Utf8": {
       "target": "project"
     },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/tests/System.Threading.Tasks.Channels.Tests/project.json
+++ b/tests/System.Threading.Tasks.Channels.Tests/project.json
@@ -3,14 +3,14 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.Threading.Tasks.Channels": {
       "target": "project"
     },
     "System.IO.Pipes": "4.0.0-rc3-24011-00",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/tests/System.Time.Tests/project.json
+++ b/tests/System.Time.Tests/project.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
-      "version": "1.0.0-rc2-3002611"
+      "version": "1.0.0-rc2-3002702"
     },
     "System.Runtime.Serialization.Primitives" : "4.1.1-rc3-24011-00",
     "System.Time": {
@@ -13,7 +13,7 @@
     "System.Runtime.Serialization.Xml": "4.1.1-rc3-24011-00",
     "System.Xml.XmlSerializer": "4.0.11-rc3-24011-00",
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-dev-140469-38"
+    "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
This updates everything to use the released version of RC2, including the version of the SDK that the CI uses.

There appears to be something I don't understand with regards to how the "compile" item in project.json works. Apparently I need to explicitly exclude stuff even if it doesn't match the "include" globbing pattern.