### PR TITLE
Unary ObjectTable for RefCounter

### DIFF
--- a/src/System.Slices/System/Buffers/ReferenceCounter.cs
+++ b/src/System.Slices/System/Buffers/ReferenceCounter.cs
@@ -49,7 +49,7 @@ namespace System.Runtime
             {
                 for (int index = 0; index < s_allTablesCount; index++)
                 {
-                    if(allTables[index].HasReference(obj)) return true;
+                    if (allTables[index].HasReference(obj)) return true;
                 }
                 return false;
             }
@@ -104,7 +104,7 @@ namespace System.Runtime
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void Increment(object obj)
         {
-            if(_first == 0)
+            if (_first == 0)
             {
                 // No space left, we must grow the table.
                 var oldLength = _items.Length;
@@ -122,7 +122,7 @@ namespace System.Runtime
 
             _items[_first - 1] = obj;
             // _items entry must update before we update the value of _first
-            // If this is not the case, then a stake reference could
+            // If this is not the case, then a stale reference could
             // be observed.
             Volatile.Write(ref _first, _first - 1);
         }
@@ -134,7 +134,7 @@ namespace System.Runtime
             {
                 if (ReferenceEquals(_items[index], obj))
                 {
-                    if(index != _first) {
+                    if (index != _first) {
                         //Condense the table
                         _items[index] = _items[_first];
                     }

--- a/tests/System.Slices.Tests/ReferenceCounterTests.cs
+++ b/tests/System.Slices.Tests/ReferenceCounterTests.cs
@@ -15,15 +15,15 @@ namespace System.Slices.Tests
         {
             var obj = new object();
             var counter = new ReferenceCounter();
-            Assert.Equal(0, (int)counter.GetGlobalCount(obj));
+            Assert.False(counter.HasReference(obj));
             counter.AddReference(obj);
-            Assert.Equal(1, (int)counter.GetGlobalCount(obj));
+            Assert.True(counter.HasReference(obj));
             counter.AddReference(obj);
-            Assert.Equal(2, (int)counter.GetGlobalCount(obj));
+            Assert.True(counter.HasReference(obj));
             counter.Release(obj);
-            Assert.Equal(1, (int)counter.GetGlobalCount(obj));
+            Assert.True(counter.HasReference(obj));
             counter.Release(obj);
-            Assert.Equal(0, (int)counter.GetGlobalCount(obj));
+            Assert.False(counter.HasReference(obj));
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace System.Slices.Tests
             });
 
             Task.WaitAll(t1, t2);
-            Assert.Equal(0, (int)counter.GetGlobalCount(obj));
+            Assert.False(counter.HasReference(obj));
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace System.Slices.Tests
                 thread.Start();
             }
             WaitHandle.WaitAll(threads.ToArray());
-            Assert.Equal(0, (int)counter.GetGlobalCount(0));
+            Assert.False(counter.HasReference(obj));
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace System.Slices.Tests
             }
             foreach (var obj in objects)
             {
-                Assert.Equal(0, (int)counter.GetGlobalCount(obj));
+                Assert.False(counter.HasReference(obj));
             }
         }
     }


### PR DESCRIPTION
Rather than storing the count, we use an entry per reference. This
means it is very quick to add a reference, we simple put the object
in the next slot of the array.

Releasing a reference, is a little harder, we scan the array looking
for the entry, once we find it we can collapse the list into a
condensed form, by moving the first element into the gap, and nudging
the first up.

The API has changed to only return a bool for whether a reference
exists or not. We don't care how many references there are. This means
we can short cut several searchs as soon as we find something.