### PR TITLE
Refactored IFormatter based on discussions with the channels team

### DIFF
--- a/samples/LowAllocationWebServer/Framework/SharedData.cs
+++ b/samples/LowAllocationWebServer/Framework/SharedData.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Net.Http
         public ResponseFormatter Headers { get { return new ResponseFormatter(_data, 2); } }
     }
 
-    public struct ResponseFormatter : IFormatter
+    public struct ResponseFormatter : ITextOutput
     {
         int _order;
         SharedData _data;
@@ -212,7 +212,7 @@ namespace Microsoft.Net.Http
             }
         }
 
-        public Span<byte> FreeBuffer
+        public Span<byte> Buffer
         {
             get
             {
@@ -221,14 +221,14 @@ namespace Microsoft.Net.Http
             }
         }
 
-        public void CommitBytes(int bytes)
+        public void Advance(int bytes)
         {
             _data.Commit(_order, bytes);
         }
 
-        public void ResizeBuffer(int desiredFreeBytesHint = -1)
+        public void Enlarge(int desiredBufferLength = 0)
         {
-            _data.Allocate(desiredFreeBytesHint == -1 ? 1024 : desiredFreeBytesHint, _order);
+            _data.Allocate(desiredBufferLength == 0 ? 1024 : desiredBufferLength, _order);
         }
     }
 }

--- a/src/System.Slices/System/Buffers/IOutput.cs
+++ b/src/System.Slices/System/Buffers/IOutput.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Buffers
+{
+    public interface IOutput
+    {
+        Span<byte> Buffer { get; }
+        void Advance(int bytes);
+
+        /// <summary>desiredBufferLength == 0 means "i don't care"</summary>
+        void Enlarge(int desiredBufferLength = 0);
+    }
+}

