### PR TITLE
Added support for handling integer overflow

### DIFF
--- a/src/System.Text.Primitives/System/Text/InvariantParser_byte.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_byte.cs
@@ -35,17 +35,20 @@ namespace System.Text
                         return true; // otherwise return true
                     }
                 }
-                byte candidate = (byte)(value * 10); // left shift the value
-                candidate += (byte)(nextByte - '0'); // parse the current digit to a byte and add it to the temporary value
-                if (candidate >= value) // if it was a digit 0-9, this should be true
+                try
                 {
+                    byte candidate = checked((byte)(value * 10 + nextByte - '0')); // left shift the value and add the nextByte.
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++; // increment the number of bytes consumed, then loop
                 }
-                else // this should never happen, but just in case
+                catch (OverflowException e) // catch any overflow
                 {
-                    return true;
+                    value = 0;
+                    bytesConsumed = 0;
+                    return false;
                 }
-                bytesConsumed++; // increment the number of bytes consumed, then loop
             }
 
             return true;
@@ -70,13 +73,20 @@ namespace System.Text
                         return true;
                     }
                 }
-                byte candidate = (byte)(value * 10);
-                candidate += (byte)(nextByte - '0');
-                if (candidate >= value)
+                try
                 {
+                    byte candidate = checked((byte)(value * 10 + nextByte - '0')); // left shift the value and add the nextByte.
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++; // increment the number of bytes consumed, then loop
                 }
-                bytesConsumed++;
+                catch (OverflowException e) // catch any overflow
+                {
+                    value = 0;
+                    bytesConsumed = 0;
+                    return false;
+                }
             }
             return true;
         }

--- a/src/System.Text.Primitives/System/Text/InvariantParser_int.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_int.cs
@@ -59,27 +59,31 @@ namespace System.Text
                         return true; // otherwise return true
                     }
                 }
-                int candidate = (value * 10); // left shift the value
-                candidate += (nextByte - '0'); // parse the current digit to an int and add it to the temporary value
-                if (candidate >= value) // if it was a digit 0-9, this should be true
+                //int candidate = 0; // we declare candidate out of the try-block so that it is still available to the catch (only necessary for signed types)
+                try
                 {
+                    int candidate = checked(value * 10 + (nextByte - '0')); // parse the current digit to an int and add it to the left-shifted value
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++; // increment the number of bytes consumed, then loop
                 }
-                else // for signed types this will occur at the min values as overflow occurs during addition, so we handle that
+                catch (OverflowException e)
                 {
-                    if (candidate == int.MinValue)
+                    int candidate = value * 10 + (nextByte - '0');
+                    if (negative && candidate == int.MinValue) // overflow is expected when calculating the minimum value.
                     {
                         bytesConsumed++;
                         value = candidate;
                         return true;
                     }
-                    if (negative) // We check if the value is negative at the very end to save on comp time
+                    else
                     {
-                        value = -value;
+                        value = 0;
+                        bytesConsumed = 0;
+                        return false;
                     }
-                    return true;
                 }
-                bytesConsumed++; // increment the number of bytes consumed, then loop
             }
 
             if (negative) // We check if the value is negative at the very end to save on comp time
@@ -125,27 +129,30 @@ namespace System.Text
                         return true;
                     }
                 }
-                int candidate = (value * 10);
-                candidate += (nextByte - '0');
-                if (candidate >= value)
+                try
                 {
+                    int candidate = checked(value * 10 + (nextByte - '0')); // parse the current digit to an int and add it to the left-shifted value
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++; // increment the number of bytes consumed, then loop
                 }
-                else // for signed types this will occur at the min values as overflow occurs during addition, so we handle that
+                catch (OverflowException e)
                 {
-                    if (candidate == int.MinValue)
+                    int candidate = value * 10 + (nextByte - '0');
+                    if (negative && candidate == int.MinValue) // overflow is expected when calculating the minimum value.
                     {
                         bytesConsumed++;
                         value = candidate;
                         return true;
                     }
-                    if (negative) // We check if the value is negative at the very end to save on comp time
+                    else
                     {
-                        value = -value;
+                        value = 0;
+                        bytesConsumed = 0;
+                        return false;
                     }
-                    return true;
                 }
-                bytesConsumed++;
             }
             return true;
         }

