### PR TITLE
Changed DefaultWritableBufferExtensions.Write to take ReadOnlySpan<byte>

### DIFF
--- a/src/System.IO.Pipelines/DefaultWritableBufferExtensions.cs
+++ b/src/System.IO.Pipelines/DefaultWritableBufferExtensions.cs
@@ -17,7 +17,7 @@ namespace System.IO.Pipelines
         /// </summary>
         /// <param name="buffer">The <see cref="WritableBuffer"/></param>
         /// <param name="source">The <see cref="Span{Byte}"/> to write</param>
-        public static void Write(this WritableBuffer buffer, Span<byte> source)
+        public static void Write(this WritableBuffer buffer, ReadOnlySpan<byte> source)
         {
             if (buffer.Memory.IsEmpty)
             {


### PR DESCRIPTION
The Write method currently takes Span<byte> as a parameter.
It should take ReadOnlySpan<byte> as the method does not mutate the contents of the data it writes.
This will enable writing new Utf8String("Hello World!).Bytes, and no technology can succeed without supporting the Hello World. 

cc: @botaberg, @joshfree, @davidfowl, @AtsushiKan