### PR TITLE
Renamed CreateArray and TryCopyTo

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/MultispanExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/MultispanExtensions.cs
@@ -45,9 +45,9 @@ namespace System.Buffers
                 }
             }
 
-            first.TryCopyTo(temp);
+            first.CopyTo(temp);
 
-            second.Slice(0, numberOfBytesFromSecond).TryCopyTo(temp.Slice(first.Length));
+            second.Slice(0, numberOfBytesFromSecond).CopyTo(temp.Slice(first.Length));
 
             if (!PrimitiveParser.TryParse(temp, EncodingData.Encoding.Utf8, out value, out consumed)) {
                 return false;

--- a/src/System.Slices/System/DebuggerViews.cs
+++ b/src/System.Slices/System/DebuggerViews.cs
@@ -19,7 +19,7 @@ namespace System
         {
             get
             {
-                return _slice.CreateArray();
+                return _slice.ToArray();
             }
         }
     }

--- a/src/System.Slices/System/ReadOnlySpan.cs
+++ b/src/System.Slices/System/ReadOnlySpan.cs
@@ -177,10 +177,10 @@ namespace System
         /// allocates, so should generally be avoided, however is sometimes
         /// necessary to bridge the gap with APIs written in terms of arrays.
         /// </summary>
-        public T[] CreateArray()
+        public T[] ToArray()
         {
             var dest = new T[Length];
-            TryCopyTo(dest.Slice());
+            CopyTo(dest.Slice());
             return dest;
         }
 
@@ -189,14 +189,13 @@ namespace System
         /// must be at least as big as the source, and may be bigger.
         /// </summary>
         /// <param name="destination">The span to copy items into.</param>
-        public bool TryCopyTo(Span<T> destination)
+        public void CopyTo(Span<T> destination)
         {
             // There are some benefits of making local copies. See https://github.com/dotnet/coreclr/issues/5556
             var dest = destination;
             var src = this;
 
-            if (src.Length > dest.Length)
-                return false;
+            Contract.Requires(src.Length <= dest.Length);
 
             if (default(T) != null && MemoryUtils.IsPrimitiveValueType<T>())
             {
@@ -213,8 +212,6 @@ namespace System
                     UnsafeUtilities.Set(dest.Object, dest.Offset, (UIntPtr)i, value);
                 }
             }
-
-            return true;
         }
 
         /// <summary>
@@ -222,10 +219,10 @@ namespace System
         /// must be at least as big as the source, and may be bigger.
         /// </summary>
         /// <param name="destination">The span to copy items into.</param>
-        public bool TryCopyTo(T[] destination)
+        public void CopyTo(T[] destination)
         {
             var src = new Span<T>(Object, Offset, Length);
-            return src.TryCopyTo(destination);
+            src.CopyTo(destination);
         }
 
         /// <summary>
@@ -328,8 +325,8 @@ namespace System
 
         public bool Equals(T[] other) => Equals(new ReadOnlySpan<T>(other));
 
-        public static bool operator ==(ReadOnlySpan<T> span1, ReadOnlySpan<T> span2) => span1.Equals(span2);
+        public static bool operator ==(ReadOnlySpan<T> left, ReadOnlySpan<T> right) => left.Equals(right);
 
-        public static bool operator !=(ReadOnlySpan<T> span1, ReadOnlySpan<T> span2) => !span1.Equals(span2);
+        public static bool operator !=(ReadOnlySpan<T> left, ReadOnlySpan<T> right) => !left.Equals(right);
     }
 }

--- a/src/System.Slices/System/SpanExtensions.cs
+++ b/src/System.Slices/System/SpanExtensions.cs
@@ -673,14 +673,8 @@ namespace System
 
         public unsafe static void Set(this Span<byte> bytes, byte* values, int length)
         {
-            if (bytes.Length < length) {
-                throw new ArgumentOutOfRangeException("values");
-            }
-
             var valuesSpan = new Span<byte>(values, length);
-            if (!valuesSpan.TryCopyTo(bytes)) {
-                throw new Exception("internal error"); // this should never happen
-            }
+            valuesSpan.CopyTo(bytes);
         }
     }
 }