--- a/src/System.Text.Primitives/System/Text/InvariantParser_long.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_long.cs
@@ -59,27 +59,30 @@ namespace System.Text
                         return true; // otherwise return true
                     }
                 }
-                long candidate = (value * 10); // left shift the value
-                candidate += (nextByte - '0'); // parse the current digit to a long and add it to the temporary value
-                if (candidate >= value) // if it was a digit 0-9, this should be true
+                try
                 {
+                    long candidate = checked(value * 10 + (nextByte - '0')); // parse the current digit to a long and add it to the left-shifted value
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++; // increment the number of bytes consumed, then loop
                 }
-                else // for signed types this will occur at the min values as overflow occurs during addition, so we handle that
-                {
-                    if (candidate == long.MinValue)
+               catch (OverflowException e)
+               {
+                    long candidate = (value * 10) + nextByte - '0';
+                    if (negative && candidate == long.MinValue)
                     {
                         bytesConsumed++;
                         value = candidate;
                         return true;
                     }
-                    if (negative) // We check if the value is negative at the very end to save on comp time
+                    else
                     {
-                        value = -value;
+                        value = 0;
+                        bytesConsumed = 0;
+                        return false;
                     }
-                    return true;
                 }
-                bytesConsumed++; // increment the number of bytes consumed, then loop
             }
 
             if (negative) // We check if the value is negative at the very end to save on comp time
@@ -125,27 +128,30 @@ namespace System.Text
                         return true;
                     }
                 }
-                long candidate = (value * 10);
-                candidate += (nextByte - '0');
-                if (candidate >= value)
+                try
                 {
+                    long candidate = checked(value * 10 + (nextByte - '0')); // parse the current digit to a long and add it to the left-shifted value
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++; // increment the number of bytes consumed, then loop
                 }
-                else // for signed types this will occur at the min values as overflow occurs during addition, so we handle that
+                catch (OverflowException e)
                 {
-                    if (candidate == long.MinValue)
+                    long candidate = (value * 10) + nextByte - '0';
+                    if (negative && candidate == long.MinValue)
                     {
                         bytesConsumed++;
                         value = candidate;
                         return true;
                     }
-                    if (negative) // We check if the value is negative at the very end to save on comp time
+                    else
                     {
-                        value = -value;
+                        value = 0;
+                        bytesConsumed = 0;
+                        return false;
                     }
-                    return true;
                 }
-                bytesConsumed++;
             }
             return true;
         }

--- a/src/System.Text.Primitives/System/Text/InvariantParser_sbyte.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_sbyte.cs
@@ -59,27 +59,30 @@ namespace System.Text
                         return true; // otherwise return true
                     }
                 }
-                sbyte candidate = (sbyte)(value * 10); // left shift the value
-                candidate += (sbyte)(nextByte - '0'); // parse the current digit to a sbyte and add it to the temporary value
-                if (candidate >= value) // if it was a digit 0-9, this should be true
+                try
                 {
+                    sbyte candidate = checked((sbyte)(value * 10 + nextByte - '0')); // parse the current digit to a sbyte and add it to the left-shifted value
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++; // increment the number of bytes consumed, then loop
                 }
-                else // for signed types this will occur at the min values as overflow occurs during addition, so we handle that
+                catch (OverflowException e)
                 {
-                    if (candidate == sbyte.MinValue)
+                    sbyte candidate = (sbyte)((value * 10) + nextByte - '0'); 
+                    if (negative && candidate == sbyte.MinValue)
                     {
                         bytesConsumed++;
                         value = candidate;
                         return true;
                     }
-                    if (negative) // We check if the value is negative at the very end to save on comp time
+                    else
                     {
-                        value = (sbyte)-value;
+                        value = 0;
+                        bytesConsumed = 0;
+                        return false;
                     }
-                    return true;
                 }
-                bytesConsumed++; // increment the number of bytes consumed, then loop
             }
 
             if (negative) // We check if the value is negative at the very end to save on comp time
@@ -125,27 +128,31 @@ namespace System.Text
                         return true;
                     }
                 }
