### PR TITLE
Fixed bug in InvariantParser_long perf tests.

### DIFF
--- a/tests/System.Text.Primitives.Tests/PrimitivesPerfTests.cs
+++ b/tests/System.Text.Primitives.Tests/PrimitivesPerfTests.cs
@@ -1511,7 +1511,7 @@ namespace System.Text.Primitives.Tests
             byte[] utf8ByteArray = UtfEncode(text);
             foreach (var iteration in Benchmark.Iterations)
             {
-                int value;
+                long value;
                 int bytesConsumed;
                 using (iteration.StartMeasurement())
                 {
@@ -1541,7 +1541,7 @@ namespace System.Text.Primitives.Tests
             byte[] utf8ByteArray = UtfEncode(text);
             foreach (var iteration in Benchmark.Iterations)
             {
-                int value;
+                long value;
                 int bytesConsumed;
                 fixed (byte* utf8ByteStar = utf8ByteArray)
                 {


### PR DESCRIPTION
This was the bug that made it appear that long parsing was significantly worse for ByteStarUnmanaged than for ByteStar or ByteArray.

Before:
![7_long](https://cloud.githubusercontent.com/assets/13228069/17536794/74652186-5e4c-11e6-91e0-59c89b55be65.png)

After:
![7_long](https://cloud.githubusercontent.com/assets/13228069/17536798/7c155f5e-5e4c-11e6-87e7-ca33719c952f.png)

Still some investigation necessary (the first three tests have weird baseline values).