--- a/src/System.Text.Formatting/System/Text/Formatting/SequenceFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/SequenceFormatter.cs
@@ -70,13 +70,13 @@ namespace System.Text.Formatting
                 var previous = Previous;
                 var spaceInPrevious = previous.Length - _previousWrittenBytes;
                 if(spaceInPrevious < bytes) {
-                    if (!current.Slice(0, spaceInPrevious).TryCopyTo(previous.Slice(_previousWrittenBytes))) throw new NotImplementedException();
-                    current.Slice(spaceInPrevious, bytes - spaceInPrevious).TryCopyTo(current);
+                    current.Slice(0, spaceInPrevious).CopyTo(previous.Slice(_previousWrittenBytes));
+                    current.Slice(spaceInPrevious, bytes - spaceInPrevious).CopyTo(current);
                     _previousWrittenBytes = -1;
                     _currentWrittenBytes = bytes - spaceInPrevious;
                 }
                 else {
-                    if (!current.Slice(0, bytes).TryCopyTo(previous.Slice(_previousWrittenBytes))) throw new NotImplementedException();
+                    current.Slice(0, bytes).CopyTo(previous.Slice(_previousWrittenBytes));
                     _currentPosition = _previousPosition;
                     _currentWrittenBytes = _previousWrittenBytes + bytes;
                 }

--- a/src/System.Text.Utf8/System/Text/Utf8/Utf8String.cs
+++ b/src/System.Text.Utf8/System/Text/Utf8/Utf8String.cs
@@ -476,20 +476,12 @@ namespace System.Text.Utf8
 
         public void CopyTo(Span<byte> buffer)
         {
-            if (buffer.Length < Length)
-            {
-                throw new ArgumentException("buffer");
-            }
-
-            if (!_buffer.TryCopyTo(buffer))
-            {
-                throw new Exception("Internal error: range check already done, no errors expected here");
-            }
+            _buffer.CopyTo(buffer);
         }
 
         public void CopyTo(byte[] buffer)
         {
-            CopyTo(new Span<byte>(buffer));
+            _buffer.CopyTo(buffer);
         }
 
         // TODO: write better hashing function
@@ -728,7 +720,7 @@ namespace System.Text.Utf8
         // TODO: Name TBD, CopyArray? GetBytes?
         public byte[] CopyBytes()
         {
-            return _buffer.CreateArray();
+            return _buffer.ToArray();
         }
 
         public Utf8CodeUnit[] CopyCodeUnits()

--- a/tests/System.Slices.Tests/BasicUnitTests.cs
+++ b/tests/System.Slices.Tests/BasicUnitTests.cs
@@ -12,7 +12,7 @@ namespace System.Slices.Tests
         public void ByteSpanEmptyCreateArrayTest()
         {
             var empty = Span<byte>.Empty;
-            var array = empty.CreateArray();
+            var array = empty.ToArray();
             Assert.Equal(0, array.Length);
         }
 
@@ -20,7 +20,7 @@ namespace System.Slices.Tests
         public void ByteReadOnlySpanEmptyCreateArrayTest()
         {
             var empty = ReadOnlySpan<byte>.Empty;
-            var array = empty.CreateArray();
+            var array = empty.ToArray();
             Assert.Equal(0, array.Length);
         }
 

--- a/tests/System.Slices.Tests/EqualityTests.cs
+++ b/tests/System.Slices.Tests/EqualityTests.cs
@@ -511,7 +511,7 @@ namespace System.Slices.Tests
             // we just don't call memcmp for these structures
             var sliceOfStructuresWithCustomEquals =
                 Enumerable.Range(0, 200).Select(index => new CustomStructWithNonTrivialEquals(index)).ToArray().Slice();
-            var sliceOfSameBytes = sliceOfStructuresWithCustomEquals.CreateArray().Slice();
+            var sliceOfSameBytes = sliceOfStructuresWithCustomEquals.ToArray().Slice();
 
             Assert.False(sliceOfStructuresWithCustomEquals.SequenceEqual(sliceOfSameBytes));
             Assert.False(sliceOfSameBytes.SequenceEqual(sliceOfStructuresWithCustomEquals));
