### PR TITLE
Implement PrimitiveParser.InvariantUtf8.TryParseUInt32 span and Hex overloads

### DIFF
--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_UInt32.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_UInt32.cs
@@ -10,11 +10,10 @@ namespace System.Text
     {
         public static partial class InvariantUtf8
         {
-            #region static
-            const int s_uint32OverflowLength = 10;
-            const int s_uint32OverflowLengthHex = 8;
+            const int s_UInt32OverflowLength = 10;
+            const int s_UInt32OverflowLengthHex = 8;
 
-            static readonly byte[] s_hexLookup =
+            static readonly byte[] s_HexLookup =
             {
                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,             // 15
                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,             // 31
@@ -33,7 +32,6 @@ namespace System.Text
                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,             // 239
                 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF              // 255
             };
-            #endregion
             
             public unsafe static bool TryParseUInt32(byte* text, int length, out uint value)
             {
@@ -52,7 +50,7 @@ namespace System.Text
                 }
                 value = firstDigit;
 
-                if (length < s_uint32OverflowLength)
+                if (length < s_UInt32OverflowLength)
                 {
                     // Length is less than OVERFLOW_LENGTH; overflow is not possible
                     for (int index = 1; index < length; index++)
@@ -69,7 +67,7 @@ namespace System.Text
                 {
                     // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                     // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                    for (int index = 1; index < s_uint32OverflowLength - 1; index++)
+                    for (int index = 1; index < s_UInt32OverflowLength - 1; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -78,7 +76,7 @@ namespace System.Text
                         }
                         value = value * 10 + nextDigit;
                     }
-                    for (int index = s_uint32OverflowLength - 1; index < length; index++)
+                    for (int index = s_UInt32OverflowLength - 1; index < length; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -120,7 +118,7 @@ namespace System.Text
                 }
                 value = firstDigit;
 
-                if (length < s_uint32OverflowLength)
+                if (length < s_UInt32OverflowLength)
                 {
                     // Length is less than OVERFLOW_LENGTH; overflow is not possible
                     for (int index = 1; index < length; index++)
@@ -138,7 +136,7 @@ namespace System.Text
                 {
                     // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                     // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                    for (int index = 1; index < s_uint32OverflowLength - 1; index++)
+                    for (int index = 1; index < s_UInt32OverflowLength - 1; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -148,7 +146,7 @@ namespace System.Text
                         }
                         value = value * 10 + nextDigit;
                     }
-                    for (int index = s_uint32OverflowLength - 1; index < length; index++)
+                    for (int index = s_UInt32OverflowLength - 1; index < length; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -190,7 +188,7 @@ namespace System.Text
                 }
                 value = firstDigit;
 
-                if (text.Length < s_uint32OverflowLength)
+                if (text.Length < s_UInt32OverflowLength)
                 {
                     // Length is less than OVERFLOW_LENGTH; overflow is not possible
                     for (int index = 1; index < text.Length; index++)
@@ -207,7 +205,7 @@ namespace System.Text
                 {
                     // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                     // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                    for (int index = 1; index < s_uint32OverflowLength - 1; index++)
+                    for (int index = 1; index < s_UInt32OverflowLength - 1; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -216,7 +214,7 @@ namespace System.Text
                         }
                         value = value * 10 + nextDigit;
                     }
-                    for (int index = s_uint32OverflowLength - 1; index < text.Length; index++)
+                    for (int index = s_UInt32OverflowLength - 1; index < text.Length; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -257,7 +255,7 @@ namespace System.Text
                 }
                 value = firstDigit;
 
-                if (text.Length < s_uint32OverflowLength)
+                if (text.Length < s_UInt32OverflowLength)
                 {
                     // Length is less than OVERFLOW_LENGTH; overflow is not possible
                     for (int index = 1; index < text.Length; index++)
@@ -275,7 +273,7 @@ namespace System.Text
                 {
                     // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                     // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                    for (int index = 1; index < s_uint32OverflowLength - 1; index++)
+                    for (int index = 1; index < s_UInt32OverflowLength - 1; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -285,7 +283,7 @@ namespace System.Text
                         }
                         value = value * 10 + nextDigit;
                     }
-                    for (int index = s_uint32OverflowLength - 1; index < text.Length; index++)
+                    for (int index = s_UInt32OverflowLength - 1; index < text.Length; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -327,7 +325,7 @@ namespace System.Text
                     }
 
                     // Cache s_hexLookup in order to avoid static constructor checks
-                    byte[] hexLookup = s_hexLookup;
+                    byte[] hexLookup = s_HexLookup;
 
                     // Parse the first digit separately. If invalid here, we need to return false.
                     byte firstByte = text[0];
@@ -339,7 +337,7 @@ namespace System.Text
                     }
                     value = (uint)firstDigit;
 
-                    if (length <= s_uint32OverflowLengthHex)
+                    if (length <= s_UInt32OverflowLengthHex)
                     {
                         // Length is less than or equal to OVERFLOW_LENGTH; overflow is not possible
                         for (int index = 1; index < length; index++)
@@ -357,7 +355,7 @@ namespace System.Text
                     {
                         // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                         // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                        for (int index = 1; index < s_uint32OverflowLengthHex; index++)
+                        for (int index = 1; index < s_UInt32OverflowLengthHex; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];
@@ -367,7 +365,7 @@ namespace System.Text
                             }
                             value = value * 0x10 + (uint)nextDigit;
                         }
-                        for (int index = s_uint32OverflowLengthHex; index < length; index++)
+                        for (int index = s_UInt32OverflowLengthHex; index < length; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];
@@ -398,7 +396,7 @@ namespace System.Text
                     }
 
                     // Cache s_hexLookup in order to avoid static constructor checks
-                    byte[] hexLookup = s_hexLookup;
+                    byte[] hexLookup = s_HexLookup;
 
                     // Parse the first digit separately. If invalid here, we need to return false.
                     byte firstByte = text[0];
@@ -411,7 +409,7 @@ namespace System.Text
                     }
                     value = (uint)firstDigit;
 
-                    if (length <= s_uint32OverflowLengthHex)
+                    if (length <= s_UInt32OverflowLengthHex)
                     {
                         // Length is less than or equal to OVERFLOW_LENGTH; overflow is not possible
                         for (int index = 1; index < length; index++)
@@ -430,7 +428,7 @@ namespace System.Text
                     {
                         // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                         // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                        for (int index = 1; index < s_uint32OverflowLengthHex; index++)
+                        for (int index = 1; index < s_UInt32OverflowLengthHex; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];
@@ -441,7 +439,7 @@ namespace System.Text
                             }
                             value = value * 0x10 + (uint)nextDigit;
                         }
-                        for (int index = s_uint32OverflowLengthHex; index < length; index++)
+                        for (int index = s_UInt32OverflowLengthHex; index < length; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];
@@ -474,7 +472,7 @@ namespace System.Text
                     }
 
                     // Cache s_hexLookup in order to avoid static constructor checks
-                    byte[] hexLookup = s_hexLookup;
+                    byte[] hexLookup = s_HexLookup;
 
                     // Parse the first digit separately. If invalid here, we need to return false.
                     byte firstByte = text[0];
@@ -486,7 +484,7 @@ namespace System.Text
                     }
                     value = (uint)firstDigit;
 
-                    if (text.Length <= s_uint32OverflowLengthHex)
+                    if (text.Length <= s_UInt32OverflowLengthHex)
                     {
                         // Length is less than or equal to OVERFLOW_LENGTH; overflow is not possible
                         for (int index = 1; index < text.Length; index++)
@@ -504,7 +502,7 @@ namespace System.Text
                     {
                         // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                         // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                        for (int index = 1; index < s_uint32OverflowLengthHex; index++)
+                        for (int index = 1; index < s_UInt32OverflowLengthHex; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];
@@ -514,7 +512,7 @@ namespace System.Text
                             }
                             value = value * 0x10 + (uint)nextDigit;
                         }
-                        for (int index = s_uint32OverflowLengthHex; index < text.Length; index++)
+                        for (int index = s_UInt32OverflowLengthHex; index < text.Length; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];
@@ -545,7 +543,7 @@ namespace System.Text
                     }
 
                     // Cache s_hexLookup in order to avoid static constructor checks
