### PR TITLE
Improved Exception handling

### DIFF
--- a/src/System.Slices/System/Contract.cs
+++ b/src/System.Slices/System/Contract.cs
@@ -12,15 +12,16 @@ namespace System
         {
             if (!condition)
             {
-                throw NewArgumentException();
+                ThrowArgumentException();
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void RequiresNonNegative(int n)
         {
             if (n < 0)
             {
-                throw NewArgumentOutOfRangeException();
+                ThrowArgumentOutOfRangeException();
             }
         }
 
@@ -29,7 +30,7 @@ namespace System
         {
             if ((uint)start >= length)
             {
-                throw NewArgumentOutOfRangeException();
+                ThrowArgumentOutOfRangeException();
             }
         }
         
@@ -38,7 +39,7 @@ namespace System
         {
             if (start >= length)
             {
-                throw NewArgumentOutOfRangeException();
+                ThrowArgumentOutOfRangeException();
             }
         }
 
@@ -47,7 +48,7 @@ namespace System
         {
             if ((uint)start > length)
             {
-                throw NewArgumentOutOfRangeException();
+                ThrowArgumentOutOfRangeException();
             }
         }
         
@@ -56,7 +57,7 @@ namespace System
         {
             if (start > length)
             {
-                throw NewArgumentOutOfRangeException();
+                ThrowArgumentOutOfRangeException();
             }
         }
 
@@ -67,7 +68,7 @@ namespace System
                 || length < 0
                 || (uint)(start + length) > existingLength)
             {
-                throw NewArgumentOutOfRangeException();
+                ThrowArgumentOutOfRangeException();
             }
         }
         
@@ -78,21 +79,18 @@ namespace System
                 || length < 0
                 || (start + length) > existingLength)
             {
-                throw NewArgumentOutOfRangeException();
+                ThrowArgumentOutOfRangeException();
             }
         }
 
-        
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static Exception NewArgumentException()
+        private static void ThrowArgumentException()
         {
-            return new ArgumentException();
+            throw new ArgumentException();
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static Exception NewArgumentOutOfRangeException()
+        private static void ThrowArgumentOutOfRangeException()
         {
-            return new ArgumentOutOfRangeException();
+            throw new ArgumentOutOfRangeException();
         }
     }
 }


### PR DESCRIPTION
Throw the exceptions directly from the void method, don't mark as no-inlining

Post https://github.com/dotnet/coreclr/pull/6103 "Do not inline methods that never return" this will give the best result. (As shown in https://github.com/dotnet/coreclr/pull/6634)

It won't inline the exception Throw function, will mark the call to the Throw function as cold code, and won't preform any register prep for the function (push+pop)