### PR TITLE
Added JSON writing to the E2E benchmark

### DIFF
--- a/tests/Benchmarks/project.json
+++ b/tests/Benchmarks/project.json
@@ -15,7 +15,8 @@
     "System.IO.Pipelines": { "target": "project" },
     "System.Text.Primitives": { "target": "project" },
     "System.Text.Formatting": { "target": "project" },
-    "System.Text.Http": { "target": "project" }
+    "System.Text.Http": { "target": "project" },
+    "System.Text.Json": { "target": "project" }
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
These are the results I got 

Test Name	Metric	Iterations	Average	stdev	Minimum	Maximum
E2EPipelineTests.TechEmpowerHelloWorldNoIO(numberOfRequests: 1000, concurrentConnections: 1024)	Duration	4	3876.773707	148.4557393	3782.389745	4097.927995
E2EPipelineTests.TechEmpowerHelloWorldNoIO(numberOfRequests: 1000, concurrentConnections: 4096)	Duration	2	15696.70992	176.1692083	15572.13948	15821.28037
E2EPipelineTests.TechEmpowerHelloWorldNoIO(numberOfRequests: 1000, concurrentConnections: 256)	Duration	12	926.6457971	10.91291388	905.5670618	940.7760337
E2EPipelineTests.TechEmpowerJsonNoIO(numberOfRequests: 1000, concurrentConnections: 1024)	Duration	4	4208.268144	22.49119549	4179.787803	4231.541506
E2EPipelineTests.TechEmpowerJsonNoIO(numberOfRequests: 1000, concurrentConnections: 256)	Duration	11	1038.525413	6.325271189	1031.545051	1052.202904
E2EPipelineTests.TechEmpowerJsonNoIO(numberOfRequests: 1000, concurrentConnections: 4096)	Duration	2	17388.95457	87.03195251	17327.41369	17450.49546

We really need to fix the reporting from xunit.perf. 
Also, it would be nice to get comparative tests using ASP.NET pipeline. @davidfowl , is there a good sample showing how to mock i/o in ASP.NET/Kestrel?
Lastly, the benchmarks don't properly implement TechEmpower, I think. I don't fully understand what the TE requirements are for JSON serialization.