### PR TITLE
Added BytesReader

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -18,11 +18,12 @@ namespace System.Buffers
         {
             Position position = Position.First;
             ReadOnlyMemory<byte> memory;
-            ResizableArray<byte> array = new ResizableArray<byte>(1024); // TODO: could this be rented from a pool?
+            ResizableArray<byte> array = new ResizableArray<byte>(memorySequence.Length.GetValueOrDefault(1024)); 
             while (memorySequence.TryGet(ref position, out memory))
             {
                 array.AddAll(memory.Span);
             }
+            array.Resize(array.Count);
             return array.Items.Slice(0, array.Count);
         }
 

--- a/src/System.Buffers.Experimental/System/Buffers/BytesReader.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BytesReader.cs
@@ -1,0 +1,348 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace System.Buffers
+{
+    /// <summary>
+    /// Used to read text from byte buffers
+    /// </summary>
+    public struct BytesReader
+    {
+        readonly EncodingData _encoding;
+        ReadOnlyBytes _unreadSegments;
+        int _index; // index relative to the begining of bytes passed to the constructor
+
+        ReadOnlyMemory<byte> _currentSegment;
+        int _currentSegmentIndex;
+        
+        public BytesReader(ReadOnlyBytes bytes, EncodingData encoding)
+        {
+            _unreadSegments = bytes;
+            _currentSegment = _unreadSegments.First;
+            _encoding = encoding;
+            _currentSegmentIndex = 0;
+            _index = 0;
+        }
+
+        public BytesReader(ReadOnlyMemory<byte> bytes, EncodingData encoding)
+        {
+            _unreadSegments = new ReadOnlyBytes(bytes);
+            _currentSegment = bytes;
+            _encoding = encoding;
+            _currentSegmentIndex = 0;
+            _index = 0;
+        }
+
+        public BytesReader(ReadOnlyMemory<byte> bytes) : this(bytes, EncodingData.InvariantUtf8)
+        { }
+
+        public BytesReader(ReadOnlyBytes bytes) : this(bytes, EncodingData.InvariantUtf8)
+        { }
+
+        public BytesReader(IReadOnlyMemoryList<byte> bytes) : this(bytes, EncodingData.InvariantUtf8)
+        { }
+
+        public BytesReader(IReadOnlyMemoryList<byte> bytes, EncodingData encoding) : this(new ReadOnlyBytes(bytes))
+        { }
+
+        public byte Peek() => _currentSegment.Span[_currentSegmentIndex];
+
+        public ReadOnlySpan<byte> Unread => _currentSegment.Span.Slice(_currentSegmentIndex);
+
+        public EncodingData Encoding => _encoding;
+
+        public ReadOnlyBytes? ReadBytesUntil(byte value)
+        {
+            var index = IndexOf(value);
+            if (index == -1) return null;
+            return ReadBytes(index);
+        }
+        public ReadOnlyBytes? ReadBytesUntil(ReadOnlySpan<byte> value)
+        {
+            var index = IndexOf(value);
+            if (index == -1) return null;
+            return ReadBytes(index);
+        }
+
+        public Range? ReadRangeUntil(byte value)
+        {
+            var index = IndexOf(value);
+            if (index == -1) return null;
+            return ReadRange(index);
+        }
+        public Range? ReadRangeUntil(ReadOnlySpan<byte> values)
+        {
+            var index = IndexOf(values);
+            if (index == -1) return null;
+            return ReadRange(index);
+        }
+
+        public ReadOnlyBytes ReadBytes(int count)
+        {
+            var result = _unreadSegments.Slice(_currentSegmentIndex, count);
+            Advance(count);
+            return result;
+        }
+        public Range ReadRange(int count)
+        {
+            var result = new Range(_index, count);
+            Advance(count);
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int IndexOf(byte value)
+        {
+            var index = Unread.IndexOf(value);
+            if (index != -1)
+            {
+                return index;
+            }
+
+            return IndexOfRest(value) + _currentSegment.Length - _currentSegmentIndex;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int IndexOf(ReadOnlySpan<byte> values)
+        {
+            var unread = Unread;
+            var index = unread.IndexOf(values);
+            if (index != -1)
+            {
+                return index;
+            }
+
+            return IndexOfStraddling(values);
+        }
+
+        public bool IsEmpty
+        {
+            get {
+                if (_currentSegment.Length - _currentSegmentIndex > 0)
+                {
+                    return false;
+                }
+                AdvanceNextSegment(0, 0);
+                if (_currentSegment.Length == 0) return true;
+                return IsEmpty;
+            }
+        }
+
+        public int Index => _index;
+
+        int CopyTo(Span<byte> buffer)
+        {
+            var first = Unread;
+            if (first.Length > buffer.Length)
+            {
+                first.Slice(0, buffer.Length).CopyTo(buffer);
+                return buffer.Length;
+            }
+            if (first.Length == buffer.Length)
+            {
+                first.CopyTo(buffer);
+                return buffer.Length;
+            }
+
+            first.CopyTo(buffer);
+            return first.Length + _unreadSegments.Rest.CopyTo(buffer.Slice(first.Length));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Advance(int count)
+        {
+            _index += count;
+            var unreadLength = _currentSegment.Length - _currentSegmentIndex;
+            if (count < unreadLength)
+            {
+                _currentSegmentIndex += count;
+            }
+            else
+            {
+                AdvanceNextSegment(count, advancedInCurrent:unreadLength);
+            }
+        }
+
+        void AdvanceNextSegment(int count, int advancedInCurrent)
+        {
+            var length = _unreadSegments.Length;
+
+            var newSegments = _unreadSegments.Rest;
+            var toAdvance = count - advancedInCurrent;
+            while(toAdvance >= 0 || _currentSegment.Length == 0)
+            {
+                // if we are advancing by exactly how many bytes there are in the reader
+                if (newSegments == null && toAdvance == 0)
+                {
+                    _unreadSegments = ReadOnlyBytes.Empty;
+                    _currentSegment = ReadOnlyMemory<byte>.Empty;
+                    _currentSegmentIndex = 0;
+                    return;
+                }
+
+                _currentSegment = newSegments.First;
+                // if currentSegment is long enough
+                if (_currentSegment.Length > toAdvance || toAdvance == 0)
+                {
+                    if (length != null) // this is to avoid computing length, if it is Unspecified
+                    {
+                        _unreadSegments = new ReadOnlyBytes(_currentSegment, newSegments.Rest, length.Value - count);
+                    }
+                    else
+                    {
+                        _unreadSegments = new ReadOnlyBytes(_currentSegment, newSegments.Rest);
+                    }
+                    _currentSegmentIndex = toAdvance;
+                    return;
+                }
+                else
+                {
+                    toAdvance -= _currentSegment.Length;
+                    newSegments = newSegments.Rest;
+                }
+            }
+        }
+
+        int IndexOf(IReadOnlyMemoryList<byte> sequence, byte value)
+        {
+            if (sequence == null) return -1;
+            var first = sequence.First;
+            var index = first.Span.IndexOf(value);
+            if (index > -1) return index;
+
+            var indexOfRest = IndexOf(sequence.Rest, value);
+            if (indexOfRest < 0) return -1;
+            return first.Length + indexOfRest;
+        }
+
+        int IndexOfStraddling(ReadOnlySpan<byte> value)
+        {
+            ReadOnlySpan<byte> unread = Unread;
+            int index = 0;
+            // try to find the bytes straddling _first and _rest
+            int bytesToSkipFromFirst = 0; // these don't have to be searched again
+            if (unread.Length > value.Length - 1)
+            {
+                bytesToSkipFromFirst = unread.Length - value.Length - 1;
+            }
+            ReadOnlySpan<byte> bytesToSearchAgain;
+            if (bytesToSkipFromFirst > 0)
+            {
+                bytesToSearchAgain = unread.Slice(bytesToSkipFromFirst);
+            }
+            else
+            {
+                bytesToSearchAgain = unread;
+            }
+
+            if (bytesToSearchAgain.IndexOf(value[0]) != -1)
+            {
+                Span<byte> tempSpan;
+                var tempLen = value.Length << 1;
+                if (tempLen < 128)
+                {
+                    unsafe
+                    {
+                        byte* temp = stackalloc byte[tempLen];
+                        tempSpan = new Span<byte>(temp, tempLen);
+                    }
+                }
+                else
+                {
+                    // TODO (pri 3): I think this could be imporved by chunking values
+                    tempSpan = new byte[tempLen];
+                }
+
+                bytesToSearchAgain.CopyTo(tempSpan);
+                _unreadSegments.Rest.CopyTo(tempSpan.Slice(bytesToSearchAgain.Length));
+                index = tempSpan.IndexOf(value);
+                if (index != -1)
+                {
+                    return index + bytesToSkipFromFirst;
+                }
+            }
+
+            // try to find the bytes in _rest
+            index = _unreadSegments.Rest.IndexOf(value);
+            if (index != -1) return unread.Length + index;
+
+            return -1;
+        }
+
+        int IndexOfRest(byte value)
+        {
+            var index = IndexOf(_unreadSegments.Rest, value);
+            if (index == -1)
+            {
+                return -1;
+            }
+            return index;
+        }
+
+        #region Parsing Methods
+        // TODO: how to we chose the lengths of the temp buffers?
+        // TODO: these methods call the slow overloads of PrimitiveParser.TryParseXXX. Do we need fast path?
+        // TODO: these methods hardcode the format. Do we need this to be something that can be specified?
+        public bool TryParseBoolean(out bool value)
+        {
+            int consumed;
+            var unread = Unread;
+            if (PrimitiveParser.TryParseBoolean(unread, out value, out consumed, _encoding))
+            {
+                if (unread.Length > consumed)
+                {
+                    _currentSegmentIndex += consumed;
+                    return true;
+                }
+            }
+
+            unsafe
+            {
+                byte* temp = stackalloc byte[15];
+                var tempSpan = new Span<byte>(temp, 15);
+                var copied = CopyTo(tempSpan);
+
+                if (PrimitiveParser.TryParseBoolean(tempSpan.Slice(0, copied), out value, out consumed, _encoding))
+                {
+                    Advance(consumed);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool TryParseUInt64(out ulong value)
+        {
+            int consumed;
+            var unread = Unread;
+            if (PrimitiveParser.TryParseUInt64(unread, out value, out consumed, _encoding))
+            {
+                if (unread.Length > consumed)
+                {
+                    _currentSegmentIndex += consumed;
+                    return true;
+                }
+            }
+
+            unsafe
+            {
+                byte* temp = stackalloc byte[32];
+                var tempSpan = new Span<byte>(temp, 32);
+                var copied = CopyTo(tempSpan);
+
+                if (PrimitiveParser.TryParseUInt64(tempSpan.Slice(0, copied), out value, out consumed, _encoding, 'G'))
+                {
+                    Advance(consumed);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        #endregion
+    }
+}

--- a/src/System.Buffers.Experimental/System/Buffers/ReadOnlyBytes.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/ReadOnlyBytes.cs
@@ -16,6 +16,8 @@ namespace System.Buffers
         IReadOnlyMemoryList<byte> _rest;
         int _length;
 
+        static readonly ReadOnlyBytes s_empty = new ReadOnlyBytes(ReadOnlyMemory<byte>.Empty);
+
         public ReadOnlyBytes(ReadOnlyMemory<byte> first, IReadOnlyMemoryList<byte> rest, int length)
         {
             _rest = rest;
@@ -90,6 +92,8 @@ namespace System.Buffers
                 return _length;
             }
         }
+
+        public static ReadOnlyBytes Empty => s_empty;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlyBytes Slice(Range range)

--- a/tests/System.Buffers.Experimental.Tests/BytesReader.cs
+++ b/tests/System.Buffers.Experimental.Tests/BytesReader.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Buffers;
+using System.Collections.Sequences;
+using System.Text;
+using System.Text.Utf8;
+using Xunit;
+
+namespace System.Slices.Tests
+{
+    public partial class ReadOnlyBytesTests
+    {
+        [Fact]
+        public void SingleSegmentBytesReader()
+        {
+            ReadOnlyBytes bytes = Create("AB CD#EF&&");
+            var reader = new BytesReader(bytes);
+
+            var ab = reader.ReadBytesUntil((byte)' ');
+            Assert.Equal("AB", ab.ToString(TextEncoder.Utf8));
+
+            reader.Advance(1);
+            var cd = reader.ReadBytesUntil((byte)'#');
+            Assert.Equal("CD", cd.ToString(TextEncoder.Utf8));
+
+            reader.Advance(1);
+            var ef = reader.ReadBytesUntil(new byte[] { (byte)'&', (byte)'&' });
+            Assert.Equal("EF", ef.ToString(TextEncoder.Utf8));
+
+            reader.Advance(2);
+
+            Assert.True(reader.IsEmpty);
+        }
+
+        [Fact]
+        public void MultiSegmentBytesReaderNumbers()
+        {
+            ReadOnlyBytes bytes = Create(new byte[][] {
+                new byte[] { 0          },
+                new byte[] { 1, 2       },
+                new byte[] { 3, 4       },
+                new byte[] { 5, 6, 7, 8 },
+                new byte[] { 8          }
+            });
+
+            var reader = new BytesReader(bytes);
+
+            var value = reader.ReadBytesUntil(2).Value.ToSingleSpan();
+            Assert.Equal(0, value[0]);
+            Assert.Equal(1, value[1]);
+            reader.Advance(1);
+
+            value = reader.ReadBytesUntil(5).Value.ToSingleSpan();
+            Assert.Equal(3, value[0]);
+            Assert.Equal(4, value[1]);
+            reader.Advance(1);
+
+            value = reader.ReadBytesUntil(new byte[] { 8, 8 }).Value.ToSingleSpan();
+            Assert.Equal(6, value[0]);
+            Assert.Equal(7, value[1]);
+            reader.Advance(2);
+
+            Assert.True(reader.IsEmpty);
+        }
+
+        [Fact]
+        public void MultiSegmentBytesReader()
+        {
+            ReadOnlyBytes bytes = Parse("A|B |CD|#EF&|&");
+            var reader = new BytesReader(bytes);
+
+            var ab = reader.ReadBytesUntil((byte)' ');
+            Assert.Equal("AB", ab.ToString(TextEncoder.Utf8));
+
+            reader.Advance(1);
+            var cd = reader.ReadBytesUntil((byte)'#');
+            Assert.Equal("CD", cd.ToString(TextEncoder.Utf8));
+
+            reader.Advance(1);
+            var ef = reader.ReadBytesUntil(new byte[] { (byte)'&', (byte)'&' });
+            Assert.Equal("EF", ef.ToString(TextEncoder.Utf8));
+
+            reader.Advance(2);
+
+            Assert.True(reader.IsEmpty);
+        }
+
+        [Fact]
+        public void EmptyBytesReader()
+        {
+            ReadOnlyBytes bytes = Create("");
+            var reader = new BytesReader(bytes);
+            var found = reader.ReadBytesUntil((byte)' ');
+            Assert.Equal("", found.ToString(TextEncoder.Utf8));
+
+            bytes = Parse("|");
+            reader = new BytesReader(bytes);
+            found = reader.ReadBytesUntil((byte)' ');
+            Assert.Equal("", found.ToString(TextEncoder.Utf8));
+
+            Assert.True(reader.IsEmpty);
+        }
+
+        [Fact]
+        public void BytesReaderParse()
+        {
+            ulong u64;
+            bool b;
+
+            ReadOnlyBytes bytes = Parse("12|3Tr|ue|456Tr|ue7|89False|");
+            var reader = new BytesReader(bytes);
+
+            Assert.True(reader.TryParseUInt64(out u64));
+            Assert.Equal(123ul, u64);
+
+            Assert.True(reader.TryParseBoolean(out b));
+            Assert.Equal(true, b);
+
+            Assert.True(reader.TryParseUInt64(out u64));
+            Assert.Equal(456ul, u64);
+
+            Assert.True(reader.TryParseBoolean(out b));
+            Assert.Equal(true, b);
+
+            Assert.True(reader.TryParseUInt64(out u64));
+            Assert.Equal(789ul, u64);
+
+            Assert.True(reader.TryParseBoolean(out b));
+            Assert.Equal(false, b);
+
+            Assert.True(reader.IsEmpty);
+        }
+    }
+
+    public static class ReadOnlyBytesTextExtensions {
+
+        public static string ToString(this ReadOnlyBytes? bytes, TextEncoder encoder)
+        {
+            if (bytes == null) return "";
+            return ToString(bytes.Value, encoder);
+        }
+
+        public static string ToString(this ReadOnlyBytes bytes, TextEncoder encoder)
+        {
+            var sb = new StringBuilder();
+            if (encoder.Scheme == TextEncoder.Id.Utf8)
+            {
+                var position = Position.First;
+                ReadOnlyMemory<byte> segment;
+                while (bytes.TryGet(ref position, out segment))
+                {
+                    sb.Append(new Utf8String(segment.Span));
+                }
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Slices.Tests
 {
-    public class ReadOnlyBytesTests
+    public partial class ReadOnlyBytesTests
     {
         [Fact]
         public void ReadOnlyBytesBasics()
@@ -186,6 +186,27 @@ namespace System.Slices.Tests
                     current = current._rest;
                 }
                 current._first = buffer;
+            }
+            return new ReadOnlyBytes(first);
+        }
+
+        private ReadOnlyBytes Create(params string[] buffers)
+        {
+            MemoryListNode first = null;
+            MemoryListNode current = null;
+            foreach (var buffer in buffers)
+            {
+                if (first == null)
+                {
+                    current = new MemoryListNode();
+                    first = current;
+                }
+                else
+                {
+                    current._rest = new MemoryListNode();
+                    current = current._rest;
+                }
+                current._first = Encoding.UTF8.GetBytes(buffer);
             }
             return new ReadOnlyBytes(first);
         }


### PR DESCRIPTION
BytesReader can be used to implement higher level parsers (e.g. JSON parsers) of ReadOnlyBytes. 

The reader takes care of efficiently finding delimiters (single-byte or multi-byte) or parsing primitives contained in multi-segmented ReadOnlyBytes, even when the delimiter or the parsed primitive straddles multiple segments.