### PR TITLE
Changed Span<byte> copy routines to use cpblk

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -11,6 +11,13 @@
     <add key="repositoryPath" value="..\packages" />
   </config>
   <packageSources>
+    <add key="dotnet.myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" protocolVersion="3" />
+    <add key="dotnet.myget.org dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/" />
+    <add key="dotnet.myget.org dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/" />    
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="dotnet.myget.org dotnet-cli" value="https://dotnet.myget.org/F/dotnet-cli/" />
+    <add key="coreclr-xunit" value="https://www.myget.org/F/coreclr-xunit/api/v2" />
+    <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
+    <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/src/System.Slices/System/PtrUtils.cs
+++ b/src/System.Slices/System/PtrUtils.cs
@@ -133,5 +133,14 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IntPtr CountOfU<T, U>(uint countOfT) { return default(IntPtr); }
 
+        [ILSub(@"
+            .maxstack 3
+            ldarg.1
+            ldarg.0
+            ldarg.2
+            cpblk
+            ret")]
+        public static void Copy(UIntPtr source, UIntPtr destination, int byteCount)
+        {}
     }
 }

--- a/src/System.Slices/System/ReadOnlySpan.cs
+++ b/src/System.Slices/System/ReadOnlySpan.cs
@@ -189,18 +189,24 @@ namespace System
         /// Copies the contents of this span into another.  The destination
         /// must be at least as big as the source, and may be bigger.
         /// </summary>
-        /// <param name="dest">The span to copy items into.</param>
-        public bool TryCopyTo(Span<T> dest)
+        /// <param name="destination">The span to copy items into.</param>
+        public bool TryCopyTo(Span<T> destination)
         {
-            if (Length > dest.Length)
-            {
+            if (Length > destination.Length) {
                 return false;
             }
 
-            // TODO(joe): specialize to use a fast memcpy if T is pointerless.
-            for (int i = 0; i < Length; i++)
-            {
-                dest[i] = this[i];
+            // For native memory, use bulk copy
+            if (Object == null && destination.Object == null) {
+                var source = PtrUtils.ComputeAddress(Object, Offset);
+                var destinationPtr = PtrUtils.ComputeAddress(destination.Object, destination.Offset);
+                var byteCount = Length * PtrUtils.SizeOf<T>();
+                PtrUtils.Copy(source, destinationPtr, byteCount);
+                return true;
+            }
+
+            for (int i = 0; i < Length; i++) {
+                destination[i] = this[i];
             }
             return true;
         }

--- a/src/System.Slices/System/Span.cs
+++ b/src/System.Slices/System/Span.cs
@@ -212,18 +212,26 @@ namespace System
         /// Copies the contents of this span into another.  The destination
         /// must be at least as big as the source, and may be bigger.
         /// </summary>
-        /// <param name="dest">The span to copy items into.</param>
-        public bool TryCopyTo(Span<T> dest)
+        /// <param name="destination">The span to copy items into.</param>
+        public bool TryCopyTo(Span<T> destination)
         {
-            if (Length > dest.Length)
+            if (Length > destination.Length)
             {
                 return false;
             }
 
-            // TODO(joe): specialize to use a fast memcpy if T is pointerless.
+            // For native memory, use bulk copy
+            if (Object==null && destination.Object==null) {
+                var source = PtrUtils.ComputeAddress(Object, Offset);
+                var destinationPtr = PtrUtils.ComputeAddress(destination.Object, destination.Offset);
+                var byteCount = Length * PtrUtils.SizeOf<T>();
+                PtrUtils.Copy(source, destinationPtr, byteCount);
+                return true;
+            }
+
             for (int i = 0; i < Length; i++)
             {
-                dest[i] = this[i];
+                destination[i] = this[i];
             }
             return true;
         }
@@ -255,9 +263,16 @@ namespace System
                 throw new ArgumentOutOfRangeException("values");
             }
 
-            // TODO(joe): specialize to use a fast memcpy if T is pointerless.
-            for (int i = 0; i < values.Length; i++)
-            {
+            // For native memory, use bulk copy
+            if (Object == null && values.Object == null) {
+                var source = PtrUtils.ComputeAddress(values.Object, values.Offset);
+                var destination = PtrUtils.ComputeAddress(Object, Offset);
+                var byteCount = values.Length * PtrUtils.SizeOf<T>();
+                PtrUtils.Copy(source, destination, byteCount);
+                return;
+            }
+
+            for (int i = 0; i < values.Length; i++) {
                 this[i] = values[i];
             }
         }


### PR DESCRIPTION
@raymcc, for span of bytes, the copy operations will now use cpblk, i.e. 

var source = new ReadOnlySpan<byte>(nativePointer);
var destination = new Span<byte>(managedArray);
source.TryCopyTo(destination);
