### PR TITLE
Cleaned up Memory<T> APIs

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/ManagedBufferPool.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/ManagedBufferPool.cs
@@ -23,12 +23,10 @@ namespace System.Buffers
 
         public override void Return(OwnedMemory<byte> buffer)
         {
-            ArraySegment<byte> segment;
-            if (!buffer.Memory.TryGetArray(out segment)) {
-                throw new Exception();
-            }
+            var ownedArray = buffer as OwnedArray<byte>;
+            if (ownedArray == null) throw new InvalidOperationException("buffer not rented from this pool");
+            ArrayPool<byte>.Shared.Return(ownedArray.Array);
             buffer.Dispose();
-            ArrayPool<byte>.Shared.Return(segment.Array);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/System.Slices/System/Buffers/OwnedMemory.cs
+++ b/src/System.Slices/System/Buffers/OwnedMemory.cs
@@ -2,7 +2,16 @@
 
 namespace System.Buffers
 {
-    public abstract class OwnedMemory<T> : IDisposable
+    /// <summary>
+    /// Known only to some by its secret name
+    /// </summary>
+    internal interface IKnown
+    {
+        void AddReference(long secretId);
+        void ReleaseReference(long secretId);
+    }
+
+    public abstract class OwnedMemory<T> : IDisposable, IKnown
     {
         long _id;
         int _references;

--- a/tests/System.Slices.Tests/MemoryTests.cs
+++ b/tests/System.Slices.Tests/MemoryTests.cs
@@ -8,7 +8,7 @@ namespace System.Slices.Tests
     public class MemoryTests
     {
         [Fact]
-        public void SimpleTest()
+        public void SimpleTestS()
         {
             {
                 OwnedArray<byte> memory = new byte[1024];
@@ -36,94 +36,66 @@ namespace System.Slices.Tests
         public void ArrayMemoryLifetime()
         {
             Memory<byte> copyStoredForLater;
-
             using (var owner = new OwnedArray<byte>(1024)) {
                 Memory<byte> memory = owner.Memory;
                 Memory<byte> memorySlice = memory.Slice(10);
                 copyStoredForLater = memorySlice;
                 using (memorySlice.Reserve()) { // increments the "outstanding span" refcount
-                    Assert.Throws<InvalidOperationException>(() => { owner.Dispose(); }); // memory is reserved; cannot dispose
+                    Assert.Throws<InvalidOperationException>(() => { // memory is reserved; cannot dispose
+                        owner.Dispose();
+                    });
                     Span<byte> span = memorySlice.Span;
                     span[0] = 255;
-
-                    ArraySegment<byte> array;
-                    if (!memorySlice.TryGetArray(out array)) {
-                        throw new Exception();
-                    }
-                    if (array.Array[10] != 255) {
-                        throw new Exception("array");
-                    }
                 } // releases the refcount
             }
-            Assert.Throws<ObjectDisposedException>(() => { var span = copyStoredForLater.Span; }); // manager is disposed
+            Assert.Throws<ObjectDisposedException>(() => { // manager is disposed
+                var span = copyStoredForLater.Span;
+            }); 
         }
 
         [Fact]
         public void NativeMemoryLifetime()
         {
             Memory<byte> copyStoredForLater;
-
             using (var owner = new OwnedNativeMemory(1024)) {
                 Memory<byte> memory = owner.Memory;
                 Memory<byte> memorySlice = memory.Slice(10);
                 copyStoredForLater = memorySlice;
                 using (memorySlice.Reserve()) {
-                    Assert.Throws<InvalidOperationException>(() => { owner.Dispose(); }); // memory is reserved; cannot dispose
+                    Assert.Throws<InvalidOperationException>(() => { // memory is reserved; cannot dispose
+                        owner.Dispose();
+                    }); 
                     Span<byte> span = memorySlice.Span;
                     span[0] = 255;
-
-                    unsafe
-                    {
-                        void* pointer;
-                        if (!memory.TryGetPointer(out pointer)) {
-                            throw new Exception();
-                        }
-                        if (((byte*)pointer)[10] != 255) {
-                            throw new Exception("native");
-                        }
-                    }
                 }
             }
-            Assert.Throws<ObjectDisposedException>(() => { var span = copyStoredForLater.Span; }); // manager is disposed
+            Assert.Throws<ObjectDisposedException>(() => { // manager is disposed
+                var span = copyStoredForLater.Span;
+            });
         }
 
         [Fact]
         public unsafe void PinnedArrayMemoryLifetime()
         {
             Memory<byte> copyStoredForLater;
-
             var bytes = new byte[1024];
-
             fixed (byte* pBytes = bytes) {
                 using (var owner = new OwnedPinnedArray<byte>(bytes, pBytes)) {
                     Memory<byte> memory = owner.Memory;
                     Memory<byte> memorySlice = memory.Slice(10);
                     copyStoredForLater = memorySlice;
                     using (memorySlice.Reserve()) {
-                        Assert.Throws<InvalidOperationException>(() => { owner.Dispose(); }); // memory is reserved; cannot dispose
-
+                        Assert.Throws<InvalidOperationException>(() => { // memory is reserved; cannot dispose
+                            owner.Dispose();
+                        }); 
                         Span<byte> span = memorySlice.Span;
                         span[0] = 255;
-
-                        ArraySegment<byte> array;
-                        if (!memorySlice.TryGetArray(out array)) {
-                            throw new Exception();
-                        }
-                        if (array.Array[10] != 255) {
-                            throw new Exception("pinned");
-                        }
-
-                        void* pointer;
-                        if (!memory.TryGetPointer(out pointer)) {
-                            throw new Exception();
-                        }
-                        if (((byte*)pointer)[10] != 255) {
-                            throw new Exception("pinned");
-                        }
                     }
                 }   
             }
-            Assert.Throws<ObjectDisposedException>(() => { var span = copyStoredForLater.Span; }); // manager is disposed
+            Assert.Throws<ObjectDisposedException>(() => { // manager is disposed
+                var span = copyStoredForLater.Span;
+            });
         }
     }
 }


### PR DESCRIPTION
I made TryGetArray methods unsafe to communicate to callers that they need to be careful,
e.g. they should call Reserve(), if they store the array for later