-                    byte[] hexLookup = s_hexLookup;
+                    byte[] hexLookup = s_HexLookup;
 
                     // Parse the first digit separately. If invalid here, we need to return false.
                     byte firstByte = text[0];
@@ -558,7 +556,7 @@ namespace System.Text
                     }
                     value = (uint)firstDigit;
 
-                    if (text.Length <= s_uint32OverflowLengthHex)
+                    if (text.Length <= s_UInt32OverflowLengthHex)
                     {
                         // Length is less than or equal to OVERFLOW_LENGTH; overflow is not possible
                         for (int index = 1; index < text.Length; index++)
@@ -577,7 +575,7 @@ namespace System.Text
                     {
                         // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                         // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                        for (int index = 1; index < s_uint32OverflowLengthHex; index++)
+                        for (int index = 1; index < s_UInt32OverflowLengthHex; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];
@@ -588,7 +586,7 @@ namespace System.Text
                             }
                             value = value * 0x10 + (uint)nextDigit;
                         }
-                        for (int index = s_uint32OverflowLengthHex; index < text.Length; index++)
+                        for (int index = s_UInt32OverflowLengthHex; index < text.Length; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];

--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_UInt32.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_UInt32.cs
@@ -11,13 +11,36 @@ namespace System.Text
     {
         public static partial class InvariantUtf8
         {
-            static int UINT_OVERFLOW_LENGTH = 10;
+            #region static
+            private static readonly int UINT_OVERFLOW_LENGTH = 10;
+            private static readonly int UINT_OVERFLOW_LENGTH_HEX = 8;
+
+            static readonly int[] hexLookup =
+            {
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,             // 15
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,             // 31
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,             // 47
+                0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, -1, -1, -1, -1, -1, -1,   // 63
+                -1, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF, -1, -1, -1, -1, -1, -1, -1, -1, -1,       // 79
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,             // 95
+                -1, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, -1, -1, -1, -1, -1, -1, -1, -1, -1,       // 111
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,             // 127
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,             // 143
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,             // 159
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,             // 175
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,             // 191
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,             // 207
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,             // 223
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,             // 239
+                -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1              // 255
+            };
+            #endregion
             
             public unsafe static bool TryParseUInt32(byte* text, int length, out uint value)
             {
-                value = default(uint);
                 if (length < 1)
                 {
+                    value = default(uint);
                     return false;
                 }
 
@@ -25,6 +48,7 @@ namespace System.Text
                 uint firstDigit = text[0] - 48u; // '0'
                 if (firstDigit > 9)
                 {
+                    value = default(uint);
                     return false;
                 }
                 value = firstDigit;
@@ -80,10 +104,10 @@ namespace System.Text
             
             public unsafe static bool TryParseUInt32(byte* text, int length, out uint value, out int bytesConsumed)
             {
-                value = default(uint);
                 if (length < 1)
                 {
                     bytesConsumed = 0;
+                    value = default(uint);
                     return false;
                 }
 
@@ -92,6 +116,7 @@ namespace System.Text
                 if (firstDigit > 9)
                 {
                     bytesConsumed = 0;
+                    value = default(uint);
                     return false;
                 }
                 value = firstDigit;
@@ -151,35 +176,425 @@ namespace System.Text
             }
             public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value)
             {
-                int consumed;
-                return PrimitiveParser.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8);
+                if (text.Length < 1)
+                {
+                    value = default(uint);
+                    return false;
+                }
+
+                // Parse the first digit separately. If invalid here, we need to return false.
+                uint firstDigit = text[0] - 48u; // '0'
+                if (firstDigit > 9)
+                {
+                    value = default(uint);
+                    return false;
+                }
+                value = firstDigit;
+
+                if (text.Length < UINT_OVERFLOW_LENGTH)
+                {
+                    // Length is less than OVERFLOW_LENGTH; overflow is not possible
+                    for (int index = 1; index < text.Length; index++)
+                    {
+                        uint nextDigit = text[index] - 48u; // '0'
+                        if (nextDigit > 9)
+                        {
+                            return true;
+                        }
+                        value = value * 10 + nextDigit;
+                    }
+                }
+                else
+                {
+                    // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
+                    // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
+                    for (int index = 1; index < UINT_OVERFLOW_LENGTH - 1; index++)
+                    {
+                        uint nextDigit = text[index] - 48u; // '0'
+                        if (nextDigit > 9)
+                        {
+                            return true;
+                        }
+                        value = value * 10 + nextDigit;
+                    }
+                    for (int index = UINT_OVERFLOW_LENGTH - 1; index < text.Length; index++)
+                    {
+                        uint nextDigit = text[index] - 48u; // '0'
+                        if (nextDigit > 9)
+                        {
+                            return true;
+                        }
+                        // uint.MaxValue is a constant 4294967295
+                        // uint.MaxValue / 10 is 429496729 (integer division truncated)
+                        // (value > uint.MaxValue / 10) implies overflow when appended to; e.g., 4294967300 > 4294967295
+                        // if value == 429496729, any nextDigit greater than 5 implies overflow
+                        if (value > uint.MaxValue / 10 || (value == uint.MaxValue / 10 && nextDigit > 5))
+                        {
+                            value = default(uint);
+                            return false;
+                        }
+                        value = value * 10 + nextDigit;
+                    }
+                }
+
+                return true;
             }
             public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int bytesConsumed)
             {
-                return PrimitiveParser.TryParseUInt32(text, out value, out bytesConsumed, EncodingData.InvariantUtf8);
-            }
+                if (text.Length < 1)
+                {
+                    bytesConsumed = 0;
+                    value = default(uint);
+                    return false;
+                }
 
