### PR TITLE
UTF-8 ulong parser method now supports byte arrays

### DIFF
--- a/src/System.Text.Formatting/System/Text/Parsing/InvariantParser_ulong.cs
+++ b/src/System.Text.Formatting/System/Text/Parsing/InvariantParser_ulong.cs
@@ -46,5 +46,49 @@ namespace System.Text.Parsing
 
             return true;
         }
+        /// <summary>
+        /// Parses an unsigned 64-bit integer from a location within a UTF-8 byte array buffer.
+        /// </summary>
+        /// <param name="text">The UTF-8 buffer, passed as a byte array.</param>
+        /// <param name="startIndex">The index location of the value to be parsed within the buffer.</param>
+        /// <param name="value">The parsed value.</param>
+        /// <param name="bytesConsumed">The length (in bytes) of the unparsed value within the UTF-8 buffer.</param>
+        /// <returns>True if parsing is successful; false otherwise.</returns>
+		public static bool TryParse(byte[] text, int startIndex, out ulong value, out int bytesConsumed)
+        {
+            Precondition.Require(text.Length > 0);
+
+            value = 0;
+            bytesConsumed = 0;
+
+            for (int byteIndex = startIndex; byteIndex < text.Length; byteIndex++)
+            {
+                if (text[byteIndex] < '0' || text[byteIndex] > '9')
+                {
+                    if (bytesConsumed == 0)
+                    {
+                        value = default(ulong);
+                        return false;
+                    }
+                    else
+                    {
+                        return true;
+                    }
+                }
+                ulong candidate = value * 10;
+                candidate += (ulong)text[byteIndex] - '0';
+                if (candidate >= value)
+                {
+                    value = candidate;
+                }
+                else
+                {
+                    return true;
+                }
+                bytesConsumed++;
+            }
+
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Overloaded UTF-8 ulong parser method to support byte arrays rather than the (currently unsafe) Utf8String class.