### PR TITLE
Start consolidation and rewriting of System.Text.PrimitiveParser

### DIFF
--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf16/InvariantUtf16_UInt32.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf16/InvariantUtf16_UInt32.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Text.Utf8;
+
+namespace System.Text
+{
+    public static partial class PrimitiveParser2
+    {
+        public static partial class InvariantUtf16
+        {
+            public unsafe static bool TryParseUInt32(char* text, int length, out uint value)
+            {
+                int consumed;
+                var span = new ReadOnlySpan<byte>(text, length);
+                return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf16);
+            }
+            public unsafe static bool TryParseUInt32(char* text, int length, out uint value, out int consumed)
+            {
+                var span = new ReadOnlySpan<byte>(text, length);
+                return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf16);
+            }
+            public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value)
+            {
+                int consumed;
+                return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf16);
+            }
+            public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int consumed)
+            {
+                return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf16);
+            }
+            public static partial class Hex
+            {
+                public unsafe static bool TryParseUInt32(char* text, int length, out uint value)
+                {
+                    int consumed;
+                    var span = new ReadOnlySpan<byte>(text, length);
+                    return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf16, 'X');
+                }
+                public unsafe static bool TryParseUInt32(char* text, int length, out uint value, out int consumed)
+                {
+                    var span = new ReadOnlySpan<byte>(text, length);
+                    return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf16, 'X');
+                }
+                public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value)
+                {
+                    int consumed;
+                    return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf16, 'X');
+                }
+                public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int consumed)
+                {
+                    return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf16, 'X');
+                }
+            }
+        }
+    }
+}

--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf16/InvariantUtf16_UInt32.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf16/InvariantUtf16_UInt32.cs
@@ -6,51 +6,68 @@ using System.Text.Utf8;
 
 namespace System.Text
 {
-    public static partial class PrimitiveParser2
+    public static partial class PrimitiveParser
     {
         public static partial class InvariantUtf16
         {
             public unsafe static bool TryParseUInt32(char* text, int length, out uint value)
             {
                 int consumed;
-                var span = new ReadOnlySpan<byte>(text, length);
-                return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf16);
+                var span = new ReadOnlySpan<byte>(text, length * 2);
+                return PrimitiveParser.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf16);
             }
             public unsafe static bool TryParseUInt32(char* text, int length, out uint value, out int consumed)
             {
-                var span = new ReadOnlySpan<byte>(text, length);
-                return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf16);
+                var span = new ReadOnlySpan<byte>(text, length * 2);
+                int bytesConsumed;
+                bool result = PrimitiveParser.TryParseUInt32(span, out value, out bytesConsumed, EncodingData.InvariantUtf16);
+                consumed = bytesConsumed / 2;
+                return result;
             }
-            public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value)
+            public static bool TryParseUInt32(ReadOnlySpan<char> text, out uint value)
             {
                 int consumed;
-                return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf16);
+                var byteSpan = text.Cast<char, byte>();
+                return PrimitiveParser.TryParseUInt32(byteSpan, out value, out consumed, EncodingData.InvariantUtf16);
             }
-            public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int consumed)
+            public static bool TryParseUInt32(ReadOnlySpan<char> text, out uint value, out int consumed)
             {
-                return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf16);
+                var byteSpan = text.Cast<char, byte>();
+                int bytesConsumed;
+                bool result = PrimitiveParser.TryParseUInt32(byteSpan, out value, out bytesConsumed, EncodingData.InvariantUtf16);
+                consumed = bytesConsumed / 2;
+                return result;
             }
+
             public static partial class Hex
             {
                 public unsafe static bool TryParseUInt32(char* text, int length, out uint value)
                 {
                     int consumed;
-                    var span = new ReadOnlySpan<byte>(text, length);
-                    return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf16, 'X');
+                    var span = new ReadOnlySpan<byte>(text, length * 2);
+                    return PrimitiveParser.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf16, 'X');
                 }
                 public unsafe static bool TryParseUInt32(char* text, int length, out uint value, out int consumed)
                 {
-                    var span = new ReadOnlySpan<byte>(text, length);
-                    return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf16, 'X');
+                    var span = new ReadOnlySpan<byte>(text, length * 2);
+                    int bytesConsumed;
+                    bool result = PrimitiveParser.TryParseUInt32(span, out value, out bytesConsumed, EncodingData.InvariantUtf16, 'X');
+                    consumed = bytesConsumed / 2;
+                    return result;
                 }
-                public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value)
+                public static bool TryParseUInt32(ReadOnlySpan<char> text, out uint value)
                 {
                     int consumed;
-                    return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf16, 'X');
+                    var byteSpan = text.Cast<char, byte>();
+                    return PrimitiveParser.TryParseUInt32(byteSpan, out value, out consumed, EncodingData.InvariantUtf16, 'X');
                 }
-                public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int consumed)
+                public static bool TryParseUInt32(ReadOnlySpan<char> text, out uint value, out int consumed)
                 {
-                    return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf16, 'X');
+                    var byteSpan = text.Cast<char, byte>();
+                    int bytesConsumed;
+                    bool result = PrimitiveParser.TryParseUInt32(byteSpan, out value, out bytesConsumed, EncodingData.InvariantUtf16, 'X');
+                    consumed = bytesConsumed / 2;
+                    return result;
                 }
             }
         }

