### PR TITLE
Compile against RC2 packages

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,5 +1,6 @@
 ﻿Param(
-    [string]$Configuration="Debug"
+    [string]$Configuration="Debug",
+    [string]$Restore="true"
 )
 
 Write-Host "Commencing full build for Configuration=$Configuration."
@@ -15,11 +16,13 @@ if (!(Test-Path "dotnet\dotnet.exe")) {
 
 $dotnetExePath="$PSScriptRoot\..\dotnet\dotnet.exe"
 
-Write-Host "Restoring all packages"
-Invoke-Expression "$dotnetExePath restore src tests"
-if (!$?) {
-    Write-Error "Failed to restore packages."
-    exit -1
+if ($Restore -eq "true") {
+    Write-Host "Restoring all packages"
+    Invoke-Expression "$dotnetExePath restore src tests"
+    if (!$?) {
+        Write-Error "Failed to restore packages."
+        exit -1
+    }
 }
 
 $errorsEncountered = 0

--- a/src/System.Binary/project.json
+++ b/src/System.Binary/project.json
@@ -20,11 +20,8 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.Diagnostics.Tools": "4.0.0",
-    "System.Runtime": "4.0.0-*",
+    "NETStandard.Library": "1.5.0-rc2-24027",
     "System.Slices": { "target": "project" },
-    "System.Resources.ResourceManager": "4.0.0"
   },
   "frameworks": {
     "netstandard1.0": {

--- a/src/System.Buffers.Experimental/project.json
+++ b/src/System.Buffers.Experimental/project.json
@@ -21,11 +21,10 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "System.Runtime": "4.0.0",
-    "System.Buffers": "4.0.0-rc3-23901",
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.Slices": "0.1.0-*",
-    "System.Threading": "4.0.0"
+    "System.Buffers": "4.0.0-rc2-24027",
+    "System.Diagnostics.Debug": "4.0.11-rc2-24027",
+    "System.Slices": { "target": "project" },
+    "System.Threading": "4.0.11-rc2-24027"
   },
   "frameworks": {
     "netstandard1.1": {

--- a/src/System.Collections.Generic.MultiValueDictionary/project.json
+++ b/src/System.Collections.Generic.MultiValueDictionary/project.json
@@ -29,10 +29,10 @@
     }
   },
   "dependencies": {
-    "System.Collections": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.Diagnostics.Tools": "4.0.1-rc3-23823",
-    "System.Resources.ResourceManager": "4.0.0"
+    "System.Collections": "4.0.11-rc2-24027",
+    "System.Diagnostics.Debug": "4.0.11-rc2-24027",
+    "System.Diagnostics.Tools": "4.0.1-rc2-24027",
+    "System.Resources.ResourceManager": "4.0.1-rc2-24027"
   },
   "frameworks": {
     "netstandard1.1": {

--- a/src/System.CommandLine/project.json
+++ b/src/System.CommandLine/project.json
@@ -26,11 +26,10 @@
     }
   },
   "dependencies": {
-    "NETStandard.Library": "1.0.0-rc2-23728"
+    "NETStandard.Library": "1.5.0-rc2-24027",
+    "System.Runtime.Extensions": "4.1.0-rc2-24027"
   },
   "frameworks": {
-    "netstandard1.3": {
-      "imports": [ "dotnet5.4" ]
-    }
+    "netstandard1.5": { }
   },
 }

--- a/src/System.Drawing.Graphics/project.json
+++ b/src/System.Drawing.Graphics/project.json
@@ -38,13 +38,7 @@
     },
   },
   "dependencies": {
-    "System.Diagnostics.Debug": "4.0.10-*",
-    "System.Diagnostics.Tools": "4.0.1-rc3-23823",
-    "System.IO": "4.0.10-*",
-    "System.IO.FileSystem":  "4.0.0-*",
-    "System.Resources.ResourceManager": "4.0.0-*",
-    "System.Runtime": "4.0.20-*",
-    "System.Runtime.InteropServices": "4.0.20-*"
+    "NETStandard.Library": "1.5.0-rc2-24027"
   },
   "frameworks": {
     "netstandard1.5": {

--- a/src/System.IO.FileSystem.Watcher.Polling/project.json
+++ b/src/System.IO.FileSystem.Watcher.Polling/project.json
@@ -24,13 +24,9 @@
     }
   },  
   "dependencies": {
-    "System.Collections": "4.0.11-rc3-24025-00",
-    "System.Diagnostics.Debug": "4.0.11-rc3-24025-00",
-    "System.Diagnostics.TraceSource": "4.0.0-rc3-24025-00",
-    "System.Resources.ResourceManager": "4.0.1-rc3-24025-00",
-    "System.Runtime.Extensions": "4.1.0-rc3-24025-00",
-    "System.Runtime.InteropServices": "4.1.0-rc3-24025-00",
-    "System.Threading.Timer": "4.0.1-rc3-24025-00"
+    "NETStandard.Library": "1.5.0-rc2-24027",
+    "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
+    "System.Threading.Timer": "4.0.1-rc2-24027"
   },
   "frameworks": {
     "netstandard1.3": {

--- a/src/System.Net.Libuv/project.json
+++ b/src/System.Net.Libuv/project.json
@@ -21,10 +21,10 @@
     "keyFile": "../../tools/Key.snk"
   },  
   "dependencies": {
-    "System.Buffers.Experimental": "0.1.0-*",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc3-23901",
-    "System.Runtime.Extensions": "4.0.0",
-    "System.Slices": "0.1.0-*"
+    "NETStandard.Library": "1.5.0-rc2-24027",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-24027",
+    "System.Buffers.Experimental": { "target": "project" },
+    "System.Slices": { "target": "project" },
   },
   "frameworks": {
         "netstandard1.1": {

--- a/src/System.Numerics.Matrices/project.json
+++ b/src/System.Numerics.Matrices/project.json
@@ -21,8 +21,7 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "System.Runtime": "4.0.20",
-    "System.Runtime.Extensions": "4.0.10"
+    "NETStandard.Library": "1.5.0-rc2-24027",
   },
   "frameworks": {
         "netstandard1.1": {

--- a/src/System.Reflection.Metadata.Cil/project.json
+++ b/src/System.Reflection.Metadata.Cil/project.json
@@ -20,11 +20,11 @@
     "allowUnsafe": true
   },
   "dependencies": {
-    "NETStandard.Library": "1.5.0-rc2*",
-    "System.Collections.Immutable": "1.2.0-rc2-*",
-    "System.Reflection.Metadata": "1.3.0-rc2-*",
-    "System.Reflection.TypeExtensions": "4.1.0-rc2-*",
-    "System.Reflection": "4.1.0-rc2-*"
+    "NETStandard.Library": "1.5.0-rc2-24027",
+    "System.Collections.Immutable": "1.2.0-rc2-24027",
+    "System.Reflection.Metadata": "1.3.0-rc2-24027",
+    "System.Reflection.TypeExtensions": "4.1.0-rc2-24027",
+    "System.Reflection": "4.1.0-rc2-24027"
   },
   "frameworks": {
     "netstandard1.5": { "imports": [ "dotnet5.6" ] }

--- a/src/System.Slices/project.json
+++ b/src/System.Slices/project.json
@@ -25,8 +25,7 @@
      }
   },
   "dependencies": {
-    "System.Runtime": "4.0.0",
-    "System.Diagnostics.Debug": "4.0.0",
+    "NETStandard.Library": "1.5.0-rc2-24027",
     "System.Runtime.InteropServices": "4.0.0"
   },
   "frameworks": {

--- a/src/System.Text.Formatting.Globalization/project.json
+++ b/src/System.Text.Formatting.Globalization/project.json
@@ -26,7 +26,7 @@
     }
   },
   "dependencies": {
-    "System.Diagnostics.Tools": "4.0.1-rc2-*",
+    "NETStandard.Library": "1.5.0-rc2-24027",
     "System.Slices": { "target": "project" },
     "System.Text.Formatting": { "target": "project" },
     "System.Text.Utf8": { "target": "project" }

--- a/src/System.Text.Formatting/project.json
+++ b/src/System.Text.Formatting/project.json
@@ -31,10 +31,10 @@
     }
   },
   "dependencies": {
-    "System.Buffers": "4.0.0-rc3-23901",
-    "System.Globalization": "4.0.10",
-    "System.Slices": "0.1.0-*",
-    "System.Text.Utf8": "0.1.0-*" 
+    "NETStandard.Library": "1.5.0-rc2-24027",
+    "System.Buffers": "4.0.0-rc2-24027",
+    "System.Slices": { "target": "project" },
+    "System.Text.Utf8": { "target": "project" }
   },
   "frameworks": {
     "netstandard1.1": {

--- a/src/System.Text.Http/project.json
+++ b/src/System.Text.Http/project.json
@@ -20,9 +20,10 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "System.Slices": "0.1.0-*",
-    "System.Text.Formatting": "0.1.0-*",
-    "System.Text.Utf8": "0.1.0-*"
+    "NETStandard.Library": "1.5.0-rc2-24027",
+    "System.Slices": { "target": "project" },
+    "System.Text.Formatting": { "target": "project" },
+    "System.Text.Utf8": { "target": "project" }
   },
   "frameworks": {
         "netstandard1.1": {

--- a/src/System.Text.Json/project.json
+++ b/src/System.Text.Json/project.json
@@ -24,9 +24,9 @@
     }
   },
   "dependencies": {
-    "System.Buffers": "4.0.0-rc3-23901",
-    "System.Runtime.Extensions": "4.0.0-*",
-    "System.Text.Formatting": "0.1.0-*"
+    "NETStandard.Library": "1.5.0-rc2-24027",
+    "System.Buffers": "4.0.0-rc2-24027",
+    "System.Text.Formatting": { "target": "project" }
   },
   "frameworks": {
     "netstandard1.1": {

--- a/src/System.Text.Utf8/project.json
+++ b/src/System.Text.Utf8/project.json
@@ -21,10 +21,8 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "System.Diagnostics.Debug": "4.0.0",
-    "System.Diagnostics.Tools": "4.0.0",
-    "System.Resources.ResourceManager": "4.0.0",
-    "System.Slices": "0.1.0-*"
+    "NETStandard.Library": "1.5.0-rc2-24027",
+    "System.Slices": { "target": "project" }
   },
   "frameworks": {
         "netstandard1.0": {

--- a/src/System.Threading.Tasks.Channels/project.json
+++ b/src/System.Threading.Tasks.Channels/project.json
@@ -20,17 +20,12 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "System.Diagnostics.Debug": "4.0.10-*",
-    "System.Diagnostics.Tools": "4.0.1-rc3-23823",
-    "System.Resources.ResourceManager": "4.0.0-*",
-    "System.Runtime": "4.0.20",
-    "System.Threading": "4.0.10",
-    "System.Threading.Tasks": "4.0.10",
-    "System.Threading.Tasks.Extensions": "4.0.0-rc3-23823"
+    "NETStandard.Library": "1.5.0-rc2-24027",
+    "System.Threading": "4.0.11-rc2-24027",
+    "System.Threading.Tasks": "4.0.11-rc2-24027",
+    "System.Threading.Tasks.Extensions": "4.0.0-rc2-24027"
   },
   "frameworks": {
-        "netstandard1.1": {
-            "imports": [ "dotnet5.2" ]
-        }
+        "netstandard1.3": { }
   }
 }

--- a/src/System.Time/project.json
+++ b/src/System.Time/project.json
@@ -26,12 +26,11 @@
     }
   },
   "dependencies": {
-    "System.Diagnostics.Contracts": "4.0.0-*",
-    "System.Xml.ReaderWriter": "4.0.10"
+    "NETStandard.Library": "1.5.0-rc2-24027",
+    "System.Diagnostics.Contracts": "4.0.1-rc2-24027",
+    "System.Xml.ReaderWriter": "4.0.11-rc2-24027"
   },
   "frameworks": {
-    "netstandard1.1": {
-      "imports": [ "dotnet5.2" ]
-    }
+    "netstandard1.3": { }
   }
 }

