### PR TITLE
Fix downgrades by updating to the latest corefx packages

### DIFF
--- a/src/System.Binary.Base64/project.json
+++ b/src/System.Binary.Base64/project.json
@@ -20,10 +20,7 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "System.Runtime": "4.1.0",
-    "System.Diagnostics.Debug": "4.0.11",
     "System.Slices": { "target": "project" },
-    "System.Memory": "4.4.0-beta-24721-02",
     "System.Text.Primitives": { "target": "project" }
   },
   "frameworks": {

--- a/src/System.Binary/project.json
+++ b/src/System.Binary/project.json
@@ -21,10 +21,6 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "System.Runtime": "4.1.0",
-    "System.Runtime.Extensions": "4.1.0",
-    "System.Diagnostics.Debug": "4.0.11",
-    "System.Memory": "4.4.0-beta-24721-02",
     "System.Slices": { "target": "project" }
   },
   "frameworks": {

--- a/src/System.Buffers.Experimental/project.json
+++ b/src/System.Buffers.Experimental/project.json
@@ -21,14 +21,10 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "System.Buffers": "4.0.0",
+    "System.Buffers": "4.4.0-*",
     "System.Collections.Sequences": { "target": "project" },
-    "System.Diagnostics.Debug": "4.0.11",
-    "System.Memory": "4.4.0-beta-24721-02",
     "System.Slices": { "target": "project" },
-    "System.Text.Primitives": { "target": "project" },
-    "System.Threading": "4.0.11",
-    "System.Runtime.InteropServices": "4.1.0"
+    "System.Text.Primitives": { "target": "project" }
   },
   "frameworks": {
     "netstandard1.1": {

--- a/src/System.Collections.Sequences/project.json
+++ b/src/System.Collections.Sequences/project.json
@@ -21,8 +21,6 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "System.Diagnostics.Debug": "4.0.11",
-    "System.Memory": "4.4.0-beta-24721-02",
     "System.Slices": { "target": "project" }
   },
   "frameworks": {

--- a/src/System.IO.Pipelines.Compression/project.json
+++ b/src/System.IO.Pipelines.Compression/project.json
@@ -23,7 +23,7 @@
     "net451": {},
     "netstandard1.3": {
       "dependencies": {
-        "System.Diagnostics.Contracts": "4.0.1"
+        "System.Diagnostics.Contracts": "4.4.0-*"
       }
     }
   }

--- a/src/System.IO.Pipelines.File/project.json
+++ b/src/System.IO.Pipelines.File/project.json
@@ -18,7 +18,7 @@
     "System.IO.Pipelines": {
       "target": "project"
     },
-    "System.Threading.Overlapped": "4.0.1"
+    "System.Threading.Overlapped": "4.4.0-*"
   },
 
 

--- a/src/System.IO.Pipelines.Networking.Libuv/project.json
+++ b/src/System.IO.Pipelines.Networking.Libuv/project.json
@@ -15,7 +15,6 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
     "System.IO.Pipelines": {
       "target": "project"
     },
@@ -26,7 +25,7 @@
     "net451": {},
     "netstandard1.3": {
       "dependencies": {
-        "System.Threading.Thread": "4.0.0"
+        "System.Threading.Thread": "4.4.0-*"
       }
     }
   }

--- a/src/System.IO.Pipelines.Networking.Sockets/project.json
+++ b/src/System.IO.Pipelines.Networking.Sockets/project.json
@@ -15,7 +15,6 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
     "System.IO.Pipelines": {
       "target": "project"
     }
@@ -25,7 +24,7 @@
     "net451": {},
     "netstandard1.3": {
       "dependencies": {
-        "System.Threading.ThreadPool": "4.0.10"
+        "System.Threading.ThreadPool": "4.4.0-*"
       }
     }
   }

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/project.json
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/project.json
@@ -24,12 +24,11 @@
     "net451": {},
     "netstandard1.3": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0",
-        "System.Threading.Thread": "4.0.0",
-        "System.Threading.Overlapped": "4.0.1",
-        "System.Threading.ThreadPool": "4.0.10",
-        "System.Diagnostics.Process": "4.1.0",
-        "System.Runtime.CompilerServices.Unsafe": "4.0.0"
+        "System.Threading.Thread": "4.4.0-*",
+        "System.Threading.Overlapped": "4.4.0-*",
+        "System.Threading.ThreadPool": "4.4.0-*",
+        "System.Diagnostics.Process": "4.4.0-*",
+        "System.Runtime.CompilerServices.Unsafe": "4.4.0-*"
       }
     }
   }

