### PR TITLE
remove all generic interfaces that put Span<T> in generic arg

### DIFF
--- a/src/System.Slices/System/Contract.cs
+++ b/src/System.Slices/System/Contract.cs
@@ -83,6 +83,8 @@ namespace System
             }
         }
 
+        internal static InvalidOperationException InvalidOperationExceptionForBoxingSpans() => new InvalidOperationException("Spans must not be boxed");
+
         private static void ThrowArgumentException()
         {
             throw new ArgumentException();

--- a/src/System.Slices/System/ReadOnlySpan.cs
+++ b/src/System.Slices/System/ReadOnlySpan.cs
@@ -345,6 +345,8 @@ namespace System
             }
         }
 
+        public override bool Equals(object obj) { throw Contract.InvalidOperationExceptionForBoxingSpans(); }
+
         /// <summary>
         /// Checks to see if two spans point at the same memory.  Note that
         /// this does *not* check to see if the *contents* are equal.

--- a/src/System.Slices/System/ReadOnlySpan.cs
+++ b/src/System.Slices/System/ReadOnlySpan.cs
@@ -12,7 +12,7 @@ namespace System
     /// </summary>
     [DebuggerTypeProxy(typeof(SpanDebuggerView<>))]
     [DebuggerDisplay("Length = {Length}")]
-    public partial struct ReadOnlySpan<T> : IEquatable<Span<T>>, IEquatable<ReadOnlySpan<T>>, IEquatable<T[]>
+    public partial struct ReadOnlySpan<T> : IEquatable<T[]>
     {
         /// <summary>A managed array/string; or null for native ptrs.</summary>
         internal readonly object Object;
@@ -148,12 +148,9 @@ namespace System
             return new ReadOnlySpan<T>(arraySegment.Array, arraySegment.Offset, arraySegment.Count);
         }
 
-        public static ReadOnlySpan<T> Empty { get { return default(ReadOnlySpan<T>); } }
+        public static ReadOnlySpan<T> Empty => default(ReadOnlySpan<T>);
 
-        public bool IsEmpty
-        {
-            get { return Length == 0; }
-        }
+        public bool IsEmpty => Length == 0; 
 
         /// <summary>
         /// Gets array if the slice is over an array, otherwise gets a pointer to memory.
@@ -352,27 +349,14 @@ namespace System
         /// Checks to see if two spans point at the same memory.  Note that
         /// this does *not* check to see if the *contents* are equal.
         /// </summary>
-        public bool Equals(ReadOnlySpan<T> other)
-        {
-            return ReferenceEquals(other);
-        }
+        public bool Equals(ReadOnlySpan<T> other) => ReferenceEquals(other);
 
-        public bool Equals(Span<T> other)
-        {
-            return other.StructuralEquals(Object, Offset, Length);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is ReadOnlySpan<T>)
-            {
-                return Equals((ReadOnlySpan<T>)obj);
-            }
-            return false;
-        }
+        public bool Equals(Span<T> other) => other.StructuralEquals(Object, Offset, Length);
 
         public bool Equals(T[] other) => Equals(new ReadOnlySpan<T>(other));
+
         public static bool operator ==(ReadOnlySpan<T> span1, ReadOnlySpan<T> span2) => span1.Equals(span2);
+
         public static bool operator !=(ReadOnlySpan<T> span1, ReadOnlySpan<T> span2) => !span1.Equals(span2);
     }
 }

--- a/src/System.Slices/System/ReadOnlySpan.cs
+++ b/src/System.Slices/System/ReadOnlySpan.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime;
 using System.Runtime.CompilerServices;
@@ -13,7 +12,7 @@ namespace System
     /// </summary>
     [DebuggerTypeProxy(typeof(SpanDebuggerView<>))]
     [DebuggerDisplay("Length = {Length}")]
