### PR TITLE
Experimental: Deferred string copies for StringFormatter.Append

### DIFF
--- a/src/System.Text.Formatting/System/Text/Formatting/StringFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/StringFormatter.cs
@@ -79,8 +79,8 @@ namespace System.Text.Formatting
 
             fixed (char* pResult = result)
             {
-                int thisIndex = 0; // Index in our buffer we're copying from.
-                int destIndex = 0; // Index in pResult we're copying to.
+                int thisIndex = 0; // Index in our buffer we're copying from. (in bytes)
+                int destIndex = 0; // Index in pResult we're copying to. (in chars)
 
                 for (int i = 0; i < _copyQueue.Count; i++)
                 {
@@ -95,12 +95,12 @@ namespace System.Text.Formatting
                     }
 
                     thisIndex = queuedIndex;
-                    destIndex += queuedIndex - thisIndex;
+                    destIndex += (queuedIndex - thisIndex) / 2;
                     
                     // Copy the queued buffer.
                     fixed (char* pBuffer = pair.Key)
                     {
-                        Unsafe.CopyBlock(pResult, pBuffer, (uint)pair.Key.Length);
+                        Unsafe.CopyBlock(pResult, pBuffer, (uint)pair.Key.Length * 2);
                     }
 
                     destIndex += pair.Key.Length;
@@ -121,7 +121,7 @@ namespace System.Text.Formatting
         {
             // Sum up the count in our buffer + the count of queued buffers.
 
-            int result = _buffer.Count;
+            int result = _buffer.Count / 2; // _buffer is in bytes.
 
             for (int i = 0; i < _copyQueue.Count; i++)
             {

--- a/src/System.Text.Formatting/System/Text/Formatting/StringFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/StringFormatter.cs
@@ -15,7 +15,7 @@ namespace System.Text.Formatting
         ResizableArray<byte> _buffer;
         ArrayPool<byte> _pool;
         public EncodingData Encoding { get; set; } = EncodingData.InvariantUtf16;
-        ResizableArray<KeyValuePair<string, int>> _copyQueue;
+        List<KeyValuePair<string, int>> _copyQueue = new List<KeyValuePair<string, int>>();
 
 
         public StringFormatter(int characterCapacity = 32, ArrayPool<byte> pool = null)
@@ -93,14 +93,14 @@ namespace System.Text.Formatting
                     {
                         Unsafe.CopyBlock(pResult + destIndex, pSource, (uint)(queuedIndex - thisIndex));
                     }
-
-                    thisIndex = queuedIndex;
-                    destIndex += (queuedIndex - thisIndex) / 2;
                     
+                    destIndex += (queuedIndex - thisIndex) / 2;
+                    thisIndex = queuedIndex;
+
                     // Copy the queued buffer.
                     fixed (char* pBuffer = pair.Key)
                     {
-                        Unsafe.CopyBlock(pResult, pBuffer, (uint)pair.Key.Length * 2);
+                        Unsafe.CopyBlock(pResult + destIndex, pBuffer, (uint)pair.Key.Length * 2);
                     }
 
                     destIndex += pair.Key.Length;

--- a/src/System.Text.Formatting/System/Text/Formatting/StringFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/StringFormatter.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Collections.Generic;
 using System.Collections.Sequences;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace System.Text.Formatting
@@ -12,6 +14,8 @@ namespace System.Text.Formatting
         ResizableArray<byte> _buffer;
         ArrayPool<byte> _pool;
         public EncodingData Encoding { get; set; } = EncodingData.InvariantUtf16;
+        ResizableArray<KeyValuePair<ReadOnlySpan<char>, int>> _copyQueue;
+
 
         public StringFormatter(int characterCapacity = 32, ArrayPool<byte> pool = null)
         {
@@ -34,10 +38,9 @@ namespace System.Text.Formatting
         //TODO: this should use Span<byte>
         public void Append(string text)
         {
-            foreach (char character in text)
-            {
-                Append(character);
-            }
+            // Strings are immutable. There is no difference between
+            // queueing a string to be copied later from eagerly appending a string.
+            QueueForCopy(text);
         }
 
         //TODO: this should use Span<byte>
@@ -54,10 +57,70 @@ namespace System.Text.Formatting
             _buffer.Clear();
         }
 
-        public override string ToString()
+        public void QueueForCopy(string text)
         {
-            var text = Text.Encoding.Unicode.GetString(_buffer.Items, 0, _buffer.Count);
-            return text;
+            QueueForCopy(text.Slice());
+        }
+
+        public void QueueForCopy(ReadOnlySpan<char> substring)
+        {
+            // Instead of copying buffers to our buffer, and then re-copying our buffer again
+            // during ToString, we can do something different. When QueueForCopy is called,
+            // we record the buffer to be copied & the index we're currently at, and add them
+            // to a queue. When ToString is called, we copy from our buffer up to that index,
+            // copy from the queued buffer, advance to that index in the destination,
+            // & continue copying from our buffer until the next queued buffer.
+
+            _copyQueue.Add(new KeyValuePair<ReadOnlySpan<char>, int>(substring, _buffer.Count));
+        }
+
+        public unsafe override string ToString()
+        {
+            // NOTE: We are violating string's immutability here.
+            // We allocate a 0-inited string buffer, then write our contents directly to it.
+            // This is what Encoding.GetString does under the hood.
+            string result = new string('\0', GetCount());
+
+            fixed (char* pResult = result)
+            {
+                int thisIndex = 0; // Index in our buffer we're copying from.
+
+                for (int i = 0; i < _copyQueue.Count; i++)
+                {
+                    var pair = _copyQueue[i];
+
+                    // Copy up to the given index in the pair.
+                    int queuedIndex = pair.Value;
+
+                    fixed (byte* pSource = &_buffer.Items[thisIndex])
+                    {
+                        Unsafe.CopyBlock(pResult, pSource, (uint)(queuedIndex - thisIndex));
+                    }
+
+                    thisIndex = queuedIndex;
+                    
+                    // Copy the queued buffer.
+                    // Note: This does not compile yet...
+                    fixed (char* pBuffer = pair.Key)
+                    {
+                        Unsafe.CopyBlock(pResult, pBuffer, (uint)pair.Key.Length);
+                    }
+                }
+            }
+        }
+
+        private int GetCount()
+        {
+            // Sum up the count in our buffer + the count of queued buffers.
+
+            int result = _buffer.Count;
+
+            for (int i = 0; i < _copyQueue.Count; i++)
+            {
+                result += _copyQueue[i].Key.Length;
+            }
+
+            return result;
         }
 
         Span<byte> IOutput.Buffer => _buffer.Free.Slice();

--- a/src/System.Text.Formatting/project.json
+++ b/src/System.Text.Formatting/project.json
@@ -38,10 +38,10 @@
     "System.Text.Utf8": { "target": "project" },
     "System.Slices": { "target": "project" },
     "System.Text.Primitives": { "target": "project" },
-    "System.Buffers.Experimental": { "target": "project" }
+    "System.Buffers.Experimental": { "target": "project" },
+    "System.Runtime.CompilerServices.Unsafe": "4.3.0"
   },
   "frameworks": {
-    "netstandard1.1": {
-    }
+    "netstandard1.1": { }
   }
 }

--- a/tests/System.Text.Formatting.Tests/PrimitiveFormattingTests.cs
+++ b/tests/System.Text.Formatting.Tests/PrimitiveFormattingTests.cs
@@ -27,6 +27,20 @@ namespace System.Text.Formatting.Tests
             CultureInfo.CurrentUICulture = culture;
         }
 
