### PR TITLE
Add net45 target for System.CommandLine

### DIFF
--- a/src/System.CommandLine/project.json
+++ b/src/System.CommandLine/project.json
@@ -30,6 +30,7 @@
     "System.Runtime.Extensions": "4.1.0-rc2-24027"
   },
   "frameworks": {
-    "netstandard1.5": { }
-  },
+    "netstandard1.5": { },
+    "net45": {} 
+  }
 }

--- a/src/System.CommandLine/project.json
+++ b/src/System.CommandLine/project.json
@@ -26,11 +26,12 @@
     }
   },
   "dependencies": {
-    "NETStandard.Library": "1.5.0-rc2-24027",
-    "System.Runtime.Extensions": "4.1.0-rc2-24027"
+    "NETStandard.Library": "1.5.0-rc2-24027"
   },
   "frameworks": {
-    "netstandard1.5": { },
+    "netstandard1.5": {
+      "dependencies": { "System.Runtime.Extensions": "4.1.0-rc2-24027" }
+    },
     "net45": {} 
   }
 }


### PR DESCRIPTION
Would like to use System.CommandLine from .NET 4.5. No code changes, just cross-compile.