### PR TITLE
Safer disposal

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/AutoBufferPool.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/AutoBufferPool.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Concurrent;
+
+namespace System.Buffers
+{
+    public class AutoBufferPool
+    {
+        private readonly static AutoBufferPool s_shared = new AutoBufferPool();
+        public static AutoBufferPool Shared => s_shared;
+
+        private ConcurrentQueue<AutoPooledMemory> _pool = new ConcurrentQueue<AutoPooledMemory>();
+
+        public OwnedMemory<byte> Rent(int minimumBufferSize)
+        {
+            var array = ArrayPool<byte>.Shared.Rent(minimumBufferSize);
+
+            AutoPooledMemory memory;
+            if (!_pool.TryDequeue(out memory))
+            {
+                memory = new AutoPooledMemory(array, this);
+            }
+            else
+            {
+                memory.Initalize(array);
+            }
+
+            return memory;
+        }
+
+        private void Return(AutoPooledMemory memory)
+        {
+            _pool.Enqueue(memory);
+        }
+
+        private class AutoPooledMemory : OwnedMemory<byte>
+        {
+            private AutoBufferPool _pool;
+
+            public AutoPooledMemory(byte[] array, AutoBufferPool pool) : base(array, 0, array.Length)
+            {
+                _pool = pool;
+            }
+
+            public void Initalize(byte[] array)
+            {
+                base.Initialize(array, 0, array.Length);
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                // Return Array to pool before clear
+                ArrayPool<byte>.Shared.Return(Array);
+                base.Dispose(disposing);
+            }
+
+            protected override void DisposeComplete()
+            {
+                // Disposal complete, no init/clear race - return AutoPooledMemory to pool
+                _pool.Return(this);
+            }
+        }
+    }
+}

--- a/src/System.Buffers.Experimental/System/Buffers/OwnedMemory.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/OwnedMemory.cs
@@ -23,7 +23,7 @@ namespace System.Buffers
 
         ~OwnedNativeMemory()
         {
-            Dispose();
+            Dispose(false);
         }
 
         protected override void Dispose(bool disposing)
@@ -32,6 +32,8 @@ namespace System.Buffers
                 Marshal.FreeHGlobal(base.Pointer);
             }
             base.Dispose(disposing);
+
+            GC.SuppressFinalize(this);
         }
 
         public new unsafe byte* Pointer => (byte*)base.Pointer.ToPointer();
@@ -84,6 +86,13 @@ namespace System.Buffers
                 _handle.Free();
             }
             base.Dispose(disposing);
+
+            GC.SuppressFinalize(this);
+        }
+
+        ~OwnedPinnedArray()
+        {
+            Dispose(false);
         }
     }
 }

--- a/src/System.Buffers.Experimental/project.json
+++ b/src/System.Buffers.Experimental/project.json
@@ -27,7 +27,8 @@
     "System.Slices": { "target": "project" },
     "System.Text.Primitives": { "target": "project" },
     "System.Threading": "4.0.11",
