### PR TITLE
Added MIT license notice to InvariantParser source files that were missing it

### DIFF
--- a/src/System.Text.Primitives/System/Text/InvariantParser_byte.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_byte.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
 using System.Text.Utf8;
 
 namespace System.Text

--- a/src/System.Text.Primitives/System/Text/InvariantParser_double.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_double.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
 using System.Text.Utf8;
 
 namespace System.Text

--- a/src/System.Text.Primitives/System/Text/InvariantParser_float.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_float.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
 using System.Text.Utf8;
 
 namespace System.Text

--- a/src/System.Text.Primitives/System/Text/InvariantParser_int.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_int.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
 using System.Text.Utf8;
 
 namespace System.Text

--- a/src/System.Text.Primitives/System/Text/InvariantParser_long.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_long.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
 using System.Text.Utf8;
 
 namespace System.Text

--- a/src/System.Text.Primitives/System/Text/InvariantParser_sbyte.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_sbyte.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
 using System.Text.Utf8;
 
 namespace System.Text

--- a/src/System.Text.Primitives/System/Text/InvariantParser_short.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_short.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
 using System.Text.Utf8;
 
 namespace System.Text

--- a/src/System.Text.Primitives/System/Text/InvariantParser_ushort.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_ushort.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
 using System.Text.Utf8;
 
 namespace System.Text


### PR DESCRIPTION
Just a quick fix. Noticed this while implementing the temporary methods.