--- a/tests/System.Collections.Generic.MultiValueDictionary.Tests/project.json
+++ b/tests/System.Collections.Generic.MultiValueDictionary.Tests/project.json
@@ -5,9 +5,7 @@
       "type": "platform",
       "version": "1.0.0-rc2-3002702"
     },
-    "System.Collections.Generic.MultiValueDictionary": {
-      "target": "project"
-    },
+    "System.Collections.Generic.MultiValueDictionary": { "target": "project" },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },

--- a/tests/System.CommandLine.Tests/project.json
+++ b/tests/System.CommandLine.Tests/project.json
@@ -5,10 +5,8 @@
       "type": "platform",
       "version": "1.0.0-rc2-3002702"
     },
-    "System.CommandLine": {
-      "target": "project"
-    },
-    "System.Linq.Expressions": "4.0.11-rc3-24011-00",
+    "System.CommandLine": { "target": "project" },
+    "System.Linq.Expressions": "4.0.11-rc2-24027",
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },

--- a/tests/System.IO.FileSystem.Watcher.Polling.Tests/project.json
+++ b/tests/System.IO.FileSystem.Watcher.Polling.Tests/project.json
@@ -8,9 +8,9 @@
     "System.IO.FileSystem.Watcher.Polling": {
       "target": "project"
     },
