### PR TITLE
RFC: Memory struct inheritence

### DIFF
--- a/samples/LibuvWithNonAllocatingFormatters/Program.cs
+++ b/samples/LibuvWithNonAllocatingFormatters/Program.cs
@@ -93,7 +93,7 @@ namespace LibuvWithNonAllocatingFormatters
                     var segment = formatter.Formatted;
                     unsafe {
                         fixed (byte* p = segment.Array) {
-                            var response = new Memory<byte>(segment.Array, segment.Offset, segment.Count, pointer: p);
+                            var response = new UnsafeMemory<byte>(segment.Array, segment.Offset, segment.Count, pointer: p);
                             connection.TryWrite(response);
                         }
                     }

--- a/samples/LowAllocationWebServer/Framework/SharedData.cs
+++ b/samples/LowAllocationWebServer/Framework/SharedData.cs
@@ -162,9 +162,9 @@ namespace Microsoft.Net.Http
                 Id = id;
             }
 
-            public Memory<byte> Commited
+            public UnsafeMemory<byte> Commited
             {
-                get { return new Memory<byte>(Array.Array, Array.Offset, Array.Count); }
+                get { return new UnsafeMemory<byte>(Array.Array, Array.Offset, Array.Count); }
             }
 
             public Span<byte> Free

--- a/samples/LowAllocationWebServer/Framework/TcpServer.cs
+++ b/samples/LowAllocationWebServer/Framework/TcpServer.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Net.Sockets
             SocketImports.closesocket(_handle);
         }
 
-        public int Send(Memory<byte> buffer)
+        public int Send(UnsafeMemory<byte> buffer)
         {
             // This can work with Span<byte> because it's synchronous but we need pinning support
             unsafe {
@@ -189,7 +189,7 @@ namespace Microsoft.Net.Sockets
             }
         }
 
-        public int Receive(Memory<byte> buffer)
+        public int Receive(UnsafeMemory<byte> buffer)
         {
             // This can work with Span<byte> because it's synchronous but we need pinning support
             unsafe

--- a/src/System.Buffers.Experimental/System/Buffers/BufferPool.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferPool.cs
@@ -5,9 +5,9 @@ namespace System.Buffers
 {
     public abstract class BufferPool : IDisposable
     {
-        public abstract Memory<byte> Rent(int minimumBufferSize);
+        public abstract UnsafeMemory<byte> Rent(int minimumBufferSize);
 
-        public abstract void Return(Memory<byte> buffer);
+        public abstract void Return(UnsafeMemory<byte> buffer);
 
         public void Dispose()
         {

--- a/src/System.Buffers.Experimental/System/Buffers/ManagedBufferPool.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/ManagedBufferPool.cs
@@ -15,13 +15,13 @@ namespace System.Buffers
             }
         }
 
-        public override Memory<byte> Rent(int minimumBufferSize)
+        public override UnsafeMemory<byte> Rent(int minimumBufferSize)
         {
             var array = ArrayPool<byte>.Shared.Rent(minimumBufferSize);
-            return new Memory<byte>(array, 0, array.Length);
+            return new UnsafeMemory<byte>(array, 0, array.Length);
         }
 
-        public override void Return(Memory<byte> buffer)
+        public override void Return(UnsafeMemory<byte> buffer)
         {
             ArraySegment<byte> segment;
             unsafe

--- a/src/System.Buffers.Experimental/System/Buffers/NativeBufferPool.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/NativeBufferPool.cs
@@ -38,7 +38,7 @@ namespace System.Buffers
             Marshal.FreeHGlobal(_memory);
         }
 
-        public override Memory<byte> Rent(int numberOfBytes)
+        public override UnsafeMemory<byte> Rent(int numberOfBytes)
         {
             if (numberOfBytes < 1) throw new ArgumentOutOfRangeException(nameof(numberOfBytes));
             if (numberOfBytes > _bufferSize) new NotSupportedException();
@@ -57,10 +57,10 @@ namespace System.Buffers
                     throw new NotImplementedException("no more buffers to rent");
             }
 
-            return new Memory<byte>((byte*)(_memory + i * _bufferSize), _bufferSize);
+            return new UnsafeMemory<byte>((byte*)(_memory + i * _bufferSize), _bufferSize);
         }
 
-        public override void Return(Memory<byte> buffer)
+        public override void Return(UnsafeMemory<byte> buffer)
         {
             void* pointer;
             if(!buffer.TryGetPointer(out pointer)) {

--- a/src/System.Net.Libuv/System/Net/Libuv/Buffer.cs
+++ b/src/System.Net.Libuv/System/Net/Libuv/Buffer.cs
@@ -20,7 +20,7 @@ namespace System.Net.Libuv
             AllocWindowsBuffer = OnAllocateWindowsBuffer;
         }
 
-        internal static void FreeBuffer(Memory<byte> buffer)
+        internal static void FreeBuffer(UnsafeMemory<byte> buffer)
         {
             _pool.Return(buffer);
         }
@@ -70,7 +70,7 @@ namespace System.Net.Libuv
             {
                 unsafe
                 {
-                    FreeBuffer(new Memory<byte>(Buffer.ToPointer(), (int)Length));
+                    FreeBuffer(new UnsafeMemory<byte>(Buffer.ToPointer(), (int)Length));
                     Length = 0;
                     Buffer = IntPtr.Zero;
                 }
@@ -93,7 +93,7 @@ namespace System.Net.Libuv
             {
                 unsafe
                 {
-                    FreeBuffer(new Memory<byte>((byte*)Buffer.ToPointer(), Length.ToInt32()));
+                    FreeBuffer(new UnsafeMemory<byte>((byte*)Buffer.ToPointer(), Length.ToInt32()));
                     Length = IntPtr.Zero;
                     Buffer = IntPtr.Zero;
                 }

--- a/src/System.Net.Libuv/System/Net/Libuv/Stream.cs
+++ b/src/System.Net.Libuv/System/Net/Libuv/Stream.cs
@@ -27,7 +27,7 @@ namespace System.Net.Libuv
             }
         }
 
-        public event Action<Memory<byte>> ReadCompleted;
+        public event Action<UnsafeMemory<byte>> ReadCompleted;
         public event Action EndOfStream;
 
         public unsafe void TryWrite(byte[] data)
@@ -77,7 +77,7 @@ namespace System.Net.Libuv
             }
         }
 