--- a/src/System.IO.Pipelines.Text.Primitives/project.json
+++ b/src/System.IO.Pipelines.Text.Primitives/project.json
@@ -15,7 +15,6 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
     "System.Text.Formatting": {
       "target": "project"
     },

--- a/src/System.IO.Pipelines/project.json
+++ b/src/System.IO.Pipelines/project.json
@@ -18,18 +18,17 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "System.Memory": "4.4.0-beta-24721-02",
-   "System.Slices": {
+    "NETStandard.Library": "1.6.2-*",
+    "System.Slices": {
       "target": "project"
     },
     "System.Binary": {
       "target": "project"
     },
-    "System.Buffers": "4.0.0",
-    "System.Runtime.CompilerServices.Unsafe": "4.0.0",
-    "System.Numerics.Vectors": "4.1.1",
-    "System.Threading.Tasks.Extensions": "4.0.0",
+    "System.Buffers": "4.4.0-*",
+    "System.Runtime.CompilerServices.Unsafe": "4.4.0-*",
+    "System.Numerics.Vectors": "4.4.0-*",
+    "System.Threading.Tasks.Extensions": "4.4.0-*",
     "System.Collections.Sequences": { "target": "project" }
   },
 

--- a/src/System.Net.Libuv/project.json
+++ b/src/System.Net.Libuv/project.json
@@ -22,14 +22,9 @@
   },
   "dependencies": {
     "Libuv": "1.9.0",
-    "System.Runtime": "4.1.0",
-    "System.Buffers": "4.0.0",
-    "System.Runtime.InteropServices": "4.1.0",
-    "System.Diagnostics.Debug": "4.0.11",
     "System.Text.Primitives": { "target": "project" },
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-*",
     "System.Buffers.Experimental": { "target": "project" },
-    "System.Memory": "4.4.0-beta-24721-02",
     "System.Slices": { "target": "project" }
   },
   "frameworks": {

--- a/src/System.Slices/project.json
+++ b/src/System.Slices/project.json
@@ -25,12 +25,9 @@
     }
   },
   "dependencies": {
-    "System.Runtime": "4.1.0",
-    "System.Runtime.InteropServices": "4.1.0",
-    "System.Threading": "4.0.11",
-    "System.Diagnostics.Debug": "4.0.11",
+    "NETStandard.Library": "1.6.2-*",
     "System.Memory": "4.4.0-beta-24721-02",
-    "System.Runtime.CompilerServices.Unsafe": "4.0.0"
+    "System.Runtime.CompilerServices.Unsafe": "4.4.0-*"
   },
   "frameworks": {
     "netstandard1.1": {}

--- a/src/System.Text.Formatting.Globalization/project.json
+++ b/src/System.Text.Formatting.Globalization/project.json
@@ -22,12 +22,10 @@
       "include": "locales.bin",
       "mappings": {
         "System.Text.Formatting.locales.bin": "locales.bin"
-      },
+      }
     }
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "System.Memory": "4.4.0-beta-24721-02",
     "System.Slices": { "target": "project" },
     "System.Text.Formatting": { "target": "project" }
   },

--- a/src/System.Text.Formatting/project.json
+++ b/src/System.Text.Formatting/project.json
@@ -31,11 +31,6 @@
     }
   },
   "dependencies": {
-    "System.Runtime": "4.1.0",
-    "System.Buffers": "4.0.0",
-    "System.Runtime.InteropServices": "4.1.0",
-    "System.Diagnostics.Debug": "4.0.11",
-    "System.Memory": "4.4.0-beta-24721-02",
     "System.Slices": { "target": "project" },
     "System.Text.Primitives": { "target": "project" },
     "System.Buffers.Experimental": { "target": "project" }

--- a/src/System.Text.Http/project.json
+++ b/src/System.Text.Http/project.json
@@ -20,10 +20,7 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "System.Runtime": "4.1.0",
-    "System.Diagnostics.Debug": "4.0.11",
     "System.Text.Formatting": { "target": "project" },
-    "System.Memory": "4.4.0-beta-24721-02",
     "System.Slices": { "target": "project" }
   },
   "frameworks": {

--- a/src/System.Text.Json.Dynamic/project.json
+++ b/src/System.Text.Json.Dynamic/project.json
@@ -24,14 +24,11 @@
     }
   },
   "dependencies": {
-    "System.Runtime": "4.1.0",
-    "System.Runtime.Extensions": "4.1.0",
     "System.Text.Formatting": { "target": "project" },
     "System.Text.Primitives": { "target": "project" },
-    "System.Memory": "4.4.0-beta-24721-02",
     "System.Slices": { "target": "project" },
     "System.Text.Json": { "target": "project" },
-    "System.Dynamic.Runtime": "4.0.11"
+    "System.Dynamic.Runtime": "4.4.0-*"
   },
   "frameworks": {
     "netstandard1.1": {

--- a/src/System.Text.Json/project.json
+++ b/src/System.Text.Json/project.json
@@ -25,10 +25,7 @@
     }
   },
   "dependencies": {
-    "System.Runtime": "4.1.0",
-    "System.Runtime.Extensions": "4.1.0",
     "System.Text.Formatting": { "target": "project" },
-    "System.Memory": "4.4.0-beta-24721-02",
     "System.Slices": { "target": "project" },
     "System.Buffers.Experimental": { "target": "project" }
   },

