### PR TITLE
Support Decoding Base64 buffers in-place

### DIFF
--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -22,19 +22,50 @@ namespace System.Binary.Tests
 
                 var sourceBytes = testBytes.Slice(0, value + 1);
                 var encodedBytes = new byte[Base64.ComputeEncodedLength(sourceBytes.Length)].Slice();
-                Base64.Encode(sourceBytes, encodedBytes);
+                var encodedBytesCount = Base64.Encode(sourceBytes, encodedBytes);
+                Assert.Equal(encodedBytes.Length, encodedBytesCount);
 
                 var encodedText = new Utf8String(encodedBytes).ToString();
                 var expectedText = Convert.ToBase64String(testBytes, 0, value + 1);
                 Assert.Equal(expectedText, encodedText);
 
                 var decodedBytes = new byte[sourceBytes.Length];
-                Base64.Decode(encodedBytes, decodedBytes.Slice());
+                var decodedByteCount = Base64.Decode(encodedBytes, decodedBytes.Slice());
+                Assert.Equal(sourceBytes.Length, decodedByteCount);
 
-                for(int i=0; i<decodedBytes.Length; i++) {
+                for (int i=0; i<decodedBytes.Length; i++) {
                     Assert.Equal(sourceBytes[i], decodedBytes[i]);
                 }
             } 
+        }
+
+        [Fact]
+        public void DecodeInPlace()
+        {
+            var list = new List<byte>();
+            for (int value = 0; value < 256; value++) {
+                list.Add((byte)value);
+            }
+            var testBytes = list.ToArray();
+
+            for (int value = 0; value < 256; value++) {
+                var sourceBytes = testBytes.Slice(0, value + 1);
+                var buffer = new byte[Base64.ComputeEncodedLength(sourceBytes.Length)];
+                var bufferSlice = buffer.Slice();
+
+                Base64.Encode(sourceBytes, bufferSlice);
+
+                var encodedText = new Utf8String(bufferSlice).ToString();
+                var expectedText = Convert.ToBase64String(testBytes, 0, value + 1);
+                Assert.Equal(expectedText, encodedText);
+
+                var decodedByteCount = Base64.DecodeInPlace(bufferSlice);
+                Assert.Equal(sourceBytes.Length, decodedByteCount);
+
+                for (int i = 0; i < decodedByteCount; i++) {
+                    Assert.Equal(sourceBytes[i], buffer[i]);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
cc @davidfowl 

Base64 decoder is shrinking data size when decoding. This makes it possible to easily decode in-place.

Encoding expands the size, and so it will be harder, slower, and will require some creative APIs.
