### PR TITLE
Preparing for an experiment with OwnedMemory<T>

### DIFF
--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -14,7 +14,7 @@ namespace System
         int _length;
 
         internal Memory(OwnedMemory<T> owner, long id)
-            : this(owner, id, 0, owner.GetSpan(id).Length)
+            : this(owner, id, 0, owner.GetSpanInternal(id).Length)
         { }
 
         private Memory(OwnedMemory<T> owner, long id, int index, int length)
@@ -51,13 +51,13 @@ namespace System
             return new Memory<T>(_owner, _id, _index + index, length);
         }
 
-        public Span<T> Span => _owner.GetSpan(_id).Slice(_index, _length);
+        public Span<T> Span => _owner.GetSpanInternal(_id).Slice(_index, _length);
 
         public DisposableReservation Reserve() => new DisposableReservation(_owner, _id);
 
         public unsafe bool TryGetPointer(out void* pointer)
         {
-            if (!_owner.TryGetPointer(_id, out pointer)) {
+            if (!_owner.TryGetPointerInternal(_id, out pointer)) {
                 return false;
             }
             pointer = Add(pointer, _index);
@@ -66,7 +66,7 @@ namespace System
 
         public bool TryGetArray(out ArraySegment<T> buffer)
         {
-            if (!_owner.TryGetArray(_id, out buffer)) {
+            if (!_owner.TryGetArrayInternal(_id, out buffer)) {
                 return false;
             }
             buffer = new ArraySegment<T>(buffer.Array, buffer.Offset + _index, _length);

--- a/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
@@ -13,7 +13,7 @@ namespace System
         int _length;
 
         internal ReadOnlyMemory(OwnedMemory<T> owner, long id)
-            : this(owner, id, 0, owner.GetSpan(id).Length)
+            : this(owner, id, 0, owner.GetSpanInternal(id).Length)
         { }
 
         internal ReadOnlyMemory(OwnedMemory<T> owner, long id, int index, int length)
@@ -45,7 +45,7 @@ namespace System
             return new ReadOnlyMemory<T>(_owner, _id, _index + index, length);
         }
 
-        public ReadOnlySpan<T> Span => _owner.GetSpan(_id).Slice(_index, _length);
+        public ReadOnlySpan<T> Span => _owner.GetSpanInternal(_id).Slice(_index, _length);
 
         public DisposableReservation Reserve()
         {
@@ -54,7 +54,7 @@ namespace System
    
         public unsafe bool TryGetPointer(out void* pointer)
         {
-            if (!_owner.TryGetPointer(_id, out pointer)) {
+            if (!_owner.TryGetPointerInternal(_id, out pointer)) {
                 return false;
             }
             pointer = Memory<T>.Add(pointer, _index);
@@ -63,7 +63,7 @@ namespace System
 
         public unsafe bool TryGetArray(out ArraySegment<T> buffer)
         {
-            if (!_owner.TryGetArray(_id, out buffer)) {
+            if (!_owner.TryGetArrayInternal(_id, out buffer)) {
                 return false;
             }
             buffer = new ArraySegment<T>(buffer.Array, buffer.Offset + _index, _length);


### PR DESCRIPTION
I would like to experiment with an OwnedMemory<T> abstraction. This is so we could implement it on T[] and String, and so allow creating Memory<T>/Span<T> out of these without an allocation (for the owned memory wrapper). 

In the past, when we changed OwnedMemory<T>.GetSpan to a virtual method, we saw a significant perf regression in some scenarios. This experiment is using an interface, which because of stub dispatch, might make the performance hit acceptable.

cc: @davidfowl, @jaredpar  