-                sbyte candidate = (sbyte)(value * 10);
-                candidate += (sbyte)(nextByte - '0');
-                if (candidate >= value)
+                try
                 {
-                    value = candidate;
+                    sbyte candidate = checked((sbyte)(value * 10 + nextByte - '0')); // parse the current digit to a sbyte and add it to the left-shifted value
+                    if (candidate >= value) // if it was a digit 0-9, this should be true
+                    {
+                        value = candidate;
+                    }
+                    bytesConsumed++; // increment the number of bytes consumed, then loop
                 }
-                else // for signed types this will occur at the min values as overflow occurs during addition, so we handle that
+                catch (OverflowException e)
                 {
-                    if (candidate == sbyte.MinValue)
+                    sbyte candidate = (sbyte)((value * 10) + nextByte - '0');
+                    if (negative && candidate == sbyte.MinValue)
                     {
                         bytesConsumed++;
                         value = candidate;
                         return true;
                     }
-                    if (negative) // We check if the value is negative at the very end to save on comp time
+                    else
                     {
-                        value = (sbyte)-value;
+                        value = 0;
+                        bytesConsumed = 0;
+                        return false;
                     }
-                    return true;
                 }
-                bytesConsumed++;
             }
             return true;
         }

--- a/src/System.Text.Primitives/System/Text/InvariantParser_short.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_short.cs
@@ -59,27 +59,30 @@ namespace System.Text
                         return true; // otherwise return true
                     }
                 }
-                short candidate = (short)(value * 10); // left shift the value
-                candidate += (short)(nextByte - '0'); // parse the current digit to a short and add it to the temporary value
-                if (candidate >= value) // if it was a digit 0-9, this should be true
+                try
                 {
+                    short candidate = checked((short)(value * 10 + nextByte - '0')); // parse the current digit to a short and add it to the left-shifted value
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++; // increment the number of bytes consumed, then loop
                 }
-                else // for signed types this will occur at the min values as overflow occurs during addition, so we handle that
+                catch (OverflowException e)
                 {
-                    if (candidate == short.MinValue)
+                    short candidate = (short)(value * 10 + nextByte - '0');
+                    if (negative && candidate == short.MinValue)
                     {
                         bytesConsumed++;
                         value = candidate;
                         return true;
                     }
-                    if (negative) // We check if the value is negative at the very end to save on comp time
+                    else
                     {
-                        value = (short)-value;
+                        value = 0;
+                        bytesConsumed = 0;
+                        return false;
                     }
-                    return true;
                 }
-                bytesConsumed++; // increment the number of bytes consumed, then loop
             }
 
             if (negative) // We check if the value is negative at the very end to save on comp time
@@ -125,27 +128,30 @@ namespace System.Text
                         return true;
                     }
                 }
-                short candidate = (short)(value * 10);
-                candidate += (short)(nextByte - '0');
-                if (candidate >= value)
+                try
                 {
+                    short candidate = checked((short)(value * 10 + nextByte - '0')); // parse the current digit to a short and add it to the left-shifted value
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++; // increment the number of bytes consumed, then loop
                 }
-                else // for signed types this will occur at the min values as overflow occurs during addition, so we handle that
+                catch (OverflowException e)
                 {
-                    if (candidate == short.MinValue)
+                    short candidate = (short)(value * 10 + nextByte - '0');
+                    if (negative && candidate == short.MinValue)
                     {
                         bytesConsumed++;
                         value = candidate;
                         return true;
                     }
-                    if (negative) // We check if the value is negative at the very end to save on comp time
+                    else
                     {
-                        value = (short)-value;
+                        value = 0;
+                        bytesConsumed = 0;
+                        return false;
                     }
-                    return true;
                 }
-                bytesConsumed++;
             }
             return true;
         }

--- a/src/System.Text.Primitives/System/Text/InvariantParser_uint.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_uint.cs
@@ -60,13 +60,20 @@ namespace System.Text
                         return true;
                     }
                 }
-                uint candidate = value * 10;
-                candidate += (uint)nextByte - '0';
-                if (candidate >= value)
+                try
                 {
+                    uint candidate = checked(value * 10 + nextByte - '0');
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++;
                 }
-                bytesConsumed++;
+                catch (OverflowException e)
+                {
+                    value = 0;
+                    bytesConsumed = 0;
+                    return false;
+                }
             }
 
             return true;