-        public unsafe void TryWrite(Memory<byte> data)
+        public unsafe void TryWrite(UnsafeMemory<byte> data)
         {
             // This can work with Span<byte> because it's synchronous but we need pinning support
             EnsureNotDisposed();
@@ -144,7 +144,7 @@ namespace System.Net.Libuv
             }
             else
             {
-                var readSlice = new Memory<byte>((byte*)buffer.Buffer, (int)bytesRead);
+                var readSlice = new UnsafeMemory<byte>((byte*)buffer.Buffer, (int)bytesRead);
                 OnReadCompleted(readSlice);
                 buffer.Dispose();
             }
@@ -175,13 +175,13 @@ namespace System.Net.Libuv
             {
                 // This can be a Span<byte> but the samples pass it directly to TryWrite which
                 // needs to unpack the data and turn it back into either an array or native memory
-                var readSlice = new Memory<byte>((byte*)buffer.Buffer, (int)bytesRead);
+                var readSlice = new UnsafeMemory<byte>((byte*)buffer.Buffer, (int)bytesRead);
                 OnReadCompleted(readSlice);
                 buffer.Dispose();
             }
         }
 
-        void OnReadCompleted(Memory<byte> bytesRead)
+        void OnReadCompleted(UnsafeMemory<byte> bytesRead)
         {
             if (ReadCompleted != null)
             {

--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Runtime;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Buffers
 {
@@ -13,24 +14,14 @@ namespace System.Buffers
     /// <remarks>
     /// This struct is not safe for multithreaded access, i.e. it's subject to struct tearing that can result in unsafe memory access. 
     /// </remarks>
+    [StructLayout(LayoutKind.Sequential)]
     public struct Memory<T>
     {
-        public static unsafe Memory<T> Empty = default(Memory<T>);
+        public static Memory<T> Empty = default(Memory<T>);
 
         private readonly T[] _array;
-        private readonly int _offset;
-        private readonly unsafe void* _memory;
         private readonly int _memoryLength;
-
-        public unsafe Memory(void* pointer, int length)
-        {
-            Contract.RequiresNotNull(ExceptionArgument.pointer, pointer);
-
-            _memory = pointer;
-            _array = null;
-            _offset = 0;
-            _memoryLength = length;
-        }
+        private readonly int _offset;
 
         public Memory(T[] array) : this(array, 0, array?.Length ?? 0)
         {
@@ -40,87 +31,30 @@ namespace System.Buffers
         {
             Contract.RequiresNotNull(ExceptionArgument.array, array);
 
-            unsafe
-            {
-                _memory = null;
-            }
-
             _array = array;
-            _offset = offset;
             _memoryLength = length;
+            _offset = offset;
         }
 
-        public unsafe Memory(T[] array, int offset, int length, void* pointer = null)
+        // Used by UnsafeMemory
+        internal Memory(int offset, int length)
         {
-            Contract.RequiresNotNull(ExceptionArgument.array, array);
+            _array = null;
+            _memoryLength = length;
+            _offset = offset;
+        }
 
-            unsafe
-            {
-                if (pointer != null)
-                {
-                    _memory = Unsafe.AsPointer(ref array[offset]);
-
-                    Contract.RequiresSameReference(_memory, pointer);
-                }
-                else
-                {
-                    _memory = null;
-                }
-            }
-
+        // Used by UnsafeMemory
+        internal Memory(int offset, int length, T[] array)
+        {
             _array = array;
-            _offset = offset;
             _memoryLength = length;
-        }
-
-        internal unsafe Memory(int offset, int length, T[] array, void* pointer = null)
-        {
-            Contract.RequiresOneNotNull(array, pointer);
-
-            unsafe
-            {
-                if (array != null && pointer != null)
-                {
-                    _memory = Unsafe.AsPointer(ref array[offset]);
-
-                    Contract.RequiresSameReference(_memory, pointer);
-                }
-                else
-                {
-                    _memory = pointer;
-                }
-            }
-
-            _array = array;
             _offset = offset;
-            _memoryLength = length;
         }
 
-        public Span<T> Span
-        {
-            get
-            {
-                if (Length == 0)
-                {
-                    return Span<T>.Empty;
-                }
+        public bool IsArraySet => _array != null;
 
-                if (_array != null)
-                {
-                    return _array.Slice(_offset, Length);
-                }
-                else
-                {
-                    unsafe
-                    {
-                        void* pointer;
-                        // This shouldn't fail
-                        TryGetPointer(out pointer);
-                        return new Span<T>(pointer, Length);
-                    }
-                }
-            }
-        }
+        public Span<T> Span => Length == 0 ? Span<T>.Empty : _array.Slice(_offset, Length);
 
         public bool IsEmpty => Length == 0;
 
@@ -134,29 +68,27 @@ namespace System.Buffers
             return memory.Span;
         }
 
+        public static implicit operator UnsafeMemory<T>(Memory<T> memory)
+        {
+            return new UnsafeMemory<T>(memory);
+        }
+
         public int Length => _memoryLength;
 
-        public unsafe Memory<T> Slice(int offset, int length)
+        public Memory<T> Slice(int offset, int length)
         {
             // TODO: Bounds check
-            return new Memory<T>(_offset + offset, length, _array, _memory == null ? null : Add(_memory, offset));
+            return new Memory<T>(_array, _offset + offset, length);
         }
 
-        public unsafe Memory<T> Slice(int offset)
+        internal Memory<T> SliceUnsafe(int offset, int length)
+        {
+            return new Memory<T>(_offset + offset, length, _array);
+        }
+
+        public Memory<T> Slice(int offset)
         {
             return Slice(offset, Length - offset);
-        }
-
-        public unsafe bool TryGetPointer(out void* pointer)
-        {
-            if (_memory == null)
-            {
-                pointer = null;
-                return false;
-            }
-
-            pointer = _memory;
-            return true;
         }
 
         public bool TryGetArray(out ArraySegment<T> buffer)
@@ -166,14 +98,9 @@ namespace System.Buffers
                 buffer = default(ArraySegment<T>);
                 return false;
             }
+            
             buffer = new ArraySegment<T>(_array, _offset, Length);
             return true;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe void* Add(void* pointer, int offset)
-        {
-            return (byte*)pointer + ((ulong)Unsafe.SizeOf<T>() * (ulong)offset);
         }
     }
 }

--- a/src/System.Slices/System/Buffers/UnsafeMemory.cs
+++ b/src/System.Slices/System/Buffers/UnsafeMemory.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Buffers
+{
+    /// <summary>
+    /// Represents a Span<byte> factory</byte>
+    /// </summary>
+    /// <remarks>
+    /// This struct is not safe for multithreaded access, i.e. it's subject to struct tearing that can result in unsafe memory access. 
+    /// </remarks>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct UnsafeMemory<T>
+    {
+        public static UnsafeMemory<T> Empty = default(UnsafeMemory<T>);
+
+        private readonly unsafe void* _ptrMemory;
+        private Memory<T> _memory;
+
+        internal unsafe UnsafeMemory(Memory<T> memory)
+        {
+            _ptrMemory = null;
+            _memory = memory;
+        }
+
+        public unsafe UnsafeMemory(void* pointer, int length)
+        {
+            Contract.RequiresNotNull(ExceptionArgument.pointer, pointer);
+
+            _ptrMemory = pointer;
+            _memory = new Memory<T>(0, length);
+        }
+
+        public UnsafeMemory(T[] array) : this(array, 0, array?.Length ?? 0)
+        {
+        }
+
+        public UnsafeMemory(T[] array, int offset, int length)
+        {
+            _memory = new Memory<T>(array, offset, length);
+
+            unsafe
+            {
+                _ptrMemory = null;
+            }
+        }
+
+        public unsafe UnsafeMemory(T[] array, int offset, int length, void* pointer = null)
+        {
+            _memory = new Memory<T>(array, offset, length);
+
+            unsafe
+            {
+                if (pointer != null)
+                {
+                    _ptrMemory = Unsafe.AsPointer(ref array[offset]);
+
+                    Contract.RequiresSameReference(_ptrMemory, pointer);
+                }
+                else
+                {
+                    _ptrMemory = null;
+                }
+            }
+
+        }
+
+        internal unsafe UnsafeMemory(Memory<T> memory, void* pointer = null)
+        {
+            _memory = memory;
+            _ptrMemory = pointer;
+        }
+
+        public Span<T> Span
+        {
+            get
+            {
+                if (Length == 0)
+                {
+                    return Span<T>.Empty;
+                }
+
+                if (_memory.IsArraySet)
+                {
+                    return _memory.Slice(Length);
+                }
+                else
+                {
+                    unsafe
+                    {
+                        void* pointer;
+                        // This shouldn't fail
+                        TryGetPointer(out pointer);
+                        return new Span<T>(pointer, Length);
+                    }
+                }
+            }
+        }
+
+        public bool IsEmpty => Length == 0;
+
+        public static implicit operator Span<T>(UnsafeMemory<T> memory)
+        {
+            return memory.Span;
+        }
+
+        public static implicit operator ReadOnlySpan<T>(UnsafeMemory<T> memory)
+        {
+            return memory.Span;
+        }
+
+        public int Length => _memory.Length;
+
+        public unsafe UnsafeMemory<T> Slice(int offset, int length)
+        {
+            // TODO: Bounds check
+            return new UnsafeMemory<T>(_memory.SliceUnsafe(offset, length), _ptrMemory == null ? null : Add(_ptrMemory, offset));
+        }
+
+        public UnsafeMemory<T> Slice(int offset)
+        {
+            return Slice(offset, Length - offset);
+        }
+
+        public unsafe bool TryGetPointer(out void* pointer)
+        {
+            if (_ptrMemory == null)
+            {
+                pointer = null;
+                return false;
+            }
+
+            pointer = _ptrMemory;
+            return true;
+        }
+
+        public bool TryGetArray(out ArraySegment<T> buffer)
+        {
+            return _memory.TryGetArray(out buffer);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe void* Add(void* pointer, int offset)
+        {
+            return (byte*)pointer + ((ulong)Unsafe.SizeOf<T>() * (ulong)offset);
+        }
+    }
+}

--- a/src/System.Text.Json/System/Text/Json/JsonParseObject.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonParseObject.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json
     public struct JsonObject : IDisposable
     {
         private BufferPool _pool;
-        private Memory<byte> _dbMemory;
+        private UnsafeMemory<byte> _dbMemory;
         private ReadOnlySpan<byte> _db; 
         private ReadOnlySpan<byte> _values;
 
@@ -28,7 +28,7 @@ namespace System.Text.Json
             return result;
         }
 
-        internal JsonObject(ReadOnlySpan<byte> values, ReadOnlySpan<byte> db, BufferPool pool = null, Memory<byte> dbMemory = default(Memory<byte>))
+        internal JsonObject(ReadOnlySpan<byte> values, ReadOnlySpan<byte> db, BufferPool pool = null, UnsafeMemory<byte> dbMemory = default(UnsafeMemory<byte>))
         {
             _db = db;
             _values = values;
@@ -65,7 +65,7 @@ namespace System.Text.Json
                         newEnd = newEnd + DbRow.Size * record.Length;
                     }
 
-                    value = new JsonObject(_values, _db.Slice(newStart, newEnd - newStart), null, Memory<byte>.Empty);
+                    value = new JsonObject(_values, _db.Slice(newStart, newEnd - newStart), null, UnsafeMemory<byte>.Empty);
                     return true;
                 }
 
@@ -346,7 +346,7 @@ namespace System.Text.Json
             _db = ReadOnlySpan<byte>.Empty;
             _values = ReadOnlySpan<byte>.Empty;
             _pool.Return(_dbMemory);
-            _dbMemory = Memory<byte>.Empty;
+            _dbMemory = UnsafeMemory<byte>.Empty;
         }
     }
 }