+                // Parse the first digit separately. If invalid here, we need to return false.
+                uint firstDigit = text[0] - 48u; // '0'
+                if (firstDigit > 9)
+                {
+                    bytesConsumed = 0;
+                    value = default(uint);
+                    return false;
+                }
+                value = firstDigit;
+
+                if (text.Length < UINT_OVERFLOW_LENGTH)
+                {
+                    // Length is less than OVERFLOW_LENGTH; overflow is not possible
+                    for (int index = 1; index < text.Length; index++)
+                    {
+                        uint nextDigit = text[index] - 48u; // '0'
+                        if (nextDigit > 9)
+                        {
+                            bytesConsumed = index;
+                            return true;
+                        }
+                        value = value * 10 + nextDigit;
+                    }
+                }
+                else
+                {
+                    // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
+                    // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
+                    for (int index = 1; index < UINT_OVERFLOW_LENGTH - 1; index++)
+                    {
+                        uint nextDigit = text[index] - 48u; // '0'
+                        if (nextDigit > 9)
+                        {
+                            bytesConsumed = index;
+                            return true;
+                        }
+                        value = value * 10 + nextDigit;
+                    }
+                    for (int index = UINT_OVERFLOW_LENGTH - 1; index < text.Length; index++)
+                    {
+                        uint nextDigit = text[index] - 48u; // '0'
+                        if (nextDigit > 9)
+                        {
+                            bytesConsumed = index;
+                            return true;
+                        }
+                        // uint.MaxValue is a constant 4294967295
+                        // uint.MaxValue / 10 is 429496729 (integer division truncated)
+                        // (value > uint.MaxValue / 10) implies overflow when appended to; e.g., 4294967300 > 4294967295
+                        // if value == 429496729, any nextDigit greater than 5 implies overflow
+                        if (value > uint.MaxValue / 10 || (value == uint.MaxValue / 10 && nextDigit > 5))
+                        {
+                            bytesConsumed = 0;
+                            value = default(uint);
+                            return false;
+                        }
+                        value = value * 10 + nextDigit;
+                    }
+                }
+
+                bytesConsumed = text.Length;
+                return true;
+            }
+            
             public static partial class Hex
             {
                 public unsafe static bool TryParseUInt32(byte* text, int length, out uint value)
                 {
-                    int consumed;
-                    var span = new ReadOnlySpan<byte>(text, length);
-                    return PrimitiveParser.TryParseUInt32(span, out value, out consumed, EncodingData.InvariantUtf8, 'X');
+                    if (length < 1)
+                    {
+                        value = default(uint);
+                        return false;
+                    }
+
+                    // Parse the first digit separately. If invalid here, we need to return false.
+                    byte firstByte = text[0];
+                    int firstDigit = hexLookup[firstByte];
+                    if (firstDigit == -1)
+                    {
+                        value = default(uint);
+                        return false;
+                    }
+                    value = (uint)firstDigit;
+
+                    if (length <= UINT_OVERFLOW_LENGTH_HEX)
+                    {
+                        // Length is less than or equal to OVERFLOW_LENGTH; overflow is not possible
+                        for (int index = 1; index < length; index++)
+                        {
+                            byte nextByte = text[index];
+                            int nextDigit = hexLookup[nextByte];
+                            if (nextDigit == -1)
+                            {
+                                return true;
+                            }
+                            value = value * 0x10 + (uint)nextDigit;
+                        }
+                    }
+                    else
+                    {
+                        // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
+                        // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
+                        for (int index = 1; index < UINT_OVERFLOW_LENGTH_HEX; index++)
+                        {
+                            byte nextByte = text[index];
+                            int nextDigit = hexLookup[nextByte];
+                            if (nextDigit == -1)
+                            {
+                                return true;
+                            }
+                            value = value * 0x10 + (uint)nextDigit;
+                        }
+                        for (int index = UINT_OVERFLOW_LENGTH_HEX; index < length; index++)
+                        {
+                            byte nextByte = text[index];
+                            int nextDigit = hexLookup[nextByte];
+                            if (nextDigit == -1)
+                            {
+                                return true;
+                            }
+                            // uint.MaxValue is a constant 0xFFFFFFFF
+                            // If we try to append a digit to anything larger than 0x0FFFFFFF, there will be overflow
+                            if (value > uint.MaxValue / 0x10)
+                            {
+                                value = default(uint);
+                                return false;
+                            }
+                            value = value * 0x10 + (uint)nextDigit;
+                        }
+                    }
+
+                    return true;
                 }
                 public unsafe static bool TryParseUInt32(byte* text, int length, out uint value, out int bytesConsumed)
                 {
-                    var span = new ReadOnlySpan<byte>(text, length);
-                    return PrimitiveParser.TryParseUInt32(span, out value, out bytesConsumed, EncodingData.InvariantUtf8, 'X');
+                    if (length < 1)
+                    {
+                        bytesConsumed = 0;
+                        value = default(uint);
+                        return false;
+                    }
+
+                    // Parse the first digit separately. If invalid here, we need to return false.
+                    byte firstByte = text[0];
+                    int firstDigit = hexLookup[firstByte];
+                    if (firstDigit == -1)
+                    {
+                        bytesConsumed = 0;
+                        value = default(uint);
+                        return false;
+                    }
+                    value = (uint)firstDigit;
+
+                    if (length <= UINT_OVERFLOW_LENGTH_HEX)
+                    {
+                        // Length is less than or equal to OVERFLOW_LENGTH; overflow is not possible
+                        for (int index = 1; index < length; index++)
+                        {
+                            byte nextByte = text[index];
+                            int nextDigit = hexLookup[nextByte];
+                            if (nextDigit == -1)
+                            {
+                                bytesConsumed = index;
+                                return true;
+                            }
+                            value = value * 0x10 + (uint)nextDigit;
+                        }
+                    }
+                    else
+                    {
+                        // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
+                        // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
+                        for (int index = 1; index < UINT_OVERFLOW_LENGTH_HEX; index++)
+                        {
+                            byte nextByte = text[index];
+                            int nextDigit = hexLookup[nextByte];
+                            if (nextDigit == -1)
+                            {
+                                bytesConsumed = index;
+                                return true;
+                            }
+                            value = value * 0x10 + (uint)nextDigit;
+                        }
+                        for (int index = UINT_OVERFLOW_LENGTH_HEX; index < length; index++)
+                        {
+                            byte nextByte = text[index];
+                            int nextDigit = hexLookup[nextByte];
+                            if (nextDigit == -1)
+                            {
+                                bytesConsumed = index;
+                                return true;
+                            }
+                            // uint.MaxValue is a constant 0xFFFFFFFF
+                            // If we try to append a digit to anything larger than 0x0FFFFFFF, there will be overflow
+                            if (value > uint.MaxValue / 0x10)
+                            {
+                                bytesConsumed = 0;
+                                value = default(uint);
+                                return false;
+                            }
+                            value = value * 0x10 + (uint)nextDigit;
+                        }
+                    }
+
+                    bytesConsumed = length;
+                    return true;
                 }
                 public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value)
                 {
-                    int consumed;
-                    return PrimitiveParser.TryParseUInt32(text, out value, out consumed, EncodingData.InvariantUtf8, 'X');
+                    if (text.Length < 1)
+                    {
+                        value = default(uint);
+                        return false;
+                    }
+
+                    // Parse the first digit separately. If invalid here, we need to return false.
+                    byte firstByte = text[0];
+                    int firstDigit = hexLookup[firstByte];
+                    if (firstDigit == -1)
+                    {
+                        value = default(uint);
+                        return false;
+                    }
+                    value = (uint)firstDigit;
+
+                    if (text.Length <= UINT_OVERFLOW_LENGTH_HEX)
+                    {
+                        // Length is less than or equal to OVERFLOW_LENGTH; overflow is not possible
+                        for (int index = 1; index < text.Length; index++)
+                        {
+                            byte nextByte = text[index];
+                            int nextDigit = hexLookup[nextByte];
+                            if (nextDigit == -1)
+                            {
+                                return true;
+                            }
+                            value = value * 0x10 + (uint)nextDigit;
+                        }
+                    }
+                    else
+                    {
+                        // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
+                        // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
+                        for (int index = 1; index < UINT_OVERFLOW_LENGTH_HEX; index++)
+                        {
+                            byte nextByte = text[index];
+                            int nextDigit = hexLookup[nextByte];
+                            if (nextDigit == -1)
+                            {
+                                return true;
+                            }
+                            value = value * 0x10 + (uint)nextDigit;
+                        }
+                        for (int index = UINT_OVERFLOW_LENGTH_HEX; index < text.Length; index++)
+                        {
+                            byte nextByte = text[index];
+                            int nextDigit = hexLookup[nextByte];
+                            if (nextDigit == -1)
+                            {
+                                return true;
+                            }
+                            // uint.MaxValue is a constant 0xFFFFFFFF
+                            // If we try to append a digit to anything larger than 0x0FFFFFFF, there will be overflow
+                            if (value > uint.MaxValue / 0x10)
+                            {
+                                value = default(uint);
+                                return false;
+                            }
+                            value = value * 0x10 + (uint)nextDigit;
+                        }
+                    }
+
+                    return true;
                 }
                 public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int bytesConsumed)
                 {
-                    return PrimitiveParser.TryParseUInt32(text, out value, out bytesConsumed, EncodingData.InvariantUtf8, 'X');
+                    if (text.Length < 1)
+                    {
+                        bytesConsumed = 0;
+                        value = default(uint);
+                        return false;
+                    }
+
+                    // Parse the first digit separately. If invalid here, we need to return false.
+                    byte firstByte = text[0];
+                    int firstDigit = hexLookup[firstByte];
+                    if (firstDigit == -1)
+                    {
+                        bytesConsumed = 0;
+                        value = default(uint);
+                        return false;
+                    }
+                    value = (uint)firstDigit;
+
+                    if (text.Length <= UINT_OVERFLOW_LENGTH_HEX)
+                    {
+                        // Length is less than or equal to OVERFLOW_LENGTH; overflow is not possible
+                        for (int index = 1; index < text.Length; index++)
+                        {
+                            byte nextByte = text[index];
+                            int nextDigit = hexLookup[nextByte];
+                            if (nextDigit == -1)
+                            {
+                                bytesConsumed = index;
+                                return true;
+                            }
+                            value = value * 0x10 + (uint)nextDigit;
+                        }
+                    }
+                    else
+                    {
+                        // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
+                        // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
+                        for (int index = 1; index < UINT_OVERFLOW_LENGTH_HEX; index++)
+                        {
+                            byte nextByte = text[index];
+                            int nextDigit = hexLookup[nextByte];
+                            if (nextDigit == -1)
+                            {
+                                bytesConsumed = index;
+                                return true;
+                            }
+                            value = value * 0x10 + (uint)nextDigit;
+                        }
+                        for (int index = UINT_OVERFLOW_LENGTH_HEX; index < text.Length; index++)
+                        {
+                            byte nextByte = text[index];
+                            int nextDigit = hexLookup[nextByte];
+                            if (nextDigit == -1)
+                            {
+                                bytesConsumed = index;
+                                return true;
+                            }
+                            // uint.MaxValue is a constant 0xFFFFFFFF
+                            // If we try to append a digit to anything larger than 0x0FFFFFFF, there will be overflow
+                            if (value > uint.MaxValue / 0x10)
+                            {
+                                bytesConsumed = 0;
+                                value = default(uint);
+                                return false;
+                            }
+                            value = value * 0x10 + (uint)nextDigit;
+                        }
+                    }
+
+                    bytesConsumed = text.Length;
+                    return true;
                 }
             }
         }

