### PR TITLE
Adding a prototype of safe Memory<T>

### DIFF
--- a/src/System.Slices/System/Buffers/Memory2.cs
+++ b/src/System.Slices/System/Buffers/Memory2.cs
@@ -1,0 +1,113 @@
+﻿using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace System
+{
+    public struct Memory2<T> 
+    {
+        MemoryManager<T> _manager;
+        long _id;
+        int _index;
+        int _length;
+
+        internal Memory2(MemoryManager<T> manager, long id)
+            : this(manager, id, 0, manager.GetSpan(id).Length)
+        { }
+
+        private Memory2(MemoryManager<T> manager, long id, int index, int length)
+        {
+            _manager = manager;
+            _id = id;
+            _index = index;
+            _length = length;
+        }
+
+        public static Memory2<T> Empty => EmptyManager.Shared.Memory;
+
+        public int Length => _length;
+
+        public bool IsEmpty => Length == 0;
+
+        public Memory2<T> Slice(int index)
+        {
+            return new Memory2<T>(_manager, _id, _index + index, _length - index);
+        }
+        public Memory2<T> Slice(int index, int length)
+        {
+            return new Memory2<T>(_manager, _id, _index + index, length);
+        }
+
+        public Span<T> Span => _manager.GetSpan(_id).Slice(_index, _length);
+
+        public DisposableReservation Reserve() => new DisposableReservation(_manager, _id);
+
+        public unsafe bool TryGetPointer(out void* pointer)
+        {
+            if (!_manager.TryGetPointer(_id, out pointer)) {
+                return false;
+            }
+            pointer = Add(pointer, _index);
+            return true;
+        }
+
+        public bool TryGetArray(out ArraySegment<T> buffer)
+        {
+            if (!_manager.TryGetArray(_id, out buffer)) {
+                return false;
+            }
+            buffer = new ArraySegment<T>(buffer.Array, buffer.Offset + _index, _length);
+            return true;
+        }
+
+        public struct DisposableReservation : IDisposable
+        {
+            MemoryManager<T> _manager;
+            long _id;
+
+            internal DisposableReservation(MemoryManager<T> manager, long id)
+            {
+                _id = id;
+                _manager = manager;
+                _manager.AddReference(_id);
+            }
+
+            public void Dispose()
+            {
+                _manager.ReleaseReference(_id);
+                _manager = null;
+            }
+        }
+
+        class EmptyManager : MemoryManager<T>
+        {
+            public readonly static MemoryManager<T> Shared = new EmptyManager();
+            readonly static ArraySegment<T> s_empty = new ArraySegment<T>(new T[0], 0, 0);
+              
+            protected override bool TryGetArrayCore(out ArraySegment<T> buffer)
+            {
+                buffer = s_empty;
+                return true;
+            }
+
+            protected override unsafe bool TryGetPointerCore(out void* pointer)
+            {
+                pointer = null;
+                return false;
+            }
+
+            protected override void DisposeCore()
+            { }
+
+            protected override Span<T> GetSpanCore()
+            {
+                return Span<T>.Empty;
+            }
+        }
+
+        static unsafe void* Add(void* pointer, int offset)
+        {
+            return (byte*)pointer + ((ulong)Unsafe.SizeOf<T>() * (ulong)offset);
+        }
+    }
+}

--- a/src/System.Slices/System/Buffers/MemoryManager.cs
+++ b/src/System.Slices/System/Buffers/MemoryManager.cs
@@ -1,0 +1,81 @@
+﻿using System.Threading;
+
+namespace System.Buffers
+{
+    public abstract class MemoryManager<T> : IDisposable
+    {
+        long _id;
+        int _references;
+
+        static long _nextId = InitializedId + 1;
+
+        const long InitializedId = long.MinValue;
+        
+        public Memory2<T> Memory => new Memory2<T>(this, _id);
+
+        public void Dispose()
+        {
+            if (_references != 0) throw new InvalidOperationException("outstanding references detected.");
+            _id = InitializedId;
+            DisposeCore();
+        }
+
+        public bool IsDisposed => _id == InitializedId;
+
+        public int ReferenceCount => _references;
+
+        public void AddReference(long id)
+        {
+            if (_id != id) throw new ObjectDisposedException(nameof(Memory2<T>));
+            Interlocked.Increment(ref _references);
+        }
+        public void ReleaseReference(long id)
+        {
+            if (_id != id) throw new ObjectDisposedException(nameof(Memory2<T>));
+            Interlocked.Decrement(ref _references);
+        }
+
+        public virtual void Initialize()
+        {
+            if(!IsDisposed) {
+                throw new InvalidOperationException("manager has to be disposed to initialize");
+            }
+            _id = Interlocked.Increment(ref _nextId);
+            _references = 0;
+        }
+
+        // abstract members
+        protected abstract Span<T> GetSpanCore();
+        protected abstract void DisposeCore();
+
+        protected abstract bool TryGetArrayCore(out ArraySegment<T> buffer);
+
+        protected abstract unsafe bool TryGetPointerCore(out void* pointer);
+
+        // used by Memory<T>
+        internal unsafe bool TryGetPointer(long id, out void* pointer)
+        {
+            if (_id != id) throw new ObjectDisposedException(nameof(Memory2<T>));
+            return TryGetPointerCore(out pointer);
+        }
+
+        internal bool TryGetArray(long id, out ArraySegment<T> buffer)
+        {
+            if (_id != id) throw new ObjectDisposedException(nameof(Memory2<T>));
+            return TryGetArrayCore(out buffer);
+        }
+
+        internal Span<T> GetSpan(long id)
+        {
+            if (_id != id) throw new ObjectDisposedException(nameof(Memory2<T>));
+            return GetSpanCore();
+        }
+
+        // protected
+        protected MemoryManager()
+        {
+            _id = InitializedId;
+            Initialize();
+        }
+    }
+}

