### PR TITLE
Expose LocalEndPoint property on SocketListener

### DIFF
--- a/src/System.IO.Pipelines.Networking.Sockets/SocketListener.cs
+++ b/src/System.IO.Pipelines.Networking.Sockets/SocketListener.cs
@@ -86,6 +86,8 @@ namespace System.IO.Pipelines.Networking.Sockets
             }
         }
 
+        public EndPoint LocalEndPoint => _socket == null ? new IPEndPoint(IPAddress.None, 0) : _socket.LocalEndPoint;
+
         private Socket GetReusableSocket() => null; // TODO: socket pooling / re-use
 
         private void BeginAccept(SocketAsyncEventArgs args)

--- a/src/System.IO.Pipelines.Networking.Sockets/SocketListener.cs
+++ b/src/System.IO.Pipelines.Networking.Sockets/SocketListener.cs
@@ -86,7 +86,7 @@ namespace System.IO.Pipelines.Networking.Sockets
             }
         }
 
-        public Socket ListeningSocket { get { return _socket;} }
+        public Socket ListeningSocket => _socket;
 
         private Socket GetReusableSocket() => null; // TODO: socket pooling / re-use
 

--- a/src/System.IO.Pipelines.Networking.Sockets/SocketListener.cs
+++ b/src/System.IO.Pipelines.Networking.Sockets/SocketListener.cs
@@ -14,7 +14,7 @@ namespace System.IO.Pipelines.Networking.Sockets
     public class SocketListener : IDisposable
     {
         private readonly bool _ownsFactory;
-        public Socket _socket;
+        private Socket _socket;
         private Socket Socket => _socket;
         private PipelineFactory _factory;
         private PipelineFactory PipelineFactory => _factory;
@@ -85,6 +85,8 @@ namespace System.IO.Pipelines.Networking.Sockets
                 _socket = null;
             }
         }
+
+        public Socket ListeningSocket { get { return _socket;} }
 
         private Socket GetReusableSocket() => null; // TODO: socket pooling / re-use
 

--- a/src/System.IO.Pipelines.Networking.Sockets/SocketListener.cs
+++ b/src/System.IO.Pipelines.Networking.Sockets/SocketListener.cs
@@ -14,7 +14,7 @@ namespace System.IO.Pipelines.Networking.Sockets
     public class SocketListener : IDisposable
     {
         private readonly bool _ownsFactory;
-        private Socket _socket;
+        public Socket _socket;
         private Socket Socket => _socket;
         private PipelineFactory _factory;
         private PipelineFactory PipelineFactory => _factory;
@@ -85,8 +85,6 @@ namespace System.IO.Pipelines.Networking.Sockets
                 _socket = null;
             }
         }
-
-        public EndPoint LocalEndPoint => _socket == null ? new IPEndPoint(IPAddress.None, 0) : _socket.LocalEndPoint;
 
         private Socket GetReusableSocket() => null; // TODO: socket pooling / re-use
 


### PR DESCRIPTION
When using a system assigned port for the SocketListener. The SocketListener class needs to expose the address of the socket so the caller can obtain the assigned port. I've added a property to expose the endpoint of the socket. If the socket is null, then the property will return a empty endpoint. 