--- a/src/System.Text.Json/System/Text/Json/JsonParser.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonParser.cs
@@ -101,7 +101,7 @@ namespace System.Text.Json
             return value;
         }
 
-        internal void Resize(Memory<byte> newStackMemory)
+        internal void Resize(UnsafeMemory<byte> newStackMemory)
         {
             _memory.Slice(0, Math.Max(objectStackCount, arrayStackCount) * 8).CopyTo(newStackMemory);
             _memory = newStackMemory;
@@ -112,7 +112,7 @@ namespace System.Text.Json
     {
         private Span<byte> _db;
         private ReadOnlySpan<byte> _values;
-        private Memory<byte> _scratch;
+        private UnsafeMemory<byte> _scratch;
         BufferPool _pool;
         TwoStacks _stack;
 
@@ -206,7 +206,7 @@ namespace System.Text.Json
             }
 
             var result =  new JsonObject(_values, _db.Slice(0, _dbIndex), _pool, _scratch);
-            _scratch = Memory<byte>.Empty;
+            _scratch = UnsafeMemory<byte>.Empty;
             return result;
         }
 

--- a/tests/System.Slices.Tests/BasicUnitTests.cs
+++ b/tests/System.Slices.Tests/BasicUnitTests.cs
@@ -273,7 +273,7 @@ namespace System.Slices.Tests
         [Fact]
         public void EmptyMemoryAcessible()
         {
-            var empty = Memory<byte>.Empty;
+            var empty = UnsafeMemory<byte>.Empty;
             Assert.Equal(0, empty.Length);
             ArraySegment<byte> data;
             Assert.False(empty.TryGetArray(out data));
@@ -289,20 +289,20 @@ namespace System.Slices.Tests
         {
             var original = new int[] { 1, 2, 3 };
             ArraySegment<int> array;
-            Memory<int> slice;
+            UnsafeMemory<int> slice;
 
-            slice = new Memory<int>(original, 1, 2);
+            slice = new UnsafeMemory<int>(original, 1, 2);
             Assert.True(slice.TryGetArray(out array));
             Assert.Equal(2, array.Array[array.Offset + 0]);
             Assert.Equal(3, array.Array[array.Offset + 1]);
 
-            slice = new Memory<int>(original, 0, 3);
+            slice = new UnsafeMemory<int>(original, 0, 3);
             Assert.True(slice.TryGetArray(out array));
             Assert.Equal(1, array.Array[array.Offset + 0]);
             Assert.Equal(2, array.Array[array.Offset + 1]);
             Assert.Equal(3, array.Array[array.Offset + 2]);
 
-            slice = new Memory<int>(original, 0, 0);
+            slice = new UnsafeMemory<int>(original, 0, 0);
             Assert.True(slice.TryGetArray(out array));
             Assert.Equal(0, array.Offset);
             Assert.Equal(original, array.Array);
@@ -312,7 +312,7 @@ namespace System.Slices.Tests
             {
                 fixed (int* pBytes = original)
                 {
-                    slice = new Memory<int>(pBytes, 1);
+                    slice = new UnsafeMemory<int>(pBytes, 1);
                     Assert.False(slice.TryGetArray(out array));
                     void* p;
                     Assert.True(slice.TryGetPointer(out p));
@@ -343,7 +343,7 @@ namespace System.Slices.Tests
         public void TryGetPointerReturnsFalseIfNotPinned()
         {
             var data = new byte[10];
-            var memory = new Memory<byte>(data, 0, data.Length);
+            var memory = new UnsafeMemory<byte>(data, 0, data.Length);
             unsafe
             {
                 void* pointer;
@@ -357,7 +357,7 @@ namespace System.Slices.Tests
             unsafe
             {
                 IntPtr raw = Marshal.AllocHGlobal(10);
-                var memory = new Memory<byte>((void*)raw, 10);
+                var memory = new UnsafeMemory<byte>((void*)raw, 10);
                 void* pointer;
                 Assert.True(memory.TryGetPointer(out pointer));
                 Assert.True(raw.ToPointer() == pointer);
@@ -373,7 +373,7 @@ namespace System.Slices.Tests
                 var data = new byte[10];
                 fixed (byte* ptr = data)
                 {
-                    var memory = new Memory<byte>(data, 0, data.Length, ptr);
+                    var memory = new UnsafeMemory<byte>(data, 0, data.Length, ptr);
                     void* pointer;
                     Assert.True(memory.TryGetPointer(out pointer));
                     Assert.True(ptr == pointer);
@@ -392,7 +392,7 @@ namespace System.Slices.Tests
 
                     fixed (byte* ptr = data)
                     {
-                        var memory = new Memory<byte>(data, 0, data.Length, ptr + 1);
+                        var memory = new UnsafeMemory<byte>(data, 0, data.Length, ptr + 1);
                     }
                 }
             });
@@ -411,7 +411,7 @@ namespace System.Slices.Tests
 
                 fixed (byte* ptr = data)
                 {
-                    var memory = new Memory<byte>(data, 5, 5, ptr + 5);
+                    var memory = new UnsafeMemory<byte>(data, 5, 5, ptr + 5);
                     Assert.Equal(5, memory.Length);
                     var span = memory.Span;
                     for (int i = 0; i < 5; i++)
@@ -432,7 +432,7 @@ namespace System.Slices.Tests
                 data[i] = (byte)i;
             }
 
-            var memory = new Memory<byte>(data, 0, data.Length);
+            var memory = new UnsafeMemory<byte>(data, 0, data.Length);
             var slice = memory.Slice(0, 5);
             var span = slice.Span;
             for (int i = 0; i < 5; i++)
@@ -457,7 +457,7 @@ namespace System.Slices.Tests
 
                 fixed (byte* ptr = data)
                 {
-                    var memory = new Memory<byte>(ptr, data.Length);
+                    var memory = new UnsafeMemory<byte>(ptr, data.Length);
                     var slice = memory.Slice(0, 5);
                     var span = slice.Span;
                     for (int i = 0; i < 5; i++)


### PR DESCRIPTION
Memory->UnsafeMemory
Add Memory

The structs compose:
```csharp
struct Memory<T>
{
    byte[] Array;
    int Offset;
    int Length;
}

struct UnsafeMemory<T>
{
    void* Pointer;
    Memory<T> Memory;
}
```
In `Memory` the worst that can happen with a torn read is an Exception for a range check failure on the array and the array doesn't need extra protection as its GC handled.

In `UnsafeMemory` a torn read could lead to an out of boundary access and you may desire it to have an extra class reference for protection to detect disposal of the memory.

I think some of the uses of `UnsafeMemory` could be changed to `Memory`

/cc @jkotas @davidfowl @KrzysztofCwalina 