### PR TITLE
In parsing methods, check for default(EncodingData) and default(TextFormat)

### DIFF
--- a/src/System.Text.Primitives/System/Text/Parsing/Signed.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/Signed.cs
@@ -11,7 +11,12 @@ namespace System.Text
     {
         public static bool TryParseSByte(ReadOnlySpan<byte> text, out sbyte value, out int bytesConsumed, EncodingData encoding = default(EncodingData), TextFormat format = default(TextFormat))
         {
-            if (format.HasPrecision)
+            if (encoding == default(EncodingData))
+            {
+                encoding = EncodingData.InvariantUtf8;
+            }
+
+            if (!format.IsDefault && format.HasPrecision)
             {
                 throw new NotImplementedException("Format with precision not supported.");
             }
@@ -123,7 +128,12 @@ namespace System.Text
 
         public static bool TryParseInt16(ReadOnlySpan<byte> text, out short value, out int bytesConsumed, EncodingData encoding = default(EncodingData), TextFormat format = default(TextFormat))
         {
-            if (format.HasPrecision)
+            if (encoding == default(EncodingData))
+            {
+                encoding = EncodingData.InvariantUtf8;
+            }
+
+            if (!format.IsDefault && format.HasPrecision)
             {
                 throw new NotImplementedException("Format with precision not supported.");
             }
@@ -235,7 +245,12 @@ namespace System.Text
 
         public static bool TryParseInt32(ReadOnlySpan<byte> text, out int value, out int bytesConsumed, EncodingData encoding = default(EncodingData), TextFormat format = default(TextFormat))
         {
-            if (format.HasPrecision)
+            if (encoding == default(EncodingData))
+            {
+                encoding = EncodingData.InvariantUtf8;
+            }
+
+            if (!format.IsDefault && format.HasPrecision)
             {
                 throw new NotImplementedException("Format with precision not supported.");
             }
@@ -347,7 +362,12 @@ namespace System.Text
 
         public static bool TryParseInt64(ReadOnlySpan<byte> text, out long value, out int bytesConsumed, EncodingData encoding = default(EncodingData), TextFormat format = default(TextFormat))
         {
-            if (format.HasPrecision)
+            if (encoding == default(EncodingData))
+            {
+                encoding = EncodingData.InvariantUtf8;
+            }
+
+            if (!format.IsDefault && format.HasPrecision)
             {
                 throw new NotImplementedException("Format with precision not supported.");
             }

--- a/src/System.Text.Primitives/System/Text/Parsing/Signed.tt
+++ b/src/System.Text.Primitives/System/Text/Parsing/Signed.tt
@@ -28,7 +28,12 @@ foreach (IntegerTypeToParse typeToParse in typesToParse)
 #>
         public static bool TryParse<#=typeToParse.ClassName#>(ReadOnlySpan<byte> text, out <#=typeToParse.PrimitiveName#> value, out int bytesConsumed, EncodingData encoding = default(EncodingData), TextFormat format = default(TextFormat))
         {
-            if (format.HasPrecision)
+            if (encoding == default(EncodingData))
+            {
+                encoding = EncodingData.InvariantUtf8;
+            }
+
+            if (!format.IsDefault && format.HasPrecision)
             {
                 throw new NotImplementedException("Format with precision not supported.");
             }

--- a/src/System.Text.Primitives/System/Text/Parsing/Unsigned.cs
+++ b/src/System.Text.Primitives/System/Text/Parsing/Unsigned.cs
@@ -11,7 +11,12 @@ namespace System.Text
     {
         public static bool TryParseByte(ReadOnlySpan<byte> text, out byte value, out int bytesConsumed, EncodingData encoding = default(EncodingData), TextFormat format = default(TextFormat))
         {
-            if (format.HasPrecision)
+            if (encoding == default(EncodingData))
+            {
+                encoding = EncodingData.InvariantUtf8;
+            }
+
+            if (!format.IsDefault && format.HasPrecision)
             {
                 throw new NotImplementedException("Format with precision not supported.");
             }
@@ -102,7 +107,12 @@ namespace System.Text
         }
         public static bool TryParseUInt16(ReadOnlySpan<byte> text, out ushort value, out int bytesConsumed, EncodingData encoding = default(EncodingData), TextFormat format = default(TextFormat))
         {
-            if (format.HasPrecision)
+            if (encoding == default(EncodingData))
+            {
+                encoding = EncodingData.InvariantUtf8;
+            }
+
+            if (!format.IsDefault && format.HasPrecision)
             {
                 throw new NotImplementedException("Format with precision not supported.");
             }
@@ -193,7 +203,12 @@ namespace System.Text
         }
         public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int bytesConsumed, EncodingData encoding = default(EncodingData), TextFormat format = default(TextFormat))
         {
-            if (format.HasPrecision)
+            if (encoding == default(EncodingData))
+            {
+                encoding = EncodingData.InvariantUtf8;
+            }
+
+            if (!format.IsDefault && format.HasPrecision)
             {
                 throw new NotImplementedException("Format with precision not supported.");
             }
@@ -284,7 +299,12 @@ namespace System.Text
         }
         public static bool TryParseUInt64(ReadOnlySpan<byte> text, out ulong value, out int bytesConsumed, EncodingData encoding = default(EncodingData), TextFormat format = default(TextFormat))
         {
-            if (format.HasPrecision)
+            if (encoding == default(EncodingData))
+            {
+                encoding = EncodingData.InvariantUtf8;
+            }
+
+            if (!format.IsDefault && format.HasPrecision)
             {
                 throw new NotImplementedException("Format with precision not supported.");
             }

--- a/src/System.Text.Primitives/System/Text/Parsing/Unsigned.tt
+++ b/src/System.Text.Primitives/System/Text/Parsing/Unsigned.tt
@@ -28,7 +28,12 @@ foreach (IntegerTypeToParse typeToParse in typesToParse)
 #>
         public static bool TryParse<#=typeToParse.ClassName#>(ReadOnlySpan<byte> text, out <#=typeToParse.PrimitiveName#> value, out int bytesConsumed, EncodingData encoding = default(EncodingData), TextFormat format = default(TextFormat))
         {
-            if (format.HasPrecision)
+            if (encoding == default(EncodingData))
+            {
+                encoding = EncodingData.InvariantUtf8;
+            }
+
+            if (!format.IsDefault && format.HasPrecision)
             {
                 throw new NotImplementedException("Format with precision not supported.");
             }

--- a/tests/System.Text.Primitives.Tests/PrimitiveParserIntegerTests.cs
+++ b/tests/System.Text.Primitives.Tests/PrimitiveParserIntegerTests.cs
@@ -161,6 +161,11 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
+			result = PrimitiveParser.TryParseByte(utf8Span, out parsedValue, out consumed);
+            Assert.Equal(expectSuccess, result);
+            Assert.Equal(expectedValue, parsedValue);
+            Assert.Equal(expectedConsumed, consumed);
+
             result = PrimitiveParser.InvariantUtf8.TryParseByte(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
@@ -307,6 +312,11 @@ namespace System.Text.Primitives.Tests
             bool result;
 
             result = PrimitiveParser.TryParseUInt16(utf8Span, out parsedValue, out consumed, EncodingData.InvariantUtf8, 'G');
+            Assert.Equal(expectSuccess, result);
+            Assert.Equal(expectedValue, parsedValue);
+            Assert.Equal(expectedConsumed, consumed);
+
+			result = PrimitiveParser.TryParseUInt16(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
@@ -461,6 +471,11 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
+			result = PrimitiveParser.TryParseUInt32(utf8Span, out parsedValue, out consumed);
+            Assert.Equal(expectSuccess, result);
+            Assert.Equal(expectedValue, parsedValue);
+            Assert.Equal(expectedConsumed, consumed);
+
             result = PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
@@ -607,6 +622,11 @@ namespace System.Text.Primitives.Tests
             bool result;
 
             result = PrimitiveParser.TryParseUInt64(utf8Span, out parsedValue, out consumed, EncodingData.InvariantUtf8, 'G');
+            Assert.Equal(expectSuccess, result);
+            Assert.Equal(expectedValue, parsedValue);
+            Assert.Equal(expectedConsumed, consumed);
+
+			result = PrimitiveParser.TryParseUInt64(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
@@ -759,6 +779,11 @@ namespace System.Text.Primitives.Tests
             bool result;
 
             result = PrimitiveParser.TryParseSByte(utf8Span, out parsedValue, out consumed, EncodingData.InvariantUtf8, 'G');
+            Assert.Equal(expectSuccess, result);
+            Assert.Equal(expectedValue, parsedValue);
+            Assert.Equal(expectedConsumed, consumed);
+
+			result = PrimitiveParser.TryParseSByte(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
@@ -942,6 +967,11 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
+			result = PrimitiveParser.TryParseInt16(utf8Span, out parsedValue, out consumed);
+            Assert.Equal(expectSuccess, result);
+            Assert.Equal(expectedValue, parsedValue);
+            Assert.Equal(expectedConsumed, consumed);
+
             result = PrimitiveParser.InvariantUtf8.TryParseInt16(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
@@ -1121,6 +1151,11 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
+			result = PrimitiveParser.TryParseInt32(utf8Span, out parsedValue, out consumed);
+            Assert.Equal(expectSuccess, result);
+            Assert.Equal(expectedValue, parsedValue);
+            Assert.Equal(expectedConsumed, consumed);
+
             result = PrimitiveParser.InvariantUtf8.TryParseInt32(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
@@ -1296,6 +1331,11 @@ namespace System.Text.Primitives.Tests
             bool result;
 
             result = PrimitiveParser.TryParseInt64(utf8Span, out parsedValue, out consumed, EncodingData.InvariantUtf8, 'G');
+            Assert.Equal(expectSuccess, result);
+            Assert.Equal(expectedValue, parsedValue);
+            Assert.Equal(expectedConsumed, consumed);
+
+			result = PrimitiveParser.TryParseInt64(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);

--- a/tests/System.Text.Primitives.Tests/PrimitiveParserIntegerTests.cs
+++ b/tests/System.Text.Primitives.Tests/PrimitiveParserIntegerTests.cs
@@ -161,7 +161,7 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-			result = PrimitiveParser.TryParseByte(utf8Span, out parsedValue, out consumed);
+            result = PrimitiveParser.TryParseByte(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
@@ -316,7 +316,7 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-			result = PrimitiveParser.TryParseUInt16(utf8Span, out parsedValue, out consumed);
+            result = PrimitiveParser.TryParseUInt16(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
@@ -471,7 +471,7 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-			result = PrimitiveParser.TryParseUInt32(utf8Span, out parsedValue, out consumed);
+            result = PrimitiveParser.TryParseUInt32(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
@@ -626,7 +626,7 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-			result = PrimitiveParser.TryParseUInt64(utf8Span, out parsedValue, out consumed);
+            result = PrimitiveParser.TryParseUInt64(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
@@ -783,7 +783,7 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-			result = PrimitiveParser.TryParseSByte(utf8Span, out parsedValue, out consumed);
+            result = PrimitiveParser.TryParseSByte(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
@@ -967,7 +967,7 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-			result = PrimitiveParser.TryParseInt16(utf8Span, out parsedValue, out consumed);
+            result = PrimitiveParser.TryParseInt16(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
@@ -1151,7 +1151,7 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-			result = PrimitiveParser.TryParseInt32(utf8Span, out parsedValue, out consumed);
+            result = PrimitiveParser.TryParseInt32(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
@@ -1335,7 +1335,7 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-			result = PrimitiveParser.TryParseInt64(utf8Span, out parsedValue, out consumed);
+            result = PrimitiveParser.TryParseInt64(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);

--- a/tests/System.Text.Primitives.Tests/PrimitiveParserIntegerTests.tt
+++ b/tests/System.Text.Primitives.Tests/PrimitiveParserIntegerTests.tt
@@ -253,7 +253,7 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-			result = PrimitiveParser.TryParse<#= unsignedType.ClassName #>(utf8Span, out parsedValue, out consumed);
+            result = PrimitiveParser.TryParse<#= unsignedType.ClassName #>(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
@@ -426,7 +426,7 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-			result = PrimitiveParser.TryParse<#= signedType.ClassName #>(utf8Span, out parsedValue, out consumed);
+            result = PrimitiveParser.TryParse<#= signedType.ClassName #>(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);

--- a/tests/System.Text.Primitives.Tests/PrimitiveParserIntegerTests.tt
+++ b/tests/System.Text.Primitives.Tests/PrimitiveParserIntegerTests.tt
@@ -253,6 +253,11 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
+			result = PrimitiveParser.TryParse<#= unsignedType.ClassName #>(utf8Span, out parsedValue, out consumed);
+            Assert.Equal(expectSuccess, result);
+            Assert.Equal(expectedValue, parsedValue);
+            Assert.Equal(expectedConsumed, consumed);
+
             result = PrimitiveParser.InvariantUtf8.TryParse<#= unsignedType.ClassName #>(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
@@ -417,6 +422,11 @@ namespace System.Text.Primitives.Tests
             bool result;
 
             result = PrimitiveParser.TryParse<#= signedType.ClassName #>(utf8Span, out parsedValue, out consumed, EncodingData.InvariantUtf8, 'G');
+            Assert.Equal(expectSuccess, result);
+            Assert.Equal(expectedValue, parsedValue);
+            Assert.Equal(expectedConsumed, consumed);
+
+			result = PrimitiveParser.TryParse<#= signedType.ClassName #>(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);


### PR DESCRIPTION
PrimitiveParser's main overloads - those which take EncodingData and TextFormat objects as parameters - are currently failing when given the default values for those objects. This change introduces better behavior. If default(EncodingData) is passed, the parser will default to InvariantUtf8 parsing. If default(TextFormat) is passed, the parser will not interpret the format as having precision, as was the case previously.

This is a fix for Issue #1106.