### PR TITLE
Added non-blocking formatters

### DIFF
--- a/src/System.Text.Formatting/System/Text/Formatting/IFormatterExtensions.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/IFormatterExtensions.cs
@@ -10,196 +10,308 @@ namespace System.Text.Formatting
     {
         public static void Append<TFormatter, T>(this TFormatter formatter, T value, Format.Parsed format = default(Format.Parsed)) where T : IBufferFormattable where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
+            while(!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
+            }
+        }
+
+        public static bool TryAppend<TFormatter, T>(this TFormatter formatter, T value, Format.Parsed format = default(Format.Parsed)) where T : IBufferFormattable where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if(!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, byte value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
+            while (!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
+            }
+        }
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, byte value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if(!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, sbyte value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
+            while (!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
+            }
+        }
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, sbyte value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, ushort value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
+            while (!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
         }
-        public static void Append<TFormatter>(this TFormatter formatter, short value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, ushort value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
-                formatter.ResizeBuffer();
-                bytesWritten = 0;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
+        }
+
+        public static void Append<TFormatter>(this TFormatter formatter, short value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            while (!formatter.TryAppend(value, format)) {
+                formatter.ResizeBuffer();
+            }
+        }
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, short value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
+            }
+            formatter.CommitBytes(bytesWritten);
+            return true;
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, uint value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
+            while (!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
         }
-        public static void Append<TFormatter>(this TFormatter formatter, int value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, uint value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
-                formatter.ResizeBuffer();
-                bytesWritten = 0;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
+        }
+
+        public static void Append<TFormatter>(this TFormatter formatter, int value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            while (!formatter.TryAppend(value, format)) {
+                formatter.ResizeBuffer();
+            }
+        }
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, int value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
+            }
+            formatter.CommitBytes(bytesWritten);
+            return true;
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, ulong value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
+            while (!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
             }
-            formatter.CommitBytes(bytesWritten);
         }
-        public static void Append<TFormatter>(this TFormatter formatter, long value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, ulong value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
             int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
-                formatter.ResizeBuffer();
-                bytesWritten = 0;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
+        }
+
+        public static void Append<TFormatter>(this TFormatter formatter, long value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            while (!formatter.TryAppend(value, format)) {
+                formatter.ResizeBuffer();
+            }
+        }
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, long value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
+            }
+            formatter.CommitBytes(bytesWritten);
+            return true;
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, char value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
+            while (!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
+            }
+        }
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, char value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, string value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
+            while (!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
+            }
+        }
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, string value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, Utf8String value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            while (!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
+            }
+        }
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, Utf8String value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, Guid value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
+            while (!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
+            }
+        }
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, Guid value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, DateTime value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
+            while (!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
+            }
+        }
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, DateTime value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, DateTimeOffset value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
+            while (!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
+            }
+        }
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, DateTimeOffset value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, TimeSpan value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
+            while (!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
+            }
+        }
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, TimeSpan value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, float value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
+            while (!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
+            }
+        }
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, float value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
         }
 
         public static void Append<TFormatter>(this TFormatter formatter, double value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
         {
-            int bytesWritten;
-            while (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten))
-            {
+            while (!formatter.TryAppend(value, format)) {
                 formatter.ResizeBuffer();
-                bytesWritten = 0;
+            }
+        }
+
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, double value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        {
+            int bytesWritten;
+            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+                return false;
             }
             formatter.CommitBytes(bytesWritten);
+            return true;
         }
     }
 }


### PR DESCRIPTION
These can be used to implement fully async formatting:

```csharp
public static async Task WriteAsync<TStream>(this TStream stream, T value) where TStream : IStream, IFormatter {
    while (true) {
        if (stream.TryAppend(value)) { // non-blocking formatter method
            await Task.CompletedTask;
            break;
        }
        await stream.FetchMoreBufferSpace(); // method on hypothetical IStream
    }
}
```