-    public partial struct ReadOnlySpan<T> : IEnumerable<T>, IEquatable<Span<T>>, IEquatable<ReadOnlySpan<T>>, IEquatable<T[]>
+    public partial struct ReadOnlySpan<T> : IEquatable<Span<T>>, IEquatable<ReadOnlySpan<T>>, IEquatable<T[]>
     {
         /// <summary>A managed array/string; or null for native ptrs.</summary>
         internal readonly object Object;

--- a/src/System.Slices/System/ReadOnlySpanEnumerators.cs
+++ b/src/System.Slices/System/ReadOnlySpanEnumerators.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Collections.Generic;
 using System.Runtime;
 
 namespace System
@@ -12,16 +10,6 @@ namespace System
         public Enumerator GetEnumerator()
         {
             return new Enumerator(Object, Offset, Length);
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return new EnumeratorObject(this);
-        }
-
-        IEnumerator<T> IEnumerable<T>.GetEnumerator()
-        {
-            return new EnumeratorObject(this);
         }
 
         /// <summary>
@@ -55,55 +43,6 @@ namespace System
             public bool MoveNext()
             {
                 return ++_position < _length;
-            }
-
-            public void Reset()
-            {
-                _position = -1;
-            }
-        }
-
-        /// <summary>
-        /// enumerator that implements <see cref="IEnumerator{T}"/> pattern (including <see cref="IDisposable"/>).
-        /// it is used by LINQ and foreach when Slice is accessed via <see cref="IEnumerable{T}"/>
-        /// it is reference type to avoid boxing when calling interface methods on stuctures
-        /// </summary>
-        internal class EnumeratorObject : IEnumerator<T>
-        {
-            ReadOnlySpan<T> _span;    // The slice being enumerated.
-            int _position; // The current position.
-
-            public EnumeratorObject(ReadOnlySpan<T> span)
-            {
-                _span = span;
-                _position = -1;
-            }
-
-            public T Current
-            {
-                get { return _span[_position]; }
-            }
-
-            object IEnumerator.Current
-            {
-                get { return Current; }
-            }
-
-            public void Dispose()
-            {
-                _span = default(Span<T>);
-                _position = -1;
-            }
-
-            public bool MoveNext()
-            {
-                int nextItemIndex = _position + 1;
-                if (nextItemIndex < _span.Length)
-                {
-                    _position = nextItemIndex;
-                    return true;
-                }
-                return false;
             }
 
             public void Reset()

--- a/src/System.Slices/System/Span.cs
+++ b/src/System.Slices/System/Span.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime;
 using System.Runtime.CompilerServices;
@@ -17,7 +15,7 @@ namespace System
     /// </summary>
     [DebuggerTypeProxy(typeof(SpanDebuggerView<>))]
     [DebuggerDisplay("Length = {Length}")]
-    public partial struct Span<T> : IEnumerable<T>, IEquatable<Span<T>>, IEquatable<ReadOnlySpan<T>>, IEquatable<T[]>
+    public partial struct Span<T> : IEquatable<Span<T>>, IEquatable<ReadOnlySpan<T>>, IEquatable<T[]>
     {
         /// <summary>A managed array/string; or null for native ptrs.</summary>
         internal readonly object Object;
@@ -414,16 +412,6 @@ namespace System
         public ReadOnlySpan<T>.Enumerator GetEnumerator()
         {
             return new ReadOnlySpan<T>.Enumerator(Object, Offset, Length);
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return new ReadOnlySpan<T>.EnumeratorObject(this);
-        }
-
-        IEnumerator<T> IEnumerable<T>.GetEnumerator()
-        {
-            return new ReadOnlySpan<T>.EnumeratorObject(this);
         }
     }
 }

--- a/src/System.Slices/System/Span.cs
+++ b/src/System.Slices/System/Span.cs
@@ -385,6 +385,8 @@ namespace System
             }
         }
 
+        public override bool Equals(object obj) { throw Contract.InvalidOperationExceptionForBoxingSpans(); }
+
         /// <summary>
         /// Checks to see if two spans point at the same memory.  Note that
         /// this does *not* check to see if the *contents* are equal.

--- a/src/System.Slices/System/Span.cs
+++ b/src/System.Slices/System/Span.cs
@@ -15,7 +15,7 @@ namespace System
     /// </summary>
     [DebuggerTypeProxy(typeof(SpanDebuggerView<>))]
     [DebuggerDisplay("Length = {Length}")]