-    "System.Diagnostics.TraceSource": "4.0.0-rc3-24011-00",
-    "System.IO.FileSystem": "4.0.1-rc3-24011-00",
-    "System.Threading.Thread": "4.0.0-rc3-24011-00",
+    "System.Diagnostics.TraceSource": "4.0.0-rc2-24027",
+    "System.IO.FileSystem": "4.0.1-rc2-24027",
+    "System.Threading.Thread": "4.0.0-rc2-24027",
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },

--- a/tests/System.Net.Libuv.Tests/project.json
+++ b/tests/System.Net.Libuv.Tests/project.json
@@ -5,10 +5,8 @@
       "type": "platform",
       "version": "1.0.0-rc2-3002702"
     },
-    "System.IO.Compression" : "4.1.0-rc3-23902",
-    "System.Net.Libuv": {
-          "target": "project"
-        },
+    "System.IO.Compression" : "4.1.0-rc2-24027",
+    "System.Net.Libuv": { "target": "project" },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },

--- a/tests/System.Numerics.Matrices.Tests/project.json
+++ b/tests/System.Numerics.Matrices.Tests/project.json
@@ -5,9 +5,7 @@
       "type": "platform",
       "version": "1.0.0-rc2-3002702"
     },
-    "System.Numerics.Matrices": {
-          "target": "project"
-        },
+    "System.Numerics.Matrices": { "target": "project" },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },

