### PR TITLE
Slices: Use RequiresInInclusiveRange in SpanExtension::Read and Write methods

### DIFF
--- a/src/System.Slices/System/SpanExtensions.cs
+++ b/src/System.Slices/System/SpanExtensions.cs
@@ -220,7 +220,7 @@ namespace System
         public static T Read<[Primitive]T>(this Span<byte> slice)
             where T : struct
         {
-            Contract.Requires(slice.Length >= PtrUtils.SizeOf<T>());
+            Contract.RequiresInInclusiveRange(PtrUtils.SizeOf<T>(), (uint)slice.Length);
             return PtrUtils.Get<T>(slice.Object, slice.Offset, (UIntPtr)0);
         }
 
@@ -231,7 +231,7 @@ namespace System
         public static T Read<[Primitive]T>(this ReadOnlySpan<byte> slice)
             where T : struct
         {
-            Contract.Requires(slice.Length >= PtrUtils.SizeOf<T>());
+            Contract.RequiresInInclusiveRange(PtrUtils.SizeOf<T>(), (uint)slice.Length);
             return PtrUtils.Get<T>(slice.Object, slice.Offset, (UIntPtr)0);
         }
 
@@ -242,7 +242,7 @@ namespace System
         public static void Write<[Primitive]T>(this Span<byte> slice, T value)
             where T : struct
         {
-            Contract.Requires(slice.Length >= PtrUtils.SizeOf<T>());
+            Contract.RequiresInInclusiveRange(PtrUtils.SizeOf<T>(), (uint)slice.Length);
             PtrUtils.Set(slice.Object, slice.Offset, (UIntPtr)0, value);
         }
 


### PR DESCRIPTION
@KrzysztofCwalina

It makes code 8 bytes smaller and better.

With the change `Read<int>()`  60% faster in microbenchmarks. 
And now it is 12 times faster than `BitConverter.ToInt32` when reading from the same memory location and 2 times when going through a 8 MB array (memory access dominates in this case).

```C#
[MethodImpl(MethodImplOptions.NoInlining)]
public static long TestSpanRead(Span<byte> span)
{
    return span.Read<long>();
}
```

**Before**
```ASM
       4883EC28             sub      rsp, 40

       488B01               mov      rax, gword ptr [rcx]
       488B5108             mov      rdx, qword ptr [rcx+8]
       8B4910               mov      ecx, dword ptr [rcx+16]
       83F908               cmp      ecx, 8
       0F9DC1               setge    cl
       0FB6C9               movzx    rcx, cl
       85C9                 test     ecx, ecx
       7409                 je       SHORT G_M42190_IG05
       488B0410             mov      rax, qword ptr [rax+rdx]

       4883C428             add      rsp, 40
       C3                   ret      
G_M42190_IG05:
       E807E1FFFF           call     System.Contract:NewArgumentException():ref
       488BC8               mov      rcx, rax
       E8FF2CEC5E           call     CORINFO_HELP_THROW
       CC                   int3     
```
**After**
```ASM
       4883EC28             sub      rsp, 40

       488B01               mov      rax, gword ptr [rcx]
       488B5108             mov      rdx, qword ptr [rcx+8]
       8B4910               mov      ecx, dword ptr [rcx+16]
       83F908               cmp      ecx, 8
       7209                 jb       SHORT G_M42190_IG05
       488B0410             mov      rax, qword ptr [rax+rdx]

       4883C428             add      rsp, 40
       C3                   ret      
G_M42190_IG05:
       E817E1FFFF           call     System.Contract:NewArgumentOutOfRangeException():ref
       488BC8               mov      rcx, rax
       E8072DEB5E           call     CORINFO_HELP_THROW
       CC                   int3     
```