### PR TITLE
Attempts at improving encoding performance of UTF8.TryEncodeFromUtf16 

### DIFF
--- a/src/System.Text.Primitives/System/Text/Encoding/Utf16/Utf16TextEncodingLE.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf16/Utf16TextEncodingLE.cs
@@ -39,10 +39,11 @@ namespace System.Text.Utf16
         public override bool TryEncodeFromUnicode(ReadOnlySpan<UnicodeCodePoint> codePoints, Span<byte> buffer, out int bytesWritten)
         {
             var availableBytes = buffer.Length;
+            var inputLength = codePoints.Length;
             int bytesWrittenForCodePoint = 0;
             bytesWritten = 0;
 
-            for (int i = 0; i < codePoints.Length; i++)
+            for (int i = 0; i < inputLength;  i++)
             {
                 if (availableBytes <= bytesWritten || !Utf16LittleEndianEncoder.TryEncodeCodePoint(codePoints[i], buffer.Slice(bytesWritten), out bytesWrittenForCodePoint))
                 {
@@ -58,10 +59,11 @@ namespace System.Text.Utf16
         public override bool TryDecodeToUnicode(Span<byte> encoded, Span<UnicodeCodePoint> decoded, out int bytesWritten)
         {
             var avaliableBytes = encoded.Length;
+            var outputLength = decoded.Length;
             int bytesWrittenForCodePoint = 0;
             bytesWritten = 0;
 
-            for (int i = 0; i < decoded.Length; i++)
+            for (int i = 0; i < outputLength; i++)
             {
                 UnicodeCodePoint decodedCodePoint = decoded[i];
 

--- a/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8TextEncoding.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8TextEncoding.cs
@@ -40,23 +40,21 @@ namespace System.Text.Utf8
 
             for (int i = 0; i < inputLength; i++)
             {
-                var utf16BE = utf16[i];
-                
-                var codePointLE = (char)((utf16BE << 8) | (utf16BE >> 8));
+                var codePoint = utf16[i];
 
-                if (codePointLE <= 0x7F)
+                if (codePoint <= 0x7F)
                 {
                     bytesWrittenForCodePoint = 1;
                 }
-                else if (codePointLE <= 0x7FF)
+                else if (codePoint <= 0x7FF)
                 {
                     bytesWrittenForCodePoint = 2;
                 }
-                else if (char.IsSurrogate(codePointLE))
+                else if (char.IsSurrogate(codePoint))
                 {
                     bytesWrittenForCodePoint = 4;
                 }
-                else if (codePointLE <= 0xFFFF)
+                else if (codePoint <= 0xFFFF)
                 {
                     bytesWrittenForCodePoint = 3;
                 }
@@ -75,31 +73,30 @@ namespace System.Text.Utf8
                 switch (bytesWrittenForCodePoint)
                 {
                     case 1:
-                        buffer[bytesWritten] = (byte)(b0111_1111U & codePointLE);
+                        buffer[bytesWritten] = (byte)(b0111_1111U & codePoint);
                         break;
                     case 2:
-                        buffer[bytesWritten] = (byte)(((codePointLE >> 6) & b0001_1111U) | b1100_0000U);
-                        buffer[bytesWritten + 1] = (byte)(((codePointLE >> 0) & b0011_1111U) | b1000_0000U);
+                        buffer[bytesWritten] = (byte)(((codePoint >> 6) & b0001_1111U) | b1100_0000U);
+                        buffer[bytesWritten + 1] = (byte)(((codePoint >> 0) & b0011_1111U) | b1000_0000U);
                         break;
                     case 3:
-                        buffer[bytesWritten] = (byte)(((codePointLE >> 12) & b0000_1111U) | b1110_0000U);
-                        buffer[bytesWritten + 1] = (byte)(((codePointLE >> 6) & b0011_1111U) | b1000_0000U);
-                        buffer[bytesWritten + 2] = (byte)(((codePointLE >> 0) & b0011_1111U) | b1000_0000U);
+                        buffer[bytesWritten] = (byte)(((codePoint >> 12) & b0000_1111U) | b1110_0000U);
+                        buffer[bytesWritten + 1] = (byte)(((codePoint >> 6) & b0011_1111U) | b1000_0000U);
+                        buffer[bytesWritten + 2] = (byte)(((codePoint >> 0) & b0011_1111U) | b1000_0000U);
                         break;
                     case 4:
                         if (++i >= inputLength)
                             throw new ArgumentException("Invalid surrogate pair.", nameof(utf16));
-                        var lowSurrogateBE = utf16[i];
-                        var lowSurrogateLE = (char)((lowSurrogateBE << 8) | (lowSurrogateBE >> 8));
+                        var lowSurrogate = utf16[i];
 
-                        if (codePointLE < UnicodeConstants.Utf16HighSurrogateFirstCodePoint
-                                || codePointLE > UnicodeConstants.Utf16HighSurrogateLastCodePoint
-                                || lowSurrogateLE < UnicodeConstants.Utf16LowSurrogateFirstCodePoint
-                                || lowSurrogateLE > UnicodeConstants.Utf16LowSurrogateLastCodePoint)
+                        if (codePoint < UnicodeConstants.Utf16HighSurrogateFirstCodePoint
+                                || codePoint > UnicodeConstants.Utf16HighSurrogateLastCodePoint
+                                || lowSurrogate < UnicodeConstants.Utf16LowSurrogateFirstCodePoint
+                                || lowSurrogate > UnicodeConstants.Utf16LowSurrogateLastCodePoint)
                             throw new ArgumentException("Invalid surrogate pair.", nameof(utf16));
 
-                        uint answer = (((codePointLE - UnicodeConstants.Utf16HighSurrogateFirstCodePoint) << 10)
-                                | (lowSurrogateLE - UnicodeConstants.Utf16LowSurrogateFirstCodePoint)) + 0x10000;
+                        uint answer = (((codePoint - UnicodeConstants.Utf16HighSurrogateFirstCodePoint) << 10)
+                                | (lowSurrogate - UnicodeConstants.Utf16LowSurrogateFirstCodePoint)) + 0x10000;
 
                         buffer[bytesWritten] = (byte)(((answer >> 18) & b0000_0111U) | b1111_0000U);
                         buffer[bytesWritten + 1] = (byte)(((answer >> 12) & b0011_1111U) | b1000_0000U);

--- a/tests/System.Text.Primitives.Tests/Encoding/Utf8EncoderTests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/Utf8EncoderTests.cs
@@ -79,10 +79,10 @@ namespace System.Text.Utf8.Tests
 
         public static object[][] TryEncodeFromUTF16ToUTF8TestData = {
             // empty
-            new object[] { TextEncoder.Utf8, new byte[] { }, new ReadOnlySpan<char>(new char[]{ (char)0x5000 } ), false },
+            new object[] { TextEncoder.Utf8, new byte[] { }, new ReadOnlySpan<char>(new char[]{ (char)0x0050 } ), false },
             // multiple bytes
             new object[] { TextEncoder.Utf8, new byte[] { 0x50, 0xCF, 0xA8,  0xEA, 0xBF, 0x88, 0xF0, 0xA4, 0xA7, 0xB0 },
-                new ReadOnlySpan<char>(new char[]{ (char)0x5000, (char)0xE803, (char)0xC8AF, (char)0x52D8, (char)0xF0DD } ), true },
+                new ReadOnlySpan<char>(new char[]{ (char)0x0050, (char)0x03E8, (char)0xAFC8, (char)0xD852, (char)0xDDF0 } ), true },
         };
 
         [Theory, MemberData("TryEncodeFromUTF16ToUTF8TestData")]

--- a/tests/System.Text.Primitives.Tests/EncodingPerfComparisonTests.cs
+++ b/tests/System.Text.Primitives.Tests/EncodingPerfComparisonTests.cs
@@ -10,15 +10,10 @@ namespace System.Text.Primitives.Tests
     public class EncodingPerfComparisonTests
     {
         [Benchmark]
-        [InlineData(false, 1000, 0x0020, 0x007F)]
-        [InlineData(false, 1000, 0x0080, 0x07FF)]
-        [InlineData(false, 1000, 0x0800, 0xd7FF)]
-        [InlineData(false, 1000, 0x0020, 0xd7FF)]
-        [InlineData(true, 1000, 0x0020, 0x007F)]
-        [InlineData(true, 1000, 0x0080, 0x07FF)]
-        [InlineData(true, 1000, 0x0800, 0xd7FF)]
-        [InlineData(true, 1000, 0x0020, 0xd7FF)]
-        public void EncodingPerformanceTestUsingCoreCLR(bool convertToArrayInLoop, int charLength, int minCodePoint, int maxCodePoint)
+        [InlineData(1000, 0x0000, 0x007F)]
+        [InlineData(1000, 0x0080, 0x07FF)]
+        [InlineData(1000, 0x0800, 0xFFFF)]
+        public void EncodingPerformanceTestUsingCoreCLR(int charLength, int minCodePoint, int maxCodePoint)
         {
             string unicodeString = GenerateString(charLength, minCodePoint, maxCodePoint);
             ReadOnlySpan<char> characters = unicodeString.Slice();
@@ -34,47 +29,48 @@ namespace System.Text.Primitives.Tests
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
-                    if (convertToArrayInLoop)
-                        utf8.GetBytes(characters.ToArray(), 0, characters.Length, utf8Buffer, 0);
-                    else
                         utf8.GetBytes(charArray, 0, characters.Length, utf8Buffer, 0);
                 span = new Span<byte>(utf8Buffer);
             }
         }
 
         [Benchmark]
-        [InlineData(1000, 0x0020, 0x007F)]
+        [InlineData(1000, 0x0000, 0x007F)]
         [InlineData(1000, 0x0080, 0x07FF)]
-        [InlineData(1000, 0x0800, 0xd7FF)]
-        [InlineData(1000, 0x0020, 0xd7FF)]
+        [InlineData(1000, 0x0800, 0xFFFF)]
         public void EncodingPerformanceTestUsingCorefxlab(int charLength, int minCodePoint, int maxCodePoint)
         {
-            string unicodeString = GenerateString(charLength, minCodePoint, maxCodePoint);
+            string unicodeString = GenerateString(charLength, minCodePoint, maxCodePoint, true);
             ReadOnlySpan<char> characters = unicodeString.Slice();
 
             int encodedBytes;
 
-            int utf8Length = Utf8Encoder.ComputeEncodedBytes(characters);
+            int utf8Length = charLength * 4;
             byte[] utf8Buffer = new byte[utf8Length];
             Span<byte> span = new Span<byte>(utf8Buffer);
 
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
-                    if (!Utf8Encoder.TryEncode(characters, span, out encodedBytes))
+                    if (!TextEncoder.Utf8.TryEncodeFromUtf16(characters, span, out encodedBytes))
                     {
                         throw new Exception(); // this should not happen
                     }
             }
         }
 
-        public string GenerateString(int charLength, int minCodePoint, int maxCodePoint)
+        public string GenerateString(int charLength, int minCodePoint, int maxCodePoint, bool isLE = false)
         {
             Random rand = new Random();
             var plainText = new StringBuilder();
             for (int j = 0; j < charLength; j++)
             {
-                plainText.Append((char)rand.Next(minCodePoint, maxCodePoint));
+                var val = rand.Next(minCodePoint, maxCodePoint);
+                while (val >= 0xD800 && val <= 0xDFFF)
+                {
+                    val = rand.Next(minCodePoint, maxCodePoint); // skip surrogate characters
+                }
+                plainText.Append(isLE ? (char)((val << 8) | (val >> 8)) : (char)val);
             }
             return plainText.ToString();
         }

--- a/tests/System.Text.Primitives.Tests/EncodingPerfComparisonTests.cs
+++ b/tests/System.Text.Primitives.Tests/EncodingPerfComparisonTests.cs
@@ -40,7 +40,7 @@ namespace System.Text.Primitives.Tests
         [InlineData(1000, 0x0800, 0xFFFF)]
         public void EncodingPerformanceTestUsingCorefxlab(int charLength, int minCodePoint, int maxCodePoint)
         {
-            string unicodeString = GenerateString(charLength, minCodePoint, maxCodePoint, true);
+            string unicodeString = GenerateString(charLength, minCodePoint, maxCodePoint);
             ReadOnlySpan<char> characters = unicodeString.Slice();
 
             int encodedBytes;
@@ -59,7 +59,7 @@ namespace System.Text.Primitives.Tests
             }
         }
 
-        public string GenerateString(int charLength, int minCodePoint, int maxCodePoint, bool isLE = false)
+        public string GenerateString(int charLength, int minCodePoint, int maxCodePoint)
         {
             Random rand = new Random();
             var plainText = new StringBuilder();
@@ -70,7 +70,7 @@ namespace System.Text.Primitives.Tests
                 {
                     val = rand.Next(minCodePoint, maxCodePoint); // skip surrogate characters
                 }
-                plainText.Append(isLE ? (char)((val << 8) | (val >> 8)) : (char)val);
+                plainText.Append((char)val);
             }
             return plainText.ToString();
         }


### PR DESCRIPTION
Fixing implementation to take in little endian UTF16 characters and adjusting tests so they use UTF16 LE bytes.

Switching EncodingPerfComparisonTests to use the TextEncoder.Utf8.TryEncodeFromUtf16 method. It should be 3x slower instead of 7x slower now.

As part of Issue #1091 - Productize Encoding APIs