### PR TITLE
Add Span<T>.IsSliceOf; addresses #827

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -528,18 +528,16 @@ namespace System.Buffers
                                                        0x01ul << 48) + 1;
         private const ulong byteBroadcastToUlong = ~0UL / Byte.MaxValue;
         private const ulong filterByteHighBitsInUlong = (byteBroadcastToUlong >> 1) | (byteBroadcastToUlong << (sizeof(ulong) * 8 - 1));
-
-
+        
         /// <summary>
         /// Determines whether the current span is a slice of the supplied span
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsSliceOf<T>(this Span<T> child, Span<T> parent) where T : struct
         {
-            int start; // ignored
             return child.Length <= parent.Length && IsSliceOf(
                 ref child.DangerousGetPinnableReference(), child.Length,
-                ref parent.DangerousGetPinnableReference(), parent.Length, out start);
+                ref parent.DangerousGetPinnableReference(), parent.Length, out int ignored);
         }
 
         /// <summary>
@@ -552,6 +550,7 @@ namespace System.Buffers
                 ref child.DangerousGetPinnableReference(), child.Length,
                 ref parent.DangerousGetPinnableReference(), parent.Length, out start);
         }
+
         private static bool IsSliceOf<T>(ref T childRef, int childLength, ref T parentRef, int parentLength, out int start) where T : struct
         {
             long startBytesOffset = Unsafe.ByteOffset(ref parentRef, ref childRef).ToInt64();

--- a/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
@@ -92,7 +92,7 @@ namespace System.Slices.Tests
         }
 
         [Fact]
-        public unsafe void IsSliceOf_PointerVersusArraySpansNeverMatch()
+        public unsafe void IsSliceOf_PointerVersusArraySpansMatch()
         {
             ulong[] data = new ulong[8];
             fixed (ulong* ptr = data)
@@ -100,14 +100,16 @@ namespace System.Slices.Tests
                 Span<ulong> arrayBased = data;
                 Span<ulong> pointerBased = new Span<ulong>(ptr, 8);
 
-                // comparing array to pointer says "no"
-                Assert.False(arrayBased.IsSliceOf(pointerBased));
-                Assert.False(pointerBased.IsSliceOf(arrayBased));
+                // justification for match: Span<T> treats as equivalent:
+                Assert.True(arrayBased == pointerBased);
+
+                // comparing array to pointer says yes (despite being different internals)
+                Assert.True(arrayBased.IsSliceOf(pointerBased));
+                Assert.True(pointerBased.IsSliceOf(arrayBased));
 
                 // comparing to self says yes
                 Assert.True(arrayBased.IsSliceOf(arrayBased));
                 Assert.True(pointerBased.IsSliceOf(pointerBased));
-
             }
         }
 

--- a/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
@@ -90,5 +90,161 @@ namespace System.Slices.Tests
                 var span = copyStoredForLater.Span;
             });
         }
