### PR TITLE
Added non-allocating Base64 encoder/decoder

### DIFF
--- a/src/System.Binary.Base64/System.Binary.Base64.xproj
+++ b/src/System.Binary.Base64/System.Binary.Base64.xproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <RootNamespace>System.Binary</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/System.Binary.Base64/System/Binary/Base64.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Utf8;
+
+namespace System.Binary
+{
+    public static class Base64
+    {
+        static string s_characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+        static byte[] s_encodingMap = new Utf8String(s_characters).CopyBytes();
+        static byte[] s_decodingMap = new byte[123];
+
+        static Base64()
+        {
+            for(int i=0; i< s_characters.Length; i++) {
+                var nextChar = s_characters[i];
+                var indexOfChar = s_characters.IndexOf(nextChar);
+                s_decodingMap[nextChar] = (byte)indexOfChar;
+            }
+        }
+        public static int ComputeEncodedLength(int inputLength)
+        {
+            var third = inputLength / 3;
+            var thirdTimes3 = third * 3;
+            if(thirdTimes3 == inputLength) return third * 4;
+            return third * 4 + 4;
+        }
+
+        public static void Encode(byte b0, byte b1, byte b2, out byte r0, out byte r1, out byte r2, out byte r3)
+        {
+            int i0 = b0 >> 2;
+            r0 = s_encodingMap[i0];
+
+            int i1 = (b0 & 3) << 4 | (b1 >> 4);
+            r1 = s_encodingMap[i1];
+
+            int i2 = (b1 & 15) << 2 | (b2 >> 6);
+            r2 = s_encodingMap[i2];
+
+            int i3 = b2 & 63;
+            r3 = s_encodingMap[i3];
+        }
+
+        public static void Encode(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            int di = 0;
+            int si = 0;
+            byte b0, b1, b2, b3;
+            for (; si<source.Length - 2;) {
+                Encode(source[si++], source[si++], source[si++], out b0, out b1, out b2, out b3);
+                destination[di++] = b0;
+                destination[di++] = b1;
+                destination[di++] = b2;
+                destination[di++] = b3;
+            }
+
+            if (si == source.Length) { return; }
+
+            if (si == source.Length - 1) {
+                Encode(source[si], 0, 0, out b0, out b1, out b2, out b3);
+                destination[di++] = b0;
+                destination[di++] = b1;
+                destination[di++] = s_encodingMap[64];
+                destination[di++] = s_encodingMap[64];
+                return;
+            }
+            if(si == source.Length - 2) {
+                Encode(source[si++], source[si], 0, out b0, out b1, out b2, out b3);
+                destination[di++] = b0;
+                destination[di++] = b1;
+                destination[di++] = b2;
+                destination[di++] = s_encodingMap[64];
+                return;
+            }
+
+            throw new NotImplementedException();
+        }
+
+        public static void Decode(byte b0, byte b1, byte b2, byte b3, out byte r0, out byte r1, out byte r2)
+        {
+            byte i0 = s_decodingMap[b0];
+            byte i1 = s_decodingMap[b1];
+            byte i2 = s_decodingMap[b2];
+            byte i3 = s_decodingMap[b3];
+
+            r0 = (byte)(i0<<2 | i1 >> 4);
+            r1 = (byte)(i1<<4 | i2>>2);
+            r2 = (byte)(i2<<6 | i3);
+        }
+
+        public static void Decode(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            int di = 0;
+            int si = 0;
+            byte r0, r1, r2;
+            int padding = 0;
+
+            if (source[source.Length - 1] == s_encodingMap[64]) {
+                padding = 1;
+                if (source[source.Length - 2] == s_encodingMap[64]) padding = 2;
+            }
+
+            for (; si < source.Length - (padding!=0?4:0);) {
+                Decode(source[si++], source[si++], source[si++], source[si++], out r0, out r1, out r2);
+                destination[di++] = r0;
+                destination[di++] = r1;
+                destination[di++] = r2;
+            }
+
+            if (padding != 0) {
+                Decode(source[si++], source[si++], source[si++], source[si++], out r0, out r1, out r2);
+                destination[di++] = r0;
+
+                if (padding == 1) {
+                    destination[di++] = r1;
+
+                }
+            }
+        }
+    }
+}