@@ -564,7 +564,7 @@ namespace System.Slices.Tests
         public void AllBytesAreTakenUnderConsideration(int bytesCount)
         {
             var slice = Enumerable.Range(0, bytesCount).Select(index => (byte)index).ToArray().Slice();
-            var copy = slice.CreateArray().Slice();
+            var copy = slice.ToArray().Slice();
 
             for (int i = 0; i < bytesCount; i++)
             {

--- a/tests/System.Slices.Tests/UsageScenarioTests.cs
+++ b/tests/System.Slices.Tests/UsageScenarioTests.cs
@@ -39,7 +39,7 @@ namespace System.Slices.Tests
             Span<byte> span = new Span<byte>(array);
             Assert.Equal(array.Length, span.Length);
 
-            Assert.NotSame(array, span.CreateArray());
+            Assert.NotSame(array, span.ToArray());
             Assert.True(span.Equals(array));
 
             ReadOnlySpan<byte>.Enumerator it = span.GetEnumerator();
@@ -88,7 +88,7 @@ namespace System.Slices.Tests
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(array);
             Assert.Equal(array.Length, span.Length);
 
-            Assert.NotSame(array, span.CreateArray());
+            Assert.NotSame(array, span.ToArray());
             Assert.True(span.Equals(array));
 
             ReadOnlySpan<byte>.Enumerator it = span.GetEnumerator();
@@ -203,7 +203,7 @@ namespace System.Slices.Tests
                 Span<byte> spanA = new Span<byte>(a, aidx, acount);
                 Span<byte> spanB = new Span<byte>(b, bidx, bcount);
 
-                Assert.True(spanA.TryCopyTo(spanB));
+                spanA.CopyTo(spanB);
                 Assert.Equal(expected, b);
 
                 Span<byte> spanExpected = new Span<byte>(expected);
@@ -214,7 +214,7 @@ namespace System.Slices.Tests
             {
                 Span<byte> spanA = new Span<byte>(a, aidx, acount);
                 Span<byte> spanB = new Span<byte>(b, bidx, bcount);
-                Assert.False(spanA.TryCopyTo(spanB));
+                Assert.ThrowsAny<Exception>(() => { spanA.CopyTo(spanB); });
             }
         }
 
@@ -306,7 +306,7 @@ namespace System.Slices.Tests
                 ReadOnlySpan<byte> spanA = new ReadOnlySpan<byte>(a, aidx, acount);
                 Span<byte> spanB = new Span<byte>(b, bidx, bcount);
 
-                Assert.True(spanA.TryCopyTo(spanB));
+                spanA.CopyTo(spanB);
                 Assert.Equal(expected, b);
 
                 ReadOnlySpan<byte> spanExpected = new ReadOnlySpan<byte>(expected);
@@ -317,7 +317,7 @@ namespace System.Slices.Tests
             {
                 ReadOnlySpan<byte> spanA = new ReadOnlySpan<byte>(a, aidx, acount);
                 Span<byte> spanB = new Span<byte>(b, bidx, bcount);
-                Assert.False(spanA.TryCopyTo(spanB));
+                Assert.ThrowsAny<Exception>(() => { spanA.CopyTo(spanB); });              
             }
 
             ReadOnlySpanOfByteCopyToAnotherSpanOfByteTwoDifferentBuffersValidCasesNative(expected, a, aidx, acount, b, bidx, bcount);
@@ -337,7 +337,7 @@ namespace System.Slices.Tests
             Span<byte> spanB = nb.Slice(bidx, bcount);
 
             if (expected != null) {               
-                Assert.True(spanA.TryCopyTo(spanB));
+                spanA.CopyTo(spanB);
                 Assert.Equal(expected, b);
 
                 ReadOnlySpan<byte> spanExpected = new ReadOnlySpan<byte>(expected);
@@ -345,7 +345,7 @@ namespace System.Slices.Tests
                 Assert.True(spanExpected.SequenceEqual(spanBAll));
             }
             else {
-                Assert.False(spanA.TryCopyTo(spanB));
+                Assert.ThrowsAny<Exception>(() => { spanA.CopyTo(spanB); });
             }
 
             Marshal.FreeHGlobal(pa);
@@ -394,7 +394,7 @@ namespace System.Slices.Tests
             {
                 Span<byte> spanA = new Span<byte>(a, aidx, acount);
 
-                Assert.True(spanA.TryCopyTo(b));
+                spanA.CopyTo(b);
                 Assert.Equal(expected, b);
 
                 Span<byte> spanExpected = new Span<byte>(expected);
@@ -404,7 +404,7 @@ namespace System.Slices.Tests
             else
             {
                 Span<byte> spanA = new Span<byte>(a, aidx, acount);
-                Assert.False(spanA.TryCopyTo(b));
+                Assert.ThrowsAny<Exception>(() => { spanA.CopyTo(b); });
             }
         }
 
@@ -450,7 +450,7 @@ namespace System.Slices.Tests
             {
                 ReadOnlySpan<byte> spanA = new ReadOnlySpan<byte>(a, aidx, acount);
 
-                Assert.True(spanA.TryCopyTo(b));
+                spanA.CopyTo(b);
                 Assert.Equal(expected, b);
 
                 ReadOnlySpan<byte> spanExpected = new ReadOnlySpan<byte>(expected);
@@ -460,7 +460,7 @@ namespace System.Slices.Tests
             else
             {
                 ReadOnlySpan<byte> spanA = new ReadOnlySpan<byte>(a, aidx, acount);
-                Assert.False(spanA.TryCopyTo(b));
+                Assert.ThrowsAny<Exception>(() => { spanA.CopyTo(b); });
             }
         }
     }


### PR DESCRIPTION
For consistency with many existing Fx APIs, I renamed:
- TryCopyTo to CopyTo
- CreateArray to ToArray