### PR TITLE
Optimized uint sequence parser to never allocate on the GC heap

### DIFF
--- a/src/System.Text.Formatting/System/Text/Parsing/SequenceParser.cs
+++ b/src/System.Text.Formatting/System/Text/Parsing/SequenceParser.cs
@@ -9,59 +9,74 @@ namespace System.Text.Parsing
 {
     public static class TextSequenceExtensions
     {
-        /// <summary>
-        /// Parses a uint from a sequence of buffers.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="memorySequence"></param>
-        /// <returns></returns>
+        const int StackBufferSize = 128;
+
         public static bool TryParseUInt32<T>(this T memorySequence, out uint value, out int consumed) where T : ISequence<ReadOnlyMemory<byte>>
         {
             value = default(uint);
             consumed = default(int);
             Position position = Position.First;
 
+            // Fetch the first segment
             ReadOnlyMemory<byte> first;
             if (!memorySequence.TryGet(ref position, out first, advance: true)) {
                 return false;
             }
 
-            // attempt to parse
+            // Attempt to parse the first segment. If it works (and it should in most cases), then return success.
             bool parsed = PrimitiveParser.TryParseUInt32(new Utf8String(first.Span), out value, out consumed);
             if (parsed && consumed < first.Length) {
                 return true;
             }
 
+            // Apparently the we need data from the second segment to succesfully parse, and so fetch the second segment.
             ReadOnlyMemory<byte> second;
             if (!memorySequence.TryGet(ref position, out second, advance: true)) {
+                // if there is no second segment and the first parsed succesfully, return the result of the parsing.
                 if (parsed) return true;
                 return false;
             }
 
+            // Combine the first, the second, and potentially more segments into a stack allocated buffer
             ReadOnlySpan<byte> combinedSpan;
             unsafe
             {
-                // TODO: this block could be optimized even more. Currently, it only attenpts to combine two spans.
-                // It should do it in a loop till it completly filles 128 bytes, at which point
-                // the method should never allocate on the GC heap as I am not aware of uints textual representation
-                // that is longer than 128 bytes.
-                if (first.Length < 128) {
-                    var data = stackalloc byte[128];
-                    var destination = new Span<byte>(data, 128);
-                    first.CopyTo(destination);
-                    var remaining = 128 - first.Length;
-                    if (remaining > second.Length) remaining = second.Length;
-                    second.Slice(0, remaining).CopyTo(destination.Slice(first.Length));
-                    combinedSpan = destination.Slice(0, first.Length + remaining);
+                if (first.Length < StackBufferSize) {
+                    var data = stackalloc byte[StackBufferSize];
+                    var destination = new Span<byte>(data, StackBufferSize);
 
+                    first.CopyTo(destination);
+                    var free = destination.Slice(first.Length);
+
+                    if (second.Length > free.Length) second = second.Slice(0, free.Length);
+                    second.CopyTo(free);
+                    free = free.Slice(second.Length);
+
+                    ReadOnlyMemory<byte> next;
+                    while (free.Length > 0) {
+                        if (memorySequence.TryGet(ref position, out next, advance: true)) {
+                            if (next.Length > free.Length) next = next.Slice(0, free.Length);
+                            next.CopyTo(free);
+                            free = free.Slice(next.Length);
+                        }
+                        else {
+                            break;
+                        }
+                    }
+
+                    combinedSpan = destination.Slice(0, StackBufferSize - free.Length);
+
+                    // if the stack allocated buffer parsed succesfully (and for uint it should always do), then return success. 
                     if (PrimitiveParser.TryParseUInt32(new Utf8String(combinedSpan), out value, out consumed)) {
-                        if (consumed < combinedSpan.Length) {
+                        if(consumed < combinedSpan.Length || combinedSpan.Length < StackBufferSize) {
                             return true;
                         }
                     }
                 }
             }
 
+            // for invariant culture, we should never reach this point, as invariant uint text is never longer than 127 bytes. 
+            // I left this code here, as we will need it for custom cultures and possibly when we shrink the stack allocated buffer.
             combinedSpan = memorySequence.ToSingleSpan();
             if (!PrimitiveParser.TryParseUInt32(new Utf8String(combinedSpan), out value, out consumed)) {
                 return false;


### PR DESCRIPTION
As a side note, this routine is a great illustration of the power of Span<T>. The fact that spans represent arbitrary memory (including stack memory) can be used to process (in this example parse) discontinuous buffers very efficiently and without heap allocations, even if the processed data straddles multiple buffers.

Without Span<T> either the processing code (PrimitiveParser.TryParseUInt32 in this example) needs to be written to handle discontinuous data, which would make such parser complicated and slow, or the routines calling the parser (like this routine) have to allocate contiguous buffer on the heap, or PrimitiveParser has to have unsafe overloads to parse stack allocated arrays.

cc: @davidfowl, @terrajobst, @joshfree