@@ -93,13 +100,20 @@ namespace System.Text
                         return true;
                     }
                 }
-                uint candidate = value * 10;
-                candidate += (uint)nextByte - '0';
-                if (candidate >= value)
+                try
                 {
+                    uint candidate = checked(value * 10 + nextByte - '0');
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++;
                 }
-                bytesConsumed++;
+                catch (OverflowException e)
+                {
+                    value = 0;
+                    bytesConsumed = 0;
+                    return false;
+                }
             }
 
             return true;
@@ -124,13 +138,20 @@ namespace System.Text
                         return true;
                     }
                 }
-                uint candidate = value * 10;
-                candidate += (uint)nextByte - '0';
-                if (candidate >= value)
+                try
                 {
+                    uint candidate = checked(value * 10 + nextByte - '0');
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++;
                 }
-                bytesConsumed++;
+                catch (OverflowException e)
+                {
+                    value = 0;
+                    bytesConsumed = 0;
+                    return false;
+                }
             }
             return true;
         }
@@ -164,7 +185,8 @@ namespace System.Text
                         value = default(uint);
                         return false;
                     }
-                    else {
+                    else
+                    {
                         return true;
                     }
                 }
@@ -174,7 +196,8 @@ namespace System.Text
                 {
                     value = candidate;
                 }
-                else {
+                else
+                {
                     return true;
                 }
                 bytesConsumed++;

--- a/src/System.Text.Primitives/System/Text/InvariantParser_ulong.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_ulong.cs
@@ -30,13 +30,20 @@ namespace System.Text
                         return true;
                     }
                 }
-                ulong candidate = value * 10;
-                candidate += (ulong)nextByte - '0';
-                if (candidate >= value)
+                try
                 {
+                    ulong candidate = checked(value * 10 + nextByte - '0');
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++;
                 }
-                bytesConsumed++;
+                catch (OverflowException e)
+                {
+                    value = 0;
+                    bytesConsumed = 0;
+                    return false;
+                }
             }
 
             return true;
@@ -71,17 +78,20 @@ namespace System.Text
                         return true; // otherwise return true
                     }
                 }
-                ulong candidate = value * 10; // left shift the value
-                candidate += (ulong)nextByte - '0'; // parse the current digit to a ulong and add it to the temporary value
-                if (candidate >= value) // if it was a digit 0-9, this should be true
+                try
                 {
+                    ulong candidate = checked(value * 10 + nextByte - '0'); // parse the current digit to a ulong and add it to the temporary value
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++; // increment the number of bytes consumed, then loop
                 }
-                else // this should never happen, but just in case
+                catch (OverflowException e)
                 {
-                    return true;
+                    value = 0;
+                    bytesConsumed = 0;
+                    return false;
                 }
-                bytesConsumed++; // increment the number of bytes consumed, then loop
             }
 
             return true;
@@ -106,13 +116,20 @@ namespace System.Text
                         return true;
                     }
                 }
-                ulong candidate = value * 10;
-                candidate += (ulong)nextByte - '0';
-                if (candidate >= value)
+                try
                 {
+                    ulong candidate = checked(value * 10 + nextByte - '0'); // parse the current digit to a ulong and add it to the temporary value
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++; // increment the number of bytes consumed, then loop
                 }
-                bytesConsumed++;
+                catch (OverflowException e)
+                {
+                    value = 0;
+                    bytesConsumed = 0;
+                    return false;
+                }
             }
             return true;
         }

--- a/src/System.Text.Primitives/System/Text/InvariantParser_ushort.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_ushort.cs
@@ -35,17 +35,20 @@ namespace System.Text
                         return true; // otherwise return true
                     }
                 }
-                ushort candidate = (ushort)(value * 10); // left shift the value
-                candidate += (ushort)(nextByte - '0'); // parse the current digit to a ushort and add it to the temporary value
-                if (candidate >= value) // if it was a digit 0-9, this should be true
+                try
                 {
+                    ushort candidate = checked((ushort)(value * 10 + nextByte - '0')); // parse the current digit to a ushort and add it to the temporary value
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++; // increment the number of bytes consumed, then loop
                 }
-                else // this should never happen, but just in case
+                catch (OverflowException e)
                 {
-                    return true;
+                    value = 0;
+                    bytesConsumed = 0;
+                    return false;
                 }