--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf16/InvariantUtf16_UInt32.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf16/InvariantUtf16_UInt32.cs
@@ -16,12 +16,12 @@ namespace System.Text
                 var span = new ReadOnlySpan<byte>(text, length * 2);
                 return PrimitiveParser.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf16);
             }
-            public unsafe static bool TryParseUInt32(char* text, int length, out uint value, out int consumed)
+            public unsafe static bool TryParseUInt32(char* text, int length, out uint value, out int charactersConsumed)
             {
                 var span = new ReadOnlySpan<byte>(text, length * 2);
                 int bytesConsumed;
                 bool result = PrimitiveParser.TryParseUInt32(span, out value, out bytesConsumed, EncodingData.InvariantUtf16);
-                consumed = bytesConsumed / 2;
+                charactersConsumed = bytesConsumed / 2;
                 return result;
             }
             public static bool TryParseUInt32(ReadOnlySpan<char> text, out uint value)
@@ -30,12 +30,12 @@ namespace System.Text
                 var byteSpan = text.Cast<char, byte>();
                 return PrimitiveParser.TryParseUInt32(byteSpan, out value, out consumed, EncodingData.InvariantUtf16);
             }
-            public static bool TryParseUInt32(ReadOnlySpan<char> text, out uint value, out int consumed)
+            public static bool TryParseUInt32(ReadOnlySpan<char> text, out uint value, out int charactersConsumed)
             {
                 var byteSpan = text.Cast<char, byte>();
                 int bytesConsumed;
                 bool result = PrimitiveParser.TryParseUInt32(byteSpan, out value, out bytesConsumed, EncodingData.InvariantUtf16);
-                consumed = bytesConsumed / 2;
+                charactersConsumed = bytesConsumed / 2;
                 return result;
             }
 
@@ -47,12 +47,12 @@ namespace System.Text
                     var span = new ReadOnlySpan<byte>(text, length * 2);
                     return PrimitiveParser.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf16, 'X');
                 }
-                public unsafe static bool TryParseUInt32(char* text, int length, out uint value, out int consumed)
+                public unsafe static bool TryParseUInt32(char* text, int length, out uint value, out int charactersConsumed)
                 {
                     var span = new ReadOnlySpan<byte>(text, length * 2);
                     int bytesConsumed;
                     bool result = PrimitiveParser.TryParseUInt32(span, out value, out bytesConsumed, EncodingData.InvariantUtf16, 'X');
-                    consumed = bytesConsumed / 2;
+                    charactersConsumed = bytesConsumed / 2;
                     return result;
                 }
                 public static bool TryParseUInt32(ReadOnlySpan<char> text, out uint value)
@@ -61,12 +61,12 @@ namespace System.Text
                     var byteSpan = text.Cast<char, byte>();
                     return PrimitiveParser.TryParseUInt32(byteSpan, out value, out consumed, EncodingData.InvariantUtf16, 'X');
                 }
-                public static bool TryParseUInt32(ReadOnlySpan<char> text, out uint value, out int consumed)
+                public static bool TryParseUInt32(ReadOnlySpan<char> text, out uint value, out int charactersConsumed)
                 {
                     var byteSpan = text.Cast<char, byte>();
                     int bytesConsumed;
                     bool result = PrimitiveParser.TryParseUInt32(byteSpan, out value, out bytesConsumed, EncodingData.InvariantUtf16, 'X');
-                    consumed = bytesConsumed / 2;
+                    charactersConsumed = bytesConsumed / 2;
                     return result;
                 }
             }

--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf16/InvariantUtf16_bool.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf16/InvariantUtf16_bool.cs
@@ -6,29 +6,37 @@ using System.Text.Utf8;
 
 namespace System.Text
 {
-    public static partial class PrimitiveParser2
+    public static partial class PrimitiveParser
     {
         public static partial class InvariantUtf16
         {
             public unsafe static bool TryParseBoolean(char* text, int length, out bool value)
             {
-                int consumedBytes;
-                var span = new ReadOnlySpan<byte>(text, length);
-                return PrimitiveParser2.TryParseBoolean(span, out value, out consumedBytes, EncodingData.InvariantUtf16);
+                int consumed;
+                var span = new ReadOnlySpan<byte>(text, length * 2);
+                return PrimitiveParser.TryParseBoolean(span, out value, out consumed, EncodingData.InvariantUtf16);
             }
-            public unsafe static bool TryParseBoolean(char* text, int length, out bool value, out int consumedBytes)
+            public unsafe static bool TryParseBoolean(char* text, int length, out bool value, out int consumed)
             {
-                var span = new ReadOnlySpan<byte>(text, length);
-                return PrimitiveParser2.TryParseBoolean(span, out value, out consumedBytes, EncodingData.InvariantUtf16);
+                var span = new ReadOnlySpan<byte>(text, length * 2);
+                int bytesConsumed;
+                bool result = PrimitiveParser.TryParseBoolean(span, out value, out bytesConsumed, EncodingData.InvariantUtf16);
+                consumed = bytesConsumed / 2;
+                return result;
             }
-            public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value)
+            public static bool TryParseBoolean(ReadOnlySpan<char> text, out bool value)
             {
-                int consumedBytes;
-                return PrimitiveParser2.TryParseBoolean(text, out value, out consumedBytes, EncodingData.InvariantUtf16);
+                int consumed;
+                var byteSpan = text.Cast<char, byte>();
+                return PrimitiveParser.TryParseBoolean(byteSpan, out value, out consumed, EncodingData.InvariantUtf16);
             }
-            public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value, out int consumedBytes)
+            public static bool TryParseBoolean(ReadOnlySpan<char> text, out bool value, out int consumed)
             {
-                return PrimitiveParser2.TryParseBoolean(text, out value, out consumedBytes, EncodingData.InvariantUtf16);
+                var byteSpan = text.Cast<char, byte>();
+                int bytesConsumed;
+                bool result = PrimitiveParser.TryParseBoolean(byteSpan, out value, out bytesConsumed, EncodingData.InvariantUtf16);
+                consumed = bytesConsumed / 2;
+                return result;
             }
         }
     }