--- a/src/System.Binary.Base64/project.json
+++ b/src/System.Binary.Base64/project.json
@@ -1,0 +1,34 @@
+{
+  "name": "System.Binary.Base64",  
+  "version": "0.1.0-*",
+  "description": "Non-allocating Base64 encoder and decoded",
+  "authors": [
+    "Microsoft Corporation"
+  ],
+  "copyright": "Microsoft Corporation, All rights reserved",
+  "packOptions": {
+    "tags": [
+      ".NET non-allocating Base64 encoder and decoder"
+    ],
+    "releaseNotes": "Pre-release package, for testing only",
+    "licenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
+    "iconUrl": "http://go.microsoft.com/fwlink/?LinkID=288859",
+    "projectUrl": "https://github.com/dotnet/corefxlab",
+    "requireLicenseAcceptance": true,
+  },
+  "buildOptions": {
+    "keyFile": "../../tools/Key.snk"
+  },
+  "dependencies": {
+    "System.Runtime": "4.0.0",
+    "System.Runtime.InteropServices": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.0",
+    "System.Slices": { "target": "project" },
+    "System.Text.Utf8": { "target": "project" }
+  },
+  "frameworks": {
+    "netstandard1.0": {
+      "imports": [ "dotnet5.1" ]
+    }
+  }
+}

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Xunit;
+using System.Binary;
+using System.Collections.Generic;
+using System.Text.Utf8;
+
+namespace System.Binary.Tests
+{
+    public class Base64Tests
+    {
+        [Fact]
+        public void BasicEncodingDecoding()
+        {
+            var list = new List<byte>();
+            for(int value=0; value < 256; value++) {
+                list.Add((byte)value);
+            }
+            var testBytes = list.ToArray();
+
+            for (int value = 0; value < 256; value++) {
+
+                var sourceBytes = testBytes.Slice(0, value + 1);
+                var encodedBytes = new byte[Base64.ComputeEncodedLength(sourceBytes.Length)].Slice();
+                Base64.Encode(sourceBytes, encodedBytes);
+
+                var encodedText = new Utf8String(encodedBytes).ToString();
+                var expectedText = Convert.ToBase64String(testBytes, 0, value + 1);
+                Assert.Equal(expectedText, encodedText);
+
+                var decodedBytes = new byte[sourceBytes.Length];
+                Base64.Decode(encodedBytes, decodedBytes.Slice());
+
+                for(int i=0; i<decodedBytes.Length; i++) {
+                    Assert.Equal(sourceBytes[i], decodedBytes[i]);
+                }
+            } 
+        }
+    }
+}

--- a/tests/System.Binary.Base64.Tests/System.Binary.Base64.tests.xproj
+++ b/tests/System.Binary.Base64.Tests/System.Binary.Base64.tests.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0.25123" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0.25123</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>d37c62b5-c15c-4f2e-a67d-e8d6324fbcbb</ProjectGuid>
+    <RootNamespace>System.Binary.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tests/System.Binary.Base64.Tests/project.json
+++ b/tests/System.Binary.Base64.Tests/project.json
@@ -1,0 +1,33 @@
+{
+  "name": "System.Binary.Tests",
+  "buildOptions": {
+    "allowUnsafe": true
+  },
+  "dependencies": {
+    "Microsoft.NETCore.App": {
+      "type": "platform",
+      "version": "1.0.0-rc2-3002702"
+    },
+    "System.Binary": {
+      "target": "project"
+    },
+    "System.Binary.Base64": {
+      "target": "project"
+    },
+    "System.Text.Utf8": {
+      "target": "project"
+    },
+    "xunit": "2.1.0",
+    "dotnet-test-xunit": "1.0.0-rc2-173384-19"
+  },
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "netstandardapp1.5",
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  },
+  "testRunner": "xunit"
+}


### PR DESCRIPTION
This is not the fastest implementation I can imagine, but at least it's non-allocating, i.e. operated passed in byte buffers.