--- a/src/System.Text.Primitives/project.json
+++ b/src/System.Text.Primitives/project.json
@@ -25,7 +25,6 @@
     }
   },
   "dependencies": {
-    "System.Memory": "4.4.0-beta-24721-02",
     "System.Slices": { "target": "project" },
     "System.Buffers": "4.4.0-*"
   },

--- a/src/System.Text.Primitives/project.json
+++ b/src/System.Text.Primitives/project.json
@@ -27,9 +27,7 @@
   "dependencies": {
     "System.Memory": "4.4.0-beta-24721-02",
     "System.Slices": { "target": "project" },
-    "System.Buffers": "4.0.0",
-    "System.Collections": "4.0.11",
-    "System.Runtime.InteropServices": "4.1.0"
+    "System.Buffers": "4.4.0-*"
   },
   "frameworks": {
     "netstandard1.1": {

--- a/src/System.Threading.Tasks.Channels/project.json
+++ b/src/System.Threading.Tasks.Channels/project.json
@@ -1,14 +1,14 @@
 {
-  "name": "System.Threading.Tasks.Channels",  
+  "name": "System.Threading.Tasks.Channels",
   "version": "0.1.0-*",
   "description": "Provides synchronization data structures for passing data between producers and consumers.",
   "authors": [
-      "Microsoft Corporation"
+    "Microsoft Corporation"
   ],
   "copyright": "Microsoft Corporation, All rights reserved",
   "packOptions": {
     "tags": [
-        "tasks channels threading asynchrony async corefxlab"
+      "tasks channels threading asynchrony async corefxlab"
     ],
     "releaseNotes": "Pre-release package, for testing only",
     "licenseUrl": "http://go.microsoft.com/fwlink/?LinkId=329770",
@@ -26,6 +26,6 @@
     "System.Threading.Tasks.Extensions": "4.0.0"
   },
   "frameworks": {
-        "netstandard1.3": { }
+    "netstandard1.3": {}
   }
 }

--- a/tests/System.Net.Libuv.Tests/project.json
+++ b/tests/System.Net.Libuv.Tests/project.json
@@ -5,7 +5,7 @@
       "type": "platform",
       "version": "1.0.0"
     },
-    "System.IO.Compression": "4.1.0",
+    "System.IO.Compression": "4.4.0-*",
     "System.Net.Libuv": { "target": "project" },
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"

--- a/tests/System.Text.Json.Tests.Dynamic/project.json
+++ b/tests/System.Text.Json.Tests.Dynamic/project.json
@@ -17,15 +17,11 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "System.Console": "4.0.0",
     "System.Text.Json.Dynamic": { "target": "project" },
-    "System.Runtime": "4.1.0",
-    "System.Runtime.Extensions": "4.1.0",
     "System.Text.Formatting": { "target": "project" },
     "System.Text.Primitives": { "target": "project" },
     "System.Slices": { "target": "project" },
-    "System.Text.Json": { "target": "project" },
-    "System.Dynamic.Runtime": "4.0.11"
+    "System.Text.Json": { "target": "project" }
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/tests/System.Text.Json.Tests/project.json
+++ b/tests/System.Text.Json.Tests/project.json
@@ -17,7 +17,6 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-*",
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "System.Console": "4.0.0",
     "System.Text.Json": { "target": "project" },
     "System.Text.Json.Dynamic": { "target": "project" }
   },

--- a/tests/System.Text.Primitives.Tests/project.json
+++ b/tests/System.Text.Primitives.Tests/project.json
@@ -12,8 +12,7 @@
     "System.Text.Primitives": { "target": "project" },
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "xunit.performance.core": "1.0.0-alpha-build0043",
-    "System.Reflection": "4.1.0"
+    "xunit.performance.core": "1.0.0-alpha-build0043"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
- Turns out downgrades are bad and made it impossible to consume in the
current state outside of corefxlab.
- This PR also minimizes the individual references and uses the latest NetStandard.Library
package for core deps.

Fixes #1018

/cc @KrzysztofCwalina  (sorry bro 😄 )