+        [Fact]
+        public void AppendString()
+        {
+            var formatter = new StringFormatter();
+
+            formatter.Append('H');
+            formatter.Append("ello");
+            formatter.Append(' ');
+            formatter.Append("world");
+            formatter.Append('!');
+
+            Assert.Equal("Hello world!", formatter.ToString());
+        }
+
         private void CheckByte(byte value, string format, string expected)
         {
             var formatter = new StringFormatter();


### PR DESCRIPTION
Currently, `StringFormatter.Append(string)` eagerly copies the string into its internal buffer. This is inefficient since we do 2 copies: one to the internal buffer, and one to the result string during `ToString`.

There is a way to improve on this. Instead of copying the string up-front when `Append` is called, we record the current index & add the string to a queue to be copied later. Then, during `ToString`, we copy from our buffer up to that index, copy the contents of our string, then continue copying from our buffer. This way, only 1 copy of the string is ever made.

Visualization for a test case I added in the PR:

```cs
var formatter = new StringFormatter();

formatter.Append('H');
formatter.Append("ello");
formatter.Append(' ');
formatter.Append("world");
formatter.Append('!');

// becomes

// Copy "ello" starting at character position 2 / sizeof(char).
// Copy "world" starting at character position 4 / sizeof(char) + "ello".Length.
_copyQueue: [ ["ello", 2], ["world", 4] ]

// Unicode representation of: ['H', ' ', '!']
_buffer: [72, 0, 32, 0, 33, 0]
```

Please note that this should not be merged yet. The code is a little sloppy-- I used `List<T>` for queueing the strings instead of a struct, I used `Unsafe.CopyBlock` instead of `Encoding.GetChars` which will undoubtedly mess up some inputs with special characters, etc. This is more of a proof-of-concept PR intended to garner initial feedback.

@KrzysztofCwalina What do you think?