### PR TITLE
Added OutputFormatter

### DIFF
--- a/src/System.Text.Formatting/System/Text/Formatting/OutputFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/OutputFormatter.cs
@@ -1,0 +1,28 @@
+﻿using System.Buffers;
+
+namespace System.Text.Formatting
+{
+    public struct OutputFormatter<TOutput> : ITextOutput where TOutput : IOutput
+    {
+        TOutput _output;
+        EncodingData _encoding;
+
+        public OutputFormatter(TOutput output, EncodingData encoding)
+        {
+            _output = output;
+            _encoding = encoding;
+        }
+
+        public OutputFormatter(TOutput output) : this(output, EncodingData.InvariantUtf8)
+        {
+        }
+
+        public Span<byte> Buffer => _output.Buffer;
+
+        public EncodingData Encoding => _encoding;
+
+        public void Advance(int bytes) => _output.Advance(bytes);
+
+        public void Enlarge(int desiredBufferLength = 0) => _output.Enlarge(desiredBufferLength);
+    }
+}


### PR DESCRIPTION
This type can be used to create ITextOutput out of IOutput.

For example, Channel's WritableBuffer implements IOutput, but not ITextOutput. This API allows to format to WritableBuffer despite the fact that formatters requre ITextOutput:
```c#
WritableBuffer output = ...
var textOutput = new OutputFormatter<WritableBuffer>(output);
textOutput.Append(0xff, 'X');
```