### PR TITLE
Cleaned up HTTP formatter

### DIFF
--- a/demos/LowAllocationWebServer/SampleServer.cs
+++ b/demos/LowAllocationWebServer/SampleServer.cs
@@ -53,7 +53,6 @@ class SampleRestServer : HttpServer
     // This method is a bit of a mess. We need to fix many Http and Json APIs
     void WriteResponseForPostJson(BufferFormatter formatter, HttpRequestLine requestLine, ReadOnlySpan<byte> body)
     {
-
         var bodyText = new Utf8String(body);
         Console.WriteLine(bodyText);
 
@@ -74,14 +73,14 @@ class SampleRestServer : HttpServer
         var responseBodyText = new Utf8String(buffer, 0, (int)stream.Position);
 
         formatter.WriteHttpStatusLine(new Utf8String("1.1"), new Utf8String("200"), new Utf8String("OK"));
-        formatter.WriteHttpHeader(new Utf8String("Content-Length"), new Utf8String(responseBodyText.Length.ToString())); // all these allocations (sic!)
+        var contentLength = formatter.WriteHttpHeader(new Utf8String("Content-Length"), Utf8String.Empty, 10); 
         formatter.WriteHttpHeader(new Utf8String("Content-Type"), new Utf8String("text/plain; charset=UTF-8"));
         formatter.WriteHttpHeader(new Utf8String("Server"), new Utf8String(".NET Core Sample Serve"));
-        // TODO: this needs to not allocate
-        formatter.WriteHttpHeader(new Utf8String("Date"), new Utf8String(DateTime.UtcNow.ToString("R"))); // this bad
+        formatter.WriteHttpHeader(new Utf8String("Date"), new Utf8String(DateTime.UtcNow.ToString("R"))); // TODO: this needs to not allocate
         formatter.EndHttpHeaderSection();
         formatter.WriteHttpBody(responseBodyText);
 
+        contentLength.UpdateValue(responseBodyText.Length.ToString()); // all these allocations (sic!)
         ArrayPool<byte>.Shared.Return(buffer);
     }
 

--- a/src/System.Slices/System/Span.cs
+++ b/src/System.Slices/System/Span.cs
@@ -256,7 +256,7 @@ namespace System
             return true;
         }
 
-        public void Set(Span<T> values)
+        public void Set(ReadOnlySpan<T> values)
         {
             if (Length < values.Length)
             {

--- a/src/System.Text.Formatting/System/Text/Formatting/IFormatterExtensions.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/IFormatterExtensions.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text.Utf8;
+
 namespace System.Text.Formatting
 {
     public static class IFormatterExtensions
@@ -117,6 +119,16 @@ namespace System.Text.Formatting
             int bytesWritten;
             while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
             {
+                formatter.ResizeBuffer();
+                bytesWritten = 0;
+            }
+            formatter.CommitBytes(bytesWritten);
+        }
+
+        public static void Append<TFormatter>(this TFormatter formatter, Utf8String value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten)) {
                 formatter.ResizeBuffer();
                 bytesWritten = 0;
             }

--- a/src/System.Text.Formatting/System/Text/Formatting/PrimitiveFormatters.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/PrimitiveFormatters.cs
@@ -190,5 +190,21 @@ namespace System.Text.Formatting
             }
             return true;
         }
+
+        public static bool TryFormat(this Utf8String value, Span<byte> buffer, Format.Parsed format, FormattingData formattingData, out int bytesWritten)
+        {
+            if (formattingData.IsUtf16) {
+                throw new NotImplementedException();
+            }
+
+            if(buffer.Length < value.Length) {
+                bytesWritten = 0;
+                return false;
+            }
+
+            buffer.Set(value.Bytes);
+            bytesWritten = value.Length;
+            return true;
+        }
     }
 }

