### PR TITLE
Added helper APIs to Memory<T>

### DIFF
--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -27,6 +27,13 @@ namespace System
         {
             return new ReadOnlyMemory<T>(memory._owner, memory._id, memory._index, memory._length);
         }
+
+        public static implicit operator Memory<T>(T[] array)
+        {
+            var owner = new OwnedArray<T>(array);
+            return owner.Memory;
+        }
+
         public static Memory<T> Empty => OwnerEmptyMemory.Shared.Memory;
 
         public int Length => _length;
@@ -107,6 +114,8 @@ namespace System
             {
                 return Span<T>.Empty;
             }
+
+            public override int Length => 0;
         }
 
         static unsafe void* Add(void* pointer, int offset)

--- a/src/System.Slices/System/Buffers/OwnedMemory.cs
+++ b/src/System.Slices/System/Buffers/OwnedMemory.cs
@@ -12,6 +12,12 @@ namespace System.Buffers
         const long InitializedId = long.MinValue;
         
         public Memory<T> Memory => new Memory<T>(this, _id);
+        public Span<T> Span => GetSpanCore();
+
+        public static implicit operator OwnedMemory<T>(T[] array)
+        {
+            return new OwnedArray<T>(array);
+        }
 
         public void Dispose()
         {

--- a/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
@@ -23,6 +23,12 @@ namespace System
             _length = length;
         }
 
+        public static implicit operator ReadOnlyMemory<T>(T[] array)
+        {
+            var owner = new OwnedArray<T>(array);
+            return owner.Memory;
+        }
+
         public static ReadOnlyMemory<T> Empty => Memory<T>.Empty;
 
         public int Length => _length;


### PR DESCRIPTION
The new APIs allow the following code:
```c#
{
    OwnedArray<byte> memory = new byte[1024];
    var span = memory.Span;
    span[10] = 10;
    Assert.Equal(10, memory.Array[10]);
}

using(var memory = new OwnedNativeMemory(1024)) {
    var span = memory.Span;
    span[10] = 10;
    unsafe { Assert.Equal(10, memory.Pointer[10]); }
}

using (OwnedPinnedArray<byte> memory = new byte[1024]) {
    var span = memory.Span;
    span[10] = 10;
    Assert.Equal(10, memory.Array[10]);

    unsafe { Assert.Equal(10, memory.Pointer[10]); }
}
```