### PR TITLE
Added support for backpressure

### DIFF
--- a/src/System.Text.Formatting/System/Text/Formatting/CompositeFormat.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/CompositeFormat.cs
@@ -126,12 +126,12 @@ namespace System.Text.Formatting {
         // TODO: this should be removed and an ability to append substrings should be added
         static void Append<TFormatter>(this TFormatter formatter, string whole, int index, int count) where TFormatter : IFormatter
         {
-            var buffer = formatter.FreeBuffer;
+            var buffer = formatter.AvaliableBytes;
             var maxBytes = count << 4; // this is the worst case, i.e. 4 bytes per char
             while(buffer.Length < maxBytes)
             {
-                formatter.ResizeBuffer();
-                buffer = formatter.FreeBuffer;
+                formatter.TryEnsureAvaliable();
+                buffer = formatter.AvaliableBytes;
             }
 
             // this should ne optimized using fixed pointer to substring, but I will wait with this till we design proper substring
@@ -147,7 +147,7 @@ namespace System.Text.Formatting {
                 buffer = buffer.Slice(bytesWritten);
             }
 
-            formatter.CommitBytes(totalWritten);
+            formatter.Advance(totalWritten);
         }
 
         static void AppendUntyped<TFormatter, T>(this TFormatter formatter, T value, Format.Parsed format) where TFormatter : IFormatter

--- a/src/System.Text.Formatting/System/Text/Formatting/IFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/IFormatter.cs
@@ -8,14 +8,20 @@ namespace System.Text.Formatting
     // this interface would be implemented by types that want to support formatting, i.e. TextWriter/StringBuilder-like types.
     // the interface is used by an extension method in IFormatterExtensions.
     // One thing I am not sure here is if it's ok for these APIs to be synchronous, but I guess I will wait till I find a concrete issue with this.
-    public interface IFormatter
+    public interface IStream
     {
-        Span<byte> FreeBuffer { get; }
-        void CommitBytes(int bytes);
+        Span<byte> AvaliableBytes { get; }
+        void Advance(int byteCount);
 
-        /// <summary>desiredFreeBytesHint == -1 means "i don't care"</summary>
-        void ResizeBuffer(int desiredFreeBytesHint = -1);
+        /// <summary>Returns false if there is backpressure and the request can be fullfiled later. Throws if the request cannot be fullfiled.</summary>
+        bool TryEnsureAvaliable(int minimunByteCount = 1);
+    }
 
+    // this interface would be implemented by types that want to support formatting, i.e. TextWriter/StringBuilder-like types.
+    // the interface is used by an extension method in IFormatterExtensions.
+    // One thing I am not sure here is if it's ok for these APIs to be synchronous, but I guess I will wait till I find a concrete issue with this.
+    public interface IFormatter : IStream
+    {       
         FormattingData FormattingData { get; }
     }
 }

--- a/src/System.Text.Formatting/System/Text/Formatting/IFormatterExtensions.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/IFormatterExtensions.cs
@@ -11,195 +11,195 @@ namespace System.Text.Formatting
         public static void Append<TFormatter, T>(this TFormatter formatter, T value, Format.Parsed format = default(Format.Parsed)) where T : IBufferFormattable where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, byte value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, sbyte value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, ushort value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
         public static void Append<TFormatter>(this TFormatter formatter, short value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, uint value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
         public static void Append<TFormatter>(this TFormatter formatter, int value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, ulong value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
         public static void Append<TFormatter>(this TFormatter formatter, long value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, char value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, string value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, Utf8String value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten)) {
-                formatter.ResizeBuffer();
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten)) {
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, Guid value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, DateTime value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, DateTimeOffset value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, TimeSpan value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, float value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, double value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.FormattingData, out bytesWritten))
+            while (!value.TryFormat(formatter.AvaliableBytes, format, formatter.FormattingData, out bytesWritten))
             {
-                formatter.ResizeBuffer();
+                formatter.TryEnsureAvaliable();
                 bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
         }
     }
 }

--- a/src/System.Text.Formatting/System/Text/Formatting/MultispanFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/MultispanFormatter.cs
@@ -1,4 +1,5 @@
-﻿using System.Buffers;
+﻿using System;
+using System.Buffers;
 
 namespace System.Text.Formatting
 {
@@ -24,7 +25,7 @@ namespace System.Text.Formatting
             get { return _buffer; }
         }
 
