### PR TITLE
Don't Slice ReadOnlySpan to Span

### DIFF
--- a/src/System.Slices/System/ReadOnlySpan.cs
+++ b/src/System.Slices/System/ReadOnlySpan.cs
@@ -254,10 +254,10 @@ namespace System
         /// Thrown when the specified start index is not in range (&lt;0 or &gt;&eq;length).
         /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> Slice(uint start)
+        public ReadOnlySpan<T> Slice(uint start)
         {
             Contract.RequiresInInclusiveRange(start, (uint)Length);
-            return new Span<T>(Object, Offset + (((int)start) * PtrUtils.SizeOf<T>()), Length - (int)start);
+            return new ReadOnlySpan<T>(Object, Offset + (((int)start) * PtrUtils.SizeOf<T>()), Length - (int)start);
         }
 
         /// <summary>
@@ -287,10 +287,10 @@ namespace System
         /// Thrown when the specified start or end index is not in range (&lt;0 or &gt;&eq;length).
         /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Span<T> Slice(uint start, uint length)
+        public ReadOnlySpan<T> Slice(uint start, uint length)
         {
             Contract.RequiresInInclusiveRange(start, length, (uint)Length);
-            return new Span<T>(
+            return new ReadOnlySpan<T>(
                 Object, Offset + (((int)start) * PtrUtils.SizeOf<T>()), (int)length);
         }
 


### PR DESCRIPTION
It breaks the immutability guarantees. 

Otherwise methods will still have to defensive copy the array rather than return a static array wrapped in a ReadOnlySpan for fixed items like lookup tables etc as they could be changed by slicing.

Resolves  #735

@jkotas @KrzysztofCwalina