### PR TITLE
Add support for cancelling the pending ReadAsync call

### DIFF
--- a/src/System.IO.Pipelines/IPipelineReader.cs
+++ b/src/System.IO.Pipelines/IPipelineReader.cs
@@ -28,6 +28,11 @@ namespace System.IO.Pipelines
         void Advance(ReadCursor consumed, ReadCursor examined);
 
         /// <summary>
+        /// Cancel to currently pending call to <see cref="ReadAsync"/> without completing the <see cref="IPipelineReader"/>.
+        /// </summary>
+        void CancelPendingRead();
+
+        /// <summary>
         /// Signal to the producer that the consumer is done reading.
         /// </summary>
         /// <param name="exception">Optional Exception indicating a failure that's causing the pipeline to complete.</param>

--- a/src/System.IO.Pipelines/PipelineReader.cs
+++ b/src/System.IO.Pipelines/PipelineReader.cs
@@ -46,6 +46,11 @@ namespace System.IO.Pipelines
         public void Advance(ReadCursor consumed, ReadCursor examined) => _input.AdvanceReader(consumed, examined);
 
         /// <summary>
+        /// Cancel to currently pending call to <see cref="ReadAsync"/>
+        /// </summary>
+        public void CancelPendingRead() => _input.CancelPendingRead();
+
+        /// <summary>
         /// Signal to the producer that the consumer is done reading.
         /// </summary>
         /// <param name="exception">Optional Exception indicating a failure that's causing the pipeline to complete.</param>

--- a/src/System.IO.Pipelines/ReadResult.cs
+++ b/src/System.IO.Pipelines/ReadResult.cs
@@ -3,16 +3,31 @@
 
 namespace System.IO.Pipelines
 {
+    /// <summary>
+    /// The result of a <see cref="IPipelineReader.ReadAsync"/> call.
+    /// </summary>
     public struct ReadResult
     {
-        public ReadResult(ReadableBuffer buffer, bool isCompleted)
+        public ReadResult(ReadableBuffer buffer, bool isCancelled, bool isCompleted)
         {
             Buffer = buffer;
+            IsCancelled = isCancelled;
             IsCompleted = isCompleted;
         }
 
+        /// <summary>
+        /// The <see cref="ReadableBuffer"/> that was read
+        /// </summary>
         public ReadableBuffer Buffer { get; }
 
+        /// <summary>
+        /// True if the currrent read was cancelled
+        /// </summary>
+        public bool IsCancelled { get; }
+
+        /// <summary>
+        /// True if the <see cref="IPipelineReader"/> is complete
+        /// </summary>
         public bool IsCompleted { get; }
     }
 }


### PR DESCRIPTION
- We need this to support things like graceful shutdown in kestrel
and to support yeilding the await in SignalR (for long polling)
- Unlike a 0 byte write, this is synchronized with the other state
in the PipelineReaderWriter and UnownedBufferReader so there are no
races/clashes
- Added IsCancelled to ReadResult so the caller can see what triggered
the await.

Fixes #1017

TODOs:
- Potentially look at the cancellation token approach as an extension method (less optimized by more idomatic)
- Maybe throw operation cancelled exception?
- Interpret 0 byte write as end of pipeline (more compatible with streams).

/cc @anurse @pakrym @halter73 @benaadams 