-    public partial struct Span<T> : IEquatable<Span<T>>, IEquatable<ReadOnlySpan<T>>, IEquatable<T[]>
+    public struct Span<T> : IEquatable<T[]>
     {
         /// <summary>A managed array/string; or null for native ptrs.</summary>
         internal readonly object Object;
@@ -389,29 +389,16 @@ namespace System
         /// Checks to see if two spans point at the same memory.  Note that
         /// this does *not* check to see if the *contents* are equal.
         /// </summary>
-        public bool Equals(Span<T> other)
-        {
-            return ReferenceEquals(other);
-        }
-
-
-        public override bool Equals(object obj)
-        {
-            if (obj is Span<T>)
-            {
-                return Equals((Span<T>)obj);
-            }
-            return false;
-        }
+        public bool Equals(Span<T> other) => ReferenceEquals(other);
 
         public bool Equals(ReadOnlySpan<T> other) => StructuralEquals(other.Object, other.Offset, other.Length);
+
         public bool Equals(T[] other) => Equals(new Span<T>(other));
+
         public static bool operator ==(Span<T> span1, Span<T> span2) => span1.Equals(span2);
+
         public static bool operator !=(Span<T> span1, Span<T> span2) => !span1.Equals(span2);
 
-        public ReadOnlySpan<T>.Enumerator GetEnumerator()
-        {
-            return new ReadOnlySpan<T>.Enumerator(Object, Offset, Length);
-        }
+        public ReadOnlySpan<T>.Enumerator GetEnumerator() => new ReadOnlySpan<T>.Enumerator(Object, Offset, Length);
     }
 }