--- a/src/System.Slices/System/Buffers/MemoryManagers.cs
+++ b/src/System.Slices/System/Buffers/MemoryManagers.cs
@@ -1,0 +1,137 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Buffers
+{
+    public sealed class ArrayManager<T> : MemoryManager<T>
+    {
+        T[] _array;
+        public ArrayManager(int length)
+        {
+            _array = new T[length];
+        }
+
+        public ArrayManager(T[] array)
+        {
+            _array = array;
+        }
+
+        protected override bool TryGetArrayCore(out ArraySegment<T> buffer)
+        {
+            buffer = new ArraySegment<T>(_array);
+            return true;
+        }
+
+        protected override unsafe bool TryGetPointerCore(out void* pointer)
+        {
+            pointer = null;
+            return false;
+        }
+
+        protected override void DisposeCore() => _array = null;
+        protected override Span<T> GetSpanCore() => _array;
+    }
+
+    public sealed class NativeMemoryManager : MemoryManager<byte>
+    {
+        IntPtr _memory;
+        int _length;
+
+        public NativeMemoryManager(int length)
+        {
+            _length = length;
+            _memory = Marshal.AllocHGlobal(length);
+        }
+
+        ~NativeMemoryManager()
+        {
+            DisposeCore();
+        }
+
+        protected override void DisposeCore()
+        {
+            if (_memory != IntPtr.Zero) {
+                Marshal.FreeHGlobal(_memory);
+                _memory = IntPtr.Zero;
+            }
+        }
+
+        protected override Span<byte> GetSpanCore()
+        {
+            unsafe
+            {
+                return new Span<byte>(_memory.ToPointer(), _length);
+            }
+        }
+
+        protected override unsafe bool TryGetPointerCore(out void* pointer)
+        {
+            pointer = _memory.ToPointer();
+            return true;
+        }
+
+        protected override bool TryGetArrayCore(out ArraySegment<byte> buffer)
+        {
+            buffer = default(ArraySegment<byte>);
+            return false;
+        }
+    }
+
+    // THis is to support secnarios today covered by Memory<T> in corefxlab
+    public class PinnedArrayManager<T> : MemoryManager<T>
+    {
+        private T[] _array;
+        private unsafe void* _pointer;
+
+        public unsafe PinnedArrayManager(T[] array, void* pointer)
+        {
+            _array = array;
+            _pointer = Unsafe.AsPointer(ref array[0]);
+            if(_pointer != pointer) {
+                throw new InvalidOperationException();
+            }
+        }
+
+        protected override void DisposeCore()
+        {
+            _array = null;
+            unsafe {
+                _pointer = null;
+            }
+        }
+
+        protected override Span<T> GetSpanCore()
+        {
+            if (_array != null) {
+                return _array;
+            }
+            else {
+                unsafe
+                {
+                    return new Span<T>(_pointer, _array.Length);
+                }
+            }
+        }
+
+        protected unsafe override bool TryGetPointerCore(out void* pointer)
+        {
+            if (_pointer == null) {
+                pointer = null;
+                return false;
+            }
+
+            pointer = _pointer;
+            return true;
+        }
+
+        protected override bool TryGetArrayCore(out ArraySegment<T> buffer)
+        {
+            if (_array == null) {
+                buffer = default(ArraySegment<T>);
+                return false;
+            }
+            buffer = new ArraySegment<T>(_array, 0, _array.Length);
+            return true;
+        }
+    }
+}

--- a/src/System.Slices/project.json
+++ b/src/System.Slices/project.json
@@ -28,6 +28,7 @@
     "System.Collections.Sequences": { "target": "project" },
     "System.Runtime": "4.1.0",
     "System.Runtime.InteropServices": "4.1.0",