--- a/src/System.Text.Formatting/System/Text/Formatting/BufferFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/BufferFormatter.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace System.Text.Formatting
 {
-    public class BufferFormatter : IFormatter
+    public class BufferFormatter : ITextOutput
     {
         byte[] _buffer;
         int _count;
@@ -37,7 +37,7 @@ namespace System.Text.Formatting
             _count = 0;
         }
 
-        Span<byte> IFormatter.FreeBuffer
+        Span<byte> IOutput.Buffer
         {
             get
             {
@@ -45,18 +45,17 @@ namespace System.Text.Formatting
             }
         }
 
-        EncodingData IFormatter.Encoding
+        public EncodingData Encoding
         {
-            get
-            {
+            get {
                 return _encoding;
             }
         }
 
-        void IFormatter.ResizeBuffer(int desiredFreeBytesHint)
+        void IOutput.Enlarge(int desiredBufferLength)
         {
-            var newSize = desiredFreeBytesHint + _buffer.Length - _count;
-            if(desiredFreeBytesHint == -1){
+            var newSize = desiredBufferLength + _buffer.Length - _count;
+            if(desiredBufferLength == 0){
                 newSize = _buffer.Length * 2;
             }
 
@@ -66,7 +65,7 @@ namespace System.Text.Formatting
             _pool.Return(temp);
         }
 
-        void IFormatter.CommitBytes(int bytes)
+        void IOutput.Advance(int bytes)
         {
             _count += bytes;
             if(_count > _buffer.Length)

--- a/src/System.Text.Formatting/System/Text/Formatting/IFormatterExtensions.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/IFormatterExtensions.cs
@@ -8,309 +8,309 @@ namespace System.Text.Formatting
 {
     public static class IFormatterExtensions
     {
-        public static void Append<TFormatter, T>(this TFormatter formatter, T value, Format.Parsed format = default(Format.Parsed)) where T : IBufferFormattable where TFormatter : IFormatter
+        public static void Append<TFormatter, T>(this TFormatter formatter, T value, Format.Parsed format = default(Format.Parsed)) where T : IBufferFormattable where TFormatter : ITextOutput
         {
             while(!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter, T>(this TFormatter formatter, T value, Format.Parsed format = default(Format.Parsed)) where T : IBufferFormattable where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter, T>(this TFormatter formatter, T value, Format.Parsed format = default(Format.Parsed)) where T : IBufferFormattable where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if(!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if(!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, byte value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, byte value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, byte value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, byte value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if(!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if(!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, sbyte value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, sbyte value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, sbyte value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, sbyte value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, ushort value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, ushort value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, ushort value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, ushort value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, short value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, short value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, short value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, short value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, uint value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, uint value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, uint value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, uint value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, int value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, int value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, int value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, int value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, ulong value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, ulong value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, ulong value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, ulong value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, long value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, long value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, long value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, long value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, char value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, char value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, char value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, char value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, string value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, string value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, string value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, string value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, Utf8String value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, Utf8String value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, Utf8String value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, Utf8String value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, Guid value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, Guid value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, Guid value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, Guid value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, DateTime value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, DateTime value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, DateTime value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, DateTime value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, DateTimeOffset value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, DateTimeOffset value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, DateTimeOffset value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, DateTimeOffset value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, TimeSpan value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, TimeSpan value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, TimeSpan value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, TimeSpan value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, float value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, float value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, float value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, float value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
 
-        public static void Append<TFormatter>(this TFormatter formatter, double value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static void Append<TFormatter>(this TFormatter formatter, double value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             while (!formatter.TryAppend(value, format)) {
-                formatter.ResizeBuffer();
+                formatter.Enlarge();
             }
         }
 
-        public static bool TryAppend<TFormatter>(this TFormatter formatter, double value, Format.Parsed format = default(Format.Parsed)) where TFormatter : IFormatter
+        public static bool TryAppend<TFormatter>(this TFormatter formatter, double value, Format.Parsed format = default(Format.Parsed)) where TFormatter : ITextOutput
         {
             int bytesWritten;
-            if (!value.TryFormat(formatter.FreeBuffer, format, formatter.Encoding, out bytesWritten)) {
+            if (!value.TryFormat(formatter.Buffer, format, formatter.Encoding, out bytesWritten)) {
                 return false;
             }
-            formatter.CommitBytes(bytesWritten);
+            formatter.Advance(bytesWritten);
             return true;
         }
     }

--- a/src/System.Text.Formatting/System/Text/Formatting/ITextOutput.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/ITextOutput.cs
@@ -1,21 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text;
+using System.Buffers;
 
 namespace System.Text.Formatting
 {
     // this interface would be implemented by types that want to support formatting, i.e. TextWriter/StringBuilder-like types.
     // the interface is used by an extension method in IFormatterExtensions.
     // One thing I am not sure here is if it's ok for these APIs to be synchronous, but I guess I will wait till I find a concrete issue with this.
-    public interface IFormatter
+    public interface ITextOutput : IOutput
     {
-        Span<byte> FreeBuffer { get; }
-        void CommitBytes(int bytes);
-
-        /// <summary>desiredFreeBytesHint == -1 means "i don't care"</summary>
-        void ResizeBuffer(int desiredFreeBytesHint = -1);
-
         EncodingData Encoding { get; }
     }
 }

--- a/src/System.Text.Formatting/System/Text/Formatting/MultispanFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/MultispanFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace System.Text.Formatting
 {
-    public class MultispanFormatter : IFormatter
+    public class MultispanFormatter : ITextOutput
     {
         Multispan<byte> _buffer;
         int _segmentSize;
@@ -24,7 +24,7 @@ namespace System.Text.Formatting
             get { return _buffer; }
         }
 
-        Span<byte> IFormatter.FreeBuffer
+        Span<byte> IOutput.Buffer
         {
             get
             {
@@ -32,26 +32,25 @@ namespace System.Text.Formatting
             }
         }
 
-        EncodingData IFormatter.Encoding
+        EncodingData ITextOutput.Encoding
         {
-            get
-            {
+            get {
                 return _encoding;
             }
         }
 
-        void IFormatter.ResizeBuffer(int desiredFreeBytesHint)
+        void IOutput.Enlarge(int desiredBufferLength)
         {
             var newSize = _segmentSize;
-            if(desiredFreeBytesHint != -1){
-                newSize = desiredFreeBytesHint;
+            if(desiredBufferLength != 0){
+                newSize = desiredBufferLength;
             }
             var index = _buffer.AppendNewSegment(newSize);
             _lastFull = _buffer.Last;
             _buffer.ResizeSegment(index, 0);
         }
 
-        void IFormatter.CommitBytes(int bytes)
+        void IOutput.Advance(int bytes)
         {
             var lastSegmentCommited = _buffer.Last.Length + bytes;
             if(lastSegmentCommited > _lastFull.Length)

--- a/src/System.Text.Formatting/System/Text/Formatting/SpanFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/SpanFormatter.cs
@@ -2,7 +2,7 @@
 
 namespace System.Text.Formatting
 {
-    public class SpanFormatter : IFormatter
+    public class SpanFormatter : ITextOutput
     {
         Span<byte> _buffer;
         int _count;
@@ -26,7 +26,7 @@ namespace System.Text.Formatting
             _count = 0;
         }
 
-        Span<byte> IFormatter.FreeBuffer
+        Span<byte> IOutput.Buffer
         {
             get
             {
@@ -34,25 +34,24 @@ namespace System.Text.Formatting
             }
         }
 
-        EncodingData IFormatter.Encoding
-        {
-            get
-            {
-                return _encoding;
-            }
-        }
-
-        void IFormatter.ResizeBuffer(int desiredFreeBytesHint)
+        void IOutput.Enlarge(int desiredBufferLength)
         {
             throw new InvalidOperationException("cannot resize fixed size buffers.");
         }
 
-        void IFormatter.CommitBytes(int bytes)
+        void IOutput.Advance(int bytes)
         {
             _count += bytes;
             if(_count > _buffer.Length)
             {
                 throw new InvalidOperationException("More bytes commited than returned from FreeBuffer");
+            }
+        }
+
+        EncodingData ITextOutput.Encoding
+        {
+            get {
+                return _encoding;
             }
         }
     }

--- a/src/System.Text.Formatting/System/Text/Formatting/StringFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/StringFormatter.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace System.Text.Formatting
 {
-    public class StringFormatter : IFormatter, IDisposable
+    public class StringFormatter : ITextOutput, IDisposable
     {
         byte[] _buffer;
         int _count;
@@ -64,7 +64,7 @@ namespace System.Text.Formatting
             return text;
         }
 
-        Span<byte> IFormatter.FreeBuffer
+        Span<byte> IOutput.Buffer
         {
             get { return new Span<byte>(_buffer, _count, _buffer.Length - _count); }
         }
@@ -81,10 +81,10 @@ namespace System.Text.Formatting
             }
         }
 
-        void IFormatter.ResizeBuffer(int desiredFreeBytesHint)
+        void IOutput.Enlarge(int desiredBufferLength)
         {
-            var newSize = desiredFreeBytesHint + _buffer.Length - _count;
-            if(desiredFreeBytesHint == -1){
+            var newSize = desiredBufferLength + _buffer.Length - _count;
+            if(desiredBufferLength == 0){
                 newSize = _buffer.Length * 2;
             }
 
@@ -94,7 +94,7 @@ namespace System.Text.Formatting
             _pool.Return(temp);
         }
 
-        void IFormatter.CommitBytes(int bytes)
+        void IOutput.Advance(int bytes)
         {
             _count += bytes;
         }

--- a/src/System.Text.Http/System/Text/Http/IFormatterHttpExtensions.cs
+++ b/src/System.Text.Http/System/Text/Http/IFormatterHttpExtensions.cs
@@ -13,7 +13,7 @@ namespace System.Text.Http
 
         private const int ULongMaxValueNumberOfCharacters = 20;
 
-        public static void AppendHttpStatusLine<TFormatter>(this TFormatter formatter, HttpVersion version, int statusCode, Utf8String reasonCode) where TFormatter : IFormatter
+        public static void AppendHttpStatusLine<TFormatter>(this TFormatter formatter, HttpVersion version, int statusCode, Utf8String reasonCode) where TFormatter : ITextOutput
         {
             switch (version) {
                 case HttpVersion.V1_0: formatter.Append(Http10); break;
@@ -29,16 +29,16 @@ namespace System.Text.Http
             formatter.AppendHttpNewLine();
         }
 
-        public static void AppendHttpNewLine<TFormatter>(this TFormatter formatter) where TFormatter : IFormatter
+        public static void AppendHttpNewLine<TFormatter>(this TFormatter formatter) where TFormatter : ITextOutput
         {
-            var buffer = formatter.FreeBuffer;
+            var buffer = formatter.Buffer;
             while(buffer.Length < 2) {
-                formatter.ResizeBuffer();
-                buffer = formatter.FreeBuffer;
+                formatter.Enlarge(2);
+                buffer = formatter.Buffer;
             }
             buffer[0] = 13;
             buffer[1] = 10;
-            formatter.CommitBytes(2);
+            formatter.Advance(2);
         }
     }
 }

--- a/src/System.Text.Json/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonWriter.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace System.Text.Json
 {
-    public struct JsonWriter<TFormatter> where TFormatter: IFormatter
+    public struct JsonWriter<TFormatter> where TFormatter: ITextOutput
     {
         TFormatter _formatter;
         bool _wroteListItem;


### PR DESCRIPTION
I split IFormatter into IOutput and ITextOutput.
IOutput represents a general output stream. ITextOutput represents an output stream of text.

I tried to completely get rid of ITextOutput, but then ran into a significant problem: the "formatters", e.g. StringFormatter, ResponseFormatter were not in control of the encoding. The code calling Append could write partial UTF8 and partial UTF16 to lets say response buffers, and the code managing the buffers would not be able to prevent it. 

Also, I tried to rename Enlarge to Ensure. The problem is that Ensure does not make much sense with the default parameter, yet the default parameter is very useful as the calling code often does not know how much space it needs (it just knows it needs more).