### PR TITLE
update package.ps1 to use $(Build.BuildNumber)

### DIFF
--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -1,6 +1,7 @@
 ﻿Param(
     [string]$Configuration="Debug",
-    [string]$ApiKey
+    [string]$ApiKey,
+    [string]$BuildVersion
 )
 
 $repoRoot = "$PSScriptRoot\.."
@@ -21,8 +22,7 @@ Function Ensure-Nuget-Exists {
 Write-Host "** Building all NuGet packages. **"
 foreach ($file in [System.IO.Directory]::EnumerateFiles("$repoRoot\src", "project.json", "AllDirectories")) {
     Write-Host "Creating NuGet package for $file..."
-    $dateSuffix = [System.DateTime]::Now.ToString('eyyMMdd-1')
-    Invoke-Expression "$dotnetExePath pack $file -c $Configuration -o $packagesPath --version-suffix $dateSuffix"
+    Invoke-Expression "$dotnetExePath pack $file -c $Configuration -o $packagesPath --version-suffix $BuildVersion"
 
     if (!$?) {
         Write-Error "Failed to create NuGet package for project $file"


### PR DESCRIPTION
The Build number format is now specified in the Build Definition
and is a supplied parameter.