### PR TITLE
Reduced a precondition check.

### DIFF
--- a/src/System.Text.Primitives/System/Text/InvariantParser_bool.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_bool.cs
@@ -117,7 +117,7 @@ namespace System.Text
             bytesConsumed = 0;
             value = default(bool);
 
-            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            if (utf8Text.Length < 1 ||  (uint)index >= utf8Text.Length)
             {
                 return false;
             }

--- a/src/System.Text.Primitives/System/Text/InvariantParser_byte.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_byte.cs
@@ -19,7 +19,7 @@ namespace System.Text
 		public static bool TryParse(byte[] utf8Text, int index, out byte value, out int bytesConsumed)
         {
             // Precondition replacement
-            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            if (utf8Text.Length < 1 ||  (uint)index >= utf8Text.Length)
             {
                 value = 0;
                 bytesConsumed = 0;

--- a/src/System.Text.Primitives/System/Text/InvariantParser_double.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_double.cs
@@ -11,7 +11,7 @@ namespace System.Text
         public static bool TryParse(byte[] utf8Text, int index, out double value, out int bytesConsumed)
         {
             // Precondition replacement
-            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            if (utf8Text.Length < 1 ||  (uint)index >= utf8Text.Length)
             {
                 value = 0;
                 bytesConsumed = 0;

--- a/src/System.Text.Primitives/System/Text/InvariantParser_float.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_float.cs
@@ -11,7 +11,7 @@ namespace System.Text
         public static bool TryParse(byte[] utf8Text, int index, out float value, out int bytesConsumed)
         {
             // Precondition replacement
-            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            if (utf8Text.Length < 1 ||  (uint)index >= utf8Text.Length)
             {
                 value = 0;
                 bytesConsumed = 0;

--- a/src/System.Text.Primitives/System/Text/InvariantParser_int.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_int.cs
@@ -19,7 +19,7 @@ namespace System.Text
 		public static bool TryParse(byte[] utf8Text, int index, out int value, out int bytesConsumed)
         {
             // Precondition replacement
-            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            if (utf8Text.Length < 1 ||  (uint)index >= utf8Text.Length)
             {
                 value = 0;
                 bytesConsumed = 0;

--- a/src/System.Text.Primitives/System/Text/InvariantParser_long.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_long.cs
@@ -19,7 +19,7 @@ namespace System.Text
 		public static bool TryParse(byte[] utf8Text, int index, out long value, out int bytesConsumed)
         {
             // Precondition replacement
-            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            if (utf8Text.Length < 1 ||  (uint)index >= utf8Text.Length)
             {
                 value = 0;
                 bytesConsumed = 0;

--- a/src/System.Text.Primitives/System/Text/InvariantParser_sbyte.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_sbyte.cs
@@ -19,7 +19,7 @@ namespace System.Text
 		public static bool TryParse(byte[] utf8Text, int index, out sbyte value, out int bytesConsumed)
         {
             // Precondition replacement
-            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            if (utf8Text.Length < 1 ||  (uint)index >= utf8Text.Length)
             {
                 value = 0;
                 bytesConsumed = 0;

--- a/src/System.Text.Primitives/System/Text/InvariantParser_short.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_short.cs
@@ -19,7 +19,7 @@ namespace System.Text
 		public static bool TryParse(byte[] utf8Text, int index, out short value, out int bytesConsumed)
         {
             // Precondition replacement
-            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            if (utf8Text.Length < 1 ||  (uint)index >= utf8Text.Length)
             {
                 value = 0;
                 bytesConsumed = 0;

--- a/src/System.Text.Primitives/System/Text/InvariantParser_uint.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_uint.cs
@@ -89,7 +89,7 @@ namespace System.Text
         public static bool TryParse(byte[] utf8Text, int index, out uint value, out int bytesConsumed)
         {
             // Precondition replacement
-            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            if (utf8Text.Length < 1 ||  (uint)index >= utf8Text.Length)
             {
                 value = 0;
                 bytesConsumed = 0;

--- a/src/System.Text.Primitives/System/Text/InvariantParser_ulong.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_ulong.cs
@@ -67,7 +67,7 @@ namespace System.Text
 		public static bool TryParse(byte[] utf8Text, int index, out ulong value, out int bytesConsumed)
         {
             // Precondition replacement
-            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            if (utf8Text.Length < 1 ||  (uint)index >= utf8Text.Length)
             {
                 value = 0;
                 bytesConsumed = 0;

--- a/src/System.Text.Primitives/System/Text/InvariantParser_ushort.cs
+++ b/src/System.Text.Primitives/System/Text/InvariantParser_ushort.cs
@@ -19,7 +19,7 @@ namespace System.Text
 		public static bool TryParse(byte[] utf8Text, int index, out ushort value, out int bytesConsumed)
         {
             // Precondition replacement
-            if (utf8Text.Length < 1 || index < 0 || index >= utf8Text.Length)
+            if (utf8Text.Length < 1 ||  (uint)index >= utf8Text.Length)
             {
                 value = 0;
                 bytesConsumed = 0;


### PR DESCRIPTION
Reduced a precondition check per comment https://github.com/dotnet/corefxlab/pull/758/files#r74155156. Perf analysis shows no statistically significant gains or losses, but it is stylistically pleasing.