### PR TITLE
Make Memory more inlinable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,4 @@ nuget.exe
 
 # VS Code Files
 .vscode
+*.props

--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -24,10 +24,7 @@ namespace System.Buffers
 
         public unsafe Memory(void* pointer, int length)
         {
-            if (pointer == null)
-            {
-                throw new ArgumentNullException(nameof(pointer));
-            }
+            Contract.RequiresNotNull(ExceptionArgument.pointer, pointer);
 
             _memory = pointer;
             _array = null;
@@ -41,10 +38,7 @@ namespace System.Buffers
 
         public Memory(T[] array, int offset, int length)
         {
-            if (array == null)
-            {
-                throw new ArgumentNullException(nameof(array));
-            }
+            Contract.RequiresNotNull(ExceptionArgument.array, array);
 
             unsafe
             {
@@ -58,10 +52,7 @@ namespace System.Buffers
 
         public unsafe Memory(T[] array, int offset, int length, void* pointer = null)
         {
-            if (array == null)
-            {
-                throw new ArgumentNullException(nameof(array));
-            }
+            Contract.RequiresNotNull(ExceptionArgument.array, array);
 
             unsafe
             {
@@ -69,10 +60,7 @@ namespace System.Buffers
                 {
                     _memory = Unsafe.AsPointer(ref array[offset]);
 
-                    if (_memory != pointer)
-                    {
-                        throw new ArgumentException(nameof(pointer));
-                    }
+                    Contract.RequiresSameReference(_memory, pointer);
                 }
                 else
                 {

--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -73,6 +73,29 @@ namespace System.Buffers
             _memoryLength = length;
         }
 
+        internal unsafe Memory(int offset, int length, T[] array, void* pointer = null)
+        {
+            Contract.RequiresOneNotNull(array, pointer);
+
+            unsafe
+            {
+                if (array != null && pointer != null)
+                {
+                    _memory = Unsafe.AsPointer(ref array[offset]);
+
+                    Contract.RequiresSameReference(_memory, pointer);
+                }
+                else
+                {
+                    _memory = pointer;
+                }
+            }
+
+            _array = array;
+            _offset = offset;
+            _memoryLength = length;
+        }
+
         public Span<T> Span
         {
             get
@@ -116,12 +139,7 @@ namespace System.Buffers
         public unsafe Memory<T> Slice(int offset, int length)
         {
             // TODO: Bounds check
-            if (_array == null)
-            {
-                return new Memory<T>(Add(_memory, offset), length);
-            }
-
-            return new Memory<T>(_array, _offset + offset, length, _memory == null ? null : Add(_memory, offset));
+            return new Memory<T>(_offset + offset, length, _array, _memory == null ? null : Add(_memory, offset));
         }
 
         public unsafe Memory<T> Slice(int offset)

--- a/src/System.Slices/System/Collections/ReadOnlySpanSequence.cs
+++ b/src/System.Slices/System/Collections/ReadOnlySpanSequence.cs
@@ -46,10 +46,12 @@ namespace System.Collections.Sequences
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get {
                 ReadOnlySpan<T> span;
-                if(_sequence.TryGet(ref _position, out span, advance: false)) {
-                    return span;
+                if(!_sequence.TryGet(ref _position, out span, advance: false))
+                {
+                    ThrowHelper.ThrowInvalidOperationException();
                 }
-                throw new InvalidOperationException();
+
+                return span;
             }
         }
     }

--- a/src/System.Slices/System/Collections/SpanSequence.cs
+++ b/src/System.Slices/System/Collections/SpanSequence.cs
@@ -36,10 +36,12 @@ namespace System.Collections.Sequences
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get {
                 Span<T> span;
-                if(_sequence.TryGet(ref _position, out span, advance: false)) {
-                    return span;
+                if (!_sequence.TryGet(ref _position, out span, advance: false))
+                {
+                    ThrowHelper.ThrowInvalidOperationException();
                 }
-                throw new InvalidOperationException();
+
+                return span;
             }
         }
     }

--- a/src/System.Slices/System/Collections/SpanSequenceExtensions.cs
+++ b/src/System.Slices/System/Collections/SpanSequenceExtensions.cs
@@ -58,10 +58,11 @@ namespace System.Collections.Sequences
         {
             Span<T> result;
             var first = Position.First;
-            if(sequence.TryGet(ref first, out result)) {
-                return result;
+            if(!sequence.TryGet(ref first, out result)) {
+                ThrowHelper.ThrowInvalidOperationException();
             }
-            throw new Exception();
+
+            return result;
         }
 
         /// <summary>

--- a/src/System.Slices/System/Contract.cs
+++ b/src/System.Slices/System/Contract.cs
@@ -78,7 +78,16 @@ namespace System
                 ThrowHelper.ThrowArgumentOutOfRangeException();
             }
         }
-        
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe void RequiresOneNotNull<T>(T[] array, void* pointer)
+        {
+            if (array == null && pointer == null)
+            {
+                ThrowHelper.ThrowArgumentException();
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void RequiresInInclusiveRange( uint start, uint length)
         {

--- a/src/System.Slices/System/Contract.cs
+++ b/src/System.Slices/System/Contract.cs
@@ -5,14 +5,41 @@ using System.Runtime.CompilerServices;
 
 namespace System
 {
-    static class Contract
+    internal static class Contract
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Requires(bool condition)
         {
             if (!condition)
             {
-                ThrowArgumentException();
+                ThrowHelper.ThrowArgumentException();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void RequiresNotNull<T>(ExceptionArgument argument, T obj) where T : class 
+        {
+            if (obj == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(argument);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void RequiresNotNull(ExceptionArgument argument, void* ptr)
+        {
+            if (ptr == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(argument);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void RequiresSameReference(void* ptr0, void* ptr1)
+        {
+            if (ptr0 != ptr1)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.pointer);
             }
         }
 
@@ -21,7 +48,7 @@ namespace System
         {
             if (n < 0)
             {
-                ThrowArgumentOutOfRangeException();
+                ThrowHelper.ThrowArgumentOutOfRangeException();
             }
         }
 
@@ -30,7 +57,7 @@ namespace System
         {
             if ((uint)start >= length)
             {
-                ThrowArgumentOutOfRangeException();
+                ThrowHelper.ThrowArgumentOutOfRangeException();
             }
         }
         
@@ -39,7 +66,7 @@ namespace System
         {
             if (start >= length)
             {
-                ThrowArgumentOutOfRangeException();
+                ThrowHelper.ThrowArgumentOutOfRangeException();
             }
         }
 
@@ -48,16 +75,16 @@ namespace System
         {
             if ((uint)start > length)
             {
-                ThrowArgumentOutOfRangeException();
+                ThrowHelper.ThrowArgumentOutOfRangeException();
             }
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void RequiresInInclusiveRange(uint start, uint length)
+        public static void RequiresInInclusiveRange( uint start, uint length)
         {
             if (start > length)
             {
-                ThrowArgumentOutOfRangeException();
+                ThrowHelper.ThrowArgumentOutOfRangeException();
             }
         }
 
@@ -68,7 +95,7 @@ namespace System
                 || length < 0
                 || (uint)(start + length) > existingLength)
             {
-                ThrowArgumentOutOfRangeException();
+                ThrowHelper.ThrowArgumentOutOfRangeException();
             }
         }
         
@@ -76,23 +103,10 @@ namespace System
         public static void RequiresInInclusiveRange(uint start, uint length, uint existingLength)
         {
             if (start > existingLength
-                || length < 0
                 || (start + length) > existingLength)
             {
-                ThrowArgumentOutOfRangeException();
+                ThrowHelper.ThrowArgumentOutOfRangeException();
             }
-        }
-
-        internal static InvalidOperationException InvalidOperationExceptionForBoxingSpans() => new InvalidOperationException("Spans must not be boxed");
-
-        private static void ThrowArgumentException()
-        {
-            throw new ArgumentException();
-        }
-
-        private static void ThrowArgumentOutOfRangeException()
-        {
-            throw new ArgumentOutOfRangeException();
         }
     }
 }

--- a/src/System.Slices/System/Contract.cs
+++ b/src/System.Slices/System/Contract.cs
@@ -39,7 +39,7 @@ namespace System
         {
             if (ptr0 != ptr1)
             {
-                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.pointer);
+                ThrowHelper.ThrowArgumentException(ExceptionArgument.pointer);
             }
         }
 

--- a/src/System.Slices/System/ReadOnlySpan.cs
+++ b/src/System.Slices/System/ReadOnlySpan.cs
@@ -313,7 +313,7 @@ namespace System
             }
         }
 
-        public override bool Equals(object obj) { throw Contract.InvalidOperationExceptionForBoxingSpans(); }
+        public override bool Equals(object obj) { ThrowHelper.ThrowInvalidOperationException_ForBoxingSpans(); return false; }
 
         /// <summary>
         /// Checks to see if two spans point at the same memory.  Note that

--- a/src/System.Slices/System/Span.cs
+++ b/src/System.Slices/System/Span.cs
@@ -330,7 +330,7 @@ namespace System
             }
         }
 
-        public override bool Equals(object obj) { throw Contract.InvalidOperationExceptionForBoxingSpans(); }
+        public override bool Equals(object obj) { ThrowHelper.ThrowInvalidOperationException_ForBoxingSpans(); return false; }
 
         /// <summary>
         /// Checks to see if two spans point at the same memory.  Note that

--- a/src/System.Slices/System/SpanExtensions.cs
+++ b/src/System.Slices/System/SpanExtensions.cs
@@ -154,7 +154,7 @@ namespace System
         {
             int countOfU;
 
-            /// This comparison is a jittime constant
+            // This comparison is a jittime constant
             if (Unsafe.SizeOf<T>() > Unsafe.SizeOf<U>())
             {
                 IntPtr count = UnsafeUtilities.CountOfU<T, U>((uint)slice.Length);
@@ -196,7 +196,7 @@ namespace System
         {
             int countOfU;
 
-            /// This comparison is a jittime constant
+            // This comparison is a jittime constant
             if (Unsafe.SizeOf<T>() > Unsafe.SizeOf<U>())
             {
                 IntPtr count = UnsafeUtilities.CountOfU<T, U>((uint)slice.Length);

--- a/src/System.Slices/System/ThrowHelper.cs
+++ b/src/System.Slices/System/ThrowHelper.cs
@@ -1,0 +1,99 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System
+{
+    internal static class ThrowHelper
+    {
+        public static void ThrowArgumentNullException(ExceptionArgument argument)
+        {
+            throw GetArgumentNullException(argument);
+        }
+
+        public static void ThrowArgumentException()
+        {
+            throw GetArgumentException();
+        }
+
+        public static void ThrowArgumentException(ExceptionArgument argument)
+        {
+            throw GetArgumentException(argument);
+        }
+
+        public static void ThrowArgumentOutOfRangeException()
+        {
+            throw GetArgumentOutOfRangeException();
+        }
+
+        public static void ThrowArgumentOutOfRangeException(ExceptionArgument argument)
+        {
+            throw GetArgumentOutOfRangeException(argument);
+        }
+
+        public static void ThrowInvalidOperationException()
+        {
+            throw GetInvalidOperationException();
+        }
+
+        public static void ThrowInvalidOperationException_ForBoxingSpans()
+        {
+            throw GetInvalidOperationException_ForBoxingSpans();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentNullException GetArgumentNullException(ExceptionArgument argument)
+        {
+            return new ArgumentNullException(GetArgumentName(argument));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentException GetArgumentException()
+        {
+            return new ArgumentException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentException GetArgumentException(ExceptionArgument argument)
+        {
+            return new ArgumentException(GetArgumentName(argument));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException()
+        {
+            return new ArgumentOutOfRangeException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument)
+        {
+            return new ArgumentOutOfRangeException(GetArgumentName(argument));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException GetInvalidOperationException()
+        {
+            return new InvalidOperationException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException GetInvalidOperationException_ForBoxingSpans()
+        {
+            return new InvalidOperationException("Spans must not be boxed");
+        }
+
+        private static string GetArgumentName(ExceptionArgument argument)
+        {
+            Debug.Assert(Enum.IsDefined(typeof(ExceptionArgument), argument),
+                "The enum value is not defined, please check the ExceptionArgument Enum.");
+
+            return argument.ToString();
+        }
+    }
+
+    internal enum ExceptionArgument
+    {
+        pointer,
+        array
+    }
+}


### PR DESCRIPTION
**Issue**

![Non-inlining-cost](https://pbs.twimg.com/media/Curo-NaW8AEYYle.jpg)
**Fix**

Use Contracts add ThrowHelper, factor out exceptions from main code path

**Result**

Now only the exception throwing branches don't inline (correctly with `FAILED: does not return`)

Pre
```[FAILED: unprofitable inline] Memory`1:.ctor(ref,int,int,long):this```

Post
```[profitable inline] Memory`1:.ctor(ref,int,int,long):this```

Pre ```Memory`1:Slice(int,int):struct:this``` inlines
```asm
Successfully inlined Memory`1:Add(long,int):long (13 IL bytes) (depth 1) [below ALWAYS_INLINE size]
Successfully inlined Unsafe:SizeOf():int (7 IL bytes) (depth 2) [below ALWAYS_INLINE size]
Successfully inlined Memory`1:.ctor(long,int):this (45 IL bytes) (depth 1) [profitable inline]
Successfully inlined Memory`1:Add(long,int):long (13 IL bytes) (depth 1) [below ALWAYS_INLINE size]
Successfully inlined Unsafe:SizeOf():int (7 IL bytes) (depth 2) [below ALWAYS_INLINE size]
**************** Inline Tree
Inlines into 060000A6 Memory`1:Slice(int,int):struct:this
  [1 IL=0015 TR=000123 060000AA] [below ALWAYS_INLINE size] Memory`1:Add(long,int):long
    [2 IL=0001 TR=000151 06000006] [below ALWAYS_INLINE size] Unsafe:SizeOf():int
  [3 IL=0021 TR=000135 0600009D] [profitable inline] Memory`1:.ctor(long,int):this
    [0 IL=0010 TR=000205 06000DBD] [FAILED: unprofitable inline] ArgumentNullException:.ctor(ref):this
  [4 IL=0059 TR=000098 060000AA] [below ALWAYS_INLINE size] Memory`1:Add(long,int):long
    [5 IL=0001 TR=000218 06000006] [below ALWAYS_INLINE size] Unsafe:SizeOf():int
  [0 IL=0068 TR=000078 060000A0] [FAILED: unprofitable inline] Memory`1:.ctor(ref,int,int,long):this
Budget: initialTime=282, finalTime=382, initialBudget=2820, currentBudget=2820
Budget: initialSize=1818, finalSize=2449
```
Post ```Memory`1:Slice(int,int):struct:this``` inlines
```asm
Successfully inlined Memory`1:Add(long,int):long (13 IL bytes) (depth 1) [below ALWAYS_INLINE size]
Successfully inlined Unsafe:SizeOf():int (7 IL bytes) (depth 2) [below ALWAYS_INLINE size]
Successfully inlined Memory`1:.ctor(long,int):this (36 IL bytes) (depth 1) [profitable inline]
Successfully inlined Contract:RequiresNotNull(int,long) (12 IL bytes) (depth 2) [below ALWAYS_INLINE size]
Successfully inlined Memory`1:Add(long,int):long (13 IL bytes) (depth 1) [below ALWAYS_INLINE size]
Successfully inlined Unsafe:SizeOf():int (7 IL bytes) (depth 2) [below ALWAYS_INLINE size]
Successfully inlined Memory`1:.ctor(ref,int,int,long):this (76 IL bytes) (depth 1) [profitable inline]
Successfully inlined Contract:RequiresNotNull(int,ref) (15 IL bytes) (depth 2) [below ALWAYS_INLINE size]
Successfully inlined Unsafe:AsPointer(byref):long (3 IL bytes) (depth 2) [below ALWAYS_INLINE size]
Successfully inlined Contract:RequiresSameReference(long,long) (11 IL bytes) (depth 2) [below ALWAYS_INLINE size]
**************** Inline Tree
Inlines into 060000A8 Memory`1:Slice(int,int):struct:this
  [1 IL=0015 TR=000123 060000AC] [below ALWAYS_INLINE size] Memory`1:Add(long,int):long
    [2 IL=0001 TR=000151 06000006] [below ALWAYS_INLINE size] Unsafe:SizeOf():int
  [3 IL=0021 TR=000135 0600009F] [profitable inline] Memory`1:.ctor(long,int):this
    [4 IL=0002 TR=000169 06000003] [below ALWAYS_INLINE size] Contract:RequiresNotNull(int,long)
      [0 IL=0006 TR=000209 0600007C] [FAILED: does not return] ThrowHelper:ThrowArgumentNullException(int)
  [5 IL=0059 TR=000098 060000AC] [below ALWAYS_INLINE size] Memory`1:Add(long,int):long
    [6 IL=0001 TR=000215 06000006] [below ALWAYS_INLINE size] Unsafe:SizeOf():int
  [7 IL=0068 TR=000078 060000A2] [profitable inline] Memory`1:.ctor(ref,int,int,long):this
    [8 IL=0002 TR=000232 06000002] [below ALWAYS_INLINE size] Contract:RequiresNotNull(int,ref)
      [0 IL=0009 TR=000299 0600007C] [FAILED: does not return] ThrowHelper:ThrowArgumentNullException(int)
    [9 IL=0021 TR=000275 06000005] [below ALWAYS_INLINE size] Unsafe:AsPointer(byref):long
    [10 IL=0039 TR=000286 06000004] [below ALWAYS_INLINE size] Contract:RequiresSameReference(long,long)
      [0 IL=0005 TR=000318 0600007C] [FAILED: does not return] ThrowHelper:ThrowArgumentNullException(int)
Budget: initialTime=282, finalTime=528, initialBudget=2820, currentBudget=2820
Budget: initialSize=1818, finalSize=2789
```

/cc @KrzysztofCwalina 