### PR TITLE
Obsoleted UnsafeBuffer and TryGetArray

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/NativeBufferPool.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/NativeBufferPool.cs
@@ -106,13 +106,21 @@ namespace System.Buffers
 
             if (clearBuffer) BufferUtilities.ClearSpan(buffer);
 
-            if (buffer.Length > _maxElements)
-            {
-                Marshal.FreeHGlobal(new IntPtr(buffer.UnsafePointer));
-            }
-            else
-            {
-                _buckets[BufferUtilities.SelectBucketIndex(buffer.Length)].Return(new NativeBuffer(buffer.UnsafePointer, 0));
+            unsafe {
+                void* pointer;
+                ArraySegment<byte> array;
+                if(buffer.TryGetArrayElseGetPointer(out array, out pointer)){
+                    throw new Exception("this span was not rented from this pool");
+                }
+
+                if (buffer.Length > _maxElements)
+                {
+                    Marshal.FreeHGlobal(new IntPtr(pointer));
+                }
+                else
+                {
+                    _buckets[BufferUtilities.SelectBucketIndex(buffer.Length)].Return(new NativeBuffer(pointer, 0));
+                }
             }
         }
     }

--- a/src/System.Net.Libuv/System/Net/Libuv/Buffer.cs
+++ b/src/System.Net.Libuv/System/Net/Libuv/Buffer.cs
@@ -30,7 +30,12 @@ namespace System.Net.Libuv
             var memory = _pool.Rent((int)length);
             unsafe
             {
-                buffer = new Unix((IntPtr)memory.UnsafePointer, (uint)memory.Length);
+                ArraySegment<byte> array;
+                void* pointer;
+                if(memory.TryGetArrayElseGetPointer(out array, out pointer)){
+                    throw new NotImplementedException("needs to pin the array");
+                }
+                buffer = new Unix(new IntPtr(pointer), (uint)memory.Length);
             }
         }
 
@@ -39,7 +44,12 @@ namespace System.Net.Libuv
             var memory = _pool.Rent((int)length);
             unsafe
             {
-                buffer = new Windows((IntPtr)memory.UnsafePointer, (uint)memory.Length);
+                ArraySegment<byte> array;
+                void* pointer;
+                if(memory.TryGetArrayElseGetPointer(out array, out pointer)){
+                    throw new NotImplementedException("needs to pin the array");
+                }
+                buffer = new Windows(new IntPtr(pointer), (uint)memory.Length);
             }
         }
 

--- a/src/System.Net.Libuv/System/Net/Libuv/Stream.cs
+++ b/src/System.Net.Libuv/System/Net/Libuv/Stream.cs
@@ -80,7 +80,16 @@ namespace System.Net.Libuv
         {
             EnsureNotDisposed();
 
-            IntPtr ptrData = (IntPtr)data.UnsafePointer;
+            ArraySegment<byte> array;
+            void* pointer;
+            IntPtr ptrData;
+            if(data.TryGetArrayElseGetPointer(out array, out pointer)){
+                throw new NotImplementedException("needs to pin the array");
+            }
+            else {
+                ptrData = (IntPtr)pointer;
+            }
+            
             if (IsUnix)
             {
                 var buffer = new UVBuffer.Unix(ptrData, (uint)data.Length);

--- a/src/System.Slices/System/ReadOnlySpan.cs
+++ b/src/System.Slices/System/ReadOnlySpan.cs
@@ -150,6 +150,29 @@ namespace System
             get { return Length == 0; }
         }
 
+        /// <summary>
+        /// Gets array if the slice is over an array, otherwise gets a pointer to memory.
+        /// </summary>
+        /// <returns>true if it's a span over an array; otherwise false (if over a pointer)</returns>
+        /// <remarks>This method can be used for interop, while we are waiting for proper pinning support. Make sure the array contents are read-only.</remarks>
+        public unsafe bool TryGetArrayElseGetPointer(out ArraySegment<T> array, out void* pointer)
+        {
+            var a = Object as T[];
+            if (a == null)
+            {
+                array = new ArraySegment<T>();
+                pointer = PtrUtils.ComputeAddress(Object, Offset).ToPointer();
+                return false;
+            }
+
+            var offsetToData = SpanHelpers<T>.OffsetToArrayData;
+            var index = (int)((Offset.ToUInt32() - offsetToData) / PtrUtils.SizeOf<T>());
+            array = new ArraySegment<T>(a, index, Length);
+            pointer = null;
+            return true;
+        }
+
+        [Obsolete("use TryGetArrayElseGetPointer instead")]
         public unsafe void* UnsafeReadOnlyPointer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Added TryGetArrayElseGetBuffer.

The existing APis need to be used together to make the interop safe.
The new API makes it more in the face.
This is how the API should be used:

```csharp
void Interop(Span<Byte> s){
    void* p;
    ArraySegment<byte> a;

    if(s.TryGetArrayOrGetPointer(out a, out p)){
        fixed(byte* pB = a.Array){
	    var pOffset = pB + a.Offset;
            DoInterop(pOffset. s.Length);
        }
    }
    else {
    	DoInterop((byte*)p, s.Length);
    }
}
```

This API might be removed altogether when we add proper pinning to spans. 