### PR TITLE
Fix Memory<T>.Empty

### DIFF
--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -15,7 +15,7 @@ namespace System.Buffers
     /// </remarks>
     public struct Memory<T>
     {
-        public static unsafe Memory<T> Empty = new Memory<T>(null, 0, 0);
+        public static unsafe Memory<T> Empty = default(Memory<T>);
 
         private readonly T[] _array;
         private readonly int _offset;
@@ -24,11 +24,12 @@ namespace System.Buffers
 
         public unsafe Memory(void* pointer, int length)
         {
-            unsafe
+            if (pointer == null)
             {
-                _memory = pointer;
+                throw new ArgumentNullException(nameof(pointer));
             }
 
+            _memory = pointer;
             _array = null;
             _offset = 0;
             _memoryLength = length;

--- a/tests/System.Slices.Tests/BasicUnitTests.cs
+++ b/tests/System.Slices.Tests/BasicUnitTests.cs
@@ -271,6 +271,20 @@ namespace System.Slices.Tests
         }
 
         [Fact]
+        public void EmptyMemoryAcessible()
+        {
+            var empty = Memory<byte>.Empty;
+            Assert.Equal(0, empty.Length);
+            ArraySegment<byte> data;
+            Assert.False(empty.TryGetArray(out data));
+            unsafe
+            {
+                void* pointer;
+                Assert.False(empty.TryGetPointer(out pointer));
+            }
+        }
+
+        [Fact]
         public void GetArrayOrPointer()
         {
             var original = new int[] { 1, 2, 3 };


### PR DESCRIPTION
- Turns out it didn't work after I added the null check
- Added tests

Found this when using it on Channels