--- a/src/System.Text.Formatting/System/Text/Formatting/SpanFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/SpanFormatter.cs
@@ -1,0 +1,59 @@
+﻿using System.Buffers;
+
+namespace System.Text.Formatting
+{
+    public class SpanFormatter : IFormatter
+    {
+        Span<byte> _buffer;
+        int _count;
+
+        FormattingData _formattingData;
+
+        public SpanFormatter(Span<byte> buffer, FormattingData formattingData)
+        {
+            _formattingData = formattingData;
+            _count = 0;
+            _buffer = buffer;
+        }
+
+        public int CommitedByteCount
+        {
+            get { return _count; }
+        }
+
+        public void Clear()
+        {
+            _count = 0;
+        }
+
+        Span<byte> IFormatter.FreeBuffer
+        {
+            get
+            {
+                return _buffer.Slice(_count);
+            }
+        }
+
+        FormattingData IFormatter.FormattingData
+        {
+            get
+            {
+                return _formattingData;
+            }
+        }
+
+        void IFormatter.ResizeBuffer()
+        {
+            throw new InvalidOperationException("cannot resize fixed size buffers.");
+        }
+
+        void IFormatter.CommitBytes(int bytes)
+        {
+            _count += bytes;
+            if(_count >= _buffer.Length)
+            {
+                throw new InvalidOperationException("More bytes commited than returned from FreeBuffer");
+            }
+        }
+    }
+}

--- a/src/System.Text.Http/System/Text/Http/IFormatterHttpExtensions.cs
+++ b/src/System.Text.Http/System/Text/Http/IFormatterHttpExtensions.cs
@@ -7,110 +7,38 @@ namespace System.Text.Http
     public static class IFormatterHttpExtensions
     {
         //TODO: Issue #387: In the Http extensions of IFormatter, we need to ensure that all the characters follow the basic rules of rfc2616
-        private static readonly Utf8String Http = new Utf8String("HTTP/");
-        private static readonly Utf8String HttpNewline = new Utf8String(new byte[] { 13, 10 });
+        private static readonly Utf8String Http10 = new Utf8String("HTTP/1.0");
+        private static readonly Utf8String Http11 = new Utf8String("HTTP/1.1");
+        private static readonly Utf8String Http20 = new Utf8String("HTTP/2.0");
+
         private const int ULongMaxValueNumberOfCharacters = 20;
 
-        public static void WriteHttpStatusLine<TFormatter>(
-            this TFormatter formatter,
-            Utf8String version,
-            Utf8String statusCode,
-            Utf8String reasonCode) where TFormatter : IFormatter
+        public static void AppendHttpStatusLine<TFormatter>(this TFormatter formatter, HttpVersion version, int statusCode, Utf8String reasonCode) where TFormatter : IFormatter
         {
-            formatter.Append(Http);
-            formatter.Append(version);
-            formatter.AppendWhiteSpace();
-            formatter.Append(statusCode);
-            formatter.AppendWhiteSpace();
-            formatter.Append(reasonCode);
-            formatter.AppendNewLine();
-        }
+            switch (version) {
+                case HttpVersion.V1_0: formatter.Append(Http10); break;
+                case HttpVersion.V1_1: formatter.Append(Http11); break;
+                case HttpVersion.V2_0: formatter.Append(Http20); break;
+                default: throw new ArgumentException(nameof(version));
+            }
 
-        public static HttpHeaderBuffer WriteHttpHeader<TFormatter>(
-            this TFormatter formatter, 
-            Utf8String name,
-            Utf8String value,
-            int reserve = ULongMaxValueNumberOfCharacters)
-            where TFormatter : IFormatter
-        {
-            formatter.Append(name);
-            formatter.Append(" : ");
-            
-            Span<byte> valueBuffer;
-            formatter.FormatWithReserve(value, reserve, out valueBuffer);                        
-
-            formatter.AppendNewLine();
-
-            return new HttpHeaderBuffer(valueBuffer, formatter.FormattingData);
-        }
-
-        public static void WriteHttpBody<TFormatter>(this TFormatter formatter, Utf8String body) 
-            where TFormatter : IFormatter
-        {
-            formatter.Append(body);
-        }
-
-        public static void EndHttpHeaderSection<TFormatter>(this TFormatter formatter) where TFormatter : IFormatter
-        {
-            formatter.AppendNewLine();
-        }
-
-        public static void AppendWhiteSpace<TFormatter>(this TFormatter formatter) where TFormatter : IFormatter
-        {
             formatter.Append(" ");
+            formatter.Append(statusCode);
+            formatter.Append(" ");
+            formatter.Append(reasonCode);
+            formatter.AppendHttpNewLine();
         }
 
-        //TODO: Issue 385: Move this method into System.Text.Formatting
-        public static void AppendNewLine<TFormatter>(this TFormatter formatter) where TFormatter : IFormatter
+        public static void AppendHttpNewLine<TFormatter>(this TFormatter formatter) where TFormatter : IFormatter
         {
-            formatter.Append(HttpNewline);
-        }
-
-        public static void Append<T>(this T formatter, Utf8String text) where T : IFormatter
-        {
-            var bytes = new byte[text.Length];
-            int i = 0;
-            foreach (var codeUnit in text)
-            {
-                bytes[i++] = codeUnit.Value;
-            }
-
-            var avaliable = formatter.FreeBuffer.Length;
-            while (avaliable < bytes.Length)
-            {
-                avaliable = formatter.FreeBuffer.Length;
+            var buffer = formatter.FreeBuffer;
+            while(buffer.Length < 2) {
                 formatter.ResizeBuffer();
+                buffer = formatter.FreeBuffer;
             }
-
-            formatter.FreeBuffer.Set(bytes);
-            formatter.CommitBytes(bytes.Length);
-        }
-
-        public static void FormatWithReserve<T>(
-            this T formatter,
-            Utf8String text,
-            int reserve,
-            out Span<byte> bufferWithReserve) where T : IFormatter
-        {
-            var bytes = new byte[text.Length];
-            var i = 0;
-            foreach (var codeUnit in text)
-            {
-                bytes[i++] = codeUnit.Value;
-            }
-
-            var avaliable = formatter.FreeBuffer.Length;
-            while (avaliable < bytes.Length + reserve)
-            {
-                avaliable = formatter.FreeBuffer.Length;
-                formatter.ResizeBuffer();
-            }
-
-            formatter.FreeBuffer.Set(bytes);
-
-            bufferWithReserve = formatter.FreeBuffer.Slice(0, bytes.Length + reserve);
-            formatter.CommitBytes(bytes.Length + reserve);
-            bufferWithReserve.SetFromRestOfSpanToEmpty(bytes.Length);
+            buffer[0] = 13;
+            buffer[1] = 10;
+            formatter.CommitBytes(2);
         }
     }
 }

