### PR TITLE
[spec]: Fix broken link to span in memory spec

### DIFF
--- a/docs/specs/memory.md
+++ b/docs/specs/memory.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-`Memory<T>` is a type complementing [Span\<T>](Span.md). As discussed in its
+`Memory<T>` is a type complementing [Span\<T>](span.md). As discussed in its
 design document, `Span<T>` is a stack-only type. The stack-only nature of
 `Span<T>` makes it unsuitable for many scenarios that require storing references
 to buffers (represented with `Span<T>`) on the heap, e.g. for routines doing


### PR DESCRIPTION
This probably isn't really important, I just noticed a dead link while digging through the specs :+1: