### PR TITLE
Renamed CreateArray() to ToArray()

### DIFF
--- a/src/System.Slices/System/ReadOnlySpan.cs
+++ b/src/System.Slices/System/ReadOnlySpan.cs
@@ -208,7 +208,7 @@ namespace System
         public T[] CreateArray()
         {
             var dest = new T[Length];
-            TryCopyTo(dest.Slice());
+            TryCopyTo(dest);
             return dest;
         }
 

--- a/src/System.Slices/System/Span.cs
+++ b/src/System.Slices/System/Span.cs
@@ -223,10 +223,10 @@ namespace System
         /// allocates, so should generally be avoided, however is sometimes
         /// necessary to bridge the gap with APIs written in terms of arrays.
         /// </summary>
-        public T[] CreateArray()
+        public T[] ToArray()
         {
             var dest = new T[Length];
-            TryCopyTo(dest.Slice());
+            TryCopyTo(dest);
             return dest;
         }
 
@@ -269,7 +269,7 @@ namespace System
         /// <param name="dest">The span to copy items into.</param>
         public bool TryCopyTo(T[] destination)
         {
-            return TryCopyTo(destination.Slice());
+            return TryCopyTo(destination);
         }
 
         public void Set(ReadOnlySpan<T> values)

--- a/src/System.Slices/System/SpanExtensions.cs
+++ b/src/System.Slices/System/SpanExtensions.cs
@@ -579,7 +579,7 @@ namespace System
 
         public static int IndexOf(this ReadOnlySpan<char> str, string value)
         {
-            return IndexOf(str, value.Slice());
+            return IndexOf(str, value);
         }
 
         public static int IndexOf(this ReadOnlySpan<char> str, ReadOnlySpan<char> value)
@@ -609,7 +609,7 @@ namespace System
 
         public static int LastIndexOf(this ReadOnlySpan<char> str, string value)
         {
-            return LastIndexOf(str, value.Slice());
+            return LastIndexOf(str, value);
         }
 
         public static int LastIndexOf(this ReadOnlySpan<char> str, ReadOnlySpan<char> value)

--- a/tests/System.Slices.Tests/BasicUnitTests.cs
+++ b/tests/System.Slices.Tests/BasicUnitTests.cs
@@ -10,7 +10,7 @@ namespace System.Slices.Tests
         public void ByteSpanEmptyCreateArrayTest()
         {
             var empty = Span<byte>.Empty;
-            var array = empty.CreateArray();
+            var array = empty.ToArray();
             Assert.Equal(0, array.Length);
         }
 

--- a/tests/System.Slices.Tests/EqualityTests.cs
+++ b/tests/System.Slices.Tests/EqualityTests.cs
@@ -508,7 +508,7 @@ namespace System.Slices.Tests
             // we just don't call memcmp for these structures
             var sliceOfStructuresWithCustomEquals =
                 Enumerable.Range(0, 200).Select(index => new CustomStructWithNonTrivialEquals(index)).ToArray().Slice();
-            var sliceOfSameBytes = sliceOfStructuresWithCustomEquals.ToArray().Slice();
+            var sliceOfSameBytes = Enumerable.ToArray(sliceOfStructuresWithCustomEquals).Slice();
 
             Assert.False(sliceOfStructuresWithCustomEquals.SequenceEqual(sliceOfSameBytes));
             Assert.False(sliceOfSameBytes.SequenceEqual(sliceOfStructuresWithCustomEquals));
@@ -561,7 +561,7 @@ namespace System.Slices.Tests
         public void AllBytesAreTakenUnderConsideration(int bytesCount)
         {
             var slice = Enumerable.Range(0, bytesCount).Select(index => (byte)index).ToArray().Slice();
-            var copy = slice.ToArray().Slice();
+            var copy = Enumerable.ToArray(slice).Slice();
 
             for (int i = 0; i < bytesCount; i++)
             {

--- a/tests/System.Slices.Tests/UsageScenarioTests.cs
+++ b/tests/System.Slices.Tests/UsageScenarioTests.cs
@@ -39,7 +39,7 @@ namespace System.Slices.Tests
             Span<byte> span = new Span<byte>(array);
             Assert.Equal(array.Length, span.Length);
 
-            Assert.NotSame(array, span.CreateArray());
+            Assert.NotSame(array, span.ToArray());
             Assert.True(span.Equals(array));
             Assert.False(span.Equals((object)array));
 


### PR DESCRIPTION
- Removed .Slice() in some places where implicit conversion is possible