### PR TITLE
Experimenting with string/array like type supporting Memory<T>

### DIFF
--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -8,16 +8,16 @@ namespace System
     [DebuggerTypeProxy(typeof(MemoryDebuggerView<>))]
     public struct Memory<T> 
     {
-        OwnedMemory<T> _owner;
+        IMemory<T> _owner;
         long _id;
         int _index;
         int _length;
 
-        internal Memory(OwnedMemory<T> owner, long id)
-            : this(owner, id, 0, owner.GetSpanInternal(id).Length)
+        public Memory(IMemory<T> owner, long id)
+            : this(owner, id, 0, owner.GetSpan(id).Length)
         { }
 
-        private Memory(OwnedMemory<T> owner, long id, int index, int length)
+        private Memory(IMemory<T> owner, long id, int index, int length)
         {
             _owner = owner;
             _id = id;
@@ -51,13 +51,13 @@ namespace System
             return new Memory<T>(_owner, _id, _index + index, length);
         }
 
-        public Span<T> Span => _owner.GetSpanInternal(_id).Slice(_index, _length);
+        public Span<T> Span => _owner.GetSpan(_id).Slice(_index, _length);
 
         public DisposableReservation Reserve() => new DisposableReservation(_owner, _id);
 
         public unsafe bool TryGetPointer(out void* pointer)
         {
-            if (!_owner.TryGetPointerInternal(_id, out pointer)) {
+            if (!_owner.TryGetPointer(_id, out pointer)) {
                 return false;
             }
             pointer = Add(pointer, _index);
@@ -66,7 +66,7 @@ namespace System
 
         public bool TryGetArray(out ArraySegment<T> buffer)
         {
-            if (!_owner.TryGetArrayInternal(_id, out buffer)) {
+            if (!_owner.TryGetArray(_id, out buffer)) {
                 return false;
             }
             buffer = new ArraySegment<T>(buffer.Array, buffer.Offset + _index, _length);

--- a/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
@@ -7,16 +7,16 @@ namespace System
     [DebuggerTypeProxy(typeof(ReadOnlyMemoryDebuggerView<>))]
     public struct ReadOnlyMemory<T>
     {
-        OwnedMemory<T> _owner;
+        IReadOnlyMemory<T> _owner;
         long _id;
         int _index;
         int _length;
 
-        internal ReadOnlyMemory(OwnedMemory<T> owner, long id)
-            : this(owner, id, 0, owner.GetSpanInternal(id).Length)
+        public ReadOnlyMemory(IReadOnlyMemory<T> owner, long id)
+            : this(owner, id, 0, owner.GetSpan(id).Length)
         { }
 
-        internal ReadOnlyMemory(OwnedMemory<T> owner, long id, int index, int length)
+        internal ReadOnlyMemory(IReadOnlyMemory<T> owner, long id, int index, int length)
         {
             _owner = owner;
             _id = id;
@@ -45,7 +45,7 @@ namespace System
             return new ReadOnlyMemory<T>(_owner, _id, _index + index, length);
         }
 
-        public ReadOnlySpan<T> Span => _owner.GetSpanInternal(_id).Slice(_index, _length);
+        public ReadOnlySpan<T> Span => _owner.GetSpan(_id).Slice(_index, _length);
 
         public DisposableReservation Reserve()
         {
@@ -54,7 +54,7 @@ namespace System
    
         public unsafe bool TryGetPointer(out void* pointer)
         {
-            if (!_owner.TryGetPointerInternal(_id, out pointer)) {
+            if (!_owner.TryGetPointer(_id, out pointer)) {
                 return false;
             }
             pointer = Memory<T>.Add(pointer, _index);
@@ -63,11 +63,8 @@ namespace System
 
         public unsafe bool TryGetArray(out ArraySegment<T> buffer)
         {
-            if (!_owner.TryGetArrayInternal(_id, out buffer)) {
-                return false;
-            }
-            buffer = new ArraySegment<T>(buffer.Array, buffer.Offset + _index, _length);
-            return true;
+            buffer = default(ArraySegment<T>);
+            return false;
         }
 
         public T[] ToArray()

--- a/src/System.Slices/System/ReadOnlySpan.cs
+++ b/src/System.Slices/System/ReadOnlySpan.cs
@@ -121,10 +121,7 @@ namespace System
             Length = length;
         }
 
-        /// <summary>
-        /// An internal helper for creating spans. Not for public use.
-        /// </summary>
-        internal ReadOnlySpan(object obj, UIntPtr offset, int length)
+        public ReadOnlySpan(object obj, UIntPtr offset, int length)
         {
             Object = obj;
             Offset = offset;

--- a/src/System.Slices/System/Span.cs
+++ b/src/System.Slices/System/Span.cs
@@ -126,10 +126,7 @@ namespace System
             Length = length;
         }
 
-        /// <summary>
-        /// An internal helper for creating spans. Not for public use.
-        /// </summary>
-        internal Span(object obj, UIntPtr offset, int length)
+        public Span(object obj, UIntPtr offset, int length)
         {
             Object = obj;
             Offset = offset;

--- a/src/System.Text.Utf8/System/Text/Utf8/Utf8String2.cs
+++ b/src/System.Text.Utf8/System/Text/Utf8/Utf8String2.cs
@@ -1,0 +1,144 @@
+﻿using System.Buffers;
+using System.Runtime.InteropServices;
+
+namespace System.Text.Utf8
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public class Utf8String2 : IReadOnlyMemory<byte>, IComparable<Utf8String2>, IEquatable<Utf8String2>
+    {
+        int _length;
+        byte _b0;
+        byte _b1;
+        byte _b2;
+        byte _b3;
+        byte _b4;
+        byte _b5;
+        byte _b6;
+        byte _b7;
+        byte _b8;
+        byte _b9;
+        byte _b10;
+        byte _b11;
+        byte _b12;
+        byte _b13;
+        byte _b14;
+        byte _b15;
+        byte _b16;
+        byte _b17;
+        byte _b18;
+        byte _b19;
+
+        public Utf8String2(string text)
+        {
+            var utf8 = new Utf8String(text);
+            if (utf8.Length > 20) throw new NotImplementedException("this type does not support strings longer than 20 bytes");
+            var span = Buffer;
+            utf8.CopyTo(Buffer);
+            _length = utf8.Length;
+        }
+
+        public Utf8String2(byte[] bytes, int offset = 0, int length = -1)
+        {
+            if (length == -1) length = bytes.Length;
+            if (length > 20) throw new NotImplementedException("this type does not support strings longer than 20 bytes");
+            var span = Buffer;
+            bytes.Slice(offset, length).CopyTo(Buffer);
+            _length = bytes.Length;
+        }
+
+        public static implicit operator Utf8String2(string text)
+        {
+            return new Utf8String2(text);
+        }
+
+        public ReadOnlyMemory<byte> Substring(int index, int length)
+        {
+            return Memory.Slice(index, length);
+        }
+        public ReadOnlyMemory<byte> Substring(int index)
+        {
+            return Memory.Slice(index);
+        }
+
+        Span<byte> Buffer => new Span<byte>(this, new UIntPtr(12), 20);
+
+        ReadOnlySpan<byte> IReadOnlyMemory<byte>.GetSpan(long id)
+        {
+            return new ReadOnlySpan<byte>(this, new UIntPtr(12), _length);
+        }
+
+        public ReadOnlyMemory<byte> Memory {
+            get {
+                return new ReadOnlyMemory<byte>(this, 0).Slice(0, _length);
+            }
+        }
+        public ReadOnlySpan<byte> Span => Buffer.Slice(0, _length);
+
+        public int Length => _length;
+
+        void IReferenceCounted.AddReference(long id)
+        { }
+
+        void IReferenceCounted.Release(long id)
+        { }
+
+        unsafe bool IReadOnlyMemory<byte>.TryGetPointer(long id, out void* pointer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public DisposableReservation Reserve(ref ReadOnlyMemory<byte> memory)
+        {
+            return new DisposableReservation(this, 0);
+        }
+
+        public override string ToString()
+        {
+            return new Utf8String(Buffer.Slice(0, _length)).ToString();
+        }
+
+        public override int GetHashCode()
+        {
+            return ToUtf8String().GetHashCode();
+        }
+        public override bool Equals(object obj)
+        {
+            Utf8String2 utf8 = obj as Utf8String2;
+            if (utf8 == null) return false;
+            return Equals(utf8);
+        }
+
+        Utf8String ToUtf8String()
+        {
+            return new Utf8String(Buffer.Slice(0, _length));
+
+        }
+        public int CompareTo(Utf8String2 other)
+        {
+            return ToUtf8String().CompareTo(other.ToUtf8String());
+        }
+
+        public bool Equals(Utf8String2 other)
+        {
+            return ToUtf8String().Equals(other.ToUtf8String());
+        }
+
+        public static bool operator ==(Utf8String2 left, Utf8String2 right)
+        {
+            return left.Equals(right);
+        }
+        public static bool operator !=(Utf8String2 left, Utf8String2 right)
+        {
+            return !left.Equals(right);
+        }
+
+        public static bool operator ==(Utf8String2 left, string right)
+        {
+            return left.Equals(right);
+        }
+        public static bool operator !=(Utf8String2 left, string right)
+        {
+            return !left.Equals(right);
+        }
+    }
+}

--- a/tests/System.Slices.Tests/MemoryTests.cs
+++ b/tests/System.Slices.Tests/MemoryTests.cs
@@ -102,7 +102,7 @@ namespace System.Slices.Tests
 
         public int ReferenceCountChangeCount => _referenceCountChangeCount;
 
-        protected override DisposableReservation Reserve(ref ReadOnlyMemory<byte> memory)
+        protected override DisposableReservation ReserveCore(ref ReadOnlyMemory<byte> memory)
         {
             if (memory.Length < Length) {
                 var copy = memory.Span.ToArray();
@@ -111,7 +111,7 @@ namespace System.Slices.Tests
                 return memory.Reserve();
             }
             else {
-                return base.Reserve(ref memory);
+                return base.ReserveCore(ref memory);
             }
         }
 

--- a/tests/System.Text.Utf8.Tests/Bugs.cs
+++ b/tests/System.Text.Utf8.Tests/Bugs.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Text.Utf16;
-using Xunit;
-using Xunit.Abstractions;
+﻿using Xunit;
 
 namespace System.Text.Utf8.Tests
 {

--- a/tests/System.Text.Utf8.Tests/RandomTests.cs
+++ b/tests/System.Text.Utf8.Tests/RandomTests.cs
@@ -6,7 +6,7 @@ using Xunit.Abstractions;
 
 namespace System.Text.Utf8.Tests
 {
-    public class Utf8StringTests
+    public partial class Utf8StringTests
     {
         #region Helpers - useful only when debugging or generating test cases
         ITestOutputHelper output;

--- a/tests/System.Text.Utf8.Tests/Utf8String2Tests.cs
+++ b/tests/System.Text.Utf8.Tests/Utf8String2Tests.cs
@@ -1,0 +1,44 @@
+﻿using Xunit;
+using System.Reflection;
+
+namespace System.Text.Utf8.Tests
+{
+    public partial class Utf8String2Tests
+    {
+        [Fact]
+        public void Utf8StringBasics()
+        {
+            Utf8String2 hello = "hello world!";
+            Assert.True(hello.GetType().GetTypeInfo().IsClass);
+
+            Assert.Equal(Encoding.UTF8.GetBytes("hello world!"), hello.Span.ToArray());
+
+            Utf8String2 alsoHello = "hello world!";
+            Utf8String2 world = "world";
+
+            Assert.True(hello == alsoHello);
+            Assert.True(hello != world);
+
+            var substring = hello.Substring(6, 5);
+            Assert.Equal(substring.ToArray(), world.Memory.ToArray());
+        }
+
+        [Fact]
+        public void Utf8StringMemory()
+        {
+            string str = "hello world";
+
+            Utf8String2 utf8 = str;
+            Assert.True(utf8 == str);
+            
+            var utf16 = utf8.ToString();
+            Assert.Equal(str, utf16);
+
+            ReadOnlyMemory<byte> memory = utf8.Memory;
+            using (memory.Reserve()) {
+                ReadOnlySpan<byte> bytes = memory.Span;
+                Assert.Equal(Encoding.UTF8.GetBytes(str), bytes.ToArray());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Experimenting with string/array like type (called Utf8String2) supporting Memory<T> without needing to inherit from or be wrapped in OwnedMemory<T>. We would use this to support Memory<T> over strings and T[].

Please don't merge this PR. The changes to Memory<T> have the potiential to regress perf in Channels. We need to run some perf tests first.

cc: @davidfowl,  @jaredpar, @benaadams, @terrajobst, @vancem, @jkotas, @joshfree 