--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf16/InvariantUtf16_bool.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf16/InvariantUtf16_bool.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Text.Utf8;
+
+namespace System.Text
+{
+    public static partial class PrimitiveParser2
+    {
+        public static partial class InvariantUtf16
+        {
+            public unsafe static bool TryParseBoolean(char* text, int length, out bool value)
+            {
+                int consumedBytes;
+                var span = new ReadOnlySpan<byte>(text, length);
+                return PrimitiveParser2.TryParseBoolean(span, out value, out consumedBytes, EncodingData.InvariantUtf16);
+            }
+            public unsafe static bool TryParseBoolean(char* text, int length, out bool value, out int consumedBytes)
+            {
+                var span = new ReadOnlySpan<byte>(text, length);
+                return PrimitiveParser2.TryParseBoolean(span, out value, out consumedBytes, EncodingData.InvariantUtf16);
+            }
+            public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value)
+            {
+                int consumedBytes;
+                return PrimitiveParser2.TryParseBoolean(text, out value, out consumedBytes, EncodingData.InvariantUtf16);
+            }
+            public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value, out int consumedBytes)
+            {
+                return PrimitiveParser2.TryParseBoolean(text, out value, out consumedBytes, EncodingData.InvariantUtf16);
+            }
+        }
+    }
+}

--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf16/InvariantUtf16_bool.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf16/InvariantUtf16_bool.cs
@@ -16,12 +16,12 @@ namespace System.Text
                 var span = new ReadOnlySpan<byte>(text, length * 2);
                 return PrimitiveParser.TryParseBoolean(span, out value, out consumed, EncodingData.InvariantUtf16);
             }
-            public unsafe static bool TryParseBoolean(char* text, int length, out bool value, out int consumed)
+            public unsafe static bool TryParseBoolean(char* text, int length, out bool value, out int charactersConsumed)
             {
                 var span = new ReadOnlySpan<byte>(text, length * 2);
                 int bytesConsumed;
                 bool result = PrimitiveParser.TryParseBoolean(span, out value, out bytesConsumed, EncodingData.InvariantUtf16);
-                consumed = bytesConsumed / 2;
+                charactersConsumed = bytesConsumed / 2;
                 return result;
             }
             public static bool TryParseBoolean(ReadOnlySpan<char> text, out bool value)
@@ -30,12 +30,12 @@ namespace System.Text
                 var byteSpan = text.Cast<char, byte>();
                 return PrimitiveParser.TryParseBoolean(byteSpan, out value, out consumed, EncodingData.InvariantUtf16);
             }
-            public static bool TryParseBoolean(ReadOnlySpan<char> text, out bool value, out int consumed)
+            public static bool TryParseBoolean(ReadOnlySpan<char> text, out bool value, out int charactersConsumed)
             {
                 var byteSpan = text.Cast<char, byte>();
                 int bytesConsumed;
                 bool result = PrimitiveParser.TryParseBoolean(byteSpan, out value, out bytesConsumed, EncodingData.InvariantUtf16);
-                consumed = bytesConsumed / 2;
+                charactersConsumed = bytesConsumed / 2;
                 return result;
             }
         }

--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_UInt32.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_UInt32.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Text.Utf8;
+
+namespace System.Text
+{
+    public static partial class PrimitiveParser2
+    {
+        public static partial class InvariantUtf8
+        {
+            public unsafe static bool TryParseUInt32(char* text, int length, out uint value)
+            {
+                int consumed;
+                var span = new ReadOnlySpan<byte>(text, length);
+                return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8);
+            }
+            public unsafe static bool TryParseUInt32(char* text, int length, out uint value, out int consumed)
+            {
+                var span = new ReadOnlySpan<byte>(text, length);
+                return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8);
+            }
+            public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value)
+            {
+                int consumed;
+                return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8);
+            }
+            public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int consumed)
+            {
+                return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8);
+            }
+            public static partial class Hex
+            {
+                public unsafe static bool TryParseUInt32(char* text, int length, out uint value)
+                {
+                    int consumed;
+                    var span = new ReadOnlySpan<byte>(text, length);
+                    return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8, 'X');
+                }
+                public unsafe static bool TryParseUInt32(char* text, int length, out uint value, out int consumed)
+                {
+                    var span = new ReadOnlySpan<byte>(text, length);
+                    return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8, 'X');
+                }
+                public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value)
+                {
+                    int consumed;
+                    return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8, 'X');
+                }
+                public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int consumed)
+                {
+                    return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8, 'X');
+                }
+            }
+        }
+    }
+}