--- a/src/System.Text.Utf8/System/Text/Utf8/Utf8String.Enumerator.cs
+++ b/src/System.Text.Utf8/System/Text/Utf8/Utf8String.Enumerator.cs
@@ -8,16 +8,14 @@ namespace System.Text.Utf8
 {
     partial struct Utf8String
     {
-        public struct Enumerator : IEnumerator<Utf8CodeUnit>, IEnumerator
+        public struct Enumerator
         {
             private ReadOnlySpan<byte>.Enumerator _enumerator;
 
-            public Enumerator(ReadOnlySpan<byte> buffer)
+            internal Enumerator(ReadOnlySpan<byte> buffer)
             {
                 _enumerator = buffer.GetEnumerator();
             }
-
-            object IEnumerator.Current { get { return Current; } }
 
             public Utf8CodeUnit Current
             {
@@ -25,10 +23,6 @@ namespace System.Text.Utf8
                 {
                     return (Utf8CodeUnit)_enumerator.Current;
                 }
-            }
-
-            void IDisposable.Dispose()
-            {
             }
 
             public bool MoveNext()

--- a/src/System.Text.Utf8/System/Text/Utf8/Utf8String.cs
+++ b/src/System.Text.Utf8/System/Text/Utf8/Utf8String.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -11,7 +10,7 @@ using System.Text.Utf16;
 namespace System.Text.Utf8
 {
     [DebuggerDisplay("{ToString()}u8")]
-    public partial struct Utf8String : IEnumerable<Utf8CodeUnit>, IEquatable<Utf8String>, IComparable<Utf8String> 
+    public partial struct Utf8String : IEquatable<Utf8String>, IComparable<Utf8String> 
     {
         private ReadOnlySpan<byte> _buffer;
 
@@ -106,16 +105,6 @@ namespace System.Text.Utf8
         public Enumerator GetEnumerator()
         {
             return new Enumerator(_buffer);
-        }
-
-        IEnumerator<Utf8CodeUnit> IEnumerable<Utf8CodeUnit>.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
         }
 
         public CodePointEnumerable CodePoints

--- a/tests/System.Slices.Tests/EqualityTests.cs
+++ b/tests/System.Slices.Tests/EqualityTests.cs
@@ -10,6 +10,30 @@ namespace System.Slices.Tests
 {
     public class EqualityTests
     {
+        [Fact]
+        public void SpansMustNotBeBoxed()
+        {
+            var span = Span<byte>.Empty;
+
+            try
+            {
+                span.Equals((object)span);
+
+                // we are not using Assert.Throw in order to not catch span in lambda/clojure
+                Assert.True(false, "Expected exception was not thrown");
+            }
+            catch (InvalidOperationException) { }
+
+            var readOnlySpan = ReadOnlySpan<byte>.Empty;
+
+            try
+            {
+                readOnlySpan.Equals((object)readOnlySpan);
+                Assert.True(false, "Expected exception was not thrown");
+            }
+            catch (InvalidOperationException) { }
+        }
+
         [Theory]
         [MemberData("ValidArraySegments")]
         public void SpansReferencingSameMemoryAreEqualInEveryAspect(byte[] bytes, int start, int length)
@@ -114,11 +138,6 @@ namespace System.Slices.Tests
             Assert.True(span.Equals(readOnlySpan));
             Assert.True(readOnlySpan.Equals(bytes));
             Assert.True(readOnlySpan.Equals(span));
-
-            Assert.False(span.Equals((object)bytes));
-            Assert.False(span.Equals((object)readOnlySpan));
-            Assert.False(readOnlySpan.Equals((object)bytes));
-            Assert.False(readOnlySpan.Equals((object)span));
         }
 
         [Theory]
@@ -150,14 +169,6 @@ namespace System.Slices.Tests
             Assert.True(readOnlySpan.Equals(impReadOnlySpan));
             Assert.True(impReadOnlySpan.Equals(readOnlySpan));
             Assert.True(impReadOnlySpan.Equals(span));
-
-            Assert.False(span.Equals((object)readOnlySpan));
-            Assert.False(readOnlySpan.Equals((object)span));
-            Assert.False(span.Equals((object)impReadOnlySpan));
-            Assert.False(impReadOnlySpan.Equals((object)span));
-
-            Assert.True(readOnlySpan.Equals((object)impReadOnlySpan));
-            Assert.True(impReadOnlySpan.Equals((object)readOnlySpan));
         }
 
         // ref is used just for the structCopy scenario, otherwise it would always be copy
@@ -170,7 +181,6 @@ namespace System.Slices.Tests
             Assert.False(span != pointingToSameMemory);
             Assert.False(pointingToSameMemory != span);
             Assert.True(span.Equals(pointingToSameMemory));
-            Assert.True(span.Equals((Object)pointingToSameMemory));
             Assert.Equal(span.GetHashCode(), pointingToSameMemory.GetHashCode());
 
             Assert.True(span.SequenceEqual(pointingToSameMemory));
@@ -187,7 +197,6 @@ namespace System.Slices.Tests
             Assert.False(span != pointingToSameMemory);
             Assert.False(pointingToSameMemory != span);
             Assert.True(span.Equals(pointingToSameMemory));
-            Assert.True(span.Equals((Object)pointingToSameMemory));
             Assert.Equal(span.GetHashCode(), pointingToSameMemory.GetHashCode());
 
             Assert.True(span.SequenceEqual(pointingToSameMemory));
@@ -237,7 +246,6 @@ namespace System.Slices.Tests
 
             Assert.False(span.ReferenceEquals(ofSameValues));
             Assert.False(span.Equals(ofSameValues));
-            Assert.False(span.Equals((Object)ofSameValues));
             Assert.NotEqual(span.GetHashCode(), ofSameValues.GetHashCode());
         }
 
@@ -262,7 +270,6 @@ namespace System.Slices.Tests
 
             Assert.False(span.ReferenceEquals(ofSameValues));
             Assert.False(span.Equals(ofSameValues));
-            Assert.False(span.Equals((Object)ofSameValues));
             Assert.NotEqual(span.GetHashCode(), ofSameValues.GetHashCode());
         }
 
@@ -287,7 +294,6 @@ namespace System.Slices.Tests
 
             Assert.False(span.ReferenceEquals(ofDifferentValues));
             Assert.False(span.Equals(ofDifferentValues));
-            Assert.False(span.Equals((Object)ofDifferentValues));
             Assert.False(span.GetHashCode() == ofDifferentValues.GetHashCode());
         }
 
@@ -312,7 +318,6 @@ namespace System.Slices.Tests
 
             Assert.False(span.ReferenceEquals(ofDifferentValues));
             Assert.False(span.Equals(ofDifferentValues));
-            Assert.False(span.Equals((Object)ofDifferentValues));
             Assert.False(span.GetHashCode() == ofDifferentValues.GetHashCode());
         }
 
