### PR TITLE
Added Slice overloads taking UInt32

### DIFF
--- a/src/System.Slices/System/Contract.cs
+++ b/src/System.Slices/System/Contract.cs
@@ -32,11 +32,29 @@ namespace System
                 throw NewArgumentOutOfRangeException();
             }
         }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresInRange(uint start, uint length)
+        {
+            if (start >= length)
+            {
+                throw NewArgumentOutOfRangeException();
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void RequiresInInclusiveRange(int start, uint length)
         {
             if ((uint)start > length)
+            {
+                throw NewArgumentOutOfRangeException();
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresInInclusiveRange(uint start, uint length)
+        {
+            if (start > length)
             {
                 throw NewArgumentOutOfRangeException();
             }
@@ -48,6 +66,17 @@ namespace System
             if ((uint)start > existingLength
                 || length < 0
                 || (uint)(start + length) > existingLength)
+            {
+                throw NewArgumentOutOfRangeException();
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresInInclusiveRange(uint start, uint length, uint existingLength)
+        {
+            if (start > existingLength
+                || length < 0
+                || (start + length) > existingLength)
             {
                 throw NewArgumentOutOfRangeException();
             }

--- a/src/System.Slices/System/ReadOnlySpan.cs
+++ b/src/System.Slices/System/ReadOnlySpan.cs
@@ -234,6 +234,20 @@ namespace System
             return new ReadOnlySpan<T>(
                 Object, Offset + (start * PtrUtils.SizeOf<T>()), Length - start);
         }
+        
+        /// <summary>
+        /// Forms a slice out of the given span, beginning at 'start'.
+        /// </summary>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified start index is not in range (&lt;0 or &gt;&eq;length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<T> Slice(uint start)
+        {
+            Contract.RequiresInInclusiveRange(start, (uint)Length);
+            return new Span<T>(Object, Offset + (((int)start) * PtrUtils.SizeOf<T>()), Length - (int)start);
+        }
 
         /// <summary>
         /// Forms a slice out of the given span, beginning at 'start', and
@@ -250,6 +264,23 @@ namespace System
             Contract.RequiresInInclusiveRange(start, length, (uint)Length);
             return new ReadOnlySpan<T>(
                 Object, Offset + (start * PtrUtils.SizeOf<T>()), length);
+        }
+        
+        /// <summary>
+        /// Forms a slice out of the given span, beginning at 'start', and
+        /// ending at 'end' (exclusive).
+        /// </summary>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <param name="end">The index at which to end this slice (exclusive).</param>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified start or end index is not in range (&lt;0 or &gt;&eq;length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<T> Slice(uint start, uint length)
+        {
+            Contract.RequiresInInclusiveRange(start, length, (uint)Length);
+            return new Span<T>(
+                Object, Offset + (((int)start) * PtrUtils.SizeOf<T>()), (int)length);
         }
 
         /// <summary>

--- a/src/System.Slices/System/Span.cs
+++ b/src/System.Slices/System/Span.cs
@@ -280,8 +280,21 @@ namespace System
         public Span<T> Slice(int start)
         {
             Contract.RequiresInInclusiveRange(start, (uint)Length);
-            return new Span<T>(
-                Object, Offset + (start * PtrUtils.SizeOf<T>()), Length - start);
+            return new Span<T>(Object, Offset + (start * PtrUtils.SizeOf<T>()), Length - start);
+        }
+        
+        /// <summary>
+        /// Forms a slice out of the given span, beginning at 'start'.
+        /// </summary>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified start index is not in range (&lt;0 or &gt;&eq;length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<T> Slice(uint start)
+        {
+            Contract.RequiresInInclusiveRange(start, (uint)Length);
+            return new Span<T>(Object, Offset + (((int)start) * PtrUtils.SizeOf<T>()), Length - (int)start);
         }
 
         /// <summary>
@@ -299,6 +312,23 @@ namespace System
             Contract.RequiresInInclusiveRange(start, length, (uint)Length);
             return new Span<T>(
                 Object, Offset + (start * PtrUtils.SizeOf<T>()), length);
+        }
+        
+        /// <summary>
+        /// Forms a slice out of the given span, beginning at 'start', and
+        /// ending at 'end' (exclusive).
+        /// </summary>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <param name="end">The index at which to end this slice (exclusive).</param>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified start or end index is not in range (&lt;0 or &gt;&eq;length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<T> Slice(uint start, uint length)
+        {
+            Contract.RequiresInInclusiveRange(start, length, (uint)Length);
+            return new Span<T>(
+                Object, Offset + (((int)start) * PtrUtils.SizeOf<T>()), (int)length);
         }
 
         /// <summary>


### PR DESCRIPTION
Often, I am finding that it's more convenient to use uints for buffers, but then slice methods require cast. These overloads solve the problem.

The casts (from uint to int) are safe because the contract checks above them.