### PR TITLE
Add AllowSynchronousContinuations support to UnboundedChannel 

### DIFF
--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/BoundedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/BoundedChannel.cs
@@ -102,7 +102,7 @@ namespace System.Threading.Tasks.Channels
                 // so we complete the completion task.
                 if (_items.Count == 0)
                 {
-                    ChannelUtilities.CompleteWithOptionalError(_completion, error);
+                    ChannelUtilities.Complete(_completion, error);
                 }
 
                 // If there are any waiting readers, fail them all, as they'll now never be satisfied.
@@ -218,7 +218,7 @@ namespace System.Threading.Tasks.Channels
             // If we're now empty and we're done writing, complete the channel.
             if (_doneWriting != null && _items.Count == 0)
             {
-                ChannelUtilities.CompleteWithOptionalError(_completion, _doneWriting);
+                ChannelUtilities.Complete(_completion, _doneWriting);
             }
 
             // If there are any writers blocked, there's now room for at least one

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/Channel.cs
@@ -10,7 +10,7 @@ namespace System.Threading.Tasks.Channels
         /// <summary>Creates an unbounded channel usable by any number of readers and writers concurrently.</summary>
         /// <typeparam name="T">Specifies the type of data in the channel.</typeparam>
         /// <returns>The created channel.</returns>
-        public static IChannel<T> CreateUnbounded<T>() => new UnboundedChannel<T>();
+        public static IChannel<T> CreateUnbounded<T>() => new UnboundedChannel<T>(runContinuationsAsynchronously: true);
 
         /// <summary>Creates an unbounded channel usable by any number of readers and writers concurrently.</summary>
         /// <typeparam name="T">Specifies the type of data in the channel.</typeparam>
@@ -23,9 +23,10 @@ namespace System.Threading.Tasks.Channels
                 throw new ArgumentNullException(nameof(optimizations));
             }
 
+            bool rca = !optimizations.AllowSynchronousContinuations;
             return optimizations.SingleReader ?
-                (IChannel<T>)new SingleConsumerUnboundedChannel<T>(!optimizations.AllowSynchronousContinuations) :
-                new UnboundedChannel<T>();
+                (IChannel<T>)new SingleConsumerUnboundedChannel<T>(rca) :
+                new UnboundedChannel<T>(rca);
         }
 
         /// <summary>Creates a channel that doesn't buffer any items.</summary>

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/SingleConsumerUnboundedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/SingleConsumerUnboundedChannel.cs
@@ -90,7 +90,7 @@ namespace System.Threading.Tasks.Channels
             // Complete the channel task if necessary
             if (completeTask)
             {
-                ChannelUtilities.CompleteWithOptionalError(_completion, error);
+                ChannelUtilities.Complete(_completion, error);
             }
 
             Debug.Assert(blockedReader == null || waitingReader == null, "There should only ever be at most one reader.");
@@ -227,7 +227,7 @@ namespace System.Threading.Tasks.Channels
             {
                 if (_doneWriting != null && _items.IsEmpty)
                 {
-                    ChannelUtilities.CompleteWithOptionalError(_completion, _doneWriting);
+                    ChannelUtilities.Complete(_completion, _doneWriting);
                 }
                 return true;
             }

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/SingleConsumerUnboundedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/SingleConsumerUnboundedChannel.cs
@@ -160,11 +160,6 @@ namespace System.Threading.Tasks.Channels
 
         public ValueTask<T> ReadAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return new ValueTask<T>(Task.FromCanceled<T>(cancellationToken));
-            }
-
             T item;
             return TryRead(out item) ?
                 new ValueTask<T>(item) :
@@ -173,6 +168,11 @@ namespace System.Threading.Tasks.Channels
 
         private ValueTask<T> ReadAsyncCore(CancellationToken cancellationToken)
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new ValueTask<T>(Task.FromCanceled<T>(cancellationToken));
+            }
+
             lock (SyncObj)
             {
                 T item;

--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/UnbufferedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/UnbufferedChannel.cs
@@ -64,7 +64,7 @@ namespace System.Threading.Tasks.Channels
                 {
                     return false;
                 }
-                ChannelUtilities.CompleteWithOptionalError(_completion, error);
+                ChannelUtilities.Complete(_completion, error);
 
                 // Fail any blocked readers, as there will be no writers to pair them with.
                 while (_blockedReaders.Count > 0)


### PR DESCRIPTION
Previously added AllowSynchronousContinuations to SingleConsumerUnboundedChannel, this adds it to UnboundedChannel as well.  Significant opt-in performance improvement for when continuations are registered off of readers, but at the expense of the producer doing the work instead of the consumer. Also updated the readme and fixed another minor issue.