### PR TITLE
Simplified ISequence<T>

### DIFF
--- a/samples/LowAllocationWebServer/Framework/SharedData.cs
+++ b/samples/LowAllocationWebServer/Framework/SharedData.cs
@@ -88,12 +88,6 @@ namespace Microsoft.Net.Http
 
         public bool TryGet(ref Position position, out Memory<byte> item, bool advance = false)
         {
-            if(position == Position.BeforeFirst) {
-                item = Memory<byte>.Empty;
-                if(advance) position = Position.First;
-                return false;
-            }
-
             if (position == Position.First) {
                 item = _head.Commited;
                 if (advance) {

--- a/src/System.Collections.Sequences/System/Collections/Sequences/ISequence.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/ISequence.cs
@@ -16,7 +16,5 @@ namespace System.Collections.Sequences
         bool TryGet(ref Position position, out T item, bool advance = false);
 
         int? Length { get; }
-
-        SequenceEnumerator<T> GetEnumerator();
     }
 }

--- a/src/System.Collections.Sequences/System/Collections/Sequences/Position.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/Position.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Collections.Sequences
 {
     public struct Position : IEquatable<Position>
@@ -8,20 +10,22 @@ namespace System.Collections.Sequences
         public int IntegerPosition;
         public object ObjectPosition;
 
-        public static Position BeforeFirst = new Position() { IntegerPosition = -1 };
-        public static Position First = new Position();
-        public static Position AfterLast = new Position() { IntegerPosition = int.MaxValue - 1 };
+        public static readonly Position First = new Position();
+        public static readonly Position AfterLast = new Position() { IntegerPosition = int.MaxValue - 1 };
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator==(Position left, Position right)
         {
             return left.Equals(right);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator!=(Position left, Position right)
         {
             return left.Equals(right);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(Position other)
         {
             return IntegerPosition == other.IntegerPosition && ObjectPosition == other.ObjectPosition;

--- a/src/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs
@@ -108,29 +108,13 @@ namespace System.Collections.Sequences
 
         public bool TryGet(ref Position position, out T item, bool advance = false)
         {
-            item = default(T);
-
-            if ( _count == 0) {
-                position = Position.AfterLast;
-                return false;
-            }
-
-            if (position.Equals(Position.BeforeFirst)) {
-                if (advance) {
-                    position = Position.First;
-                }
-                return false;
-            }
-
             if (position.IntegerPosition < _count) {
                 item = _array[position.IntegerPosition];
-                if (advance) {
-                    position.IntegerPosition++;
-                    if (position.IntegerPosition == _count) position = Position.AfterLast;
-                }
+                if (advance) { position.IntegerPosition++; }
                 return true;
             }
 
+            item = default(T);
             position = Position.AfterLast;
             return false;
         }

--- a/src/System.Collections.Sequences/System/Collections/Sequences/SequenceEnumerator.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/SequenceEnumerator.cs
@@ -10,16 +10,20 @@ namespace System.Collections.Sequences
         Position _position;
         ISequence<T> _sequence;
         T _current;
+        bool first; // this is needed so that MoveNext does not advance the first time it's called
 
         public SequenceEnumerator(ISequence<T> sequence) {
             _sequence = sequence;
             _position = Position.First;
             _current = default(T);
+            first = true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool MoveNext() {
-            return _sequence.TryGet(ref _position, out _current, advance: true);
+            var result = _sequence.TryGet(ref _position, out _current, advance: !first);
+            first = false;
+            return result;
         }
 
         public T Current => _current;

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -531,12 +531,6 @@ namespace System.IO.Pipelines
                 }
                 return true;
             }
-            else if (position == Position.BeforeFirst)
-            {
-                if (advance) position = Position.First;
-                item = default(ReadOnlyMemory<byte>);
-                return false;
-            }
             else if (position == Position.AfterLast)
             {
                 item = default(ReadOnlyMemory<byte>);
@@ -561,11 +555,6 @@ namespace System.IO.Pipelines
                 item = currentSegment.Memory.Slice(currentSegment.Start, currentSegment.End);
             }
             return true;
-        }
-
-        SequenceEnumerator<ReadOnlyMemory<byte>> ISequence<ReadOnlyMemory<byte>>.GetEnumerator()
-        {
-            return new SequenceEnumerator<ReadOnlyMemory<byte>>(this);
         }
     }
 }

--- a/tests/System.Collections.Sequences.Tests/BasicUnitTests.cs
+++ b/tests/System.Collections.Sequences.Tests/BasicUnitTests.cs
@@ -19,12 +19,6 @@ namespace System.Collections.Sequences.Tests
             while (collection.TryGet(ref position, out item, advance: true)) {
                 Assert.Equal(array[arrayIndex++], item);
             }
-
-            arrayIndex = 0;
-            var sequence = (ISequence<int>)collection;
-            foreach (var sequenceItem in sequence) {
-                Assert.Equal(array[arrayIndex++], sequenceItem);
-            }
         }
 
         private static ArrayList<int> CreateArrayList(int[] array)
