### PR TITLE
Added resize hint to IFormatter

### DIFF
--- a/src/System.Text.Formatting/System/Text/Formatting/BufferFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/BufferFormatter.cs
@@ -53,10 +53,15 @@ namespace System.Text.Formatting
             }
         }
 
-        void IFormatter.ResizeBuffer()
+        void IFormatter.ResizeBuffer(int desiredFreeBytesHint)
         {
+            var newSize = desiredFreeBytesHint + _buffer.Length - _count;
+            if(desiredFreeBytesHint == -1){
+                newSize = _buffer.Length * 2;
+            }
+
             var temp = _buffer;
-            _buffer = _pool.Rent(_buffer.Length * 2);
+            _buffer = _pool.Rent(newSize);
             Array.Copy(temp, 0, _buffer, 0, _count);
             _pool.Return(temp);
         }

--- a/src/System.Text.Formatting/System/Text/Formatting/IFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/IFormatter.cs
@@ -13,7 +13,8 @@ namespace System.Text.Formatting
         Span<byte> FreeBuffer { get; }
         void CommitBytes(int bytes);
 
-        void ResizeBuffer();
+        /// <summary>desiredFreeBytesHint == -1 means "i don't care"</summary>
+        void ResizeBuffer(int desiredFreeBytesHint = -1);
 
         FormattingData FormattingData { get; }
     }

--- a/src/System.Text.Formatting/System/Text/Formatting/MultispanFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/MultispanFormatter.cs
@@ -40,9 +40,13 @@ namespace System.Text.Formatting
             }
         }
 
-        void IFormatter.ResizeBuffer()
+        void IFormatter.ResizeBuffer(int desiredFreeBytesHint)
         {
-            var index = _buffer.AppendNewSegment(_segmentSize);
+            var newSize = _segmentSize;
+            if(desiredFreeBytesHint != -1){
+                newSize = desiredFreeBytesHint;
+            }
+            var index = _buffer.AppendNewSegment(newSize);
             _lastFull = _buffer.Last;
             _buffer.ResizeSegment(index, 0);
         }

--- a/src/System.Text.Formatting/System/Text/Formatting/SpanFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/SpanFormatter.cs
@@ -42,7 +42,7 @@ namespace System.Text.Formatting
             }
         }
 
-        void IFormatter.ResizeBuffer()
+        void IFormatter.ResizeBuffer(int desiredFreeBytesHint)
         {
             throw new InvalidOperationException("cannot resize fixed size buffers.");
         }

--- a/src/System.Text.Formatting/System/Text/Formatting/StreamFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/StreamFormatter.cs
@@ -50,10 +50,14 @@ namespace System.Text.Formatting
             }
         }
 
-        void IFormatter.ResizeBuffer()
+        void IFormatter.ResizeBuffer(int desiredFreeBytesHint)
         {
+            var newSize = _buffer.Length * 2;
+            if(desiredFreeBytesHint != -1){
+                newSize = desiredFreeBytesHint;
+            }
             var temp = _buffer;
-            _buffer = _pool.Rent(_buffer.Length * 2);
+            _buffer = _pool.Rent(newSize);
             _pool.Return(temp);
         }
 

--- a/src/System.Text.Formatting/System/Text/Formatting/StringFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/StringFormatter.cs
@@ -81,13 +81,19 @@ namespace System.Text.Formatting
             }
         }
 
-        void IFormatter.ResizeBuffer()
+        void IFormatter.ResizeBuffer(int desiredFreeBytesHint)
         {
+            var newSize = desiredFreeBytesHint + _buffer.Length - _count;
+            if(desiredFreeBytesHint == -1){
+                newSize = _buffer.Length * 2;
+            }
+
             var temp = _buffer;
-            _buffer = _pool.Rent(_buffer.Length * 2);
+            _buffer = _pool.Rent(newSize);
             Array.Copy(temp, 0, _buffer, 0, _count);
             _pool.Return(temp);
         }
+
         void IFormatter.CommitBytes(int bytes)
         {
             _count += bytes;


### PR DESCRIPTION
@davidfowl, this adds the resize hint. Having said that, I am not sure it's useful. The callers are usually primitive formatters that don't know how large of a buffer the program needs. They only know how much they need for the small number of bytes they write.