### PR TITLE
Slices: Inline ctors

### DIFF
--- a/src/System.Slices/System/ReadOnlySpan.cs
+++ b/src/System.Slices/System/ReadOnlySpan.cs
@@ -28,6 +28,8 @@ namespace System
         /// <exception cref="System.ArgumentException">
         /// Thrown if the 'array' parameter is null.
         /// </exception>
+        /// 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlySpan(T[] array)
         {
             Contract.Requires(array != null);
@@ -50,6 +52,7 @@ namespace System
         /// </exception>
         // TODO: Should we have this overload? It is really confusing when you also have Span(T* array, int length)
         //       While with Slice it makes sense it might not in here.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal ReadOnlySpan(T[] array, int start)
         {
             Contract.Requires(array != null);
@@ -82,6 +85,7 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified start or end index is not in range (&lt;0 or &gt;&eq;length).
         /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlySpan(T[] array, int start, int length)
         {
             Contract.Requires(array != null);
@@ -109,6 +113,7 @@ namespace System
         /// </summary>
         /// <param name="ptr">An unmanaged pointer to memory.</param>
         /// <param name="length">The number of T elements the memory contains.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe ReadOnlySpan(void* ptr, int length)
         {
             Contract.Requires(length >= 0);

--- a/src/System.Slices/System/Span.cs
+++ b/src/System.Slices/System/Span.cs
@@ -32,6 +32,7 @@ namespace System
         /// <exception cref="System.ArgumentException">
         /// Thrown if the 'array' parameter is null.
         /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span(T[] array)
         {
             Contract.Requires(array != null);
@@ -54,6 +55,7 @@ namespace System
         /// </exception>
         // TODO: Should we have this overload? It is really confusing when you also have Span(T* array, int length)
         //       While with Slice it makes sense it might not in here.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal Span(T[] array, int start)
         {
             Contract.Requires(array != null);
@@ -86,6 +88,7 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified start or end index is not in range (&lt;0 or &gt;&eq;length).
         /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span(T[] array, int start, int length)
         {
             Contract.Requires(array != null);
@@ -113,6 +116,7 @@ namespace System
         /// </summary>
         /// <param name="ptr">An unmanaged pointer to memory.</param>
         /// <param name="length">The number of T elements the memory contains.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe Span(void* ptr, int length)
         {
             Contract.Requires(length >= 0);

--- a/src/System.Slices/System/SpanExtensions.cs
+++ b/src/System.Slices/System/SpanExtensions.cs
@@ -66,6 +66,7 @@ namespace System
         /// <exception cref="System.ArgumentException">
         /// Thrown if the 'str' parameter is null.
         /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> Slice(this string str)
         {
             Contract.Requires(str != null);
@@ -88,6 +89,7 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified start index is not in range (&lt;0 or &gt;&eq;length).
         /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> Slice(this string str, int start)
         {
             Contract.Requires(str != null);
@@ -113,10 +115,11 @@ namespace System
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// Thrown when the specified start or end index is not in range (&lt;0 or &gt;&eq;length).
         /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ReadOnlySpan<char> Slice(this string str, int start, int length)
         {
             Contract.Requires(str != null);
-            Contract.Requires(start + length <= str.Length);
+            Contract.RequiresInInclusiveRange(start, length, (uint)str.Length);
             return new ReadOnlySpan<char>(
                 str,
                 new UIntPtr((uint)(SpanHelpers.OffsetToStringData + (start * sizeof(char)))),


### PR DESCRIPTION
I microbechmarked the following scenarios.
_The numbers is old vs new in million times per sec._

```C#
TestSpanCtor(array);          // 58 - 77
TestSpanCtor(array, 0, 0);    // 52 - 64
TestArraySlice(array);        // 37 - 67
TestArraySlice(array, 0);     // 37 - 67
TestArraySlice(array, 0, 0);  // 37 - 65
TestStringSlice(str);         // 58 - 68
TestStringSlice(str, 0);      // 57 - 67
TestStringSlice(str, 0, 0);   // 56 - 63
```

```C#
[MethodImpl(MethodImplOptions.NoInlining)]
public static void TestSpanCtor(byte[] array)
{
	var span = new Span<byte>(array);
	ConsumeSlice(span);
}

[MethodImpl(MethodImplOptions.NoInlining)]
public static void ConsumeSlice(Span<byte> span)
{
}
```