-                bytesConsumed++; // increment the number of bytes consumed, then loop
             }
 
             return true;
@@ -70,13 +73,20 @@ namespace System.Text
                         return true;
                     }
                 }
-                ushort candidate = (ushort)(value * 10);
-                candidate += (ushort)(nextByte - '0');
-                if (candidate >= value)
+                try
                 {
+                    ushort candidate = checked((ushort)(value * 10 + nextByte - '0')); // parse the current digit to a ushort and add it to the temporary value
+                    Debug.Assert(candidate >= value);
+
                     value = candidate;
+                    bytesConsumed++; // increment the number of bytes consumed, then loop
                 }
-                bytesConsumed++;
+                catch (OverflowException e)
+                {
+                    value = 0;
+                    bytesConsumed = 0;
+                    return false;
+                }
             }
             return true;
         }

--- a/tests/System.Text.Primitives.Tests/ParserTests.cs
+++ b/tests/System.Text.Primitives.Tests/ParserTests.cs
@@ -2,7 +2,7 @@
 using System.Text;
 using Xunit;
 
-namespace System.Text.Formatting.Tests
+namespace System.Text.Primitives.Tests
 {
     public class ParserTests
     {
@@ -17,7 +17,8 @@ namespace System.Text.Formatting.Tests
         [InlineData("blahblahh1751110", true, 9, 1751110, 7)]
         [InlineData("987abcdefg", true, 0, 987, 3)]
         [InlineData("The biggest ulong is 9223372036854775808.", true, 21, 9223372036854775808, 19)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("18446744073709551616", false, 0, 0, 0)] // overflow test
         public void ParseUtf8ByteArrayToUlong(string text, bool expectSuccess, int index, ulong expectedValue, int expectedBytesConsumed)
         {
             ulong parsedValue;
@@ -34,7 +35,8 @@ namespace System.Text.Formatting.Tests
         [InlineData("blahblahh1751110", true, 9, 1751110, 7)]
         [InlineData("987abcdefg", true, 0, 987, 3)]
         [InlineData("The biggest ulong is 9223372036854775808.", true, 21, 9223372036854775808, 19)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("18446744073709551616", false, 0, 0, 0)] // overflow test
         public unsafe void ParseUtf8ByteStarToUlong(string text, bool expectSuccess, int index, ulong expectedValue, int expectedBytesConsumed)
         {
             ulong parsedValue;
@@ -57,7 +59,8 @@ namespace System.Text.Formatting.Tests
         [InlineData("1728", true, 0, 1728, 4)]
         [InlineData("blahblahh1751110", true, 9, 1751110, 7)]
         [InlineData("987abcdefg", true, 0, 987, 3)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("4294967296", false, 0, 0, 0)] // overflow test
         public void ParseUtf8ByteArrayToUint(string text, bool expectSuccess, int index, uint expectedValue, int expectedBytesConsumed)
         {
             uint parsedValue;
@@ -73,7 +76,8 @@ namespace System.Text.Formatting.Tests
         [InlineData("1728", true, 0, 1728, 4)]
         [InlineData("blahblahh1751110", true, 9, 1751110, 7)]
         [InlineData("987abcdefg", true, 0, 987, 3)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("4294967296", false, 0, 0, 0)] // overflow test
         public unsafe void ParseUtf8ByteStarToUint(string text, bool expectSuccess, int index, uint expectedValue, int expectedBytesConsumed)
         {
             uint parsedValue;
@@ -96,7 +100,8 @@ namespace System.Text.Formatting.Tests
         [InlineData("1728", true, 0, 1728, 4)]
         [InlineData("blahblahh37511", true, 9, 37511, 5)]
         [InlineData("987abcdefg", true, 0, 987, 3)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("65536", false, 0, 0, 0)] // overflow test
         public void ParseUtf8ByteArrayToUshort(string text, bool expectSuccess, int index, ushort expectedValue, int expectedBytesConsumed)
         {
             ushort parsedValue;
@@ -112,7 +117,8 @@ namespace System.Text.Formatting.Tests
         [InlineData("1728", true, 0, 1728, 4)]
         [InlineData("blahblahh37511", true, 9, 37511, 5)]
         [InlineData("987abcdefg", true, 0, 987, 3)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("65536", false, 0, 0, 0)] // overflow test
         public unsafe void ParseUtf8ByteStarToUshort(string text, bool expectSuccess, int index, ushort expectedValue, int expectedBytesConsumed)
         {
             ushort parsedValue;
@@ -135,7 +141,8 @@ namespace System.Text.Formatting.Tests
         [InlineData("172", true, 0, 172, 3)]
         [InlineData("blahblahh37", true, 9, 37, 2)]
         [InlineData("187abhced", true, 0, 187, 3)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("256", false, 0, 0, 0)] // overflow test
         public unsafe void ParseUtf8ByteArrayToByte(string text, bool expectSuccess, int index, byte expectedValue, int expectedBytesConsumed)
         {
             byte parsedValue;
@@ -151,7 +158,8 @@ namespace System.Text.Formatting.Tests
         [InlineData("172", true, 0, 172, 3)]
         [InlineData("blahblahh37", true, 9, 37, 2)]
         [InlineData("187abhced", true, 0, 187, 3)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("256", false, 0, 0, 0)] // overflow test
         public unsafe void ParseUtf8ByteStarToByte(string text, bool expectSuccess, int index, byte expectedValue, int expectedBytesConsumed)
         {
             byte parsedValue;
@@ -176,8 +184,10 @@ namespace System.Text.Formatting.Tests
         [InlineData("987abcdefg", true, 0, 987, 3)]
         [InlineData("The smallest long is -9223372036854775808.", true, 21, -9223372036854775808, 20)]
         [InlineData("Letthem-32984eatcake", true, 7, -32984, 6)]
-        [InlineData("-A", false, 0, 0, 0)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("-A", false, 0, 0, 0)] // invalid character after a sign
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("9223372036854775808", false, 0, 0, 0)] // positive overflow test
+        [InlineData("-9223372036854775809", false, 0, 0, 0)] // negative overflow test
         public void ParseUtf8ByteArrayToLong(string text, bool expectSuccess, int index, long expectedValue, int expectedBytesConsumed)
         {
             long parsedValue;
@@ -195,7 +205,10 @@ namespace System.Text.Formatting.Tests
         [InlineData("987abcdefg", true, 0, 987, 3)]
         [InlineData("The smallest long is -9223372036854775808.", true, 21, -9223372036854775808, 20)]
         [InlineData("Letthem-32984eatcake", true, 7, -32984, 6)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("-A", false, 0, 0, 0)] // invalid character after a sign
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("9223372036854775808", false, 0, 0, 0)] // positive overflow test
+        [InlineData("-9223372036854775809", false, 0, 0, 0)] // negative overflow test
         public unsafe void ParseUtf8ByteStarToLong(string text, bool expectSuccess, int index, long expectedValue, int expectedBytesConsumed)
         {
             long parsedValue;
@@ -220,8 +233,10 @@ namespace System.Text.Formatting.Tests
         [InlineData("987abcdefg", true, 0, 987, 3)]
         [InlineData("-2147483648", true, 0, -2147483648, 11)]
         [InlineData("Letthem-32984eatcake", true, 7, -32984, 6)]
-        [InlineData("-A", false, 0, 0, 0)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("-A", false, 0, 0, 0)] // invalid character after a sign
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("2147483648", false, 0, 0, 0)] // positive overflow test
+        [InlineData("-2147483649", false, 0, 0, 0)] // negative overflow test
         public void ParseUtf8ByteArrayToInt(string text, bool expectSuccess, int index, int expectedValue, int expectedBytesConsumed)
         {
             int parsedValue;
@@ -239,7 +254,10 @@ namespace System.Text.Formatting.Tests
         [InlineData("987abcdefg", true, 0, 987, 3)]
         [InlineData("-2147483648", true, 0, -2147483648, 11)]
         [InlineData("Letthem-32984eatcake", true, 7, -32984, 6)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("-A", false, 0, 0, 0)] // invalid character after a sign
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("2147483648", false, 0, 0, 0)] // positive overflow test
+        [InlineData("-2147483649", false, 0, 0, 0)] // negative overflow test
         public unsafe void ParseUtf8ByteStarToInt(string text, bool expectSuccess, int index, int expectedValue, int expectedBytesConsumed)
         {
             int parsedValue;
@@ -264,8 +282,10 @@ namespace System.Text.Formatting.Tests
         [InlineData("987abcdefg", true, 0, 987, 3)]
         [InlineData("-32768", true, 0, -32768, 6)]
         [InlineData("Letthem-32684eatcake", true, 7, -32684, 6)]
-        [InlineData("-A", false, 0, 0, 0)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("-A", false, 0, 0, 0)] // invalid character after a sign
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("32768", false, 0, 0, 0)] // positive overflow test
+        [InlineData("-32769", false, 0, 0, 0)] // negative overflow test
         public void ParseUtf8ByteArrayToShort(string text, bool expectSuccess, int index, short expectedValue, int expectedBytesConsumed)
         {
             short parsedValue;
@@ -282,8 +302,10 @@ namespace System.Text.Formatting.Tests
         [InlineData("blahblahh17511", true, 9, 17511, 5)]
         [InlineData("987abcdefg", true, 0, 987, 3)]
         [InlineData("-32768", true, 0, -32768, 6)]
-        [InlineData("Letthem-32684eatcake", true, 7, -32684, 6)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("-A", false, 0, 0, 0)] // invalid character after a sign
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("32768", false, 0, 0, 0)] // positive overflow test
+        [InlineData("-32769", false, 0, 0, 0)] // negative overflow test
         public unsafe void ParseUtf8ByteStarToShort(string text, bool expectSuccess, int index, short expectedValue, int expectedBytesConsumed)
         {
             short parsedValue;
@@ -308,8 +330,10 @@ namespace System.Text.Formatting.Tests
         [InlineData("127acndasjfh", true, 0, 127, 3)]
         [InlineData("-128", true, 0, -128, 4)]
         [InlineData("Letthem-126eatcake", true, 7, -126, 4)]
-        [InlineData("-A", false, 0, 0, 0)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("-A", false, 0, 0, 0)] // invalid character after a sign
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("128", false, 0, 0, 0)] // positive overflow test
+        [InlineData("-129", false, 0, 0, 0)] // negative overflow test
         public void ParseUtf8ByteArrayToSbyte(string text, bool expectSuccess, int index, sbyte expectedValue, int expectedBytesConsumed)
         {
             sbyte parsedValue;
@@ -327,7 +351,10 @@ namespace System.Text.Formatting.Tests
         [InlineData("127acndasjfh", true, 0, 127, 3)]
         [InlineData("-128", true, 0, -128, 4)]
         [InlineData("Letthem-126eatcake", true, 7, -126, 4)]
-        [InlineData("I am 1", false, 0, 0, 0)]
+        [InlineData("-A", false, 0, 0, 0)] // invalid character after a sign
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        [InlineData("128", false, 0, 0, 0)] // positive overflow test
+        [InlineData("-129", false, 0, 0, 0)] // negative overflow test
         public unsafe void ParseUtf8ByteStarToSbyte(string text, bool expectSuccess, int index, sbyte expectedValue, int expectedBytesConsumed)
         {
             sbyte parsedValue;

--- a/tests/System.Text.Primitives.Tests/Properties/AssemblyInfo.cs
+++ b/tests/System.Text.Primitives.Tests/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
-[assembly: AssemblyProduct("System.Text.Tests")]
+[assembly: AssemblyProduct("System.Text.Primitives.Tests")]
 [assembly: AssemblyTrademark("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible

--- a/tests/System.Text.Primitives.Tests/System.Text.Primitives.Tests.xproj
+++ b/tests/System.Text.Primitives.Tests/System.Text.Primitives.Tests.xproj
@@ -4,7 +4,6 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>67b42c20-d98a-420b-82c0-04afd963e650</ProjectGuid>
@@ -13,9 +12,11 @@
     <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\</OutputPath>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/tests/System.Text.Primitives.Tests/project.json
+++ b/tests/System.Text.Primitives.Tests/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "System.Text.Tests",
+  "name": "System.Text.Primitives.Tests",
   "buildOptions": {
     "allowUnsafe": true,
     "keyFile": "../../tools/test_key.snk"


### PR DESCRIPTION
Primitive parsing APIs will now return false if overflow occurs (per #443). Also added tests for these cases, which should neatly fulfill #704 for now.