--- a/tests/System.Reflection.Metadata.Cil.Tests/project.json
+++ b/tests/System.Reflection.Metadata.Cil.Tests/project.json
@@ -5,9 +5,7 @@
       "type": "platform",
       "version": "1.0.0-rc2-3002702"
     },
-    "System.Reflection.Metadata.Cil":  {
-      "target": "project"
-    },
+    "System.Reflection.Metadata.Cil": { "target": "project" },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },

--- a/tests/System.Slices.Tests/project.json
+++ b/tests/System.Slices.Tests/project.json
@@ -8,9 +8,7 @@
       "type": "platform",
       "version": "1.0.0-rc2-3002702"
     },
-    "System.Slices": {
-      "target": "project"
-    },
+    "System.Slices": { "target": "project" },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },

--- a/tests/System.Text.Formatting.Globalization.Tests/project.json
+++ b/tests/System.Text.Formatting.Globalization.Tests/project.json
@@ -5,9 +5,7 @@
       "type": "platform",
       "version": "1.0.0-rc2-3002702"
     },
-    "System.Text.Formatting.Globalization": {
-          "target": "project"
-        },
+    "System.Text.Formatting.Globalization": { "target": "project" },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },

--- a/tests/System.Text.Formatting.Tests/project.json
+++ b/tests/System.Text.Formatting.Tests/project.json
@@ -9,9 +9,7 @@
       "type": "platform",
       "version": "1.0.0-rc2-3002702"
     },
-    "System.Text.Formatting": {
-      "target": "project"
-    },
+    "System.Text.Formatting": { "target": "project" },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },

--- a/tests/System.Text.Http.Tests/project.json
+++ b/tests/System.Text.Http.Tests/project.json
@@ -8,9 +8,7 @@
       "type": "platform",
       "version": "1.0.0-rc2-3002702"
     },
-    "System.Text.Http": {
-          "target": "project"
-        },
+    "System.Text.Http": { "target": "project" },
     "FluentAssertions": "4.0.1",
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-173361-36"

--- a/tests/System.Text.Json.Tests/project.json
+++ b/tests/System.Text.Json.Tests/project.json
@@ -14,10 +14,8 @@
       "type": "platform",
       "version": "1.0.0-rc2-3002702"
     },
-    "System.Text.Json": {
-      "target": "project"
-    },
-    "System.Console": "4.0.0-rc3-24011-00",
+    "System.Text.Json": { "target": "project" },
+    "System.Console": "4.0.0-rc2-24027",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-*",
     "dotnet-test-xunit": "1.0.0-rc2-173361-36"

--- a/tests/System.Text.Utf8.Tests/project.json
+++ b/tests/System.Text.Utf8.Tests/project.json
@@ -7,9 +7,7 @@
       "type": "platform",
       "version": "1.0.0-rc2-3002702"
     },
-    "System.Text.Utf8": {
-      "target": "project"
-    },
+    "System.Text.Utf8": { "target": "project" },
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },

--- a/tests/System.Threading.Tasks.Channels.Tests/project.json
+++ b/tests/System.Threading.Tasks.Channels.Tests/project.json
@@ -5,10 +5,8 @@
       "type": "platform",
       "version": "1.0.0-rc2-3002702"
     },
-    "System.Threading.Tasks.Channels": {
-      "target": "project"
-    },
-    "System.IO.Pipes": "4.0.0-rc3-24011-00",
+    "System.Threading.Tasks.Channels": { "target": "project" },
+    "System.IO.Pipes": "4.0.0-rc2-24027",
     "xunit": "2.1.0",
     "dotnet-test-xunit": "1.0.0-rc2-173361-36"
   },


### PR DESCRIPTION
I made a previous change to run the tests against the shared framework that gets installed with the RC2 .NET Core SDK. We should also compile against and depend upon the RC2 versions of the framework packages.

Most everything here is on nuget.org, but there's still a few things that aren't, like xunit.netcore.extensions (on the buildtools feed). We could probably remove those if we were so inclined, but I decided not to right now. EDIT: I think that only test projects depend on stuff outside of nuget.org. So the packages we publish should be consumable stricly with dependencies from nuget.org.

You can also opt to skip package restore during build by passing "-Restore false" to the build script. Don't do that unless you've restored previously :smile: 