--- a/tests/System.Text.Formatting.Tests/PrimitiveFormattingTests.cs
+++ b/tests/System.Text.Formatting.Tests/PrimitiveFormattingTests.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.Globalization;
 using System.IO;
+using System.Text.Utf8;
 using Xunit;
 
 namespace System.Text.Formatting.Tests
@@ -333,7 +334,8 @@ namespace System.Text.Formatting.Tests
                 utf8Writer.Append("World!");
                 utf8Writer.Append("\u0391"); // greek alpha
                 utf8Writer.Append("\uD950\uDF21");
-                AssertUtf8Equal(buffer.Slice(0, (int)stream.Position), "Hello World!\u0391\uD950\uDF21");
+                utf8Writer.Append(new Utf8String("Hello"));
+                AssertUtf8Equal(buffer.Slice(0, (int)stream.Position), "Hello World!\u0391\uD950\uDF21Hello");
             }
 
             stream.Position = 0;

--- a/tests/System.Text.Http.Tests/GivenIFormatterExtensionsForHttp.cs
+++ b/tests/System.Text.Http.Tests/GivenIFormatterExtensionsForHttp.cs
@@ -14,7 +14,7 @@ namespace System.Text.Http.Tests
         private const string HttpBody = "Body Part1";
 
         private const string HttpMessage =
-            "HTTP/1.1 200 OK\r\nConnection : close\r\nConnection : open\r\n\r\nBody Part1\r\nBody Part1";
+            "HTTP/1.1 200 OK\r\nConnection : open\r\n\r\nBody Part1\r\nBody Part1";
 
         private readonly byte[] _statusLineInBytes = Utf8Encoding.GetBytes("HTTP/1.1 200 OK\r\n");
         private readonly byte[] _headerInBytes = Utf8Encoding.GetBytes("Connection : close\r\n");
@@ -34,10 +34,7 @@ namespace System.Text.Http.Tests
         [Fact]
         public void It_has_an_extension_method_to_write_status_line()
         {            
-            _formatter.WriteHttpStatusLine(
-                GetUtf8EncodedString("1.1"), 
-                GetUtf8EncodedString("200"), 
-                GetUtf8EncodedString("OK"));
+            _formatter.AppendHttpStatusLine(HttpVersion.V1_1, 200, new Utf8String("OK"));
 
             var result = _formatter.Buffer;
 
@@ -46,115 +43,89 @@ namespace System.Text.Http.Tests
             ArrayPool<byte>.Shared.Return(result);
         }
 