-        Span<byte> IFormatter.FreeBuffer
+        Span<byte> IStream.AvaliableBytes
         {
             get
             {
@@ -40,18 +41,18 @@ namespace System.Text.Formatting
             }
         }
 
-        void IFormatter.ResizeBuffer(int desiredFreeBytesHint)
+        bool IStream.TryEnsureAvaliable(int minimunByteCount)
         {
             var newSize = _segmentSize;
-            if(desiredFreeBytesHint != -1){
-                newSize = desiredFreeBytesHint;
-            }
+            if(newSize < minimunByteCount) newSize = minimunByteCount;
             var index = _buffer.AppendNewSegment(newSize);
             _lastFull = _buffer.Last;
             _buffer.ResizeSegment(index, 0);
+
+            return true;
         }
 
-        void IFormatter.CommitBytes(int bytes)
+        void IStream.Advance(int bytes)
         {
             var lastSegmentCommited = _buffer.Last.Length + bytes;
             if(lastSegmentCommited > _lastFull.Length)

--- a/src/System.Text.Formatting/System/Text/Formatting/SpanFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/SpanFormatter.cs
@@ -26,7 +26,7 @@ namespace System.Text.Formatting
             _count = 0;
         }
 
-        Span<byte> IFormatter.FreeBuffer
+        Span<byte> IStream.AvaliableBytes
         {
             get
             {
@@ -42,12 +42,14 @@ namespace System.Text.Formatting
             }
         }
 
-        void IFormatter.ResizeBuffer(int desiredFreeBytesHint)
+        bool IStream.TryEnsureAvaliable(int minimunByteCount)
         {
-            throw new InvalidOperationException("cannot resize fixed size buffers.");
+            if(_count > _buffer.Length - minimunByteCount) throw new Exception("End of stream");
+            return true;
+
         }
 
-        void IFormatter.CommitBytes(int bytes)
+        void IStream.Advance(int bytes)
         {
             _count += bytes;
             if(_count > _buffer.Length)

--- a/src/System.Text.Formatting/System/Text/Formatting/StringFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/StringFormatter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Buffers;
 using System.Text;
 
@@ -64,7 +65,7 @@ namespace System.Text.Formatting
             return text;
         }
 
-        Span<byte> IFormatter.FreeBuffer
+        Span<byte> IStream.AvaliableBytes
         {
             get { return new Span<byte>(_buffer, _count, _buffer.Length - _count); }
         }
@@ -81,20 +82,19 @@ namespace System.Text.Formatting
             }
         }
 
-        void IFormatter.ResizeBuffer(int desiredFreeBytesHint)
+        bool IStream.TryEnsureAvaliable(int minimunByteCount)
         {
-            var newSize = desiredFreeBytesHint + _buffer.Length - _count;
-            if(desiredFreeBytesHint == -1){
-                newSize = _buffer.Length * 2;
-            }
-
+            var newSize = _buffer.Length * 2;
+            if(newSize < minimunByteCount) newSize = minimunByteCount;
             var temp = _buffer;
             _buffer = _pool.Rent(newSize);
             Array.Copy(temp, 0, _buffer, 0, _count);
             _pool.Return(temp);
+
+            return true;
         }
 
-        void IFormatter.CommitBytes(int bytes)
+        void IStream.Advance(int bytes)
         {
             _count += bytes;
         }

--- a/src/System.Text.Http/System/Text/Http/IFormatterHttpExtensions.cs
+++ b/src/System.Text.Http/System/Text/Http/IFormatterHttpExtensions.cs
@@ -31,14 +31,14 @@ namespace System.Text.Http
 
         public static void AppendHttpNewLine<TFormatter>(this TFormatter formatter) where TFormatter : IFormatter
         {
-            var buffer = formatter.FreeBuffer;
+            var buffer = formatter.AvaliableBytes;
             while(buffer.Length < 2) {
-                formatter.ResizeBuffer();
-                buffer = formatter.FreeBuffer;
+                formatter.TryEnsureAvaliable(2);
+                buffer = formatter.AvaliableBytes;
             }
             buffer[0] = 13;
             buffer[1] = 10;
-            formatter.CommitBytes(2);
+            formatter.Advance(2);
         }
     }
 }


### PR DESCRIPTION
David Fowler requested this so he can use IFromatter in his channels project.

For now, back pressure is synchronous. The caller (who gets StreamStatus.Backpressue) can decide to wait, retry, spin, or any other fallback it thinks is best in the situation.

As part of the change, I noticed that IFormatter basically a stream with FormattingData,
and so I am playing with the idea.