+
+        [Fact]
+        public unsafe void IsSliceOf_PointerVersusArraySpansNeverMatch()
+        {
+            ulong[] data = new ulong[8];
+            fixed (ulong* ptr = data)
+            {
+                Span<ulong> arrayBased = data;
+                Span<ulong> pointerBased = new Span<ulong>(ptr, 8);
+
+                // comparing array to pointer says "no"
+                Assert.False(arrayBased.IsSliceOf(pointerBased));
+                Assert.False(pointerBased.IsSliceOf(arrayBased));
+
+                // comparing to self says yes
+                Assert.True(arrayBased.IsSliceOf(arrayBased));
+                Assert.True(pointerBased.IsSliceOf(pointerBased));
+
+            }
+        }
+
+        [Fact]
+        public unsafe void IsSliceOf_NonOverlappingSpansNeverMatch()
+        {
+            ulong[] data = new ulong[8];
+            fixed (ulong* ptr = data)
+            {
+                Span<ulong> arrayBased = data;
+                var x = arrayBased.Slice(1, 2);
+                var y = arrayBased.Slice(5, 2);
+                Assert.False(x.IsSliceOf(y));
+                Assert.False(y.IsSliceOf(x));
+
+                Span<ulong> pointerBased = new Span<ulong>(ptr, 8);
+                x = pointerBased.Slice(1, 2);
+                y = pointerBased.Slice(5, 2);
+                Assert.False(x.IsSliceOf(y));
+                Assert.False(y.IsSliceOf(x));
+            }
+        }
+
+        [Fact]
+        public unsafe void IsSliceOf_PartialOverlappingSpansNeverMatch()
+        {
+            ulong[] data = new ulong[8];
+            fixed (ulong* ptr = data)
+            {
+                Span<ulong> arrayBased = data;
+                var x = arrayBased.Slice(1, 4);
+                var y = arrayBased.Slice(3, 4);
+                Assert.False(x.IsSliceOf(y));
+                Assert.False(y.IsSliceOf(x));
+
+                Span<ulong> pointerBased = new Span<ulong>(ptr, 8);
+                x = pointerBased.Slice(1, 4);
+                y = pointerBased.Slice(3, 4);
+                Assert.False(x.IsSliceOf(y));
+                Assert.False(y.IsSliceOf(x));
+            }
+        }
+
+        [Fact]
+        public unsafe void IsSliceOf_EqualSpansAlwaysMatch()
+        {
+            ulong[] data = new ulong[8];
+            fixed (ulong* ptr = data)
+            {
+                Span<ulong> arrayBased = data;
+                Assert.True(arrayBased.IsSliceOf(arrayBased));
+                for (int start = 0; start < 8; start++)
+                {
+                    for (int length = data.Length - start; length >= 0; length--)
+                    {
+                        Assert.True(arrayBased.Slice(start, length).IsSliceOf(arrayBased.Slice(start, length)));
+                    }
+                }
+
+                Span<ulong> pointerBased = new Span<ulong>(ptr, 8);
+                Assert.True(pointerBased.IsSliceOf(pointerBased));
+                for (int start = 0; start < 8; start++)
+                {
+                    for (int length = data.Length - start; length >= 0; length--)
+                    {
+                        Assert.True(pointerBased.Slice(start, length).IsSliceOf(pointerBased.Slice(start, length)));
+                    }
+                }
+            }
+        }
+        [Fact]
+        public void IsSliceOf_SubSpansShouldMatch_BasicArrays()
+        {
+            int[] data = new int[20];
+
+            var outer = new Span<int>(data);
+            var inner = outer.Slice(6, 3);
+
+            Assert.True(outer.IsSliceOf(outer));
+            Assert.True(inner.IsSliceOf(inner));
+
+            Assert.False(outer.IsSliceOf(inner));
+            Assert.True(inner.IsSliceOf(outer));
+            int start;
+            Assert.True(inner.IsSliceOf(outer, out start));
+            Assert.Equal(6, start);
+
+
+            var innerInner = inner.Slice(1);
+            Assert.True(innerInner.IsSliceOf(innerInner));
+            Assert.True(innerInner.IsSliceOf(inner));
+            Assert.True(innerInner.IsSliceOf(inner, out start));
+            Assert.Equal(1, start);
+            Assert.True(innerInner.IsSliceOf(outer));
+            Assert.True(innerInner.IsSliceOf(outer, out start));
+            Assert.Equal(7, start);
+        }
+
+        [Fact]
+        public unsafe void IsSliceOf_SubSpansShouldMatch_BasicPointers()
+        {
+            int* data = stackalloc int[20];
+
+            var outer = new Span<int>(data, 20);
+            var inner = outer.Slice(6, 3);
+
+            Assert.True(outer.IsSliceOf(outer));
+            Assert.True(inner.IsSliceOf(inner));
+
+            Assert.False(outer.IsSliceOf(inner));
+            Assert.True(inner.IsSliceOf(outer));
+            int start;
+            Assert.True(inner.IsSliceOf(outer, out start));
+            Assert.Equal(6, start);
+
+
+            var innerInner = inner.Slice(1);
+            Assert.True(innerInner.IsSliceOf(innerInner));
+            Assert.True(innerInner.IsSliceOf(inner));
+            Assert.True(innerInner.IsSliceOf(inner, out start));
+            Assert.Equal(1, start);
+            Assert.True(innerInner.IsSliceOf(outer));
+            Assert.True(innerInner.IsSliceOf(outer, out start));
+            Assert.Equal(7, start);
+        }
+
+
+        [Fact]
+        public unsafe void IsSliceOf_MisalignedPointersShouldNotMatch()
+        {
+            byte* data = stackalloc byte[10 * sizeof(ulong)];
+            var outer = new Span<ulong>(data, 10);
+            var inner = new Span<ulong>(data + 8, 1);
+            Assert.True(inner.IsSliceOf(outer));
+
+            inner = new Span<ulong>(data + 11, 1);
+            Assert.False(inner.IsSliceOf(outer));
+        }
     }
 }


### PR DESCRIPTION
Fix tests; fix offset bug

Fix overflow case; use ToPointer() for the left hand bounds check (hard to use for the right, as need to avoid overflow  condition)