--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_UInt32.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_UInt32.cs
@@ -16,19 +16,19 @@ namespace System.Text
                 var span = new ReadOnlySpan<byte>(text, length);
                 return PrimitiveParser.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8);
             }
-            public unsafe static bool TryParseUInt32(byte* text, int length, out uint value, out int consumed)
+            public unsafe static bool TryParseUInt32(byte* text, int length, out uint value, out int bytesConsumed)
             {
                 var span = new ReadOnlySpan<byte>(text, length);
-                return PrimitiveParser.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8);
+                return PrimitiveParser.TryParseUInt32(span, out value, out bytesConsumed, EncodingData.InvariantUtf8);
             }
             public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value)
             {
                 int consumed;
                 return PrimitiveParser.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8);
             }
-            public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int consumed)
+            public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int bytesConsumed)
             {
-                return PrimitiveParser.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8);
+                return PrimitiveParser.TryParseUInt32(text, out value, out bytesConsumed, EncodingData.InvariantUtf8);
             }
 
             public static partial class Hex
@@ -39,19 +39,19 @@ namespace System.Text
                     var span = new ReadOnlySpan<byte>(text, length);
                     return PrimitiveParser.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8, 'X');
                 }
-                public unsafe static bool TryParseUInt32(byte* text, int length, out uint value, out int consumed)
+                public unsafe static bool TryParseUInt32(byte* text, int length, out uint value, out int bytesConsumed)
                 {
                     var span = new ReadOnlySpan<byte>(text, length);
-                    return PrimitiveParser.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8, 'X');
+                    return PrimitiveParser.TryParseUInt32(span, out value, out bytesConsumed, EncodingData.InvariantUtf8, 'X');
                 }
                 public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value)
                 {
                     int consumed;
                     return PrimitiveParser.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8, 'X');
                 }
-                public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int consumed)
+                public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int bytesConsumed)
                 {
-                    return PrimitiveParser.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8, 'X');
+                    return PrimitiveParser.TryParseUInt32(text, out value, out bytesConsumed, EncodingData.InvariantUtf8, 'X');
                 }
             }
         }

--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_UInt32.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_UInt32.cs
@@ -6,51 +6,52 @@ using System.Text.Utf8;
 
 namespace System.Text
 {
-    public static partial class PrimitiveParser2
+    public static partial class PrimitiveParser
     {
         public static partial class InvariantUtf8
         {
-            public unsafe static bool TryParseUInt32(char* text, int length, out uint value)
+            public unsafe static bool TryParseUInt32(byte* text, int length, out uint value)
             {
                 int consumed;
                 var span = new ReadOnlySpan<byte>(text, length);
-                return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8);
+                return PrimitiveParser.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8);
             }
-            public unsafe static bool TryParseUInt32(char* text, int length, out uint value, out int consumed)
+            public unsafe static bool TryParseUInt32(byte* text, int length, out uint value, out int consumed)
             {
                 var span = new ReadOnlySpan<byte>(text, length);
-                return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8);
+                return PrimitiveParser.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8);
             }
             public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value)
             {
                 int consumed;
-                return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8);
+                return PrimitiveParser.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8);
             }
             public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int consumed)
             {
-                return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8);
+                return PrimitiveParser.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8);
             }
+
             public static partial class Hex
             {
-                public unsafe static bool TryParseUInt32(char* text, int length, out uint value)
+                public unsafe static bool TryParseUInt32(byte* text, int length, out uint value)
                 {
                     int consumed;
                     var span = new ReadOnlySpan<byte>(text, length);
-                    return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8, 'X');
+                    return PrimitiveParser.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8, 'X');
                 }
-                public unsafe static bool TryParseUInt32(char* text, int length, out uint value, out int consumed)
+                public unsafe static bool TryParseUInt32(byte* text, int length, out uint value, out int consumed)
                 {
                     var span = new ReadOnlySpan<byte>(text, length);
-                    return PrimitiveParser2.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8, 'X');
+                    return PrimitiveParser.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8, 'X');
                 }
                 public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value)
                 {
                     int consumed;
-                    return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8, 'X');
+                    return PrimitiveParser.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8, 'X');
                 }
                 public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int consumed)
                 {
-                    return PrimitiveParser2.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8, 'X');
+                    return PrimitiveParser.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8, 'X');
                 }
             }
         }

--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_bool.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_bool.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Text.Utf8;
+
+namespace System.Text
+{
+    public static partial class PrimitiveParser2
+    {
+        public static partial class InvariantUtf8
+        {
+            public unsafe static bool TryParseBoolean(byte* text, int length, out bool value)
+            {
+                int consumedBytes;
+                var span = new ReadOnlySpan<byte>(text, length);
+                return PrimitiveParser2.TryParseBoolean(span, out value, out consumedBytes, EncodingData.InvariantUtf8);
+            }
+            public unsafe static bool TryParseBoolean(byte* text, int length, out bool value, out int consumedBytes)
+            {
+                var span = new ReadOnlySpan<byte>(text, length);
+                return PrimitiveParser2.TryParseBoolean(span, out value, out consumedBytes, EncodingData.InvariantUtf8);
+            }
+            public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value)
+            {
+                int consumedBytes;
+                return PrimitiveParser2.TryParseBoolean(text, out value, out consumedBytes, EncodingData.InvariantUtf8);
+            }
+            public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value, out int consumedBytes)
+            {
+                return PrimitiveParser2.TryParseBoolean(text, out value, out consumedBytes, EncodingData.InvariantUtf8);
+            }
+        }
+    }
+}