+    "System.Threading": "4.0.11",
     "System.Diagnostics.Debug": "4.0.11",
     "System.Runtime.CompilerServices.Unsafe": "4.0.0"
   },

--- a/tests/System.Slices.Tests/MemoryTests.cs
+++ b/tests/System.Slices.Tests/MemoryTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Buffers;
+using Xunit;
+
+namespace System.Slices.Tests
+{
+    public class MemoryTests
+    {
+        [Fact]
+        public void ArrayMemory()
+        {
+            Memory2<byte> copyStoredForLater;
+
+            using (var manager = new ArrayManager<byte>(1024)) {
+                Memory2<byte> memory = manager.Memory;
+                Memory2<byte> memorySlice = memory.Slice(10);
+                copyStoredForLater = memorySlice;
+                using (memorySlice.Reserve()) { // increments the "outstanding span" refcount
+                    Assert.Throws<InvalidOperationException>(() => { manager.Dispose(); }); // memory is reserved; cannot dispose
+                    Span<byte> span = memorySlice.Span;
+                    span[0] = 255;
+
+                    ArraySegment<byte> array;
+                    if (!memorySlice.TryGetArray(out array)) {
+                        throw new Exception();
+                    }
+                    if (array.Array[10] != 255) {
+                        throw new Exception("array");
+                    }
+                } // releases the refcount
+            }
+            Assert.Throws<ObjectDisposedException>(() => { var span = copyStoredForLater.Span; }); // manager is disposed
+        }
+
+        [Fact]
+        public void NativeMemory()
+        {
+            Memory2<byte> copyStoredForLater;
+
+            using (var manager = new NativeMemoryManager(1024)) {
+                Memory2<byte> memory = manager.Memory;
+                Memory2<byte> memorySlice = memory.Slice(10);
+                copyStoredForLater = memorySlice;
+                using (memorySlice.Reserve()) {
+                    Assert.Throws<InvalidOperationException>(() => { manager.Dispose(); }); // memory is reserved; cannot dispose
+                    Span<byte> span = memorySlice.Span;
+                    span[0] = 255;
+
+                    unsafe
+                    {
+                        void* pointer;
+                        if (!memory.TryGetPointer(out pointer)) {
+                            throw new Exception();
+                        }
+                        if (((byte*)pointer)[10] != 255) {
+                            throw new Exception("native");
+                        }
+                    }
+                }
+            }
+            Assert.Throws<ObjectDisposedException>(() => { var span = copyStoredForLater.Span; }); // manager is disposed
+        }
+
+        [Fact]
+        public unsafe void PinnedArrayMemory()
+        {
+            Memory2<byte> copyStoredForLater;
+
+            var bytes = new byte[1024];
+
+            fixed (byte* pBytes = bytes) {
+                using (var manager = new PinnedArrayManager<byte>(bytes, pBytes)) {
+                    Memory2<byte> memory = manager.Memory;
+                    Memory2<byte> memorySlice = memory.Slice(10);
+                    copyStoredForLater = memorySlice;
+                    using (memorySlice.Reserve()) {
+                        Assert.Throws<InvalidOperationException>(() => { manager.Dispose(); }); // memory is reserved; cannot dispose
+
+                        Span<byte> span = memorySlice.Span;
+                        span[0] = 255;
+
+                        ArraySegment<byte> array;
+                        if (!memorySlice.TryGetArray(out array)) {
+                            throw new Exception();
+                        }
+                        if (array.Array[10] != 255) {
+                            throw new Exception("pinned");
+                        }
+
+                        void* pointer;
+                        if (!memory.TryGetPointer(out pointer)) {
+                            throw new Exception();
+                        }
+                        if (((byte*)pointer)[10] != 255) {
+                            throw new Exception("pinned");
+                        }
+                    }
+                }   
+            }
+            Assert.Throws<ObjectDisposedException>(() => { var span = copyStoredForLater.Span; }); // manager is disposed
+        }
+    }
+}


### PR DESCRIPTION
Memory2\<T\> is a tearing-safe[er] version of Memory\<T\>. 

It supports revocation, i.e. the underlying buffer (MemoryManager\<T\>) can be disposed, which will "poison" all existing copies of Memory2\<T\>. This makes it buffer and object pooling friendly as it is much harder for buggy code to get away with use-after-free bugs (such bugs will almost always result in ObjectDisposedExceptions).   

Also, it supports "reserving" the buffer, i.e. communicating to MemoryManager\<T\> that Memory2\<T\> instance will need the buffer for longer than the lifetime of the current stack frame. This is useful for example when the buffer will be used for an asynchronous call (e.g. async interop call).

The tests illustrate the concepts in detail.

Note that the APIs are not yet hardened for all the races I would like to harden it for. For now, I want to mainly prototype the the basic semantics we want out of this type. But any feedback on races/threading issues is welcome too.