### PR TITLE
removed obsolete attributes

### DIFF
--- a/src/System.Slices/System/ReadOnlySpan.cs
+++ b/src/System.Slices/System/ReadOnlySpan.cs
@@ -172,7 +172,6 @@ namespace System
             return true;
         }
 
-        [Obsolete("use TryGetArrayElseGetPointer instead")]
         public unsafe void* UnsafeReadOnlyPointer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Slices/System/Span.cs
+++ b/src/System.Slices/System/Span.cs
@@ -173,7 +173,6 @@ namespace System
             return true;
         }
 
-        [Obsolete("use TryGetArrayElseGetPointer instead")]
         public unsafe void* UnsafePointer
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
There are some scenarios that are not covered by the new APIs. 

For example, if the span wraps an array, but the calling code knows the array is already pinned and wants to get the pointer.