### PR TITLE
fixes #1044

### DIFF
--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -147,11 +147,16 @@ namespace System
             sb.Append("[");
 
             bool first = true;
-            for(int i=0; i<Length; i++) {
+            int i;
+            for(i=0; i<Length; i++) {
                 if (i > 7) break;
                 if (first) first = false;
                 else sb.Append(", ");
                 sb.Append(data[i].ToString());
+            }
+            if (i < Span.Length)
+            {
+                sb.Append(",...");
             }
             sb.Append("]");
             return sb.ToString();

--- a/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
@@ -142,11 +142,17 @@ namespace System
             sb.Append("[");
 
             bool first = true;
-            for (int i = 0; i < Length; i++) {
+            int i;
+            for (i = 0; i < Length; i++)
+            {
                 if (i > 7) break;
                 if (first) first = false;
                 else sb.Append(", ");
                 sb.Append(data[i].ToString());
+            }
+            if (i < Span.Length)
+            {
+                sb.Append(",...");
             }
             sb.Append("]");
             return sb.ToString();


### PR DESCRIPTION
cc @grahamehorner, @Tragetaschen, @ahsonkhan

This is addressing the issue described in #1044. I think we cannot return whole buffer from ToString, but I understand how the current behavior might be confusing, and so I added "..." when more items are in the memory than returned from ToString.

Also, note that ultimately we want to use debugger view proxies. Unfortunately they don't yet work with Spans and Memory. I filed a bug and the VS debugger team promised to fix it before the next VS ships.