-        [Fact]
-        public void It_has_an_extension_method_to_write_headers()
-        {
-            _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
+        //[Fact]
+        //public void It_has_an_extension_method_to_write_headers()
+        //{
+        //    _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
 
-            var result = _formatter.Buffer;
+        //    var result = _formatter.Buffer;
 
-            result.Should().ContainInOrder(_headerInBytes);
+        //    result.Should().ContainInOrder(_headerInBytes);
 
-            ArrayPool<byte>.Shared.Return(result);
-        }
+        //    ArrayPool<byte>.Shared.Return(result);
+        //}
 
-        [Fact]
-        public void It_has_an_extension_method_to_end_the_header_session()
-        {
-            _formatter.EndHttpHeaderSection();
+        //[Fact]
+        //public void It_is_possible_to_update_the_value_of_a_header()
+        //{
+        //    var httpHeaderBuffer = 
+        //        _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
 
-            var result = _formatter.Buffer;
+        //    httpHeaderBuffer.UpdateValue("open");
 
-            result.Should().ContainInOrder(_httpHeaderSectionDelineatorInBytes);
+        //    var result = _formatter.Buffer;
 
-            ArrayPool<byte>.Shared.Return(result);
-        }
+        //    result.Should().ContainInOrder(_updatedHeaderInBytes);
 
-        [Fact]
-        public void It_has_an_extension_method_to_write_the_body()
-        {
-            _formatter.WriteHttpBody(new Utf8String(HttpBody));
+        //    ArrayPool<byte>.Shared.Return(result);
+        //}
 
-            var result = _formatter.Buffer;
+        //[Fact]
+        //public void It_is_possible_to_specify_a_number_of_reserve_bytes_when_writing_the_header_and_it_is_set_to_empty_space()
+        //{
+        //    _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"), 30);
 
-            result.Should().ContainInOrder(_httpBodyInBytes);
+        //    var result = _formatter.Buffer;
 
-            ArrayPool<byte>.Shared.Return(result);
-        }
+        //    result.Should().ContainInOrder(_headerInBytes);
 
-        [Fact]
-        public void It_is_possible_to_update_the_value_of_a_header()
-        {
-            var httpHeaderBuffer = 
-                _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
+        //    var filledBytesCount = 30 - _headerInBytes.Length;
+        //    var fillingArray = new byte[filledBytesCount];            
+        //    for (var i = 0; i < filledBytesCount; i++)
+        //    {
+        //        fillingArray[i] = 32;
+        //    }
 
-            httpHeaderBuffer.UpdateValue("open");
+        //    result.Should().ContainInOrder(_headerInBytes);
+        //    result.Should().ContainInOrder(fillingArray);
 
-            var result = _formatter.Buffer;
+        //    ArrayPool<byte>.Shared.Return(result);
+        //}
 
-            result.Should().ContainInOrder(_updatedHeaderInBytes);
+        //[Fact]
+        //public void It_is_possible_to_use_the_reserve_to_write_a_header_value_with_more_characters_than_originally_set()
+        //{
+        //    var httpHeaderBuffer = 
+        //        _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
 
-            ArrayPool<byte>.Shared.Return(result);
-        }
+        //    httpHeaderBuffer.UpdateValue("18446744073709551615");
 
