### PR TITLE
Expanding support for "multispans"

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/ISequence.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/ISequence.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace System.Collections.Generic
+{
+    public struct Position
+    {
+        public int IntegerPosition;
+        public object ObjectPosition;
+
+        public static Position End = new Position() { IntegerPosition = int.MinValue };
+        public static Position Invalid = new Position() { IntegerPosition = int.MinValue + 1 };
+        public static Position BeforeFirst = new Position();
+
+        public bool IsValid {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return IntegerPosition != Invalid.IntegerPosition; }
+        }
+        public bool IsEnd {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return IntegerPosition == End.IntegerPosition; }
+        }
+    }
+
+    public struct Enumerator<T>
+    {
+        Position _position;
+        ISequence<T> _sequence;
+        T _item;
+
+        public Enumerator(ISequence<T> sequence)
+        {
+            _sequence = sequence;
+            _position = Position.BeforeFirst;
+            _item = default(T);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MoveNext()
+        {
+            _item = _sequence.TryGetItem(ref _position);
+            if (_position.IsValid) {
+                return true;
+            }
+            return false;
+        }
+
+        public T Current {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get {
+                return _item;
+            }
+        }
+    }
+
+    // new interface
+    public interface ISequence<T>
+    {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        T TryGetItem(ref Position position);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        Enumerator<T> GetEnumerator();
+    }
+}

--- a/src/System.Buffers.Experimental/System/Buffers/MultispanExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/MultispanExtensions.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Buffers
+{
+    public static class MultispanExtensions
+    {
+        public static bool TryParseUInt32<TMultispan>(this TMultispan bytes, FormattingData encoding, out uint value, out int consumed) where TMultispan : ISequence<Span<byte>>
+        {
+            Position position = Position.BeforeFirst;
+            var first = bytes.TryGetItem(ref position);
+            if (!position.IsValid) throw new ArgumentException("bytes cannot be empty");
+
+            if (!InvariantParser.TryParse(first, FormattingData.Encoding.Utf8, out value, out consumed)) {
+                return false; // TODO: maybe we should continue in some cases, e.g. if the first span ends in a decimal separator
+                                // ... cont, maybe consumed could be set even if TryParse returns false
+            }
+            if (position.IsEnd || first.Length > consumed) {
+                return true;
+            }
+
+            var second = bytes.TryGetItem(ref position);
+
+            Span<byte> temp;
+            int numberOfBytesFromSecond = second.Length;
+            if (numberOfBytesFromSecond > 64) numberOfBytesFromSecond = 64;
+            var tempBufferLength = first.Length + numberOfBytesFromSecond;
+            if (tempBufferLength > 128) {
+                temp = new byte[tempBufferLength];
+            } else {
+                unsafe
+                {
+                    byte* data = stackalloc byte[tempBufferLength];
+                    temp = new Span<byte>(data, tempBufferLength);
+                }
+            }
+
+            first.TryCopyTo(temp);
+
+            second.Slice(0, numberOfBytesFromSecond).TryCopyTo(temp.Slice(first.Length));
+
+            if (!InvariantParser.TryParse(temp, FormattingData.Encoding.Utf8, out value, out consumed)) {
+                return false;
+            }
+
+            if (position.IsEnd || temp.Length > consumed) {
+                return true;
+            }
+
+            throw new NotImplementedException();
+        }
+    }
+
+}

--- a/src/System.Buffers.Experimental/project.json
+++ b/src/System.Buffers.Experimental/project.json
@@ -24,6 +24,7 @@
     "System.Buffers": "4.0.0",
     "System.Diagnostics.Debug": "4.0.11",
     "System.Slices": { "target": "project" },
+    "System.Text.Primitives": { "target": "project" },
     "System.Threading": "4.0.11"
   },
   "frameworks": {

--- a/tests/System.Reflection.Metadata.Cil.Tests/System.Reflection.Metadata.Cil.Tests.xproj
+++ b/tests/System.Reflection.Metadata.Cil.Tests/System.Reflection.Metadata.Cil.Tests.xproj
@@ -11,9 +11,11 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>


### PR DESCRIPTION
Added an abstraction that can support various implementations of containers of spans
Added a method that illustrates how to parse UInt32 out of a milti-span

The multispan abstraction (ISequence<T>) allows array based and linked implementations of sequences.
A linked-list like container, would implement the interface as follows:

        public T TryGetItem(ref Position position)
        {
            if (_head != null && position.IsValid && !position.IsEnd)
            {
                var node = (Node)position.ObjectPosition;
                if(node==null) { node = _head; }
                var result = node._item;
                if (node._next != null)
                {
                    position.ObjectPosition = node._next;
                }
                else
                {
                    position = Position.End;
                }
                return result;
            }

            position = Position.Invalid;
            return default(T);
        }