### PR TITLE
Obsoleting Multispans/SpanSequences

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/ArraySegmentExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/ArraySegmentExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Sequences;
+
+namespace System.Buffers
+{
+    static class Extensions
+    {
+        public static ArraySegment<T> Slice<T>(this ArraySegment<T> source, int count)
+        {
+            var result = new ArraySegment<T>(source.Array, source.Offset + count, source.Count - count);
+            return result;
+        }
+
+        public static void CopyTo<T>(this Span<T> span, ref ResizableArray<T> array)
+        {
+            span.CopyTo(array._array.Slice(array._count));
+            array._count += span.Length;
+        }
+    }
+}

--- a/src/System.Buffers.Experimental/System/Buffers/Multispans/Multispan.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Multispans/Multispan.cs
@@ -18,6 +18,7 @@ namespace System.Buffers
     /// Also, be extra careful when disposing this type. If you dispose the original instance and its copy, 
     /// the pool used by this type will be corrupted.
     /// </remarks>
+    [Obsolete("we will use multiple Memory<T> instances to represent sequences of buffers")]
     public struct Multispan<T> : ISpanSequence<T>
     {
         ArraySegment<T> _head;
@@ -336,16 +337,8 @@ namespace System.Buffers
             return new ReadOnlySpanSequenceEnumerator<T>(this);
         }
     }
-
-    static class Extensions
-    {
-        public static ArraySegment<T> Slice<T>(this ArraySegment<T> source, int count)
-        {
-            var result = new ArraySegment<T>(source.Array, source.Offset + count, source.Count - count);
-            return result;
-        }
-    }
 }
+
 
 
 

--- a/src/System.Buffers.Experimental/System/Buffers/Multispans/ReadOnlySpanSequence.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Multispans/ReadOnlySpanSequence.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 
 namespace System.Collections.Sequences
 {
+    [Obsolete("we will use multiple Memory<T> instances to represent sequences of buffers")]
     public interface IReadOnlySpanSequence<T>
     {
         ReadOnlySpanSequenceEnumerator<T> GetEnumerator();
@@ -21,6 +22,7 @@ namespace System.Collections.Sequences
         int? Count { get; }
     }
 
+    [Obsolete("we will use multiple Memory<T> instances to represent sequences of buffers")]
     public struct ReadOnlySpanSequenceEnumerator<T>
     {
         Position _position;

--- a/src/System.Buffers.Experimental/System/Buffers/Multispans/SequenceExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Multispans/SequenceExtensions.cs
@@ -11,6 +11,7 @@ namespace System.Buffers
         public delegate TResult FuncOfSpan<T, TResult>(Span<T> span);
         public delegate void ActionOfSpan<T>(Span<T> span);
 
+        [Obsolete("we will use multiple Memory<T> instances to represent sequences of buffers")]
         public static TResult Do<T, TResult>(this ISpanSequence<T> buffer, FuncOfSpan<T, TResult> function)
         {
             Span<T> flat;
@@ -30,6 +31,7 @@ namespace System.Buffers
             return function(flat);
         }
 
+        [Obsolete("we will use multiple Memory<T> instances to represent sequences of buffers")]
         public static void Do<T>(this ISpanSequence<T> buffer, ActionOfSpan<T> action)
         {
             Span<T> flat;
@@ -49,6 +51,7 @@ namespace System.Buffers
             action(flat);
         }
 
+        [Obsolete("we will use multiple Memory<T> instances to represent sequences of buffers")]
         public static bool TryParseUInt32<TSequence>(this TSequence bytes, EncodingData encoding, out uint value, out int consumed) where TSequence : ISpanSequence<byte>
         {
             Position position = Position.First;

--- a/src/System.Buffers.Experimental/System/Buffers/Multispans/SpanSequence.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Multispans/SpanSequence.cs
@@ -5,12 +5,14 @@ using System.Runtime.CompilerServices;
 
 namespace System.Collections.Sequences
 {
+    [Obsolete("we will use multiple Memory<T> instances to represent sequences of buffers")]
     public interface ISpanSequence<T> : IReadOnlySpanSequence<T>
     {
         new SpanSequenceEnumerator<T> GetEnumerator();
         bool TryGet(ref Position position, out Span<T> item, bool advance = false);
     }
 
+    [Obsolete("we will use multiple Memory<T> instances to represent sequences of buffers")]
     public struct SpanSequenceEnumerator<T>
     {
         Position _position;

--- a/src/System.Buffers.Experimental/System/Buffers/Multispans/SpanSequenceExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Multispans/SpanSequenceExtensions.cs
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Buffers;
 
 namespace System.Collections.Sequences
 {
     public static class SpanSequenceExtensions
     {
+        [Obsolete("we will use multiple Memory<T> instances to represent sequences of buffers")]
         public static Span<T> Flatten<T>(this ISpanSequence<T> sequence)
         {
             var position = Position.First;
@@ -54,6 +56,7 @@ namespace System.Collections.Sequences
             }
         }
 
+        [Obsolete("we will use multiple Memory<T> instances to represent sequences of buffers")]
         public static Span<T> First<T>(this ISpanSequence<T> sequence)
         {
             Span<T> result;
@@ -74,6 +77,7 @@ namespace System.Collections.Sequences
         /// <param name="skip">number of items from the begining of sequence to skip, i.e. not copy.</param>
         /// <returns>True if all items did fit in the destination, false otherwise.</returns>
         /// <remarks>If the destination is too short, up to destination.Length items are copied in, even if the function returns false.</remarks>
+        [Obsolete("we will use multiple Memory<T> instances to represent sequences of buffers")]
         public static bool TryCopyTo<T>(this ISpanSequence<T> sequence, ref Span<T> destination, int skip = 0)
         {
             var position = Position.First;
@@ -102,12 +106,6 @@ namespace System.Collections.Sequences
 
             destination = destination.Slice(0, copied);
             return true;
-        }
-
-        static void CopyTo<T>(this Span<T> span, ref ResizableArray<T> array)
-        {
-            span.CopyTo(array._array.Slice(array._count));
-            array._count += span.Length;
         }
     }
 }

--- a/src/System.Text.Formatting/System/Text/Formatting/SequenceFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/SequenceFormatter.cs
@@ -14,6 +14,7 @@ namespace System.Text.Formatting
         int _previousWrittenBytes;
         int _totalWritten;
 
+        [Obsolete("we will use multiple Memory<T> instances to represent sequences of buffers")]
         public SequenceFormatter(ISpanSequence<byte> buffers, EncodingData encoding)
         {
             _encoding = encoding;

--- a/src/System.Text.Utf8/System/Text/Utf8/Utf8CodeUnit.cs
+++ b/src/System.Text.Utf8/System/Text/Utf8/Utf8CodeUnit.cs
@@ -5,6 +5,7 @@ namespace System.Text.Utf8
     // TODO: Check if name is understandable for users
     //       I personally think it is better to keep the spec name than calling it with some random new name or byte
     //       In the end it is less confusing than trying to figure out what spec means and what .NET means
+    [Obsolete("we will use byte for this.")]
     public partial struct Utf8CodeUnit : IEquatable<Utf8CodeUnit>
     {
         private byte _value;


### PR DESCRIPTION
We will use Memory<T> sequences to represent sequences of buffers. No need to have sequences of spans, which are very complex. 

I will remove these APIs soon (Monday the latest).