-        [Fact]
-        public void It_is_possible_to_specify_a_number_of_reserve_bytes_when_writing_the_header_and_it_is_set_to_empty_space()
-        {
-            _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"), 30);
+        //    var result = _formatter.Buffer;
 
-            var result = _formatter.Buffer;
+        //    result.Should().ContainInOrder(Utf8Encoding.GetBytes("Connection : 18446744073709551615\r\n"));
+        //}
 
-            result.Should().ContainInOrder(_headerInBytes);
+        //[Fact]
+        //public void HttpHeaderBuffer_UpdateValue_throws_an_exception_if_the_new_value_is_bigger_than_the_buffer_space()
+        //{
+        //    var httpHeaderBuffer = 
+        //        _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
 
-            var filledBytesCount = 30 - _headerInBytes.Length;
-            var fillingArray = new byte[filledBytesCount];            
-            for (var i = 0; i < filledBytesCount; i++)
-            {
-                fillingArray[i] = 32;
-            }
+        //    Action action = () => httpHeaderBuffer.UpdateValue("close18446744073709551615a");
 
-            result.Should().ContainInOrder(_headerInBytes);
-            result.Should().ContainInOrder(fillingArray);
-
-            ArrayPool<byte>.Shared.Return(result);
-        }
-
-        [Fact]
-        public void It_is_possible_to_use_the_reserve_to_write_a_header_value_with_more_characters_than_originally_set()
-        {
-            var httpHeaderBuffer = 
-                _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
-
-            httpHeaderBuffer.UpdateValue("18446744073709551615");
-
-            var result = _formatter.Buffer;
-
-            result.Should().ContainInOrder(Utf8Encoding.GetBytes("Connection : 18446744073709551615\r\n"));
-        }
-
-        [Fact]
-        public void HttpHeaderBuffer_UpdateValue_throws_an_exception_if_the_new_value_is_bigger_than_the_buffer_space()
-        {
-            var httpHeaderBuffer = 
-                _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
-
-            Action action = () => httpHeaderBuffer.UpdateValue("close18446744073709551615a");
-
-            action.ShouldThrow<ArgumentException>().WithMessage("newValue");
-        }
+        //    action.ShouldThrow<ArgumentException>().WithMessage("newValue");
+        //}
 
         [Fact]
         public void The_http_extension_methods_can_be_composed_to_generate_the_http_message()
         {
-            _formatter.WriteHttpStatusLine(GetUtf8EncodedString("1.1"), GetUtf8EncodedString("200"), GetUtf8EncodedString("OK"));
-            _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
-            var httpHeaderBuffer = _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
-            _formatter.EndHttpHeaderSection();
-            _formatter.WriteHttpBody(GetUtf8EncodedString(HttpBody));
-            _formatter.AppendNewLine();
-            _formatter.WriteHttpBody(GetUtf8EncodedString(HttpBody));
-
-            httpHeaderBuffer.UpdateValue("open");
+            _formatter.AppendHttpStatusLine(HttpVersion.V1_1, 200, new Utf8String("OK"));
+            _formatter.Append(new Utf8String("Connection : open"));
+            _formatter.AppendHttpNewLine();
+            _formatter.AppendHttpNewLine();
+            _formatter.Append(HttpBody);
+            _formatter.AppendHttpNewLine();
+            _formatter.Append(HttpBody);
 
             var result = _formatter.Buffer;
 
@@ -163,24 +134,19 @@ namespace System.Text.Http.Tests
             ArrayPool<byte>.Shared.Return(result);
         }
 
-        [Fact(Skip = "Issue https://github.com/dotnet/corefxlab/issues/599")]
-        public void WriteHttpHeader_resizes_the_buffer_taking_into_consideration_the_reserver()
-        {
-            _formatter = new BufferFormatter(32, FormattingData.InvariantUtf8, ArrayPool<byte>.Shared);
+        //[Fact(Skip = "Issue https://github.com/dotnet/corefxlab/issues/599")]
+        //public void WriteHttpHeader_resizes_the_buffer_taking_into_consideration_the_reserver()
+        //{
+        //    _formatter = new BufferFormatter(32, FormattingData.InvariantUtf8, ArrayPool<byte>.Shared);
 
-            var httpHeaderBuffer =
-                _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
+        //    var httpHeaderBuffer =
+        //        _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
 
-            httpHeaderBuffer.UpdateValue("18446744073709551615");
+        //    httpHeaderBuffer.UpdateValue("18446744073709551615");
 
-            var result = _formatter.Buffer;
+        //    var result = _formatter.Buffer;
 
-            result.Should().ContainInOrder(Utf8Encoding.GetBytes("Connection : 18446744073709551615\r\n"));
-        }
-
-        private static Utf8String GetUtf8EncodedString(string value)
-        {
-            return new Utf8String(Utf8Encoding.GetBytes(value));
-        }
+        //    result.Should().ContainInOrder(Utf8Encoding.GetBytes("Connection : 18446744073709551615\r\n"));
+        //}
     }
 }


### PR DESCRIPTION
I cleaned up some APIs and removed others
The APIs I removed were misleading and need to be redesigned:
1. WriteHeader APIs were forcing all values to be strings. Which means integer values were forcing unnecessary allocations
2. The reservation feature was not working properly if the response buffer got resized later.
The header value reservation buffer would still point to the old response buffer.

I will redesign and add the removed APIs in the future.