--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_UInt32.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_UInt32.cs
@@ -10,8 +10,8 @@ namespace System.Text
     {
         public static partial class InvariantUtf8
         {
-            const int s_UInt32OverflowLength = 10;
-            const int s_UInt32OverflowLengthHex = 8;
+            const int UInt32OverflowLength = 10;
+            const int UInt32OverflowLengthHex = 8;
 
             static readonly byte[] s_HexLookup =
             {
@@ -50,7 +50,7 @@ namespace System.Text
                 }
                 value = firstDigit;
 
-                if (length < s_UInt32OverflowLength)
+                if (length < UInt32OverflowLength)
                 {
                     // Length is less than OVERFLOW_LENGTH; overflow is not possible
                     for (int index = 1; index < length; index++)
@@ -67,7 +67,7 @@ namespace System.Text
                 {
                     // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                     // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                    for (int index = 1; index < s_UInt32OverflowLength - 1; index++)
+                    for (int index = 1; index < UInt32OverflowLength - 1; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -76,7 +76,7 @@ namespace System.Text
                         }
                         value = value * 10 + nextDigit;
                     }
-                    for (int index = s_UInt32OverflowLength - 1; index < length; index++)
+                    for (int index = UInt32OverflowLength - 1; index < length; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -118,7 +118,7 @@ namespace System.Text
                 }
                 value = firstDigit;
 
-                if (length < s_UInt32OverflowLength)
+                if (length < UInt32OverflowLength)
                 {
                     // Length is less than OVERFLOW_LENGTH; overflow is not possible
                     for (int index = 1; index < length; index++)
@@ -136,7 +136,7 @@ namespace System.Text
                 {
                     // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                     // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                    for (int index = 1; index < s_UInt32OverflowLength - 1; index++)
+                    for (int index = 1; index < UInt32OverflowLength - 1; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -146,7 +146,7 @@ namespace System.Text
                         }
                         value = value * 10 + nextDigit;
                     }
-                    for (int index = s_UInt32OverflowLength - 1; index < length; index++)
+                    for (int index = UInt32OverflowLength - 1; index < length; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -188,7 +188,7 @@ namespace System.Text
                 }
                 value = firstDigit;
 
-                if (text.Length < s_UInt32OverflowLength)
+                if (text.Length < UInt32OverflowLength)
                 {
                     // Length is less than OVERFLOW_LENGTH; overflow is not possible
                     for (int index = 1; index < text.Length; index++)
@@ -205,7 +205,7 @@ namespace System.Text
                 {
                     // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                     // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                    for (int index = 1; index < s_UInt32OverflowLength - 1; index++)
+                    for (int index = 1; index < UInt32OverflowLength - 1; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -214,7 +214,7 @@ namespace System.Text
                         }
                         value = value * 10 + nextDigit;
                     }
-                    for (int index = s_UInt32OverflowLength - 1; index < text.Length; index++)
+                    for (int index = UInt32OverflowLength - 1; index < text.Length; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -255,7 +255,7 @@ namespace System.Text
                 }
                 value = firstDigit;
 
-                if (text.Length < s_UInt32OverflowLength)
+                if (text.Length < UInt32OverflowLength)
                 {
                     // Length is less than OVERFLOW_LENGTH; overflow is not possible
                     for (int index = 1; index < text.Length; index++)
@@ -273,7 +273,7 @@ namespace System.Text
                 {
                     // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                     // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                    for (int index = 1; index < s_UInt32OverflowLength - 1; index++)
+                    for (int index = 1; index < UInt32OverflowLength - 1; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -283,7 +283,7 @@ namespace System.Text
                         }
                         value = value * 10 + nextDigit;
                     }
-                    for (int index = s_UInt32OverflowLength - 1; index < text.Length; index++)
+                    for (int index = UInt32OverflowLength - 1; index < text.Length; index++)
                     {
                         uint nextDigit = text[index] - 48u; // '0'
                         if (nextDigit > 9)
@@ -337,7 +337,7 @@ namespace System.Text
                     }
                     value = (uint)firstDigit;
 
-                    if (length <= s_UInt32OverflowLengthHex)
+                    if (length <= UInt32OverflowLengthHex)
                     {
                         // Length is less than or equal to OVERFLOW_LENGTH; overflow is not possible
                         for (int index = 1; index < length; index++)
@@ -355,7 +355,7 @@ namespace System.Text
                     {
                         // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                         // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                        for (int index = 1; index < s_UInt32OverflowLengthHex; index++)
+                        for (int index = 1; index < UInt32OverflowLengthHex; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];
@@ -365,7 +365,7 @@ namespace System.Text
                             }
                             value = value * 0x10 + (uint)nextDigit;
                         }
-                        for (int index = s_UInt32OverflowLengthHex; index < length; index++)
+                        for (int index = UInt32OverflowLengthHex; index < length; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];
@@ -409,7 +409,7 @@ namespace System.Text
                     }
                     value = (uint)firstDigit;
 
-                    if (length <= s_UInt32OverflowLengthHex)
+                    if (length <= UInt32OverflowLengthHex)
                     {
                         // Length is less than or equal to OVERFLOW_LENGTH; overflow is not possible
                         for (int index = 1; index < length; index++)
@@ -428,7 +428,7 @@ namespace System.Text
                     {
                         // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                         // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                        for (int index = 1; index < s_UInt32OverflowLengthHex; index++)
+                        for (int index = 1; index < UInt32OverflowLengthHex; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];
@@ -439,7 +439,7 @@ namespace System.Text
                             }
                             value = value * 0x10 + (uint)nextDigit;
                         }
-                        for (int index = s_UInt32OverflowLengthHex; index < length; index++)
+                        for (int index = UInt32OverflowLengthHex; index < length; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];
@@ -484,7 +484,7 @@ namespace System.Text
                     }
                     value = (uint)firstDigit;
 
-                    if (text.Length <= s_UInt32OverflowLengthHex)
+                    if (text.Length <= UInt32OverflowLengthHex)
                     {
                         // Length is less than or equal to OVERFLOW_LENGTH; overflow is not possible
                         for (int index = 1; index < text.Length; index++)
@@ -502,7 +502,7 @@ namespace System.Text
                     {
                         // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                         // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                        for (int index = 1; index < s_UInt32OverflowLengthHex; index++)
+                        for (int index = 1; index < UInt32OverflowLengthHex; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];
@@ -512,7 +512,7 @@ namespace System.Text
                             }
                             value = value * 0x10 + (uint)nextDigit;
                         }
-                        for (int index = s_UInt32OverflowLengthHex; index < text.Length; index++)
+                        for (int index = UInt32OverflowLengthHex; index < text.Length; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];
@@ -556,7 +556,7 @@ namespace System.Text
                     }
                     value = (uint)firstDigit;
 
-                    if (text.Length <= s_UInt32OverflowLengthHex)
+                    if (text.Length <= UInt32OverflowLengthHex)
                     {
                         // Length is less than or equal to OVERFLOW_LENGTH; overflow is not possible
                         for (int index = 1; index < text.Length; index++)
@@ -575,7 +575,7 @@ namespace System.Text
                     {
                         // Length is greater than OVERFLOW_LENGTH; overflow is only possible after OVERFLOW_LENGTH
                         // digits. There may be no overflow after OVERFLOW_LENGTH if there are leading zeroes.
-                        for (int index = 1; index < s_UInt32OverflowLengthHex; index++)
+                        for (int index = 1; index < UInt32OverflowLengthHex; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];
@@ -586,7 +586,7 @@ namespace System.Text
                             }
                             value = value * 0x10 + (uint)nextDigit;
                         }
-                        for (int index = s_UInt32OverflowLengthHex; index < text.Length; index++)
+                        for (int index = UInt32OverflowLengthHex; index < text.Length; index++)
                         {
                             byte nextByte = text[index];
                             int nextDigit = hexLookup[nextByte];

--- a/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_UInt32.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/InvariantUtf8/InvariantUtf8_UInt32.cs
@@ -343,7 +343,7 @@ namespace System.Text
                         for (int index = 1; index < length; index++)
                         {
                             byte nextByte = text[index];
-                            int nextDigit = hexLookup[nextByte];
+                            byte nextDigit = hexLookup[nextByte];
                             if (nextDigit == 0xFF)
                             {
                                 return true;
@@ -358,7 +358,7 @@ namespace System.Text
                         for (int index = 1; index < UInt32OverflowLengthHex; index++)
                         {
                             byte nextByte = text[index];
-                            int nextDigit = hexLookup[nextByte];
+                            byte nextDigit = hexLookup[nextByte];
                             if (nextDigit == 0xFF)
                             {
                                 return true;
@@ -368,7 +368,7 @@ namespace System.Text
                         for (int index = UInt32OverflowLengthHex; index < length; index++)
                         {
                             byte nextByte = text[index];
-                            int nextDigit = hexLookup[nextByte];
+                            byte nextDigit = hexLookup[nextByte];
                             if (nextDigit == 0xFF)
                             {
                                 return true;
@@ -415,7 +415,7 @@ namespace System.Text
                         for (int index = 1; index < length; index++)
                         {
                             byte nextByte = text[index];
-                            int nextDigit = hexLookup[nextByte];
+                            byte nextDigit = hexLookup[nextByte];
                             if (nextDigit == 0xFF)
                             {
                                 bytesConsumed = index;
@@ -431,7 +431,7 @@ namespace System.Text
                         for (int index = 1; index < UInt32OverflowLengthHex; index++)
                         {
                             byte nextByte = text[index];
-                            int nextDigit = hexLookup[nextByte];
+                            byte nextDigit = hexLookup[nextByte];
                             if (nextDigit == 0xFF)
                             {
                                 bytesConsumed = index;
@@ -442,7 +442,7 @@ namespace System.Text
                         for (int index = UInt32OverflowLengthHex; index < length; index++)
                         {
                             byte nextByte = text[index];
-                            int nextDigit = hexLookup[nextByte];
+                            byte nextDigit = hexLookup[nextByte];
                             if (nextDigit == 0xFF)
                             {
                                 bytesConsumed = index;
@@ -490,7 +490,7 @@ namespace System.Text
                         for (int index = 1; index < text.Length; index++)
                         {
                             byte nextByte = text[index];
-                            int nextDigit = hexLookup[nextByte];
+                            byte nextDigit = hexLookup[nextByte];
                             if (nextDigit == 0xFF)
                             {
                                 return true;
@@ -505,7 +505,7 @@ namespace System.Text
                         for (int index = 1; index < UInt32OverflowLengthHex; index++)
                         {
                             byte nextByte = text[index];
-                            int nextDigit = hexLookup[nextByte];
+                            byte nextDigit = hexLookup[nextByte];
                             if (nextDigit == 0xFF)
                             {
                                 return true;
@@ -515,7 +515,7 @@ namespace System.Text
                         for (int index = UInt32OverflowLengthHex; index < text.Length; index++)
                         {
                             byte nextByte = text[index];
-                            int nextDigit = hexLookup[nextByte];
+                            byte nextDigit = hexLookup[nextByte];
                             if (nextDigit == 0xFF)
                             {
                                 return true;
@@ -562,7 +562,7 @@ namespace System.Text
                         for (int index = 1; index < text.Length; index++)
                         {
                             byte nextByte = text[index];
-                            int nextDigit = hexLookup[nextByte];
+                            byte nextDigit = hexLookup[nextByte];
                             if (nextDigit == 0xFF)
                             {
                                 bytesConsumed = index;
@@ -578,7 +578,7 @@ namespace System.Text
                         for (int index = 1; index < UInt32OverflowLengthHex; index++)
                         {
                             byte nextByte = text[index];
-                            int nextDigit = hexLookup[nextByte];
+                            byte nextDigit = hexLookup[nextByte];
                             if (nextDigit == 0xFF)
                             {
                                 bytesConsumed = index;
@@ -589,7 +589,7 @@ namespace System.Text
                         for (int index = UInt32OverflowLengthHex; index < text.Length; index++)
                         {
                             byte nextByte = text[index];
-                            int nextDigit = hexLookup[nextByte];
+                            byte nextDigit = hexLookup[nextByte];
                             if (nextDigit == 0xFF)
                             {
                                 bytesConsumed = index;

--- a/tests/System.Text.Primitives.Tests/PrimitiveParserUInt32Tests.cs
+++ b/tests/System.Text.Primitives.Tests/PrimitiveParserUInt32Tests.cs
@@ -85,8 +85,16 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, actualValue);
             Assert.Equal(expectedConsumed, actualConsumed);
         }
-        
-        [Theory (Skip = "UInt32 hex parsing not implemented yet")]
+
+        [Theory]
+        [InlineData("123", 3, 0x123, 3)]
+        [InlineData("12a", 3, 0x12a, 3)]
+        [InlineData("abc", 3, 0xabc, 3)]
+        [InlineData("ABC", 3, 0xABC, 3)]
+        [InlineData("AbC4", 4, 0xAbC4, 4)]
+        [InlineData("abcdefghi", 9, 0xabcdef, 6)]
+        [InlineData("0", 1, uint.MinValue, 1)]
+        [InlineData("FFFFFFFF", 8, uint.MaxValue, 8)]
         public unsafe void UInt32PositiveHexTests(string text, int length, uint expectedValue, int expectedConsumed)
         {
             byte[] byteBuffer = new Utf8String(text).CopyBytes();
@@ -99,11 +107,11 @@ namespace System.Text.Primitives.Tests
             uint actualValue;
             int actualConsumed;
 
-            result = PrimitiveParser.TryParseUInt32(byteSpan, out actualValue, out actualConsumed, EncodingData.InvariantUtf8, 'X');
+            /*result = PrimitiveParser.TryParseUInt32(byteSpan, out actualValue, out actualConsumed, EncodingData.InvariantUtf8, 'X');
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
-            Assert.Equal(expectedConsumed, actualConsumed);
+            Assert.Equal(expectedConsumed, actualConsumed);*/
 
             fixed (byte* bytePointer = byteBuffer)
             {
@@ -130,7 +138,7 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, actualValue);
             Assert.Equal(expectedConsumed, actualConsumed);
 
-            ReadOnlySpan<byte> utf16ByteSpan = charSpan.Cast<char, byte>();
+            /*ReadOnlySpan<byte> utf16ByteSpan = charSpan.Cast<char, byte>();
             result = PrimitiveParser.TryParseUInt32(utf16ByteSpan, out actualValue, out actualConsumed, EncodingData.InvariantUtf16, 'X');
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
@@ -159,7 +167,7 @@ namespace System.Text.Primitives.Tests
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
-            Assert.Equal(expectedConsumed, actualConsumed);
+            Assert.Equal(expectedConsumed, actualConsumed);*/
         }
     }
 }


### PR DESCRIPTION
Implement PrimitiveParser.InvariantUtf8.TryParseUInt32 span and Hex overloads, and add performance tests for these new implementations. Hex translation from ASCII/Utf8 byte to integer is done by indexing into a static readonly array; suggestions for improvement in this area or others are welcome.

Observations about performance so far:
- Hex parsing takes about the same time per character as parsing in base 10
- Parsing byte* seems to be slightly faster than ReadOnlySpan<byte>, but overall the two are very comparable

I don't have a gist with performance numbers this time around; my hope is that we can get some good analysis going soon.