### PR TITLE
Seek overload with limit now considers end cursor

### DIFF
--- a/src/System.IO.Pipelines/SeekExtensions.cs
+++ b/src/System.IO.Pipelines/SeekExtensions.cs
@@ -69,12 +69,15 @@ namespace System.IO.Pipelines
                                 bytesScanned = limit;
                                 return -1;
                             }
-                            else if (block == end.Segment && index + _vectorSpan >= end.Index)
+
+                            bytesScanned += _vectorSpan;
+
+                            if (block == end.Segment && index + _vectorSpan >= end.Index)
                             {
                                 return -1;
                             }
 
-                            bytesScanned += _vectorSpan;
+
                             following -= _vectorSpan;
                             index += _vectorSpan;
                             continue;
@@ -88,14 +91,16 @@ namespace System.IO.Pipelines
                             bytesScanned = limit;
                             return -1;
                         }
-                        else if (block == end.Segment && index + vectorBytesScanned > end.Index)
+
+                        if (block == end.Segment && index + firstEqualByteIndex >= end.Index)
                         {
                             // Ensure iterator is left at limit position
+                            bytesScanned += firstEqualByteIndex;
                             return -1;
                         }
-                        
-                        bytesScanned += vectorBytesScanned;
 
+
+                        bytesScanned += vectorBytesScanned;
                         result = new ReadCursor(block, index + firstEqualByteIndex);
                         return byte0;
                     }
@@ -107,7 +112,19 @@ namespace System.IO.Pipelines
                     {
                         var pCurrent = pCurrentFixed + array.Offset + index;
 
-                        var pEnd = pCurrent + Math.Min(following, limit - bytesScanned);
+                        //var pEnd = pCurrent + Math.Min(following,  limit - bytesScanned);
+
+                        var pEnd = block == end.Segment ? pCurrentFixed + array.Offset + Math.Min(end.Index, index + Math.Min(following, limit - bytesScanned)) : pCurrent + Math.Min(following, limit - bytesScanned);
+
+                        //if (block == end.Segment)
+                        //{
+                        //    pEnd = pCurrentFixed + array.Offset + Math.Min(end.Index, index + limit - bytesScanned);
+                        //}
+                        //else {
+                        //    pEnd = pCurrent + Math.Min(following, limit - bytesScanned);
+                        //}
+
+
                         do
                         {
                             bytesScanned++;

--- a/src/System.IO.Pipelines/SeekExtensions.cs
+++ b/src/System.IO.Pipelines/SeekExtensions.cs
@@ -36,7 +36,7 @@ namespace System.IO.Pipelines
             {
                 while (following == 0)
                 {
-                    if (bytesScanned >= limit || wasLastBlock)
+                    if (bytesScanned >= limit || (block == end.Segment && index >= end.Index) || wasLastBlock)
                     {
                         return -1;
                     }
@@ -69,6 +69,10 @@ namespace System.IO.Pipelines
                                 bytesScanned = limit;
                                 return -1;
                             }
+                            else if (block == end.Segment && index + _vectorSpan >= end.Index)
+                            {
+                                return -1;
+                            }
 
                             bytesScanned += _vectorSpan;
                             following -= _vectorSpan;
@@ -84,7 +88,12 @@ namespace System.IO.Pipelines
                             bytesScanned = limit;
                             return -1;
                         }
-
+                        else if (block == end.Segment && index + vectorBytesScanned > end.Index)
+                        {
+                            // Ensure iterator is left at limit position
+                            return -1;
+                        }
+                        
                         bytesScanned += vectorBytesScanned;
 
                         result = new ReadCursor(block, index + firstEqualByteIndex);

--- a/src/System.IO.Pipelines/SeekExtensions.cs
+++ b/src/System.IO.Pipelines/SeekExtensions.cs
@@ -77,7 +77,6 @@ namespace System.IO.Pipelines
                                 return -1;
                             }
 
-
                             following -= _vectorSpan;
                             index += _vectorSpan;
                             continue;
@@ -111,20 +110,8 @@ namespace System.IO.Pipelines
                     fixed (byte* pCurrentFixed = array.Array)
                     {
                         var pCurrent = pCurrentFixed + array.Offset + index;
-
-                        //var pEnd = pCurrent + Math.Min(following,  limit - bytesScanned);
-
                         var pEnd = block == end.Segment ? pCurrentFixed + array.Offset + Math.Min(end.Index, index + Math.Min(following, limit - bytesScanned)) : pCurrent + Math.Min(following, limit - bytesScanned);
-
-                        //if (block == end.Segment)
-                        //{
-                        //    pEnd = pCurrentFixed + array.Offset + Math.Min(end.Index, index + limit - bytesScanned);
-                        //}
-                        //else {
-                        //    pEnd = pCurrent + Math.Min(following, limit - bytesScanned);
-                        //}
-
-
+                        
                         do
                         {
                             bytesScanned++;

--- a/tests/System.IO.Pipelines.Tests/SeekTests.cs
+++ b/tests/System.IO.Pipelines.Tests/SeekTests.cs
@@ -129,7 +129,7 @@ namespace System.IO.Pipelines.Tests
             int bytesScanned;
             ReadCursor result;
             var end = new ReadCursor(cursors.Item2.Segment, input.Length + limit);
-            var returnValue = SeekExtensions.Seek(cursors.Item1, end, out result, (byte)seek, out bytesScanned,limit);
+            var returnValue = SeekExtensions.Seek(cursors.Item1, end, out result, (byte)seek, out bytesScanned);
 
             // Assert
             Assert.Equal(expectedBytesScanned, bytesScanned);


### PR DESCRIPTION
Previously the seek overload that takes a limit did not take the end cursor into account, only the limit.

cc @pakrym 