### PR TITLE
Added boolean support to InvariantParser.

### DIFF
--- a/src/System.Text.Primitives/System/Text/InvariantParser_bool.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_bool.cs
@@ -1,0 +1,199 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Text.Utf8;
+
+namespace System.Text
+{
+    public static partial class InvariantParser
+    {
+        #region Helper Methods
+        private static bool isTrue(byte[] utf8Text, int index)
+        {
+            if (utf8Text.Length - index < 4)
+                return false;
+
+            byte firstChar = utf8Text[index];
+            if (firstChar != 't' && firstChar != 'T')
+                return false;
+
+            byte secondChar = utf8Text[index + 1];
+            if (secondChar != 'r' && secondChar != 'R')
+                return false;
+
+            byte thirdChar = utf8Text[index + 2];
+            if (thirdChar != 'u' && thirdChar != 'U')
+                return false;
+
+            byte fourthChar = utf8Text[index + 3];
+            if (fourthChar != 'e' && fourthChar != 'E')
+                return false;
+
+            return true;
+        }
+        private unsafe static bool isTrue(byte* utf8Text, int index, int length)
+        {
+            if (length < 4)
+                return false;
+
+            byte firstChar = utf8Text[index];
+            if (firstChar != 't' && firstChar != 'T')
+                return false;
+
+            byte secondChar = utf8Text[index + 1];
+            if (secondChar != 'r' && secondChar != 'R')
+                return false;
+
+            byte thirdChar = utf8Text[index + 2];
+            if (thirdChar != 'u' && thirdChar != 'U')
+                return false;
+
+            byte fourthChar = utf8Text[index + 3];
+            if (fourthChar != 'e' && fourthChar != 'E')
+                return false;
+
+            return true;
+        }
+
+        private static bool isFalse(byte[] utf8Text, int index)
+        {
+            if (utf8Text.Length - index < 5)
+                return false;
+
+            byte firstChar = utf8Text[index];
+            if (firstChar != 'f' && firstChar != 'F')
+                return false;
+
+            byte secondChar = utf8Text[index + 1];
+            if (secondChar != 'a' && secondChar != 'A')
+                return false;
+
+            byte thirdChar = utf8Text[index + 2];
+            if (thirdChar != 'l' && thirdChar != 'L')
+                return false;
+
+            byte fourthChar = utf8Text[index + 3];
+            if (fourthChar != 's' && fourthChar != 'S')
+                return false;
+
+            byte fifthChar = utf8Text[index + 4];
+            if (fifthChar != 'e' && fifthChar != 'E')
+                return false;
+
+            return true;
+        }
+        private unsafe static bool isFalse(byte* utf8Text, int index, int length)
+        {
+            if (length < 5)
+                return false;
+
+            byte firstChar = utf8Text[index];
+            if (firstChar != 'f' && firstChar != 'F')
+                return false;
+
+            byte secondChar = utf8Text[index + 1];
+            if (secondChar != 'a' && secondChar != 'A')
+                return false;
+
+            byte thirdChar = utf8Text[index + 2];
+            if (thirdChar != 'l' && thirdChar != 'L')
+                return false;
+
+            byte fourthChar = utf8Text[index + 3];
+            if (fourthChar != 's' && fourthChar != 'S')
+                return false;
+
+            byte fifthChar = utf8Text[index + 4];
+            if (fifthChar != 'e' && fifthChar != 'E')
+                return false;
+
+            return true;
+        }
+        #endregion
+
+        public static bool TryParse(byte[] utf8Text, int index, out bool value, out int bytesConsumed)
+        {
+            bytesConsumed = 0;
+            value = default(bool);
+
+            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            {
+                return false;
+            }
+
+            byte firstByte = utf8Text[index];
+
+            if (firstByte == '1')
+            {
+                bytesConsumed = 1;
+                value = true;
+                return true;
+            }
+            else if (firstByte == '0')
+            {
+                bytesConsumed = 1;
+                value = false;
+                return true;
+            }
+            else if (isTrue(utf8Text, index))
+            {
+                bytesConsumed = 4;
+                value = true;
+                return true;
+            }
+            else if (isFalse(utf8Text, index))
+            {
+                bytesConsumed = 5;
+                value = false;
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static unsafe bool TryParse(byte* utf8Text, int index, int length, out bool value, out int bytesConsumed)
+        {
+            bytesConsumed = 0;
+            value = default(bool);
+
+            if (length < 1 || index < 0)
+            {
+                return false;
+            }
+
+            byte firstByte = utf8Text[index];
+
+            if (firstByte == '1')
+            {
+                bytesConsumed = 1;
+                value = true;
+                return true;
+            }
+            else if (firstByte == '0')
+            {
+                bytesConsumed = 1;
+                value = false;
+                return true;
+            }
+            else if (isTrue(utf8Text, index, length))
+            {
+                bytesConsumed = 4;
+                value = true;
+                return true;
+            }
+            else if (isFalse(utf8Text, index, length))
+            {
+                bytesConsumed = 5;
+                value = false;
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/tests/System.Text.Primitives.Tests/ParserTests.cs
+++ b/tests/System.Text.Primitives.Tests/ParserTests.cs
@@ -517,5 +517,54 @@ namespace System.Text.Primitives.Tests
         }
 
         #endregion
+
+        #region bool
+        [Theory]
+        [InlineData("blahblahhTrue", true, 9, true, 4)]
+        [InlineData("trueacndasjfh", true, 0, true, 4)]
+        [InlineData("LetthemFALSEeatcake", true, 7, false, 5)]
+        [InlineData("false", true, 0, false, 5)]
+        [InlineData("FaLsE", true, 0, false, 5)]
+        [InlineData("0", true, 0, false, 1)]
+        [InlineData("1", true, 0, true, 1)]
+        [InlineData("-A", false, 0, 0, 0)] // invalid character after a sign
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        public void ParseUtf8ByteArrayToBool(string text, bool expectSuccess, int index, bool expectedValue, int expectedBytesConsumed)
+        {
+            bool parsedValue;
+            int bytesConsumed;
+            bool result = InvariantParser.TryParse(UtfEncode(text), index, out parsedValue, out bytesConsumed);
+
+            Assert.Equal(expectSuccess, result);
+            Assert.Equal(expectedValue, parsedValue);
+            Assert.Equal(expectedBytesConsumed, bytesConsumed);
+        }
+
+        [Theory]
+        [InlineData("blahblahhTrue", true, 9, true, 4)]
+        [InlineData("trueacndasjfh", true, 0, true, 4)]
+        [InlineData("LetthemFALSEeatcake", true, 7, false, 5)]
+        [InlineData("false", true, 0, false, 5)]
+        [InlineData("FaLsE", true, 0, false, 5)]
+        [InlineData("0", true, 0, false, 1)]
+        [InlineData("1", true, 0, true, 1)]
+        [InlineData("-A", false, 0, 0, 0)] // invalid character after a sign
+        [InlineData("I am 1", false, 0, 0, 0)] // invalid character test
+        public unsafe void ParseUtf8ByteStarToBool(string text, bool expectSuccess, int index, bool expectedValue, int expectedBytesConsumed)
+        {
+            bool parsedValue;
+            int bytesConsumed;
+
+            byte[] textBytes = UtfEncode(text);
+            fixed (byte* arrayPointer = textBytes)
+            {
+                bool result = InvariantParser.TryParse(arrayPointer, index, textBytes.Length, out parsedValue, out bytesConsumed);
+
+                Assert.Equal(expectSuccess, result);
+                Assert.Equal(expectedValue, parsedValue);
+                Assert.Equal(expectedBytesConsumed, bytesConsumed);
+            }
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
Added boolean support to the InvariantParser. These methods are _not_ prototype methods; I started implementing the prototypes when I realized that booleans were simple enough that I could quickly and easily implement the parsers fully.

I also added unit & perf tests for these methods. Here is a graph of perf gains.

![8_bool](https://cloud.githubusercontent.com/assets/13228069/17534757/8ab6895a-5e3f-11e6-8a4b-5ca83a471ba9.png)