### PR TITLE
Specify the SDK version in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,3 +1,6 @@
 {
-  "projects": [ "src" ]
+  "projects": [ "src" ],
+  "sdk": {
+    "version": "1.0.0-preview2-003121"
+  }
 }


### PR DESCRIPTION
- After installing both VS 2017 RC and VS2015, you'll end up
with the preview3 and preview2 CLI. Pick a project.json compatible one
(the one that matches the build script)