### PR TITLE
Slices: Made copying methods use cpblk without pinning

### DIFF
--- a/src/System.Slices/System/MemoryUtils.cs
+++ b/src/System.Slices/System/MemoryUtils.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace System
@@ -145,6 +146,28 @@ namespace System
                     }
                 }
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsPrimitiveValueType<T>()
+        {
+            // When inlined in the caller this all become a JIT time constant.
+            // HACK: what about AOT scenarions?
+
+            return typeof(T) == typeof(byte) ||
+                   typeof(T) == typeof(char) ||
+                   typeof(T) == typeof(sbyte) ||
+                   typeof(T) == typeof(short) ||
+                   typeof(T) == typeof(ushort) ||
+                   typeof(T) == typeof(int) ||
+                   typeof(T) == typeof(uint) ||
+                   typeof(T) == typeof(long) ||
+                   typeof(T) == typeof(ulong) ||
+                   typeof(T) == typeof(IntPtr) ||
+                   typeof(T) == typeof(UIntPtr) ||
+                   typeof(T) == typeof(float) ||
+                   typeof(T) == typeof(double) ||
+                   typeof(T) == typeof(bool);
         }
     }
 }

--- a/src/System.Slices/System/PtrUtils.cs
+++ b/src/System.Slices/System/PtrUtils.cs
@@ -135,12 +135,22 @@ namespace System
 
         [ILSub(@"
             .maxstack 3
-            ldarg.1
-            ldarg.0
-            ldarg.2
+            .locals([0] uint8 & destAddr, 
+                    [1] uint8 & scrAddr)
+            ldarg.2     // load destObj
+            stloc.0     // convert the object pointer to a byref
+            ldloc.0     // load the object pointer as a byref
+            ldarg.3     // load destOffset
+            add         // add destOffset
+            ldarg.0     // load srcObj
+            stloc.1     // convert the object pointer to a byref
+            ldloc.1     // load the object pointer as a byref
+            ldarg.1     // load srcOffset
+            add         // add srcOffset
+            ldarg.s 4   // load byteCount
             cpblk
             ret")]
-        public static void Copy(UIntPtr source, UIntPtr destination, int byteCount)
+        public static void CopyBlock(object srcObj, UIntPtr srcOffset, object destObj, UIntPtr destOffset, int byteCount)
         {}
     }
 }


### PR DESCRIPTION
Fixes #699

`cpblk` can work with managed pointers. This PR exploits that.

[The generated code ](https://gist.github.com/omariom/543db8c8502ca42492e057e02460d685)for Spans of `byte`, ` char`, `DateTime` and `string`.

For the predefined list of primitives it uses `cpblk`, for types not in the list and ref types it loops. The decision is made at JIT time.

@KrzysztofCwalina @adamsitnik 