--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_bool.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_bool.cs
@@ -16,19 +16,19 @@ namespace System.Text
                 var span = new ReadOnlySpan<byte>(text, length);
                 return PrimitiveParser.TryParseBoolean(span, out value, out consumed, EncodingData.InvariantUtf8);
             }
-            public unsafe static bool TryParseBoolean(byte* text, int length, out bool value, out int consumed)
+            public unsafe static bool TryParseBoolean(byte* text, int length, out bool value, out int bytesConsumed)
             {
                 var span = new ReadOnlySpan<byte>(text, length);
-                return PrimitiveParser.TryParseBoolean(span, out value, out consumed, EncodingData.InvariantUtf8);
+                return PrimitiveParser.TryParseBoolean(span, out value, out bytesConsumed, EncodingData.InvariantUtf8);
             }
             public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value)
             {
                 int consumed;
                 return PrimitiveParser.TryParseBoolean(text, out value, out consumed, EncodingData.InvariantUtf8);
             }
-            public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value, out int consumed)
+            public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value, out int bytesConsumed)
             {
-                return PrimitiveParser.TryParseBoolean(text, out value, out consumed, EncodingData.InvariantUtf8);
+                return PrimitiveParser.TryParseBoolean(text, out value, out bytesConsumed, EncodingData.InvariantUtf8);
             }
         }
     }

--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_bool.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_bool.cs
@@ -6,29 +6,29 @@ using System.Text.Utf8;
 
 namespace System.Text
 {
-    public static partial class PrimitiveParser2
+    public static partial class PrimitiveParser
     {
         public static partial class InvariantUtf8
         {
             public unsafe static bool TryParseBoolean(byte* text, int length, out bool value)
             {
-                int consumedBytes;
+                int consumed;
                 var span = new ReadOnlySpan<byte>(text, length);
-                return PrimitiveParser2.TryParseBoolean(span, out value, out consumedBytes, EncodingData.InvariantUtf8);
+                return PrimitiveParser.TryParseBoolean(span, out value, out consumed, EncodingData.InvariantUtf8);
             }
-            public unsafe static bool TryParseBoolean(byte* text, int length, out bool value, out int consumedBytes)
+            public unsafe static bool TryParseBoolean(byte* text, int length, out bool value, out int consumed)
             {
                 var span = new ReadOnlySpan<byte>(text, length);
-                return PrimitiveParser2.TryParseBoolean(span, out value, out consumedBytes, EncodingData.InvariantUtf8);
+                return PrimitiveParser.TryParseBoolean(span, out value, out consumed, EncodingData.InvariantUtf8);
             }
             public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value)
             {
-                int consumedBytes;
-                return PrimitiveParser2.TryParseBoolean(text, out value, out consumedBytes, EncodingData.InvariantUtf8);
+                int consumed;
+                return PrimitiveParser.TryParseBoolean(text, out value, out consumed, EncodingData.InvariantUtf8);
             }
-            public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value, out int consumedBytes)
+            public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value, out int consumed)
             {
-                return PrimitiveParser2.TryParseBoolean(text, out value, out consumedBytes, EncodingData.InvariantUtf8);
+                return PrimitiveParser.TryParseBoolean(text, out value, out consumed, EncodingData.InvariantUtf8);
             }
         }
     }

--- a/src/System.Text.Primitives/System/Text/Parsing/PrimitiveParser2_UInt32.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/PrimitiveParser2_UInt32.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Text.Utf8;
+
+namespace System.Text
+{
+    public static partial class PrimitiveParser2
+    {
+        #region helpers
+        #endregion
+
+        public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int consumedBytes, EncodingData encoding = default(EncodingData), Format.Parsed format = default(Format.Parsed))
+        {
+            return PrimitiveParser.TryParseUInt32(text, encoding, format, out value, out consumedBytes);
+        }
+    }
+}

