### PR TITLE
Changed sequence default to advance

### DIFF
--- a/samples/LowAllocationWebServer/Framework/SharedData.cs
+++ b/samples/LowAllocationWebServer/Framework/SharedData.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Net.Http
             _head.Dispose();
         }
 
-        public bool TryGet(ref Position position, out Memory<byte> item, bool advance = false)
+        public bool TryGet(ref Position position, out Memory<byte> item, bool advance = true)
         {
             if (position == Position.First) {
                 item = _head.Commited;

--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -19,7 +19,7 @@ namespace System.Buffers
             Position position = Position.First;
             ReadOnlyMemory<byte> memory;
             ResizableArray<byte> array = new ResizableArray<byte>(1024); // TODO: could this be rented from a pool?
-            while (memorySequence.TryGet(ref position, out memory, advance: true))
+            while (memorySequence.TryGet(ref position, out memory))
             {
                 array.AddAll(memory.Span);
             }

--- a/src/System.Buffers.Experimental/System/Buffers/ReadOnlyBytes.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/ReadOnlyBytes.cs
@@ -39,7 +39,7 @@ namespace System.Buffers
             this(segments.First, segments.Rest, Unspecified)
         { }
 
-        public bool TryGet(ref Position position, out ReadOnlyMemory<byte> value, bool advance = false)
+        public bool TryGet(ref Position position, out ReadOnlyMemory<byte> value, bool advance = true)
         {
             if (position == Position.First)
             {
@@ -185,7 +185,7 @@ namespace System.Buffers
             {
                 Position position = new Position();
                 ReadOnlyMemory<byte> segment;
-                while (_rest.TryGet(ref position, out segment, true))
+                while (_rest.TryGet(ref position, out segment))
                 {
                     length += segment.Length;
                 }

--- a/src/System.Collections.Sequences/System/Collections/Sequences/ArrayList.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/ArrayList.cs
@@ -31,7 +31,7 @@ namespace System.Collections.Sequences
             return new SequenceEnumerator<T>(this);
         }
 
-        public bool TryGet(ref Position position, out T item, bool advance = false)
+        public bool TryGet(ref Position position, out T item, bool advance = true)
         {
             return _items.TryGet(ref position, out item, advance);
         }

--- a/src/System.Collections.Sequences/System/Collections/Sequences/ISequence.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/ISequence.cs
@@ -13,7 +13,7 @@ namespace System.Collections.Sequences
         /// <param name="advance"></param>
         /// <returns></returns>
         /// <remarks></remarks>
-        bool TryGet(ref Position position, out T item, bool advance = false);
+        bool TryGet(ref Position position, out T item, bool advance = true);
 
         int? Length { get; }
     }

--- a/src/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs
@@ -106,7 +106,7 @@ namespace System.Collections.Sequences
             return oldArray;
         }
 
-        public bool TryGet(ref Position position, out T item, bool advance = false)
+        public bool TryGet(ref Position position, out T item, bool advance = true)
         {
             if (position.IntegerPosition < _count) {
                 item = _array[position.IntegerPosition];

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/SequenceFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/SequenceFormatter.cs
@@ -39,7 +39,7 @@ namespace System.Text.Formatting
         private Memory<byte> Current { 
             get {
                 Memory<byte> result;
-                if (!_buffers.TryGet(ref _currentPosition, out result)) { throw new InvalidOperationException(); }
+                if (!_buffers.TryGet(ref _currentPosition, out result, advance: false)) { throw new InvalidOperationException(); }
                 return result;
             }
         }
@@ -47,7 +47,7 @@ namespace System.Text.Formatting
         {
             get {
                 Memory<byte> result;
-                if (!_buffers.TryGet(ref _previousPosition, out result)) { throw new InvalidOperationException(); }
+                if (!_buffers.TryGet(ref _previousPosition, out result, advance: false)) { throw new InvalidOperationException(); }
                 return result;
             }
         }
@@ -65,7 +65,7 @@ namespace System.Text.Formatting
             _previousWrittenBytes = _currentWrittenBytes;
 
             Memory<byte> span;
-            if (!_buffers.TryGet(ref _currentPosition, out span, advance: true)) {
+            if (!_buffers.TryGet(ref _currentPosition, out span)) {
                 throw new InvalidOperationException();
             }
             _currentWrittenBytes = 0;            

--- a/src/System.Text.Formatting/System/Text/Parsing/SequenceParser.cs
+++ b/src/System.Text.Formatting/System/Text/Parsing/SequenceParser.cs
@@ -19,7 +19,7 @@ namespace System.Text.Parsing
 
             // Fetch the first segment
             ReadOnlyMemory<byte> first;
-            if (!memorySequence.TryGet(ref position, out first, advance: true)) {
+            if (!memorySequence.TryGet(ref position, out first)) {
                 return false;
             }
 
@@ -31,7 +31,7 @@ namespace System.Text.Parsing
 
             // Apparently the we need data from the second segment to succesfully parse, and so fetch the second segment.
             ReadOnlyMemory<byte> second;
-            if (!memorySequence.TryGet(ref position, out second, advance: true)) {
+            if (!memorySequence.TryGet(ref position, out second)) {
                 // if there is no second segment and the first parsed succesfully, return the result of the parsing.
                 if (parsed) return true;
                 return false;
@@ -54,7 +54,7 @@ namespace System.Text.Parsing
 
                     ReadOnlyMemory<byte> next;
                     while (free.Length > 0) {
-                        if (memorySequence.TryGet(ref position, out next, advance: true)) {
+                        if (memorySequence.TryGet(ref position, out next)) {
                             if (next.Length > free.Length) next = next.Slice(0, free.Length);
                             next.CopyTo(free);
                             free = free.Slice(next.Length);
@@ -92,7 +92,7 @@ namespace System.Text.Parsing
 
             // Fetch the first segment
             ReadOnlyMemory<byte> first;
-            if (!memorySequence.TryGet(ref position, out first, advance: true)) {
+            if (!memorySequence.TryGet(ref position, out first)) {
                 return false;
             }
 
@@ -104,7 +104,7 @@ namespace System.Text.Parsing
 
             // Apparently the we need data from the second segment to succesfully parse, and so fetch the second segment.
             ReadOnlyMemory<byte> second;
-            if (!memorySequence.TryGet(ref position, out second, advance: true)) {
+            if (!memorySequence.TryGet(ref position, out second)) {
                 // if there is no second segment and the first parsed succesfully, return the result of the parsing.
                 if (parsed) return true;
                 return false;
@@ -127,7 +127,7 @@ namespace System.Text.Parsing
 
                     ReadOnlyMemory<byte> next;
                     while (free.Length > 0) {
-                        if (memorySequence.TryGet(ref position, out next, advance: true)) {
+                        if (memorySequence.TryGet(ref position, out next)) {
                             if (next.Length > free.Length) next = next.Slice(0, free.Length);
                             next.CopyTo(free);
                             free = free.Slice(next.Length);

--- a/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
@@ -42,7 +42,7 @@ namespace System.Slices.Tests
             var position = new Position();
             int length = 0;
             ReadOnlyMemory<byte> segment;
-            while (bytes.TryGet(ref position, out segment, true))
+            while (bytes.TryGet(ref position, out segment))
             {
                 length += segment.Length;
             }
@@ -51,7 +51,7 @@ namespace System.Slices.Tests
             var multibytes = Parse("A|CD|EFG");
             position = new Position();
             length = 0;
-            while (multibytes.TryGet(ref position, out segment, true))
+            while (multibytes.TryGet(ref position, out segment))
             {
                 length += segment.Length;
             }
@@ -68,7 +68,7 @@ namespace System.Slices.Tests
                 var position = new Position();
                 var length = 0;
                 ReadOnlyMemory<byte> segment;
-                while (multibytes.TryGet(ref position, out segment, true))
+                while (multibytes.TryGet(ref position, out segment))
                 {
                     length += segment.Length;
                 }
@@ -86,7 +86,7 @@ namespace System.Slices.Tests
                 var position = new Position();
                 var length = 0;
                 ReadOnlyMemory<byte> segment;
-                while (multibytes.TryGet(ref position, out segment, true))
+                while (multibytes.TryGet(ref position, out segment))
                 {
                     length += segment.Length;
                 }
@@ -141,7 +141,7 @@ namespace System.Slices.Tests
                 return copied;
             }
 
-            public bool TryGet(ref Position position, out ReadOnlyMemory<byte> item, bool advance = false)
+            public bool TryGet(ref Position position, out ReadOnlyMemory<byte> item, bool advance = true)
             {
                 if (position == Position.First)
                 {

--- a/tests/System.Collections.Sequences.Tests/BasicUnitTests.cs
+++ b/tests/System.Collections.Sequences.Tests/BasicUnitTests.cs
@@ -16,7 +16,7 @@ namespace System.Collections.Sequences.Tests
             var position = Position.First;
             int arrayIndex = 0;
             int item;
-            while (collection.TryGet(ref position, out item, advance: true)) {
+            while (collection.TryGet(ref position, out item)) {
                 Assert.Equal(array[arrayIndex++], item);
             }
         }
@@ -39,7 +39,7 @@ namespace System.Collections.Sequences.Tests
             var position = Position.First;
             int arrayIndex = array.Length;
             int item;
-            while (collection.TryGet(ref position, out item, advance: true)) {
+            while (collection.TryGet(ref position, out item)) {
                 Assert.Equal(array[--arrayIndex], item);
             }
         }
@@ -62,7 +62,7 @@ namespace System.Collections.Sequences.Tests
             int arrayIndex = 0;
             var position = Position.First;
             KeyValuePair<int, string> item;
-            while (collection.TryGet(ref position, out item, advance: true)) {
+            while (collection.TryGet(ref position, out item)) {
                 Assert.Equal(array[arrayIndex++], item.Key);
             }
         }

--- a/tests/System.Collections.Sequences.Tests/SampleCollections/Hashtable.cs
+++ b/tests/System.Collections.Sequences.Tests/SampleCollections/Hashtable.cs
@@ -85,7 +85,7 @@ namespace System.Collections.Sequences
 
         int? ISequence<KeyValuePair<K, V>>.Length => Length;
 
-        public bool TryGet(ref Position position, out KeyValuePair<K, V> item, bool advance = false)
+        public bool TryGet(ref Position position, out KeyValuePair<K, V> item, bool advance = true)
         {
             item = default(KeyValuePair<K, V>);
 

--- a/tests/System.Collections.Sequences.Tests/SampleCollections/LinkedContainer.cs
+++ b/tests/System.Collections.Sequences.Tests/SampleCollections/LinkedContainer.cs
@@ -26,7 +26,7 @@ namespace System.Collections.Sequences
 
         int? ISequence<T>.Length => Length;
 
-        public bool TryGet(ref Position position, out T item, bool advance = false)
+        public bool TryGet(ref Position position, out T item, bool advance = true)
         {
             item = default(T);
 

--- a/tests/System.IO.Pipelines.Tests/ReadableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/ReadableBufferFacts.cs
@@ -494,7 +494,7 @@ namespace System.IO.Pipelines.Tests
                     var position = Position.First;
                     ReadOnlyMemory<byte> memory;
                     int spanCount = 0;
-                    while (readable.TryGet(ref position, out memory, advance: true))
+                    while (readable.TryGet(ref position, out memory))
                     {
                         spanCount++;
                         Assert.Equal(0, memory.Length);
@@ -513,7 +513,7 @@ namespace System.IO.Pipelines.Tests
                     var position = Position.First;
                     ReadOnlyMemory<byte> memory;
                     int spanCount = 0;
-                    while (readable.TryGet(ref position, out memory, advance: true))
+                    while (readable.TryGet(ref position, out memory))
                     {
                         spanCount++;
                         Assert.Equal(spanCount, memory.Length);


### PR DESCRIPTION
Now that I work more with sequences, I realized how annoying the advance default was. In real scenarios, you almost always want to advance the sequence. And so I am changing the default.

Enumerating sequences got a little bit nicer:
```c#
ArrayList<int> sequence= ...

var position = Position.First;
while (sequence.TryGet(ref position, out var item)) {
    Console.WriteLine(item);
}
```