### PR TITLE
Slices: Don't allow covariant Spans

### DIFF
--- a/src/System.Slices/System/Span.cs
+++ b/src/System.Slices/System/Span.cs
@@ -35,6 +35,7 @@ namespace System
         public Span(T[] array)
         {
             Contract.Requires(array != null);
+            Contract.Requires(default(T) != null || array.GetType() == typeof(T[]));
             Object = array;
             Offset = new UIntPtr((uint)SpanHelpers<T>.OffsetToArrayData);
             Length = array.Length;
@@ -57,6 +58,7 @@ namespace System
         internal Span(T[] array, int start)
         {
             Contract.Requires(array != null);
+            Contract.Requires(default(T) != null || array.GetType() == typeof(T[]));
             Contract.RequiresInInclusiveRange(start, (uint)array.Length);
             if (start < array.Length)
             {
@@ -89,6 +91,7 @@ namespace System
         public Span(T[] array, int start, int length)
         {
             Contract.Requires(array != null);
+            Contract.Requires(default(T) != null || array.GetType() == typeof(T[]));
             Contract.RequiresInInclusiveRange(start, length, (uint)array.Length);
             if (start < array.Length)
             {

--- a/tests/System.Slices.Tests/BasicUnitTests.cs
+++ b/tests/System.Slices.Tests/BasicUnitTests.cs
@@ -301,5 +301,26 @@ namespace System.Slices.Tests
             Assert.Equal(original, array.Array);
             Assert.Equal(0, array.Count);
         }
+
+        [Fact]
+        public void CovariantSlicesNotSupported1()
+        {
+            object[] array = new string[10];
+            Assert.Throws<ArgumentException>(() => { var slice = new Span<object>(array); });
+        }
+
+        [Fact]
+        public void CovariantSlicesNotSupported2()
+        {
+            object[] array = new string[10];
+            Assert.Throws<ArgumentException>(() => { var slice = array.Slice(0); });
+        }
+
+        [Fact]
+        public void CovariantSlicesNotSupported3()
+        {
+            object[] array = new string[10];
+            Assert.Throws<ArgumentException>(() => { var slice = new Span<object>(array, 0, 10); });
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefxlab/issues/614

Luckily the check added is a noop for value types. 