-    "System.Runtime.InteropServices": "4.1.0"
+    "System.Runtime.InteropServices": "4.1.0",
+    "System.Collections.Concurrent": "4.0.12"
   },
   "frameworks": {
     "netstandard1.1": {

--- a/src/System.Slices/System/Buffers/OwnedMemory.cs
+++ b/src/System.Slices/System/Buffers/OwnedMemory.cs
@@ -4,38 +4,86 @@ using System.Threading;
 
 namespace System.Buffers
 {
+    public interface IReferenceCounted<T>
+    {
+        int AddReference(long versionId, int reservationId);
+        void Release(long versionId, int reservationId);
+    }
+
+    public interface IAllowsDependencyMemory<T> : IReferenceCounted<T>
+    {
+        void ThrowIfDisposed(long versionId, int reservationId);
+        bool IsDependancyDisposed(long versionId, int reservationId);
+    }
+
+    public interface IReadOnlyMemory<T> : IAllowsDependencyMemory<T>
+    {
+        ReservedReadOnlyMemory<T> Reserve(ref ReadOnlyMemory<T> memory, long versionId, int reservationId);
+        ReadOnlySpan<T> GetSpan(long versionId, int reservationId);
+    }
+
+    public interface IMemory<T> : IReadOnlyMemory<T>
+    {
+        ReservedMemory<T> Reserve(ref Memory<T> memory, long versionId, int reservationId);
+        new Span<T> GetSpan(long versionId, int reservationId);
+        bool TryGetDependancyArray(long _versionId, int _reservationId, out ArraySegment<T> buffer);
+        unsafe bool TryGetDependancyPointer(long versionId, int reservationId, out void* pointer);
+    }
+
     public abstract class OwnedMemory<T> : IDisposable, IMemory<T>
     {
-        static long _nextId = InitializedId + 1;
+        const int BaseReservationId = 0;
         const long InitializedId = long.MinValue;
-        int _referenceCount;
+        static long _nextId = InitializedId + 1;
+        static readonly uint[] EmptyReferences = new uint[0];
+
+        long _versionId;
+        int _lastReference;
+        int _references;
+        uint[] _outstandingReferences = EmptyReferences;
 
         public int Length { get; private set; }
-        protected long Id { get; private set; }
         protected T[] Array { get; private set; }
         protected IntPtr Pointer { get; private set; }
         protected int Offset { get; private set; }
-        public int ReferenceCount { get { return _referenceCount; } }
+        public int ReferenceCount => _references;
 
         private OwnedMemory() { }
 
         protected OwnedMemory(T[] array, int arrayOffset, int length, IntPtr pointer = default(IntPtr))
         {
-            Id = InitializedId;
+            _versionId = InitializedId;
             Initialize(array, arrayOffset, length, pointer);
         }
 
-        public Memory<T> Memory => new Memory<T>(this, Id);
+        public Memory<T> Memory
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return new Memory<T>(this, _versionId, BaseReservationId);
+            }
+        }
+
         public Span<T> Span
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get {
-                if (Array != null)
-                    return Array.Slice(Offset, Length);
-                else unsafe {
+            get
+            {
+                ThrowIfDisposed();
+                return GetSpanCore();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private Span<T> GetSpanCore()
+        {
+            if (Array != null)
+                return Array.Slice(Offset, Length);
+            else unsafe
+                {
                     return new Span<T>(Pointer.ToPointer(), Length);
                 }
-            }
         }
 
         public static implicit operator OwnedMemory<T>(T[] array)
@@ -43,9 +91,16 @@ namespace System.Buffers
             return new OwnedArray<T>(array);
         }
 
-        protected bool TryGetArrayCore(out ArraySegment<T> buffer)
+        protected bool TryGetArray(out ArraySegment<T> buffer)
         {
-            if (Array == null) {
+            ThrowIfDisposed();
+            return TryGetArrayCore(out buffer);
+        }
+
+        private bool TryGetArrayCore(out ArraySegment<T> buffer)
+        {
+            if (Array == null)
+            {
                 buffer = default(ArraySegment<T>);
                 return false;
             }
@@ -54,9 +109,16 @@ namespace System.Buffers
             return true;
         }
 
-        protected unsafe bool TryGetPointerCore(out void* pointer)
+        protected unsafe bool TryGetPointer(out void* pointer)
         {
-            if (Pointer == IntPtr.Zero) {
+            ThrowIfDisposed();
+            return TryGetPointerCore(out pointer);
+        }
+
+        private unsafe bool TryGetPointerCore(out void* pointer)
+        {
+            if (Pointer == IntPtr.Zero)
+            {
                 pointer = null;
                 return false;
             }
@@ -65,7 +127,6 @@ namespace System.Buffers
             return true;
         }
 
-        #region Lifetime Management
         protected void Initialize(T[] array, int arrayOffset, int length, IntPtr pointer = default(IntPtr))
         {
             Contract.Requires(array != null || pointer != null);
@@ -74,139 +135,189 @@ namespace System.Buffers
                 throw new InvalidOperationException("this instance has to be disposed to initialize");
             }
 
-            Id = Interlocked.Increment(ref _nextId);
+            _versionId = Interlocked.Increment(ref _nextId);
             Array = array;
             Offset = arrayOffset;
             Length = length;
             Pointer = pointer;
-            _referenceCount = 0;
+            _references = 1;
+            _lastReference = 0;
+
+            if (_outstandingReferences.Length == 0)
+            {
+                _outstandingReferences = new uint[1];
+            }
+            _outstandingReferences[0] = 1;
         }
 
         public void Dispose()
         {
-            if (ReferenceCount != 0) throw new InvalidOperationException("outstanding references detected.");
+            var refCount = DisposeReservation(BaseReservationId);
+            if (refCount == 0)
+            {
+                DisposeCore(refCount);
+            }
+        }
+
+        private void DisposeCore(int references)
+        {
             Dispose(true);
-            Id = InitializedId;
+
+            _versionId = InitializedId;
             Array = null;
             Pointer = IntPtr.Zero;
             Length = 0;
             Offset = 0;
+            if (_outstandingReferences.Length > 1)
+            {
+                // Release memory for large reservations
+                _outstandingReferences = EmptyReferences;
+            }
+
+            DisposeComplete();
         }
 
+        /// <summary>
+        /// Override this to dispose of native data or pool the referenced data.
+        /// Use <seealso cref="DisposeComplete"/> to pool the object to avoid race conditions with its data being cleared.
+        /// </summary>
         protected virtual void Dispose(bool disposing)
         { }
 
-        public bool IsDisposed => Id == InitializedId;
-
-        public void AddReference()
-        {
-            OnReferenceCountChanged(Interlocked.Increment(ref _referenceCount));
-        }
-
-        public void Release()
-        {
-            OnReferenceCountChanged(Interlocked.Decrement(ref _referenceCount));
-        }
-
-        protected virtual void OnReferenceCountChanged(int newReferenceCount)
+        /// <summary>
+        /// Override this if you need notification of when pooling the <seealso cref="OwnedMemory{T}"/> itself is safe. 
+        /// Its references will be cleared by this point, so use <seealso cref="Dispose(bool)"/> if you want to pool its data.
+        /// </summary>
+        protected virtual void DisposeComplete()
         { }
 
-        protected internal virtual DisposableReservation Reserve(ref ReadOnlyMemory<T> memory)
+        public bool IsDisposed => _versionId == InitializedId;
+
+        bool IAllowsDependencyMemory<T>.IsDependancyDisposed(long versionId, int reservationId)
         {
-            return new DisposableReservation(this, Id);
+            return (_versionId != versionId || IsReservationDisposed(reservationId));
         }
 
-        #endregion
-
-        #region Used by Memory<T>
-        void IKnown.AddReference(long id)
+        private bool IsReservationDisposed(int reservationId)
         {
-            VerifyId(id);
-            AddReference();
+            var index = reservationId >> 5; // divide 32
+            var offset = (uint)(1 << (reservationId & 31));
+
+            return (_outstandingReferences[index] & offset) == 0;
         }
 
-        void IKnown.Release(long id)
+        private int DisposeReservation(int reservationId)
         {
-            VerifyId(id);
-            Release();
+            var index = reservationId >> 5; // divide 32
+            var offset = (uint)(1 << (reservationId & 31));
+            var current = _outstandingReferences[index];
+
+            if ((current & offset) != 0) {
+                _outstandingReferences[index] = current & ~offset;
+                return Interlocked.Decrement(ref _references);
+            }
+            return -1;
         }
 
-        internal unsafe bool TryGetPointerInternal(long id, out void* pointer)
+        ReservedMemory<T> IMemory<T>.Reserve(ref Memory<T> memory, long versionId, int reservationId)
+            => Reserve(ref memory, versionId, reservationId);
+
+        protected internal virtual ReservedMemory<T> Reserve(ref Memory<T> memory, long versionId, int reservationId)
         {
-            VerifyId(id);
+            return new ReservedMemory<T>(ref memory, this, versionId, reservationId);
+        }
+
+        ReservedReadOnlyMemory<T> IReadOnlyMemory<T>.Reserve(ref ReadOnlyMemory<T> memory, long versionId, int reservationId)
+            => Reserve(ref memory, versionId, reservationId);
+
+        protected internal virtual ReservedReadOnlyMemory<T> Reserve(ref ReadOnlyMemory<T> memory, long versionId, int reservationId)
+        {
+            return new ReservedReadOnlyMemory<T>(ref memory, this, versionId, reservationId);
+        }
+
+        int IReferenceCounted<T>.AddReference(long versionId, int reservationId)
+        {
+            ThrowIfDisposed(versionId, reservationId);
+            Interlocked.Increment(ref _references);
+            var newReservationId = Interlocked.Increment(ref _lastReference);
+            var index = newReservationId >> 5; // divide 32
+            var offset = (uint)(1 << (newReservationId & 31));
+
+            if (index >= _outstandingReferences.Length)
+            {
+                var refs = new uint[index + 1];
+                _outstandingReferences.CopyTo(refs, 0);
+                _outstandingReferences = refs;
+            }
+
+            _outstandingReferences[index] |= offset;
+            return newReservationId;
+        }
+
+        void IReferenceCounted<T>.Release(long versionId, int reservationId)
+        {
+            if (!IsActive(versionId, reservationId)) return;
+
+            var refCount = DisposeReservation(reservationId);
+            if (refCount == 0)
+            {
+                DisposeCore(refCount);
+            }
+        }
+
+        unsafe bool IMemory<T>.TryGetDependancyPointer(long versionId, int reservationId, out void* pointer)
+        {
+            ThrowIfDisposed(versionId, reservationId);
             return TryGetPointerCore(out pointer);
         }
 
-        unsafe bool IMemory<T>.TryGetPointer(long id, out void* pointer)
+        bool IMemory<T>.TryGetDependancyArray(long versionId, int reservationId, out ArraySegment<T> buffer)
         {
-            return TryGetPointerInternal(id, out pointer);
-        }
-
-        internal bool TryGetArrayInternal(long id, out ArraySegment<T> buffer)
-        {
-            VerifyId(id);
+            ThrowIfDisposed(versionId, reservationId);
             return TryGetArrayCore(out buffer);
         }
 
-        bool IMemory<T>.TryGetArray(long id, out ArraySegment<T> buffer)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        Span<T> IMemory<T>.GetSpan(long versionId, int reservationId)
         {
-            return TryGetArrayInternal(id, out buffer);
+            ThrowIfDisposed(versionId, reservationId);
+            return GetSpanCore();
+        }
+
+        ReadOnlySpan<T> IReadOnlyMemory<T>.GetSpan(long versionId, int reservationId)
+        {
+            ThrowIfDisposed(versionId, reservationId);
+            return GetSpanCore();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal Span<T> GetSpanInternal(long id)
+        internal bool IsActive(long versionId, int reservationId)
         {
-            VerifyId(id);
-            return Span;
+            return !(_versionId != versionId || IsReservationDisposed(reservationId));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        Span<T> IMemory<T>.GetSpan(long id)
+        internal bool IsActive()
         {
-            return GetSpanInternal(id);
+            return !(IsDisposed || IsReservationDisposed(BaseReservationId));
+        }
+
+        void IAllowsDependencyMemory<T>.ThrowIfDisposed(long versionId, int reservationId)
+            => ThrowIfDisposed(versionId, reservationId);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void ThrowIfDisposed(long versionId, int reservationId) {
+            if (!IsActive(versionId, reservationId)) ThrowObjectDisposedException();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        void VerifyId(long id) {
-            if (Id != id) ThrowIdHelper();
+        private void ThrowIfDisposed()
+        {
+            if (!IsActive()) ThrowObjectDisposedException();
         }
 
-        void ThrowIdHelper() {
+        void ThrowObjectDisposedException() {
             throw new ObjectDisposedException(nameof(Memory<T>));
-        }
-        #endregion
-    }
-
-    interface IKnown
-    {
-        void AddReference(long id);
-        void Release(long id);
-    }
-
-    internal interface IMemory<T> : IKnown
-    {
-        Span<T> GetSpan(long id);
-
-        bool TryGetArray(long id, out ArraySegment<T> buffer);
-        unsafe bool TryGetPointer(long id, out void* pointer);
-    }
-
-    public struct DisposableReservation : IDisposable
-    {
-        IKnown _owner;
-        long _id;
-
-        internal DisposableReservation(IKnown owner, long id)
-        {
-            _id = id;
-            _owner = owner;
-            _owner.AddReference(_id);
-        }
-
-        public void Dispose()
-        {
-            _owner.Release(_id);
-            _owner = null;
         }
     }
 }

--- a/src/System.Slices/System/Buffers/ReservedMemory.cs
+++ b/src/System.Slices/System/Buffers/ReservedMemory.cs
@@ -1,0 +1,34 @@
+﻿namespace System.Buffers
+{
+    public struct ReservedMemory<T> : IDisposable
+    {
+        IMemory<T> _owner;
+        Memory<T> _memory;
+        long _versionId;
+        int _reservationId;
+
+        internal ReservedMemory(ref Memory<T> memory, OwnedMemory<T> owner, long versionId, int reservationId)
+        {
+            _versionId = versionId;
+            _owner = owner;
+            _reservationId = _owner.AddReference(versionId, reservationId);
+            _memory = new Memory<T>(ref memory, _reservationId);
+        }
+
+        public bool IsDisposed => _owner.IsDependancyDisposed(_versionId, _reservationId);
+
+        public Memory<T> Memory
+        {
+            get
+            {
+                _owner.ThrowIfDisposed(_versionId, _reservationId);
+                return _memory;
+            }
+        }
+
+        public void Dispose()
+        {
+            _owner.Release(_versionId, _reservationId);
+        }
+    }
+}

--- a/src/System.Slices/System/Buffers/ReservedReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReservedReadOnlyMemory.cs
@@ -1,0 +1,34 @@
+﻿namespace System.Buffers
+{
+    public struct ReservedReadOnlyMemory<T> : IDisposable
+    {
+        IReadOnlyMemory<T> _owner;
+        ReadOnlyMemory<T> _memory;
+        long _versionId;
+        int _reservationId;
+
+        internal ReservedReadOnlyMemory(ref ReadOnlyMemory<T> memory, OwnedMemory<T> owner, long versionId, int reservationId)
+        {
+            _versionId = versionId;
+            _owner = owner;
+            _reservationId = _owner.AddReference(versionId, reservationId);
+            _memory = new ReadOnlyMemory<T>(ref memory, _reservationId);
+        }
+
+        public bool IsDisposed => _owner.IsDependancyDisposed(_versionId, _reservationId);
+
+        public ReadOnlyMemory<T> Memory
+        {
+            get
+            {
+                _owner.ThrowIfDisposed(_versionId, _reservationId);
+                return _memory;
+            }
+        }
+
+        public void Dispose()
+        {
+            _owner.Release(_versionId, _reservationId);
+        }
+    }
+}

--- a/src/System.Slices/System/ReadOnlySpan.cs
+++ b/src/System.Slices/System/ReadOnlySpan.cs
@@ -207,8 +207,8 @@ namespace System
             if (default(T) != null && MemoryUtils.IsPrimitiveValueType<T>())
             {
                 // review: (#848) - overflow and alignment
-                UnsafeUtilities.CopyBlock(src.Object, src.Offset, dest.Object, dest.Offset,
-                                   src.Length * Unsafe.SizeOf<T>());
+                //UnsafeUtilities.CopyBlock(src.Object, src.Offset, dest.Object, dest.Offset,
+                //                   src.Length * Unsafe.SizeOf<T>());
             }
             else
             {

--- a/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
@@ -8,7 +8,7 @@ namespace System.Slices.Tests
     public class MemoryTests
     {
         [Fact]
-        public void SimpleTestS()
+        public void SimpleTests()
         {            
             using(var owned = new OwnedNativeMemory(1024)) {
                 var span = owned.Span;
@@ -46,46 +46,161 @@ namespace System.Slices.Tests
         [Fact]
         public void NativeMemoryLifetime()
         {
-            Memory<byte> copyStoredForLater;
-            using (var owner = new OwnedNativeMemory(1024)) {
-                Memory<byte> memory = owner.Memory;
-                Memory<byte> memorySlice = memory.Slice(10);
-                copyStoredForLater = memorySlice;
-                using (memorySlice.Reserve()) {
-                    Assert.Throws<InvalidOperationException>(() => { // memory is reserved; cannot dispose
-                        owner.Dispose();
-                    }); 
-                    Span<byte> span = memorySlice.Span;
-                    span[0] = 255;
-                }
-            }
-            Assert.Throws<ObjectDisposedException>(() => { // manager is disposed
-                var span = copyStoredForLater.Span;
-            });
+            var owner = new OwnedNativeMemory(1024);
+            TestMemoryLifetime(owner);
         }
 
         [Fact]
         public unsafe void PinnedArrayMemoryLifetime()
         {
-            Memory<byte> copyStoredForLater;
             var bytes = new byte[1024];
             fixed (byte* pBytes = bytes) {
-                using (var owner = new OwnedPinnedArray<byte>(bytes, pBytes)) {
-                    Memory<byte> memory = owner.Memory;
-                    Memory<byte> memorySlice = memory.Slice(10);
-                    copyStoredForLater = memorySlice;
-                    using (memorySlice.Reserve()) {
-                        Assert.Throws<InvalidOperationException>(() => { // memory is reserved; cannot dispose
-                            owner.Dispose();
-                        }); 
-                        Span<byte> span = memorySlice.Span;
-                        span[0] = 255;
-                    }
-                }   
+                var owner = new OwnedPinnedArray<byte>(bytes, pBytes);
+                TestMemoryLifetime(owner);
             }
-            Assert.Throws<ObjectDisposedException>(() => { // manager is disposed
-                var span = copyStoredForLater.Span;
+        }
+
+        public static void TestMemoryLifetime(OwnedMemory<byte> owned)
+        {
+            Assert.Equal(1, owned.ReferenceCount);
+
+            var baseMemory = owned.Memory;
+
+            var reservation0 = baseMemory.Reserve();
+
+            Assert.Equal(2, owned.ReferenceCount);
+
+            var memory0 = reservation0.Memory;
+
+            var reservation1 = memory0.Reserve();
+
+            Assert.Equal(3, owned.ReferenceCount);
+
+            NonDisposedDoesNotThrow(memory0);
+            NonDisposedDoesNotThrow(reservation0);
+
+            reservation0.Dispose();
+
+            Assert.Equal(2, owned.ReferenceCount);
+
+            DisposedDoesThrow(reservation0);
+            DisposedDoesThrow(memory0);
+            NonDisposedDoesNotThrow(reservation1);
+
+            NonDisposedDoesNotThrow(owned);
+            NonDisposedDoesNotThrow(baseMemory);
+
+            var reservation2 = baseMemory.Reserve();
+
+            Assert.Equal(3, owned.ReferenceCount);
+
+            owned.Dispose();
+
+            Assert.Equal(2, owned.ReferenceCount);
+
+            DisposedDoesThrow(owned);
+            DisposedDoesThrow(baseMemory);
+
+            NonDisposedDoesNotThrow(reservation1);
+            NonDisposedDoesNotThrow(reservation2);
+
+            reservation1.Dispose();
+            reservation2.Dispose();
+
+            DisposedDoesThrow(reservation1);
+            DisposedDoesThrow(reservation2);
+
+            Assert.Equal(0, owned.ReferenceCount);
+        }
+
+        static void NonDisposedDoesNotThrow<T>(OwnedMemory<T> owned)
+        {
+            Assert.False(owned.IsDisposed);
+            Assert.True(owned.ReferenceCount >= 1);
+
+            var span = owned.Span;
+            var memory = owned.Memory;
+
+            NonDisposedDoesNotThrow(memory);
+        }
+
+        static void NonDisposedDoesNotThrow<T>(ReservedMemory<T> reservation)
+        {
+            Assert.False(reservation.IsDisposed);
+
+            var memory = reservation.Memory;
+            NonDisposedDoesNotThrow(memory);
+        }
+
+        static void NonDisposedDoesNotThrow<T>(Memory<T> memory)
+        {
+            Assert.False(memory.IsDisposed);
+            var span = memory.Span;
+            using (var reservation = memory.Reserve()) { }
+            memory = memory.Slice(0);
+
+            ArraySegment<T> buffer;
+            memory.TryGetArray(out buffer);
+
+            unsafe
+            {
+                void* pointer;
+                memory.TryGetPointer(out pointer);
+            }
+        }
+
+        static void DisposedDoesThrow<T>(OwnedMemory<T> owned)
+        {
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                var span = owned.Span;
             });
-        }   
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                var memory = owned.Memory;
+            });
+        }
+
+        static void DisposedDoesThrow<T>(ReservedMemory<T> reservation)
+        {
+            Assert.True(reservation.IsDisposed);
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                var memory = reservation.Memory;
+            });
+        }
+
+        static void DisposedDoesThrow<T>(Memory<T> memory)
+        {
+            Assert.True(memory.IsDisposed);
+
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                var span = memory.Span;
+            });
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                using (var reservation = memory.Reserve()) { }
+            });
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                memory = memory.Slice(0);
+            });
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                ArraySegment<T> buffer;
+                memory.TryGetArray(out buffer);
+            });
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                unsafe
+                {
+                    void* pointer;
+                    memory.TryGetPointer(out pointer);
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION
Calling dispose on reservation disposes all associated `Memory`.

Reservation dispose can only dispose itself and Memory derived from it; not other Reservations or owner (reference count only decrements once).

Calling dispose on owner disposes itself and all associated `Memory` it does not dispose any Reservations or their Memory (reference count only decrements once).

Lifetimes are independent and disposes can't effect each other e.g. you can't copy the Reservation struct and then over dispose the reference.

Full compliance with Dispose pattern

> If an object's Dispose method is called more than once, the object must ignore all calls after the first one. The object must not throw an exception if its Dispose method is called multiple times.
