### PR TITLE
Fixed #869

### DIFF
--- a/src/System.Text.Utf8/System/Text/UnicodeCodePoint.cs
+++ b/src/System.Text.Utf8/System/Text/UnicodeCodePoint.cs
@@ -41,6 +41,12 @@ namespace System.Text
         {
             return codePoint.Value >= UnicodeConstants.Utf16HighSurrogateFirstCodePoint && codePoint.Value <= UnicodeConstants.Utf16HighSurrogateLastCodePoint;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsBmp(UnicodeCodePoint codePoint)
+        {
+            return ((uint)codePoint < 0x10000);
+        }
         #endregion
 
         public static explicit operator uint(UnicodeCodePoint codePoint) { return codePoint.Value; }
@@ -81,6 +87,11 @@ namespace System.Text
         public static bool IsWhitespace(UnicodeCodePoint codePoint)
         {
             return Array.BinarySearch<uint>(UnicodeConstants.SortedWhitespaceCodePoints, codePoint.Value) >= 0;
+        }
+
+        public override string ToString()
+        {
+            return Value.ToString("x");
         }
     }
 }

--- a/src/System.Text.Utf8/System/Text/Utf16/Utf16LittleEndianEncoder.cs
+++ b/src/System.Text.Utf8/System/Text/Utf16/Utf16LittleEndianEncoder.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Text.Utf16
 {
     public static class Utf16LittleEndianEncoder
@@ -66,9 +68,7 @@ namespace System.Text.Utf16
                 return false;
             }
 
-            // TODO: Can we add this in UnicodeCodePoint class?
-            // Should be represented as Surrogate?
-            encodedBytes = ((uint)codePoint >= 0x10000) ? 4 : 2;
+            encodedBytes = UnicodeCodePoint.IsBmp(codePoint) ? 2 : 4;
 
             if (buffer.Length < encodedBytes)
             {
@@ -89,9 +89,9 @@ namespace System.Text.Utf16
             {
                 unchecked
                 {
-                    uint highSurrogate = ((uint)codePoint >> 10) + UnicodeConstants.Utf16HighSurrogateFirstCodePoint;
-                    uint lowSurrogate = ((uint)codePoint & MaskLow10Bits) + UnicodeConstants.Utf16LowSurrogateFirstCodePoint;
-
+                    uint codePointValue = (uint)codePoint;
+                    uint highSurrogate = ((codePointValue - 0x010000u) >> 10) + UnicodeConstants.Utf16HighSurrogateFirstCodePoint;
+                    uint lowSurrogate = (codePointValue & MaskLow10Bits) + UnicodeConstants.Utf16LowSurrogateFirstCodePoint;
                     buffer.Write(highSurrogate | (lowSurrogate << 16));
                 }
             }

--- a/src/System.Text.Utf8/System/Text/Utf8/Utf8String.cs
+++ b/src/System.Text.Utf8/System/Text/Utf8/Utf8String.cs
@@ -149,7 +149,7 @@ namespace System.Text.Utf8
             foreach (var codePoint in CodePoints)
             {
                 len++;
-                if (UnicodeCodePoint.IsSurrogate(codePoint))
+                if (!UnicodeCodePoint.IsBmp(codePoint))
                 {
                     len++;
                 }
@@ -161,7 +161,7 @@ namespace System.Text.Utf8
                 char* stackChars = null;
                 char[] characters = null;
 
-                if (len <= 256)
+                if (len <= 256) 
                 {
                     char* stackallocedChars = stackalloc char[len];
                     stackChars = stackallocedChars;

--- a/tests/System.Text.Utf8.Tests/Bugs.cs
+++ b/tests/System.Text.Utf8.Tests/Bugs.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.Utf16;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Text.Utf8.Tests
+{
+    public class BugTests
+    {
+        [Fact]
+        //[Fact(Skip = "issue #869")]
+        public void Bug869DoesNotRepro()
+        {
+            var bytes = new byte[] { 0xF0, 0xA4, 0xAD, 0xA2 };
+            var utf8String = new Utf8String(bytes);
+            var str = "𤭢";
+            var strFromUtf8 = utf8String.ToString();
+
+            Assert.Equal(str, strFromUtf8);
+        }
+    }
+}


### PR DESCRIPTION
The existing code was checking if a code point is a surrogate characters, but it should be checking for whether the code point needs a surrogate characters.

Also the encoder was incorrectly computing the high surrogate value.