### PR TITLE
Fix race condition in ResizingThreadTableWorks.

### DIFF
--- a/tests/System.Slices.Tests/ReferenceCounterTests.cs
+++ b/tests/System.Slices.Tests/ReferenceCounterTests.cs
@@ -65,10 +65,10 @@ namespace System.Slices.Tests
             var obj = new object();
             for (int threadNumber = 0; threadNumber < defaultThreadTableSize * 2; threadNumber++)
             {
+                var handle = new AutoResetEvent(false);
+                threads.Add(handle);
                 var thread = new Thread(new ThreadStart(() =>
                 {
-                    var handle = new AutoResetEvent(false);
-                    threads.Add(handle);
                     for (int itteration = 0; itteration < 100; itteration++)
                     {
                         counter.AddReference(obj);


### PR DESCRIPTION
I believe this fixes an intermittent fault on ResizingThreadTableWorks.
The race could be observed by inserting a Thread.Sleep(10) as the first
command of the thread body, then the test fails consistently.

The WaitHandles are now made in sequential code, so there is no race on
adding to the threads list, with other additions, or the wait at the
end of the test.

@KrzysztofCwalina @joshfree does this fix the issue you were observing?