### PR TITLE
Ported corfxlab libraries to use the PrimitiveParser

### DIFF
--- a/src/System.IO.Pipelines.Text.Primitives/ReadableBufferExtensions.cs
+++ b/src/System.IO.Pipelines.Text.Primitives/ReadableBufferExtensions.cs
@@ -102,7 +102,7 @@ namespace System.IO.Pipelines.Text.Primitives
         {
             byte* addr;
             ulong value;
-            int consumed, len = buffer.Length;
+            int len = buffer.Length;
             if (buffer.IsSingleSpan)
             {
                 // It fits!
@@ -110,14 +110,14 @@ namespace System.IO.Pipelines.Text.Primitives
                 ArraySegment<byte> data;
                 if (buffer.First.TryGetPointer(out pointer))
                 {
-                    if (!InternalParser.TryParseUInt64((byte*)pointer, 0, len, EncodingData.InvariantUtf8, TextFormat.HexUppercase, out value, out consumed))
+                    if (!PrimitiveParser.InvariantUtf8.Hex.TryParseUInt64((byte*)pointer, len, out value)) 
                     {
                         throw new InvalidOperationException();
                     }
                 }
                 else if (buffer.First.TryGetArray(out data))
                 {
-                    if (!InternalParser.TryParseUInt64(data.Array, 0, EncodingData.InvariantUtf8, TextFormat.HexUppercase, out value, out consumed))
+                    if (!PrimitiveParser.InvariantUtf8.Hex.TryParseUInt64(data.Array, out value)) 
                     {
                         throw new InvalidOperationException();
                     }
@@ -132,9 +132,7 @@ namespace System.IO.Pipelines.Text.Primitives
                 var data = stackalloc byte[len];
                 buffer.CopyTo(new Span<byte>(data, len));
                 addr = data;
-
-                if (!InternalParser.TryParseUInt64(addr, 0, len, EncodingData.InvariantUtf8, TextFormat.HexUppercase, out value, out consumed))
-                {
+                if (!PrimitiveParser.InvariantUtf8.Hex.TryParseUInt64(addr, len, out value)) {
                     throw new InvalidOperationException();
                 }
             }
@@ -142,8 +140,7 @@ namespace System.IO.Pipelines.Text.Primitives
             {
                 // Heap allocated copy to parse into array (should be rare)
                 var arr = buffer.ToArray();
-                if (!InternalParser.TryParseUInt64(arr, 0, EncodingData.InvariantUtf8, TextFormat.HexUppercase, out value, out consumed))
-                {
+                if (!PrimitiveParser.InvariantUtf8.Hex.TryParseUInt64(arr, out value)) {
                     throw new InvalidOperationException();
                 }
 

--- a/src/System.Text.Formatting/System/Text/Parsing/SequenceParser.cs
+++ b/src/System.Text.Formatting/System/Text/Parsing/SequenceParser.cs
@@ -25,7 +25,7 @@ namespace System.Text.Parsing
             }
 
             // Attempt to parse the first segment. If it works (and it should in most cases), then return success.
-            bool parsed = InternalParser.TryParseUInt64(first.Span, EncodingData.InvariantUtf8, default(TextFormat), out value, out consumed);
+            bool parsed = PrimitiveParser.InvariantUtf8.TryParseUInt64(first.Span, out value, out consumed);
             if (parsed && consumed < first.Length) {
                 return true;
             }
@@ -68,7 +68,7 @@ namespace System.Text.Parsing
                     combinedSpan = destination.Slice(0, StackBufferSize - free.Length);
 
                     // if the stack allocated buffer parsed succesfully (and for uint it should always do), then return success. 
-                    if (InternalParser.TryParseUInt64(combinedSpan, EncodingData.InvariantUtf8, default(TextFormat), out value, out consumed)) {
+                    if (PrimitiveParser.InvariantUtf8.TryParseUInt64(combinedSpan, out value, out consumed)) {
                         if(consumed < combinedSpan.Length || combinedSpan.Length < StackBufferSize) {
                             return true;
                         }
@@ -79,7 +79,7 @@ namespace System.Text.Parsing
             // for invariant culture, we should never reach this point, as invariant uint text is never longer than 127 bytes. 
             // I left this code here, as we will need it for custom cultures and possibly when we shrink the stack allocated buffer.
             combinedSpan = memorySequence.ToSingleSpan();
-            if (!InternalParser.TryParseUInt64(first.Span, EncodingData.InvariantUtf8, default(TextFormat), out value, out consumed)) {
+            if (!PrimitiveParser.InvariantUtf8.TryParseUInt64(first.Span, out value, out consumed)) {
                 return false;
             }
             return true;
@@ -98,7 +98,7 @@ namespace System.Text.Parsing
             }
 
             // Attempt to parse the first segment. If it works (and it should in most cases), then return success.
-            bool parsed = InternalParser.TryParseUInt32(new Utf8String(first.Span), out value, out consumed);
+            bool parsed = PrimitiveParser.InvariantUtf8.TryParseUInt32(first.Span, out value, out consumed);
             if (parsed && consumed < first.Length) {
                 return true;
             }
@@ -141,7 +141,7 @@ namespace System.Text.Parsing
                     combinedSpan = destination.Slice(0, StackBufferSize - free.Length);
 
                     // if the stack allocated buffer parsed succesfully (and for uint it should always do), then return success. 
-                    if (InternalParser.TryParseUInt32(new Utf8String(combinedSpan), out value, out consumed)) {
+                    if (PrimitiveParser.InvariantUtf8.TryParseUInt32(combinedSpan, out value, out consumed)) {
                         if(consumed < combinedSpan.Length || combinedSpan.Length < StackBufferSize) {
                             return true;
                         }
@@ -152,7 +152,7 @@ namespace System.Text.Parsing
             // for invariant culture, we should never reach this point, as invariant uint text is never longer than 127 bytes. 
             // I left this code here, as we will need it for custom cultures and possibly when we shrink the stack allocated buffer.
             combinedSpan = memorySequence.ToSingleSpan();
-            if (!InternalParser.TryParseUInt32(new Utf8String(combinedSpan), out value, out consumed)) {
+            if (!PrimitiveParser.InvariantUtf8.TryParseUInt32(combinedSpan, out value, out consumed)) {
                 return false;
             }
             return true;

--- a/src/System.Text.Json.Dynamic/System/Text/Json/JsonDynamicObject.cs
+++ b/src/System.Text.Json.Dynamic/System/Text/Json/JsonDynamicObject.cs
@@ -98,8 +98,7 @@ namespace System.Text.Json
             {
                 throw new InvalidOperationException();
             }
-            int consumed;
-            return InternalParser.TryParseUInt32(jsonValue.Value, out value, out consumed);
+            return PrimitiveParser.InvariantUtf8.TryParseUInt32(jsonValue.Value.Bytes, out value);
         }
 
         public bool TryGetString(Utf8String property, out Utf8String value)

--- a/src/System.Text.Json/System/Text/Json/JsonParseObject.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonParseObject.cs
@@ -212,8 +212,7 @@ namespace System.Text.Json
             var slice = json._values.Slice(record.Location);
 
             bool result;
-            int consumed;
-            if(!Internal.InternalParser.TryParseBoolean(slice, EncodingData.InvariantUtf8, default(TextFormat), out result, out consumed)){
+            if(!PrimitiveParser.InvariantUtf8.TryParseBoolean(slice, out result)){
                 throw new InvalidCastException();
             }
             return result;
@@ -229,8 +228,7 @@ namespace System.Text.Json
             var slice = json._values.Slice(record.Location);
 
             int result;
-            int consumed;
-            if (!InternalParser.TryParseInt32(slice, EncodingData.InvariantUtf8, default(TextFormat), out result, out consumed)) {
+            if (!PrimitiveParser.InvariantUtf8.TryParseInt32(slice, out result)) {
                 throw new InvalidCastException();
             }
             return result;

--- a/src/System.Text.Primitives/System/Text/ParsedFormat.cs
+++ b/src/System.Text.Primitives/System/Text/ParsedFormat.cs
@@ -1,44 +1,36 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.ComponentModel;
+
 namespace System.Text
 {
-    public struct TextFormat
+    public struct TextFormat : IEquatable<TextFormat>
     {
+        public static TextFormat HexUppercase = new TextFormat('X', NoPrecision);
+        public static TextFormat HexLowercase = new TextFormat('x', NoPrecision);
+
         public const byte NoPrecision = byte.MaxValue;
         internal const byte MaxPrecision = 99;
 
-        public char Symbol;
-        public byte Precision;
+        byte _format;
+        byte _precision;
 
-        // once we have a non allocating conversion from string to ReadOnlySpan<char>, we can remove this overload
-        public static TextFormat Parse(string format)
+        public char Symbol
         {
-            if (format == null || format.Length == 0)
-            {
-                return default(TextFormat);
-            }
+            get { return (char)_format; }
+            set { _format = (byte)value; } //TODO: do we want to validate here?
+        }
+        public byte Precision => _precision;
 
-            uint precision = NoPrecision;
-            if (format.Length > 1)
-            {
-                if (!Internal.InternalParser.TryParseUInt32(format, 1, format.Length - 1, out precision))
-                {
-                    throw new NotImplementedException("Unable to parse precision specification");
-                }
-
-                if (precision > TextFormat.MaxPrecision)
-                {
-                    // TODO: this is a contract violation
-                    throw new Exception("PrecisionValueOutOfRange");
-                }
-            }
-
-            var specifier = format[0];
-            return new TextFormat(specifier, (byte)precision);
+        public TextFormat(char symbol, byte precision = NoPrecision)
+        {
+            _format = (byte)symbol; //TODO: do we want to validate here?
+            _precision = precision;
         }
 
-        // TODO: format should be ReadOnlySpan<T>
+        public static implicit operator TextFormat(char symbol) => new TextFormat(symbol);
+
         public static TextFormat Parse(ReadOnlySpan<char> format)
         {
             if (format.Length == 0)
@@ -56,7 +48,7 @@ namespace System.Text
                     throw new NotImplementedException("UnableToParsePrecision");
                 }
 
-                if (precision > TextFormat.MaxPrecision)
+                if (precision > MaxPrecision)
                 {
                     // TODO: this is a contract violation
                     throw new Exception("PrecisionValueOutOfRange");
@@ -68,35 +60,51 @@ namespace System.Text
             return new TextFormat(specifier, (byte)precision);
         }
 
-        public static TextFormat Parse(char format)
+        public static TextFormat Parse(char format) => new TextFormat(format, NoPrecision);
+
+        // once we have a non allocating conversion from string to ReadOnlySpan<char>, we can remove this overload
+        public static TextFormat Parse(string format)
         {
-            return new TextFormat(format, NoPrecision);
+            if (format == null) return default(TextFormat);
+            return Parse(format.Slice());
         }
- 
-        public TextFormat(char symbol, byte precision = NoPrecision)
+         
+        public bool IsHexadecimal => Symbol == 'X' || Symbol == 'x';
+
+        public bool HasPrecision => Precision != NoPrecision;
+
+        public bool IsDefault => _format == 0 && _precision == 0;
+
+        public override string ToString()
         {
-            Symbol = symbol;
-            Precision = precision;
-        }
-        public bool IsHexadecimal
-        {
-            get { return Symbol == 'X' || Symbol == 'x'; }
-        }
-        public bool HasPrecision
-        {
-            get { return Precision != NoPrecision; }
+            return string.Format("{0}:{1}", Symbol, Precision);
         }
 
-        public bool IsDefault {
-            get { return Symbol == (char)0; }
+        public static bool operator==(TextFormat left, TextFormat right) => left.Equals(right);
+        public static bool operator !=(TextFormat left, TextFormat right) => !left.Equals(right);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj)
+        {
+            if (!(obj is TextFormat)) return false;
+            return Equals((TextFormat)obj);
         }
 
-        public static TextFormat HexUppercase = new TextFormat('X', TextFormat.NoPrecision);
-        public static TextFormat HexLowercase = new TextFormat('x', TextFormat.NoPrecision);
-
-        public static implicit operator TextFormat(char symbol)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Equals(TextFormat other)
         {
-            return new TextFormat(symbol);
-        }      
+            return Symbol.Equals(other.Symbol) && Precision.Equals(other.Precision);
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode()
+        {
+            return CombineHashCodes(Symbol.GetHashCode(), Precision.GetHashCode());
+        }
+
+        static int CombineHashCodes(int h1, int h2)
+        {
+            return ((h1 << 5) + h1) ^ h2;
+        }
     }
 }


### PR DESCRIPTION
Removed all consumers (except tests) of the InternalParser

cc: @botaberg, @AtsushiKan, @joshfree 