### PR TITLE
Removed potential exception throwing preconditions.

### DIFF
--- a/src/System.Text.Primitives/System/Text/InvariantParser_byte.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_byte.cs
@@ -15,7 +15,13 @@ namespace System.Text
         /// <returns>True if parsing is successful; false otherwise.</returns>
 		public static bool TryParse(byte[] utf8Text, int index, out byte value, out int bytesConsumed)
         {
-            Precondition.Require(utf8Text.Length > 0);
+            // Precondition replacement
+            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
 
             value = 0;
             bytesConsumed = 0;
@@ -57,6 +63,14 @@ namespace System.Text
         }
         unsafe public static bool TryParse(byte* utf8Text, int index, int length, out byte value, out int bytesConsumed)
         {
+            // Precondition replacement
+            if (length < 1 || index < 0)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
+
             value = 0;
             bytesConsumed = 0;
 

--- a/src/System.Text.Primitives/System/Text/InvariantParser_int.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_int.cs
@@ -15,7 +15,13 @@ namespace System.Text
         /// <returns>True if parsing is successful; false otherwise.</returns>
 		public static bool TryParse(byte[] utf8Text, int index, out int value, out int bytesConsumed)
         {
-            Precondition.Require(utf8Text.Length > 0);
+            // Precondition replacement
+            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
 
             value = 0;
             bytesConsumed = 0;
@@ -85,6 +91,14 @@ namespace System.Text
 
         unsafe public static bool TryParse(byte* utf8Text, int index, int length, out int value, out int bytesConsumed)
         {
+            // Precondition replacement
+            if (length < 1 || index < 0)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
+
             value = 0;
             bytesConsumed = 0;
             bool negative = false;

--- a/src/System.Text.Primitives/System/Text/InvariantParser_long.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_long.cs
@@ -15,7 +15,13 @@ namespace System.Text
         /// <returns>True if parsing is successful; false otherwise.</returns>
 		public static bool TryParse(byte[] utf8Text, int index, out long value, out int bytesConsumed)
         {
-            Precondition.Require(utf8Text.Length > 0);
+            // Precondition replacement
+            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
 
             value = 0;
             bytesConsumed = 0;
@@ -85,6 +91,14 @@ namespace System.Text
 
         unsafe public static bool TryParse(byte* utf8Text, int index, int length, out long value, out int bytesConsumed)
         {
+            // Precondition replacement
+            if (length < 1 || index < 0)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
+
             value = 0;
             bytesConsumed = 0;
             bool negative = false;

--- a/src/System.Text.Primitives/System/Text/InvariantParser_sbyte.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_sbyte.cs
@@ -15,7 +15,13 @@ namespace System.Text
         /// <returns>True if parsing is successful; false otherwise.</returns>
 		public static bool TryParse(byte[] utf8Text, int index, out sbyte value, out int bytesConsumed)
         {
-            Precondition.Require(utf8Text.Length > 0);
+            // Precondition replacement
+            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
 
             value = 0;
             bytesConsumed = 0;
@@ -85,6 +91,14 @@ namespace System.Text
 
         unsafe public static bool TryParse(byte* utf8Text, int index, int length, out sbyte value, out int bytesConsumed)
         {
+            // Precondition replacement
+            if (length < 1 || index < 0)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
+
             value = 0;
             bytesConsumed = 0;
             bool negative = false;

--- a/src/System.Text.Primitives/System/Text/InvariantParser_short.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_short.cs
@@ -15,7 +15,13 @@ namespace System.Text
         /// <returns>True if parsing is successful; false otherwise.</returns>
 		public static bool TryParse(byte[] utf8Text, int index, out short value, out int bytesConsumed)
         {
-            Precondition.Require(utf8Text.Length > 0);
+            // Precondition replacement
+            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
 
             value = 0;
             bytesConsumed = 0;
@@ -85,6 +91,14 @@ namespace System.Text
 
         unsafe public static bool TryParse(byte* utf8Text, int index, int length, out short value, out int bytesConsumed)
         {
+            // Precondition replacement
+            if (length < 1 || index < 0)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
+
             value = 0;
             bytesConsumed = 0;
             bool negative = false;

--- a/src/System.Text.Primitives/System/Text/InvariantParser_uint.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_uint.cs
@@ -40,7 +40,13 @@ namespace System.Text
 
         public static bool TryParse(Utf8String utf8Text, out uint value, out int bytesConsumed)
         {
-            Precondition.Require(utf8Text.Length > 0);
+            // Precondition replacement
+            if (utf8Text.Length < 1)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
 
             value = 0;
             bytesConsumed = 0;
@@ -82,7 +88,13 @@ namespace System.Text
         }
         public static bool TryParse(byte[] utf8Text, int index, out uint value, out int bytesConsumed)
         {
-            Precondition.Require(utf8Text.Length > 0);
+            // Precondition replacement
+            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
 
             value = 0;
             bytesConsumed = 0;
@@ -124,6 +136,14 @@ namespace System.Text
         }
         unsafe public static bool TryParse(byte* utf8Text, int index, int length, out uint value, out int bytesConsumed)
         {
+            // Precondition replacement
+            if (length < 1 || index < 0)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
+
             value = 0;
             bytesConsumed = 0;
 

--- a/src/System.Text.Primitives/System/Text/InvariantParser_ulong.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_ulong.cs
@@ -10,7 +10,13 @@ namespace System.Text
     {      
         public static bool TryParse(Utf8String utf8Text, out ulong value, out int bytesConsumed)
         {
-            Precondition.Require(utf8Text.Length > 0);
+            // Precondition replacement
+            if (utf8Text.Length < 1)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
 
             value = 0;
             bytesConsumed = 0;
@@ -60,7 +66,13 @@ namespace System.Text
         /// <returns>True if parsing is successful; false otherwise.</returns>
 		public static bool TryParse(byte[] utf8Text, int index, out ulong value, out int bytesConsumed)
         {
-            Precondition.Require(utf8Text.Length > 0);
+            // Precondition replacement
+            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
 
             value = 0;
             bytesConsumed = 0;
@@ -102,6 +114,14 @@ namespace System.Text
         }
         unsafe public static bool TryParse(byte *utf8Text, int index, int length, out ulong value, out int bytesConsumed)
         {
+            // Precondition replacement
+            if (length < 1 || index < 0)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
+
             value = 0;
             bytesConsumed = 0;
 

--- a/src/System.Text.Primitives/System/Text/InvariantParser_ushort.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_ushort.cs
@@ -15,7 +15,13 @@ namespace System.Text
         /// <returns>True if parsing is successful; false otherwise.</returns>
 		public static bool TryParse(byte[] utf8Text, int index, out ushort value, out int bytesConsumed)
         {
-            Precondition.Require(utf8Text.Length > 0);
+            // Precondition replacement
+            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
 
             value = 0;
             bytesConsumed = 0;
@@ -57,6 +63,14 @@ namespace System.Text
         }
         unsafe public static bool TryParse(byte* utf8Text, int index, int length, out ushort value, out int bytesConsumed)
         {
+            // Precondition replacement
+            if (length < 1 || index < 0)
+            {
+                value = 0;
+                bytesConsumed = 0;
+                return false;
+            }
+
             value = 0;
             bytesConsumed = 0;
 


### PR DESCRIPTION
Preconditions raise exceptions when they are invalid. Since we want to avoid exceptions in our code (as it's a TryParse method), I have replaced these with simple if statements that return false if error conditions are met.