### PR TITLE
Go back to stable versions

### DIFF
--- a/src/System.Buffers.Experimental/project.json
+++ b/src/System.Buffers.Experimental/project.json
@@ -21,7 +21,7 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "System.Buffers": "4.4.0-*",
+    "System.Buffers": "4.3.0",
     "System.Collections.Sequences": { "target": "project" },
     "System.Slices": { "target": "project" },
     "System.Text.Primitives": { "target": "project" }

--- a/src/System.IO.Pipelines.Compression/project.json
+++ b/src/System.IO.Pipelines.Compression/project.json
@@ -23,7 +23,7 @@
     "net451": {},
     "netstandard1.3": {
       "dependencies": {
-        "System.Diagnostics.Contracts": "4.4.0-*"
+        "System.Diagnostics.Contracts": "4.3.0"
       }
     }
   }

--- a/src/System.IO.Pipelines.File/project.json
+++ b/src/System.IO.Pipelines.File/project.json
@@ -18,7 +18,7 @@
     "System.IO.Pipelines": {
       "target": "project"
     },
-    "System.Threading.Overlapped": "4.4.0-*"
+    "System.Threading.Overlapped": "4.3.0"
   },
 
 

--- a/src/System.IO.Pipelines.Networking.Libuv/project.json
+++ b/src/System.IO.Pipelines.Networking.Libuv/project.json
@@ -25,7 +25,7 @@
     "net451": {},
     "netstandard1.3": {
       "dependencies": {
-        "System.Threading.Thread": "4.4.0-*"
+        "System.Threading.Thread": "4.3.0"
       }
     }
   }

--- a/src/System.IO.Pipelines.Networking.Sockets/project.json
+++ b/src/System.IO.Pipelines.Networking.Sockets/project.json
@@ -24,7 +24,7 @@
     "net451": {},
     "netstandard1.3": {
       "dependencies": {
-        "System.Threading.ThreadPool": "4.4.0-*"
+        "System.Threading.ThreadPool": "4.3.0"
       }
     }
   }

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/project.json
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/project.json
@@ -24,11 +24,10 @@
     "net451": {},
     "netstandard1.3": {
       "dependencies": {
-        "System.Threading.Thread": "4.4.0-*",
-        "System.Threading.Overlapped": "4.4.0-*",
-        "System.Threading.ThreadPool": "4.4.0-*",
-        "System.Diagnostics.Process": "4.4.0-*",
-        "System.Runtime.CompilerServices.Unsafe": "4.4.0-*"
+        "System.Threading.Thread": "4.3.0",
+        "System.Threading.Overlapped": "4.3.0",
+        "System.Threading.ThreadPool": "4.3.0",
+        "System.Diagnostics.Process": "4.3.0"
       }
     }
   }

--- a/src/System.IO.Pipelines/project.json
+++ b/src/System.IO.Pipelines/project.json
@@ -27,7 +27,7 @@
     },
     "System.Buffers": "4.3.0",
     "System.Numerics.Vectors": "4.3.0",
-    "System.Threading.Tasks.Extensions": "4.3.0*",
+    "System.Threading.Tasks.Extensions": "4.3.0",
     "System.Collections.Sequences": { "target": "project" }
   },
 

--- a/src/System.IO.Pipelines/project.json
+++ b/src/System.IO.Pipelines/project.json
@@ -18,17 +18,16 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.6.2-*",
+    "NETStandard.Library": "1.6.0",
     "System.Slices": {
       "target": "project"
     },
     "System.Binary": {
       "target": "project"
     },
-    "System.Buffers": "4.4.0-*",
-    "System.Runtime.CompilerServices.Unsafe": "4.4.0-*",
-    "System.Numerics.Vectors": "4.4.0-*",
-    "System.Threading.Tasks.Extensions": "4.4.0-*",
+    "System.Buffers": "4.3.0",
+    "System.Numerics.Vectors": "4.3.0",
+    "System.Threading.Tasks.Extensions": "4.3.0*",
     "System.Collections.Sequences": { "target": "project" }
   },
 

--- a/src/System.Net.Libuv/project.json
+++ b/src/System.Net.Libuv/project.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "Libuv": "1.9.0",
     "System.Text.Primitives": { "target": "project" },
-    "System.Runtime.InteropServices.RuntimeInformation": "4.4.0-*",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
     "System.Buffers.Experimental": { "target": "project" },
     "System.Slices": { "target": "project" }
   },

--- a/src/System.Slices/project.json
+++ b/src/System.Slices/project.json
@@ -25,8 +25,8 @@
     }
   },
   "dependencies": {
-    "NETStandard.Library": "1.6.2-*",
-    "System.Memory": "4.4.0-beta-24721-02",
+    "NETStandard.Library": "1.6.0",
+    "System.Memory": "4.4.0-*",
     "System.Runtime.CompilerServices.Unsafe": "4.4.0-*"
   },
   "frameworks": {

--- a/src/System.Text.Encodings.Web.Utf8/project.json
+++ b/src/System.Text.Encodings.Web.Utf8/project.json
@@ -21,7 +21,6 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "System.Memory": "4.4.0-beta-24721-02",
     "System.Slices": {
       "target": "project"
     }

--- a/src/System.Text.Json.Dynamic/project.json
+++ b/src/System.Text.Json.Dynamic/project.json
@@ -28,7 +28,7 @@
     "System.Text.Primitives": { "target": "project" },
     "System.Slices": { "target": "project" },
     "System.Text.Json": { "target": "project" },
-    "System.Dynamic.Runtime": "4.4.0-*"
+    "System.Dynamic.Runtime": "4.3.0"
   },
   "frameworks": {
     "netstandard1.1": {

--- a/src/System.Text.Primitives/project.json
+++ b/src/System.Text.Primitives/project.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "System.Slices": { "target": "project" },
-    "System.Buffers": "4.4.0-*"
+    "System.Buffers": "4.3.0"
   },
   "frameworks": {
     "netstandard1.1": {

--- a/tests/System.Net.Libuv.Tests/project.json
+++ b/tests/System.Net.Libuv.Tests/project.json
@@ -5,7 +5,7 @@
       "type": "platform",
       "version": "1.0.0"
     },
-    "System.IO.Compression": "4.4.0-*",
+    "System.IO.Compression": "4.3.0",
     "System.Net.Libuv": { "target": "project" },
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"

--- a/tests/System.Slices.Tests/project.json
+++ b/tests/System.Slices.Tests/project.json
@@ -8,7 +8,6 @@
       "type": "platform",
       "version": "1.0.0"
     },
-    "System.Memory": "4.4.0-beta-24721-02",
     "System.Slices": { "target": "project" },
     "xunit": "2.2.0-beta2-build3300",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"


### PR DESCRIPTION
- Now that System.Memory and Unsafe have been re-baselined
to stable dependencies, we can go back to using RTM bits for
corefx.
- Now we float for System.Memory and System.CompilerServices.Unsafe

/cc @KrzysztofCwalina 

I'm going go merge this when the CI passes. It'll unblock ASP.NET pulling new bits and will make @KrzysztofCwalina happy 😄 