@@ -48,12 +42,6 @@ namespace System.Collections.Sequences.Tests
             while (collection.TryGet(ref position, out item, advance: true)) {
                 Assert.Equal(array[--arrayIndex], item);
             }
-
-            arrayIndex = array.Length;
-            var sequence = (ISequence<int>)collection;
-            foreach (var sequenceItem in sequence) {
-                Assert.Equal(array[--arrayIndex], sequenceItem);
-            }
         }
 
         private static LinkedContainer<int> CreateLinkedContainer(int[] array)
@@ -76,12 +64,6 @@ namespace System.Collections.Sequences.Tests
             KeyValuePair<int, string> item;
             while (collection.TryGet(ref position, out item, advance: true)) {
                 Assert.Equal(array[arrayIndex++], item.Key);
-            }
-
-            arrayIndex = 0;
-            var sequence = (ISequence<KeyValuePair<int, string>>)collection;
-            foreach (var sequenceItem in sequence) {
-                Assert.Equal(array[arrayIndex++], sequenceItem.Key);
             }
         }
 

--- a/tests/System.Collections.Sequences.Tests/SampleCollections/Hashtable.cs
+++ b/tests/System.Collections.Sequences.Tests/SampleCollections/Hashtable.cs
@@ -94,13 +94,6 @@ namespace System.Collections.Sequences
                 return false;
             }
 
-            if (position.Equals(Position.BeforeFirst)) {
-                if (advance) {
-                    position.IntegerPosition = FindFirstStartingAt(0);
-                }
-                return false;
-            }
-
             if (position.Equals(Position.First)) {
                 var firstOccupiedSlot = FindFirstStartingAt(0);
                 if (firstOccupiedSlot == -1) {

--- a/tests/System.Collections.Sequences.Tests/SampleCollections/LinkedContainer.cs
+++ b/tests/System.Collections.Sequences.Tests/SampleCollections/LinkedContainer.cs
@@ -35,11 +35,6 @@ namespace System.Collections.Sequences
                 return false;
             }
 
-            if (position.Equals(Position.BeforeFirst)) {
-                if (advance) position = Position.First;
-                return false;
-            }
-
             if (position.Equals(Position.AfterLast)) {
                 return false;
             }

--- a/tests/System.Slices.Tests/MemoryTests.cs
+++ b/tests/System.Slices.Tests/MemoryTests.cs
@@ -83,7 +83,7 @@ namespace System.Slices.Tests
                         try {
                             owners[i].Dispose();
                             disposeSuccesses[i] = true;
-                        } catch (InvalidOperationException e) {
+                        } catch (InvalidOperationException) {
                             disposeSuccesses[i] = false;
                         }
                     }
@@ -94,7 +94,7 @@ namespace System.Slices.Tests
                         try {
                             reserves[i] = memories[i].Reserve();
                             reserveSuccesses[i] = true;
-                        } catch (ObjectDisposedException e) {
+                        } catch (ObjectDisposedException) {
                             reserveSuccesses[i] = false;
                         }
                     }


### PR DESCRIPTION
I am trying to use ISequence for more multi-segment scenarios and I am finding it too hard to implement.
Once of the reasons is that ISequence was supporting easy foreach style enumeration.
But foreach is not a mainline scenario for ISequence, so I made the support for it optional.

cc: @davidfowl, @joshfree, @shiftylogic, @terrajobst 