--- a/src/System.Text.Primitives/System/Text/Parsing/PrimitiveParser2_UInt32.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/PrimitiveParser2_UInt32.cs
@@ -6,14 +6,11 @@ using System.Text.Utf8;
 
 namespace System.Text
 {
-    public static partial class PrimitiveParser2
+    public static partial class PrimitiveParser
     {
-        #region helpers
-        #endregion
-
         public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int consumedBytes, EncodingData encoding = default(EncodingData), Format.Parsed format = default(Format.Parsed))
         {
-            return PrimitiveParser.TryParseUInt32(text, encoding, format, out value, out consumedBytes);
+            return TryParseUInt32(text, encoding, format, out value, out consumedBytes);
         }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Parsing/PrimitiveParser2_bool.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/PrimitiveParser2_bool.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Text.Utf8;
+
+namespace System.Text
+{
+    public static partial class PrimitiveParser2
+    {
+        #region helpers
+
+        private static bool IsTrue(ReadOnlySpan<byte> utf8Bytes)
+        {
+            if (utf8Bytes.Length < 4)
+                return false;
+
+            byte firstChar = utf8Bytes[0];
+            if (firstChar != 't' && firstChar != 'T')
+                return false;
+
+            byte secondChar = utf8Bytes[1];
+            if (secondChar != 'r' && secondChar != 'R')
+                return false;
+
+            byte thirdChar = utf8Bytes[2];
+            if (thirdChar != 'u' && thirdChar != 'U')
+                return false;
+
+            byte fourthChar = utf8Bytes[3];
+            if (fourthChar != 'e' && fourthChar != 'E')
+                return false;
+
+            return true;
+        }
+
+        private static bool IsFalse(ReadOnlySpan<byte> utf8Bytes)
+        {
+            if (utf8Bytes.Length < 5)
+                return false;
+
+            byte firstChar = utf8Bytes[0];
+            if (firstChar != 'f' && firstChar != 'F')
+                return false;
+
+            byte secondChar = utf8Bytes[1];
+            if (secondChar != 'a' && secondChar != 'A')
+                return false;
+
+            byte thirdChar = utf8Bytes[2];
+            if (thirdChar != 'l' && thirdChar != 'L')
+                return false;
+
+            byte fourthChar = utf8Bytes[3];
+            if (fourthChar != 's' && fourthChar != 'S')
+                return false;
+
+            byte fifthChar = utf8Bytes[4];
+            if (fifthChar != 'e' && fifthChar != 'E')
+                return false;
+
+            return true;
+        }
+
+        #endregion
+
+        public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value, out int consumedBytes, EncodingData encoding = default(EncodingData))
+        {
+            consumedBytes = 0;
+            value = default(bool);
+            if (text.Length < 1)
+            {
+                return false;
+            }
+
+            if (encoding.IsInvariantUtf8)
+            {
+                byte firstCodeUnit = text[0];
+
+                if (firstCodeUnit == '1')
+                {
+                    consumedBytes = 1;
+                    value = true;
+                    return true;
+                }
+                else if (firstCodeUnit == '0')
+                {
+                    consumedBytes = 1;
+                    value = false;
+                    return true;
+                }
+                else if (IsTrue(text))
+                {
+                    consumedBytes = 4;
+                    value = true;
+                    return true;
+                }
+                else if (IsFalse(text))
+                {
+                    consumedBytes = 5;
+                    value = false;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            if (encoding.IsInvariantUtf16)
+            {
+                throw new NotImplementedException();
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/System.Text.Primitives/System/Text/Parsing/PrimitiveParser2_bool.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/PrimitiveParser2_bool.cs
@@ -6,56 +6,56 @@ using System.Text.Utf8;
 
 namespace System.Text
 {
-    public static partial class PrimitiveParser2
+    public static partial class PrimitiveParser
     {
         #region helpers
 
-        private static bool IsTrue(ReadOnlySpan<byte> utf8Bytes)
+        private static bool IsTrue(ReadOnlySpan<char> utf16Chars)
         {
-            if (utf8Bytes.Length < 4)
+            if (utf16Chars.Length < 4)
                 return false;
 
-            byte firstChar = utf8Bytes[0];
+            char firstChar = utf16Chars[0];
             if (firstChar != 't' && firstChar != 'T')
                 return false;
 
-            byte secondChar = utf8Bytes[1];
+            char secondChar = utf16Chars[1];
             if (secondChar != 'r' && secondChar != 'R')
                 return false;
 
-            byte thirdChar = utf8Bytes[2];
+            char thirdChar = utf16Chars[2];
             if (thirdChar != 'u' && thirdChar != 'U')
                 return false;
 
-            byte fourthChar = utf8Bytes[3];
+            char fourthChar = utf16Chars[3];
             if (fourthChar != 'e' && fourthChar != 'E')
                 return false;
 
             return true;
         }
 
-        private static bool IsFalse(ReadOnlySpan<byte> utf8Bytes)
+        private static bool IsFalse(ReadOnlySpan<char> utf16Chars)
         {
-            if (utf8Bytes.Length < 5)
+            if (utf16Chars.Length < 5)
                 return false;
 
-            byte firstChar = utf8Bytes[0];
+            char firstChar = utf16Chars[0];
             if (firstChar != 'f' && firstChar != 'F')
                 return false;
 
-            byte secondChar = utf8Bytes[1];
+            char secondChar = utf16Chars[1];
             if (secondChar != 'a' && secondChar != 'A')
                 return false;
 
-            byte thirdChar = utf8Bytes[2];
+            char thirdChar = utf16Chars[2];
             if (thirdChar != 'l' && thirdChar != 'L')
                 return false;
 
-            byte fourthChar = utf8Bytes[3];
+            char fourthChar = utf16Chars[3];
             if (fourthChar != 's' && fourthChar != 'S')
                 return false;
 
-            byte fifthChar = utf8Bytes[4];
+            char fifthChar = utf16Chars[4];
             if (fifthChar != 'e' && fifthChar != 'E')
                 return false;
 
@@ -109,7 +109,37 @@ namespace System.Text
 
             if (encoding.IsInvariantUtf16)
             {
-                throw new NotImplementedException();
+                ReadOnlySpan<char> textChars = text.Cast<byte, char>();
+                char firstCodeUnit = textChars[0];
+
+                if (firstCodeUnit == '1')
+                {
+                    consumedBytes = 2;
+                    value = true;
+                    return true;
+                }
+                else if (firstCodeUnit == '0')
+                {
+                    consumedBytes = 2;
+                    value = false;
+                    return true;
+                }
+                else if (IsTrue(textChars))
+                {
+                    consumedBytes = 8;
+                    value = true;
+                    return true;
+                }
+                else if (IsFalse(textChars))
+                {
+                    consumedBytes = 10;
+                    value = false;
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
             }
 
             return false;

--- a/tests/System.Text.Primitives.Tests/PrimitiveParserBoolTests.cs
+++ b/tests/System.Text.Primitives.Tests/PrimitiveParserBoolTests.cs
@@ -1,0 +1,97 @@
+﻿using System.Text;
+using System.Text.Utf8;
+using Xunit;
+
+namespace System.Text.Primitives.Tests
+{
+    public partial class PrimitiveParserTests
+    {
+        [Theory]
+        [InlineData("True", 4, true, 4)]
+        [InlineData("False", 5, false, 5)]
+        [InlineData("1", 1, true, 1)]
+        [InlineData("0", 1, false, 1)]
+        [InlineData("True1234", 4, true, 4)]
+        [InlineData("False1234", 5, false, 5)]
+        [InlineData("11234", 1, true, 1)]
+        [InlineData("01234", 1, false, 1)]
+        [InlineData("True1234", 6, true, 4)]
+        [InlineData("False1234", 7, false, 5)]
+        [InlineData("11234", 3, true, 1)]
+        [InlineData("01234", 3, false, 1)]
+        public unsafe void BooleanPositiveTests(string text, int length, bool expectedValue, int expectedConsumed)
+        {
+            byte[] byteBuffer = new Utf8String(text).CopyBytes();
+            ReadOnlySpan<byte> byteSpan = new ReadOnlySpan<byte>(byteBuffer);
+            
+            char[] charBuffer = text.ToCharArray();
+            ReadOnlySpan<char> charSpan = new ReadOnlySpan<char>(charBuffer);
+
+            bool result;
+            bool actualValue;
+            int actualConsumed;
+
+            result = PrimitiveParser.TryParseBoolean(byteSpan, out actualValue, out actualConsumed, EncodingData.InvariantUtf8);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedConsumed, actualConsumed);
+
+            fixed (byte* bytePointer = byteBuffer)
+            {
+                result = PrimitiveParser.InvariantUtf8.TryParseBoolean(bytePointer, length, out actualValue);
+
+                Assert.True(result);
+                Assert.Equal(expectedValue, actualValue);
+
+                result = PrimitiveParser.InvariantUtf8.TryParseBoolean(bytePointer, length, out actualValue, out actualConsumed);
+
+                Assert.True(result);
+                Assert.Equal(expectedValue, actualValue);
+                Assert.Equal(expectedConsumed, actualConsumed);
+            }
+
+            result = PrimitiveParser.InvariantUtf8.TryParseBoolean(byteSpan, out actualValue);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+
+            result = PrimitiveParser.InvariantUtf8.TryParseBoolean(byteSpan, out actualValue, out actualConsumed);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedConsumed, actualConsumed);
+
+            ReadOnlySpan<byte> utf16ByteSpan = charSpan.Cast<char, byte>();
+            result = PrimitiveParser.TryParseBoolean(utf16ByteSpan, out actualValue, out actualConsumed, EncodingData.InvariantUtf16);
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedConsumed, actualConsumed / 2);
+
+            fixed (char* charPointer = charBuffer)
+            {
+                result = PrimitiveParser.InvariantUtf16.TryParseBoolean(charPointer, length, out actualValue);
+
+                Assert.True(result);
+                Assert.Equal(expectedValue, actualValue);
+
+                result = PrimitiveParser.InvariantUtf16.TryParseBoolean(charPointer, length, out actualValue, out actualConsumed);
+
+                Assert.True(result);
+                Assert.Equal(expectedValue, actualValue);
+                Assert.Equal(expectedConsumed, actualConsumed);
+            }
+
+            result = PrimitiveParser.InvariantUtf16.TryParseBoolean(charSpan, out actualValue);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+
+            result = PrimitiveParser.InvariantUtf16.TryParseBoolean(charSpan, out actualValue, out actualConsumed);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedConsumed, actualConsumed);
+        }
+    }
+}

--- a/tests/System.Text.Primitives.Tests/PrimitiveParserUInt32Tests.cs
+++ b/tests/System.Text.Primitives.Tests/PrimitiveParserUInt32Tests.cs
@@ -1,0 +1,166 @@
+﻿using System.Text;
+using System.Text.Utf8;
+using Xunit;
+
+namespace System.Text.Primitives.Tests
+{
+    public partial class PrimitiveParserTests
+    {
+        [Theory]
+        [InlineData("123", 3, 123, 3)]
+        [InlineData("12a", 3, 12, 2)]
+        public unsafe void UInt32PositiveTests(string text, int length, uint expectedValue, int expectedConsumed)
+        {
+            byte[] byteBuffer = new Utf8String(text).CopyBytes();
+            ReadOnlySpan<byte> byteSpan = new ReadOnlySpan<byte>(byteBuffer);
+            
+            char[] charBuffer = text.ToCharArray();
+            ReadOnlySpan<char> charSpan = new ReadOnlySpan<char>(charBuffer);
+
+            bool result;
+            uint actualValue;
+            int actualConsumed;
+
+            result = PrimitiveParser.TryParseUInt32(byteSpan, out actualValue, out actualConsumed, EncodingData.InvariantUtf8);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedConsumed, actualConsumed);
+
+            fixed (byte* bytePointer = byteBuffer)
+            {
+                result = PrimitiveParser.InvariantUtf8.TryParseUInt32(bytePointer, length, out actualValue);
+
+                Assert.True(result);
+                Assert.Equal(expectedValue, actualValue);
+
+                result = PrimitiveParser.InvariantUtf8.TryParseUInt32(bytePointer, length, out actualValue, out actualConsumed);
+
+                Assert.True(result);
+                Assert.Equal(expectedValue, actualValue);
+                Assert.Equal(expectedConsumed, actualConsumed);
+            }
+
+            result = PrimitiveParser.InvariantUtf8.TryParseUInt32(byteSpan, out actualValue);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+
+            result = PrimitiveParser.InvariantUtf8.TryParseUInt32(byteSpan, out actualValue, out actualConsumed);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedConsumed, actualConsumed);
+
+            ReadOnlySpan<byte> utf16ByteSpan = charSpan.Cast<char, byte>();
+            result = PrimitiveParser.TryParseUInt32(utf16ByteSpan, out actualValue, out actualConsumed, EncodingData.InvariantUtf16);
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedConsumed, actualConsumed / 2);
+
+            fixed (char* charPointer = charBuffer)
+            {
+                result = PrimitiveParser.InvariantUtf16.TryParseUInt32(charPointer, length, out actualValue);
+
+                Assert.True(result);
+                Assert.Equal(expectedValue, actualValue);
+
+                result = PrimitiveParser.InvariantUtf16.TryParseUInt32(charPointer, length, out actualValue, out actualConsumed);
+
+                Assert.True(result);
+                Assert.Equal(expectedValue, actualValue);
+                Assert.Equal(expectedConsumed, actualConsumed);
+            }
+
+            result = PrimitiveParser.InvariantUtf16.TryParseUInt32(charSpan, out actualValue);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+
+            result = PrimitiveParser.InvariantUtf16.TryParseUInt32(charSpan, out actualValue, out actualConsumed);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedConsumed, actualConsumed);
+        }
+        
+        [Theory (Skip = "UInt32 hex parsing not implemented yet")]
+        [InlineData("01234", 8, 0x01234, 8)]
+        [InlineData("012af", 8, 0x012af, 8)]
+        [InlineData("012gh", 8, 0x012, 6)]
+        public unsafe void UInt32PositiveHexTests(string text, int length, uint expectedValue, int expectedConsumed)
+        {
+            byte[] byteBuffer = new Utf8String(text).CopyBytes();
+            ReadOnlySpan<byte> byteSpan = new ReadOnlySpan<byte>(byteBuffer);
+
+            char[] charBuffer = text.ToCharArray();
+            ReadOnlySpan<char> charSpan = new ReadOnlySpan<char>(charBuffer);
+
+            bool result;
+            uint actualValue;
+            int actualConsumed;
+
+            result = PrimitiveParser.TryParseUInt32(byteSpan, out actualValue, out actualConsumed, EncodingData.InvariantUtf8, 'X');
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedConsumed, actualConsumed);
+
+            fixed (byte* bytePointer = byteBuffer)
+            {
+                result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(bytePointer, length, out actualValue);
+
+                Assert.True(result);
+                Assert.Equal(expectedValue, actualValue);
+
+                result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(bytePointer, length, out actualValue, out actualConsumed);
+
+                Assert.True(result);
+                Assert.Equal(expectedValue, actualValue);
+                Assert.Equal(expectedConsumed, actualConsumed);
+            }
+
+            result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(byteSpan, out actualValue);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+
+            result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(byteSpan, out actualValue, out actualConsumed);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedConsumed, actualConsumed);
+
+            ReadOnlySpan<byte> utf16ByteSpan = charSpan.Cast<char, byte>();
+            result = PrimitiveParser.TryParseUInt32(utf16ByteSpan, out actualValue, out actualConsumed, EncodingData.InvariantUtf16, 'X');
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedConsumed, actualConsumed / 2);
+
+            fixed (char* charPointer = charBuffer)
+            {
+                result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt32(charPointer, length, out actualValue);
+
+                Assert.True(result);
+                Assert.Equal(expectedValue, actualValue);
+
+                result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt32(charPointer, length, out actualValue, out actualConsumed);
+
+                Assert.True(result);
+                Assert.Equal(expectedValue, actualValue);
+                Assert.Equal(expectedConsumed, actualConsumed);
+            }
+
+            result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt32(charSpan, out actualValue);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+
+            result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt32(charSpan, out actualValue, out actualConsumed);
+
+            Assert.True(result);
+            Assert.Equal(expectedValue, actualValue);
+            Assert.Equal(expectedConsumed, actualConsumed);
+        }
+    }
+}


### PR DESCRIPTION
Introduce class PrimitiveParser2 with intent for it to replace PrimitiveParser. The class right now contains skeleton implementations of the overloads of TryParseBoolean and TryParseUInt32.

PrimitiveParser2.TryParseBoolean and PrimitiveParser2.TryParseUInt32 are the main overloads. The overloads in PrimitiveParser2.InvariantUtf8 and PrimitiveParser2.InvariantUtf16 are wrappers around the main overloads currently, but could provide performance improvements if separately implemented.