### PR TITLE
OwnedMemory tidy and performance testing

### DIFF
--- a/scripts/PerfHarness/PerfHarness.cs
+++ b/scripts/PerfHarness/PerfHarness.cs
@@ -29,7 +29,8 @@ public class PerfHarness
         return new [] {
             "Benchmarks",
             "System.Binary.Base64.Tests",
-            "System.Text.Primitives.Tests"
+            "System.Text.Primitives.Tests",
+            "System.Slices.Tests"
         };
     }
 }

--- a/scripts/PerfHarness/project.json
+++ b/scripts/PerfHarness/project.json
@@ -7,6 +7,7 @@
     "dependencies": {
         "Benchmarks": { "target": "project" },
         "System.Binary.Base64.Tests": { "target": "project" },
+        "System.Slices.Tests": { "target": "project" },
         "System.Text.Primitives.Tests": { "target": "project" },
         "xunit.performance.api": "1.0.0-alpha-build0043"
     },

--- a/src/System.IO.Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/BufferSegment.cs
@@ -85,11 +85,11 @@ namespace System.IO.Pipelines
 
         public void Dispose()
         {
-            Debug.Assert(_buffer.ReferenceCount >= 1);
+            Debug.Assert(_buffer.HasOutstandingReferences);
 
             _buffer.Release();
 
-            if (_buffer.ReferenceCount == 0)
+            if (!_buffer.HasOutstandingReferences)
             {
                 _buffer.Dispose();
             }

--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -55,7 +55,7 @@ namespace System
 
         public Span<T> Span => _owner.GetSpanInternal(_id).Slice(_index, _length);
 
-        public DisposableReservation Reserve() => new DisposableReservation(_owner, _id);
+        public DisposableReservation<T> Reserve() => new DisposableReservation<T>(_owner, _id);
 
         public unsafe bool TryGetPointer(out void* pointer)
         {

--- a/src/System.Slices/System/Buffers/OwnedMemory.cs
+++ b/src/System.Slices/System/Buffers/OwnedMemory.cs
@@ -114,10 +114,6 @@ namespace System.Buffers
         protected virtual void OnZeroReferences()
         { }
 
-        protected internal virtual DisposableReservation Reserve(ref ReadOnlyMemory<T> memory)
-        {
-            return new DisposableReservation(this, Id);
-        }
 
         #endregion
 

--- a/src/System.Slices/System/Buffers/OwnedMemory.cs
+++ b/src/System.Slices/System/Buffers/OwnedMemory.cs
@@ -195,21 +195,23 @@ namespace System.Buffers
         unsafe bool TryGetPointer(long id, out void* pointer);
     }
 
-    public struct DisposableReservation : IDisposable
+    public struct DisposableReservation<T> : IDisposable
     {
-        IKnown _owner;
+        OwnedMemory<T> _owner;
         long _id;
 
-        internal DisposableReservation(IKnown owner, long id)
+        internal DisposableReservation(OwnedMemory<T> owner, long id)
         {
             _id = id;
             _owner = owner;
-            _owner.AddReference(_id);
+            ((IKnown)_owner).AddReference(_id);
         }
+
+        public Span<T> Span => _owner.Span;
 
         public void Dispose()
         {
-            _owner.Release(_id);
+            ((IKnown)_owner).Release(_id);
             _owner = null;
         }
     }

--- a/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
@@ -49,7 +49,7 @@ namespace System
 
         public ReadOnlySpan<T> Span => _owner.GetSpanInternal(_id).Slice(_index, _length);
 
-        public DisposableReservation Reserve()
+        public DisposableReservation<T> Reserve()
         {
             return _owner.Memory.Reserve();
         }

--- a/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
@@ -51,7 +51,7 @@ namespace System
 
         public DisposableReservation Reserve()
         {
-            return _owner.Reserve(ref this);
+            return _owner.Memory.Reserve();
         }
    
         public unsafe bool TryGetPointer(out void* pointer)

--- a/src/System.Slices/System/Buffers/ReferenceCounter.cs
+++ b/src/System.Slices/System/Buffers/ReferenceCounter.cs
@@ -24,7 +24,7 @@ namespace System.Runtime
         static int s_allTablesCount;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void AddReference(object obj)
+        static public void AddReference(object obj)
         {
             var localCounts = t_threadLocalCounts;
             if (localCounts == null)
@@ -35,14 +35,14 @@ namespace System.Runtime
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Release(object obj)
+        static public void Release(object obj)
         {
             var localCounts = t_threadLocalCounts;
             localCounts.Decrement(obj);
         }
 
         // TODO: can we detect if the object was only refcounted on one thread and its the current thread? If yes, we don't need to synchronize?
-        public bool HasReference(object obj)
+        static public bool HasReference(object obj)
         {
             var allTables = s_allTables;
             lock (allTables)
@@ -56,7 +56,7 @@ namespace System.Runtime
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool HasThreadLocalReference(object obj)
+        static public bool HasThreadLocalReference(object obj)
         {
             var localCounts = t_threadLocalCounts;
             if (localCounts == null) return false;

--- a/tests/System.Slices.Tests/MemoryTests.cs
+++ b/tests/System.Slices.Tests/MemoryTests.cs
@@ -69,7 +69,7 @@ namespace System.Slices.Tests
             for(int k = 0; k < 1000; k++) {
                 var owners   = new OwnedArray<byte>[128];
                 var memories = new Memory<byte>[owners.Length];
-                var reserves = new DisposableReservation[owners.Length];
+                var reserves = new DisposableReservation<byte>[owners.Length];
                 var disposeSuccesses = new bool[owners.Length];
                 var reserveSuccesses = new bool[owners.Length];
 

--- a/tests/System.Slices.Tests/MemoryTests.cs
+++ b/tests/System.Slices.Tests/MemoryTests.cs
@@ -124,22 +124,6 @@ namespace System.Slices.Tests
         }
 
         [Fact]
-        public unsafe void CopyOnReserve()
-        {
-            var owned = new CustomMemory();
-            ReadOnlyMemory<byte> memory = owned.Memory;
-            var slice = memory.Slice(0, 1);
-
-            // this copies on reserve
-            using (slice.Reserve()) {
-                Assert.Equal(0, owned.OnZeroRefencesCount);
-                Assert.True(owned.HasZeroReferences);
-            }
-            Assert.Equal(0, owned.OnZeroRefencesCount);
-            Assert.True(owned.HasZeroReferences);
-        }
-
-        [Fact]
         public void AutoDispose()
         {
             OwnedMemory<byte> owned = new AutoDisposeMemory(1000);
@@ -161,19 +145,6 @@ namespace System.Slices.Tests
         public CustomMemory() : base(new byte[256], 0, 256) { }
 
         public int OnZeroRefencesCount => _onZeroRefencesCount;
-
-        protected override DisposableReservation Reserve(ref ReadOnlyMemory<byte> memory)
-        {
-            if (memory.Length < Length) {
-                var copy = memory.Span.ToArray();
-                OwnedArray<byte> newOwned = copy;
-                memory = newOwned.Memory;
-                return memory.Reserve();
-            }
-            else {
-                return base.Reserve(ref memory);
-            }
-        }
 
         protected override void OnZeroReferences()
         {

--- a/tests/System.Slices.Tests/ReferenceCounterTests.cs
+++ b/tests/System.Slices.Tests/ReferenceCounterTests.cs
@@ -14,46 +14,44 @@ namespace System.Slices.Tests
         public void BasicSingleThreadedCounts()
         {
             var obj = new object();
-            var counter = new ReferenceCounter();
-            Assert.False(counter.HasReference(obj));
-            counter.AddReference(obj);
-            Assert.True(counter.HasReference(obj));
-            counter.AddReference(obj);
-            Assert.True(counter.HasReference(obj));
-            counter.Release(obj);
-            Assert.True(counter.HasReference(obj));
-            counter.Release(obj);
-            Assert.False(counter.HasReference(obj));
+            Assert.False(ReferenceCounter.HasReference(obj));
+            ReferenceCounter.AddReference(obj);
+            Assert.True(ReferenceCounter.HasReference(obj));
+            ReferenceCounter.AddReference(obj);
+            Assert.True(ReferenceCounter.HasReference(obj));
+            ReferenceCounter.Release(obj);
+            Assert.True(ReferenceCounter.HasReference(obj));
+            ReferenceCounter.Release(obj);
+            Assert.False(ReferenceCounter.HasReference(obj));
         }
 
         [Fact]
         public void BasicMultiThreadedCounts()
         {
             var obj = new object();
-            var counter = new ReferenceCounter();
 
             var t1 = Task.Run(() => {
                 for (int i = 0; i < 100000; i++)
                 {
-                    counter.AddReference(obj);
-                    counter.AddReference(obj);
-                    counter.Release(obj);
-                    counter.Release(obj);
+                    ReferenceCounter.AddReference(obj);
+                    ReferenceCounter.AddReference(obj);
+                    ReferenceCounter.Release(obj);
+                    ReferenceCounter.Release(obj);
                 }
             });
 
             var t2 = Task.Run(() => {
                 for (int i = 0; i < 100000; i++)
                 {
-                    counter.AddReference(obj);
-                    counter.AddReference(obj);
-                    counter.Release(obj);
-                    counter.Release(obj);
+                    ReferenceCounter.AddReference(obj);
+                    ReferenceCounter.AddReference(obj);
+                    ReferenceCounter.Release(obj);
+                    ReferenceCounter.Release(obj);
                 }
             });
 
             Task.WaitAll(t1, t2);
-            Assert.False(counter.HasReference(obj));
+            Assert.False(ReferenceCounter.HasReference(obj));
         }
 
         [Fact]
@@ -61,7 +59,7 @@ namespace System.Slices.Tests
         {
             var defaultThreadTableSize = Environment.ProcessorCount;
             var threads = new List<WaitHandle>();
-            var counter = new ReferenceCounter();
+
             var obj = new object();
             for (int threadNumber = 0; threadNumber < defaultThreadTableSize * 2; threadNumber++)
             {
@@ -71,16 +69,16 @@ namespace System.Slices.Tests
                 {
                     for (int itteration = 0; itteration < 100; itteration++)
                     {
-                        counter.AddReference(obj);
+                        ReferenceCounter.AddReference(obj);
                         Thread.Sleep(10);
-                        counter.Release(obj);
+                        ReferenceCounter.Release(obj);
                     }
                     handle.Set();
                 }));
                 thread.Start();
             }
             WaitHandle.WaitAll(threads.ToArray());
-            Assert.False(counter.HasReference(obj));
+            Assert.False(ReferenceCounter.HasReference(obj));
         }
 
         [Fact]
@@ -88,20 +86,19 @@ namespace System.Slices.Tests
         {
             var defaultObjectTableSize = 16;
             var objects = new List<object>();
-            var counter = new ReferenceCounter();
             for (int objectNumber = 0; objectNumber < defaultObjectTableSize * 2; objectNumber++)
             {
                 var obj = new object();
-                counter.AddReference(obj);
+                ReferenceCounter.AddReference(obj);
                 objects.Add(obj);
             }
             foreach(var obj in objects)
             {
-                counter.Release(obj);
+                ReferenceCounter.Release(obj);
             }
             foreach (var obj in objects)
             {
-                Assert.False(counter.HasReference(obj));
+                Assert.False(ReferenceCounter.HasReference(obj));
             }
         }
     }

--- a/tests/System.Slices.Tests/project.json
+++ b/tests/System.Slices.Tests/project.json
@@ -10,6 +10,7 @@
     },
     "System.Slices": { "target": "project" },
     "xunit": "2.2.0-beta2-build3300",
+    "xunit.performance.core": "1.0.0-alpha-build0043",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "frameworks": {


### PR DESCRIPTION
Main changes
* Made Reference Count value not directly accessible, only whether it is zero or not.  
* Added a setting for whether reservations should use:
   * Interlocked Reference Counting (slow),
   * Reference Counter (almost safe), or
   * Nothing (unsafe).
* Added a simple performance test for reservations that does parameter sweep. 

Minor tidying to 
* Remove unused Reserve method.
* Make DisposableReservations be able to return the Span, as in the design doc.
 