### PR TITLE
This fixes the races with the previous cancellation support

### DIFF
--- a/src/System.IO.Pipelines/IPipelineReader.cs
+++ b/src/System.IO.Pipelines/IPipelineReader.cs
@@ -28,7 +28,7 @@ namespace System.IO.Pipelines
         void Advance(ReadCursor consumed, ReadCursor examined);
 
         /// <summary>
-        /// Cancel to currently pending call to <see cref="ReadAsync"/> without completing the <see cref="IPipelineReader"/>.
+        /// Cancel to currently pending or next call to <see cref="ReadAsync"/> if none is pending, without completing the <see cref="IPipelineReader"/>.
         /// </summary>
         void CancelPendingRead();
 


### PR DESCRIPTION
- If CancelPendingRead was called before calling Advance (like on a
background thread),the cancellation would never be observed by the following read.
This change introduces a tri-state that tracks if cancellation was observed by read
before resetting it.
- Added tests