@@ -328,7 +333,6 @@ namespace System.Slices.Tests
             Assert.True(span.BlockEquals(ofSameValuesOfDifferentType));
             Assert.True(ofSameValuesOfDifferentType.BlockEquals(span));
 
-            Assert.False(span.Equals((Object)ofSameValuesOfDifferentType));
             Assert.NotEqual(span.GetHashCode(), ofSameValuesOfDifferentType.GetHashCode());
         }
 
@@ -344,7 +348,6 @@ namespace System.Slices.Tests
             Assert.True(span.BlockEquals(ofSameValuesOfDifferentType));
             Assert.True(ofSameValuesOfDifferentType.BlockEquals(span));
 
-            Assert.False(span.Equals((Object)ofSameValuesOfDifferentType));
             Assert.NotEqual(span.GetHashCode(), ofSameValuesOfDifferentType.GetHashCode());
         }
 

--- a/tests/System.Slices.Tests/EqualityTests.cs
+++ b/tests/System.Slices.Tests/EqualityTests.cs
@@ -508,7 +508,7 @@ namespace System.Slices.Tests
             // we just don't call memcmp for these structures
             var sliceOfStructuresWithCustomEquals =
                 Enumerable.Range(0, 200).Select(index => new CustomStructWithNonTrivialEquals(index)).ToArray().Slice();
-            var sliceOfSameBytes = sliceOfStructuresWithCustomEquals.ToArray().Slice();
+            var sliceOfSameBytes = sliceOfStructuresWithCustomEquals.CreateArray().Slice();
 
             Assert.False(sliceOfStructuresWithCustomEquals.SequenceEqual(sliceOfSameBytes));
             Assert.False(sliceOfSameBytes.SequenceEqual(sliceOfStructuresWithCustomEquals));
@@ -561,7 +561,7 @@ namespace System.Slices.Tests
         public void AllBytesAreTakenUnderConsideration(int bytesCount)
         {
             var slice = Enumerable.Range(0, bytesCount).Select(index => (byte)index).ToArray().Slice();
-            var copy = slice.ToArray().Slice();
+            var copy = slice.CreateArray().Slice();
 
             for (int i = 0; i < bytesCount; i++)
             {

--- a/tests/System.Slices.Tests/UsageScenarioTests.cs
+++ b/tests/System.Slices.Tests/UsageScenarioTests.cs
@@ -41,7 +41,6 @@ namespace System.Slices.Tests
 
             Assert.NotSame(array, span.CreateArray());
             Assert.True(span.Equals(array));
-            Assert.False(span.Equals((object)array));
 
             ReadOnlySpan<byte>.Enumerator it = span.GetEnumerator();
             for (int i = 0; i < span.Length; i++)
@@ -91,7 +90,6 @@ namespace System.Slices.Tests
 
             Assert.NotSame(array, span.CreateArray());
             Assert.True(span.Equals(array));
-            Assert.False(span.Equals((object)array));
 
             ReadOnlySpan<byte>.Enumerator it = span.GetEnumerator();
             for (int i = 0; i < span.Length; i++)

--- a/tests/System.Text.Http.Tests/GivenAnHttpHeaders.cs
+++ b/tests/System.Text.Http.Tests/GivenAnHttpHeaders.cs
@@ -54,7 +54,7 @@ Accept-Language: en-US,en;q=0.8,pt-BR;q=0.6,pt;q=0.4
         [Fact]
         public void It_returns_empty_string_when_header_is_not_present()
         {
-            ((IEnumerable)_httpHeaders["Content-Length"]).Should().BeEmpty();
+            _httpHeaders["Content-Length"].Length.Should().Be(0);
         }
 
         [Fact]


### PR DESCRIPTION
@KrzysztofCwalina I have removed it also from Utf8String since it's based on Span as well