### PR TITLE
Improve reliability of memory consumption test

### DIFF
--- a/tests/System.Text.Json.Tests/PerfSmokeTests.cs
+++ b/tests/System.Text.Json.Tests/PerfSmokeTests.cs
@@ -52,6 +52,7 @@ namespace System.Text.Json.Tests
 
             for (var j = 0; j < NumberOfSamples; j++)
             {
+                GC.Collect(2);
                 var memoryBefore = GC.GetTotalMemory(true);
                 Timer.Restart();
                 for (var i = 0; i < NumberOfIterations; i++)
@@ -63,7 +64,7 @@ namespace System.Text.Json.Tests
                 var consumption = memoryAfter - memoryBefore;
                 timeIterReadResults.Add(time);
                 memoryIterReadResults.Add(consumption);
-                Assert.True(consumption <= ExpectedMemoryBenchMark);
+                Assert.True(consumption <= ExpectedMemoryBenchMark, consumption.ToString());
             }
             Output(timeIterReadResults.Average().ToString(CultureInfo.InvariantCulture));
             Output((memoryIterReadResults.Average()).ToString(CultureInfo.InvariantCulture));


### PR DESCRIPTION
Some of the JSON tests have not been very reliable. This small change improves the reliability.
Having said that, maybe we should just remove the memory consumption check (if we still see the failure) and wait for proper harness/CLR-feature to measure memory consumption.