### PR TITLE
Added Multi-Segment HTTP Parser

### DIFF
--- a/samples/LowAllocationWebServer/Framework/HttpServer.cs
+++ b/samples/LowAllocationWebServer/Framework/HttpServer.cs
@@ -1,11 +1,15 @@
-﻿using Microsoft.Net.Sockets;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Net.Sockets;
 using System;
 using System.Buffers;
 using System.Diagnostics;
 using System.Text.Formatting;
-using System.Text.Http;
+using System.Text.Http.SingleSegment;
 using System.Text.Utf8;
 using System.Threading;
+using System.Text.Http;
 
 namespace Microsoft.Net.Http
 {
@@ -74,7 +78,7 @@ namespace Microsoft.Net.Http
             }
 
             var requestBytes = requestBuffer.Slice(0, requestByteCount);
-            var request = HttpRequest.Parse(requestBytes);
+            var request = HttpRequestSingleSegment.Parse(requestBytes);
             Log.LogRequest(request);
 
             using (var response = new HttpResponse(1024)) {
@@ -104,7 +108,7 @@ namespace Microsoft.Net.Http
             new ResponseFormatter(response.Headers).Append(HttpNewline);
         }
 
-        protected virtual void WriteResponseFor404(HttpRequest request, HttpResponse response) // Not Found
+        protected virtual void WriteResponseFor404(HttpRequestSingleSegment request, HttpResponse response) // Not Found
         {
             Log.LogMessage(Log.Level.Warning, "Request {0}, Response: 404 Not Found", request.RequestLine);
             WriteCommonHeaders(response, HttpVersion.V1_1, 404, "Not Found", false);
@@ -135,6 +139,6 @@ namespace Microsoft.Net.Http
             }
         }
 
-        protected abstract void WriteResponse(HttpRequest request, HttpResponse response);
+        protected abstract void WriteResponse(HttpRequestSingleSegment request, HttpResponse response);
     }
 }

--- a/samples/LowAllocationWebServer/Framework/Log.cs
+++ b/samples/LowAllocationWebServer/Framework/Log.cs
@@ -1,6 +1,10 @@
-﻿using System.IO;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
 using System.Text;
 using System.Text.Http;
+using System.Text.Http.SingleSegment;
 
 namespace System.Diagnostics
 {
@@ -79,7 +83,7 @@ namespace System.Diagnostics
 
     public static class HttpLogExtensions
     {
-        public static void LogRequest(this Log log, HttpRequest request)
+        public static void LogRequest(this Log log, HttpRequestSingleSegment request)
         {
             if (log.IsVerbose)
             {

--- a/samples/LowAllocationWebServer/Framework/RoutingTable.cs
+++ b/samples/LowAllocationWebServer/Framework/RoutingTable.cs
@@ -1,5 +1,9 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Text.Http;
+using System.Text.Http.SingleSegment;
 using System.Text.Utf8;
 
 namespace Microsoft.Net.Http
@@ -10,7 +14,7 @@ namespace Microsoft.Net.Http
         Utf8String[] _uris = new Utf8String[tablecapacity];
         TRequestId[] _requestIds = new TRequestId[tablecapacity];
         HttpMethod[] _verbs = new HttpMethod[tablecapacity];
-        Action<HttpRequest, HttpResponse>[] _handlers = new Action<HttpRequest, HttpResponse>[tablecapacity];
+        Action<HttpRequestSingleSegment, HttpResponse>[] _handlers = new Action<HttpRequestSingleSegment, HttpResponse>[tablecapacity];
         int _count;
 
         public TRequestId GetRequestId(HttpRequestLine requestLine)
@@ -21,7 +25,7 @@ namespace Microsoft.Net.Http
             return default(TRequestId);
         }
 
-        public bool TryHandle(HttpRequest request, HttpResponse response)
+        public bool TryHandle(HttpRequestSingleSegment request, HttpResponse response)
         {
             for (int i = 0; i < _count; i++) {
                 if (request.RequestLine.RequestUri.Equals(_uris[i]) && request.RequestLine.Method == _verbs[i]) {
@@ -32,7 +36,7 @@ namespace Microsoft.Net.Http
             return false;
         }
 
-        public void Add(HttpMethod method, Utf8String requestUri, TRequestId requestId, Action<HttpRequest, HttpResponse> handler = null)
+        public void Add(HttpMethod method, Utf8String requestUri, TRequestId requestId, Action<HttpRequestSingleSegment, HttpResponse> handler = null)
         {
             if (_count == tablecapacity) throw new NotImplementedException("ApiReoutingTable does not resize yet.");
             _uris[_count] = requestUri;
@@ -42,7 +46,7 @@ namespace Microsoft.Net.Http
             _count++;
         }
 
-        public void Add(HttpMethod method, string requestUri, TRequestId requestId, Action<HttpRequest, HttpResponse> handler = null)
+        public void Add(HttpMethod method, string requestUri, TRequestId requestId, Action<HttpRequestSingleSegment, HttpResponse> handler = null)
         {
             Add(method, new Utf8String(requestUri), requestId, handler);
         }

--- a/samples/LowAllocationWebServer/SampleRestServer.cs
+++ b/samples/LowAllocationWebServer/SampleRestServer.cs
@@ -5,9 +5,10 @@ using Microsoft.Net.Http;
 using System;
 using System.Diagnostics;
 using System.Text.Formatting;
-using System.Text.Http;
+using System.Text.Http.SingleSegment;
 using System.Text.Json;
 using System.Text.Utf8;
+using System.Text.Http;
 
 namespace LowAllocationWebServer
 {
@@ -29,7 +30,7 @@ namespace LowAllocationWebServer
             Apis.Add(HttpMethod.Post, "/json", Api.PostJson, WriteResponseForPostJson); // post body along the lines of: "{ "Count" = 3 }" 
         }
 
-        protected override void WriteResponse(HttpRequest request, HttpResponse response)
+        protected override void WriteResponse(HttpRequestSingleSegment request, HttpResponse response)
         {
             if (!Apis.TryHandle(request, response))
             {
@@ -37,7 +38,7 @@ namespace LowAllocationWebServer
             }
         }
 
-        void WriteResponseForPostJson(HttpRequest request, HttpResponse response)
+        void WriteResponseForPostJson(HttpRequestSingleSegment request, HttpResponse response)
         {
             // read request json
             int requestedCount;
@@ -72,7 +73,7 @@ namespace LowAllocationWebServer
             headers.AppendHttpNewLine();
         }
 
-        static void WriteResponseForHelloWorld(HttpRequest request, HttpResponse response)
+        static void WriteResponseForHelloWorld(HttpRequestSingleSegment request, HttpResponse response)
         {
             var body = new ResponseFormatter(response.Body);
             body.Append("Hello, World");
@@ -92,7 +93,7 @@ namespace LowAllocationWebServer
             headers.AppendHttpNewLine();
         }
 
-        static void WriteResponseForGetTime(HttpRequest request, HttpResponse response)
+        static void WriteResponseForGetTime(HttpRequestSingleSegment request, HttpResponse response)
         {
             var body = new ResponseFormatter(response.Body);
             body.Format(@"<html><head><title>Time</title></head><body>{0:O}</body></html>", DateTime.UtcNow);

--- a/src/System.Text.Http/System/Text/Http/HttpRequest.cs
+++ b/src/System.Text.Http/System/Text/Http/HttpRequest.cs
@@ -1,0 +1,211 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers;
+using System.Collections.Sequences;
+using System.Text.Formatting;
+using System.Text.Utf8;
+
+namespace System.Text.Http
+{
+    public struct HttpRequestLine
+    {
+        public HttpMethod Method;
+        public HttpVersion Version;
+        public Memory<byte> RequestUri;
+
+        public override string ToString()
+        {
+            return RequestUri.ToString();
+        }
+    }
+
+    public struct HttpRequest
+    {
+        internal static readonly byte[] Cr = new byte[] { (byte)'\r', (byte)'\n' };
+        internal static readonly byte[] Cr2 = new byte[] { (byte)'\r', (byte)'\n', (byte)'\r', (byte)'\n' };
+
+        internal ReadOnlyBytes Bytes;
+        internal Range _verb;
+        internal Range _path;
+        internal Range _version;
+        internal HttpHeaders _headers;
+        internal int _bodyIndex;
+
+        public ReadOnlyBytes Verb => Bytes.Slice(_verb);
+        public ReadOnlyBytes Path => Bytes.Slice(_path);
+        public ReadOnlyBytes Version => Bytes.Slice(_version);
+
+        public HttpHeaders Headers => _headers;
+
+        public int Body => _bodyIndex;
+
+        public static HttpRequest Parse(ReadOnlyBytes bytes)
+        {
+            var request = new HttpRequest();
+            request.Bytes = bytes;
+
+            var reader = new BytesReader(bytes);
+            Range? verb = reader.ReadRangeUntil((byte)' ');
+            request._verb = verb.Value;
+            reader.Advance(1);
+
+            Range? path = reader.ReadRangeUntil((byte)' ');
+            request._path = path.Value;
+            reader.Advance(1);
+
+            Range? version = reader.ReadRangeUntil(Cr);
+            request._version = version.Value;
+            reader.Advance(2);
+
+            var headers = reader.ReadRangeUntil(Cr2).Value;
+            request._headers = new HttpHeaders() { _headers = bytes.Slice(headers.Index, headers.Length + 2) };
+
+            request._bodyIndex = headers.Index + headers.Length + 4;
+            return request;
+        }
+    }
+
+    public struct HttpHeader
+    {
+        public ReadOnlyBytes Name; // TODO (pri 2): this is pretty wasteful; too many references to ReadOnlyBytes; we should store ranges only
+        public ReadOnlyBytes Value;
+
+        public void Deconstruct(out string name, out string value)
+        {
+            name = Name.ToString(TextEncoder.Utf8);
+            value = Value.ToString(TextEncoder.Utf8);
+        }
+
+        public void Deconstruct(out Utf8String name, out Utf8String value)
+        {
+            name = Name.ToUtf8String(TextEncoder.Utf8);
+            value = Value.ToUtf8String(TextEncoder.Utf8);
+        }
+    }
+
+    public struct HttpHeaders : ISequence<HttpHeader>
+    {
+        internal ReadOnlyBytes _headers;
+
+        public int? Length => null;
+
+        public bool TryGet(ref Position position, out HttpHeader value, bool advance = false)
+        {
+            var bytes = _headers.Slice(position.IntegerPosition);
+            if (bytes.Length == 0)
+            {
+                value = default(HttpHeader);
+                return false;
+            }
+
+            int consumed;
+            ParseHeader(bytes, out value, out consumed);
+            if (advance)
+            {
+                position.IntegerPosition += consumed;
+            }
+            return true;
+        }
+
+        static void ParseHeader(ReadOnlyBytes bytes, out HttpHeader value, out int consumed)
+        {
+            int indexOfValue = bytes.IndexOf((byte)':');
+            var headerName = bytes.Slice(0, indexOfValue);
+            var endOfValue = bytes.IndexOf(HttpRequest.Cr);
+            var headerValue = bytes.Slice(indexOfValue + 2, endOfValue - indexOfValue - 2);
+            value = new HttpHeader() { Name = headerName, Value = headerValue };
+            consumed = endOfValue + 2;
+        }
+
+        public override string ToString()
+        {
+            return _headers.ToString(TextEncoder.Utf8);
+        }
+    }
+
+    public enum HttpMethod : byte
+    {
+        Unknown = 0,
+        Other,
+        Get,
+        Post,
+        Put,
+        Delete,
+    }
+
+    public enum HttpVersion : byte
+    {
+        Unknown = 0,
+        Other,
+        V1_0,
+        V1_1,
+        V2_0,
+    }
+
+    // TODO: these should be improved and moved to System.Text.Primtives
+    public static class PrimitiveEncoder
+    {
+        public static string ToString(this ReadOnlyBytes? bytes, TextEncoder encoder)
+        {
+            if (bytes == null) return "";
+            return ToString(bytes.Value, encoder);
+        }
+
+        public static string ToString(this Memory<byte> bytes, TextEncoder encoder)
+        {
+            if (encoder.Scheme == TextEncoder.Id.Utf8)
+            {
+                return new Utf8String(bytes.Span).ToString();
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public static string ToString(this ReadOnlyBytes bytes, TextEncoder encoder)
+        {
+            var sb = new StringBuilder();
+            if (encoder.Scheme == TextEncoder.Id.Utf8)
+            {
+                var position = Position.First;
+                ReadOnlyMemory<byte> segment;
+                while (bytes.TryGet(ref position, out segment, true))
+                {
+                    sb.Append(new Utf8String(segment.Span));
+                }
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+            return sb.ToString();
+        }
+
+        public static Utf8String ToUtf8String(this ReadOnlyBytes? bytes, TextEncoder encoder)
+        {
+            if (bytes == null) return Utf8String.Empty;
+            return ToUtf8String(bytes.Value, encoder);
+        }
+
+        public static Utf8String ToUtf8String(this ReadOnlyBytes bytes, TextEncoder encoder)
+        {
+            var sb = new ArrayFormatter(bytes.ComputeLength(), EncodingData.InvariantUtf8);
+            if (encoder.Scheme == TextEncoder.Id.Utf8)
+            {
+                var position = Position.First;
+                ReadOnlyMemory<byte> segment;
+                while (bytes.TryGet(ref position, out segment, true))
+                {
+                    sb.Append(new Utf8String(segment.Span));
+                }
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+            return new Utf8String(sb.Formatted.Slice());
+        }
+    }
+}

--- a/src/System.Text.Http/System/Text/Http/IFormatterHttpExtensions.cs
+++ b/src/System.Text.Http/System/Text/Http/IFormatterHttpExtensions.cs
@@ -1,5 +1,7 @@
-﻿using System.Text.Formatting;
-using System.Text.Http;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Formatting;
 using System.Text.Utf8;
 
 namespace System.Text.Http

--- a/src/System.Text.Http/System/Text/Http/Obsolete/HttpHeaderBuffer.cs
+++ b/src/System.Text.Http/System/Text/Http/Obsolete/HttpHeaderBuffer.cs
@@ -1,6 +1,7 @@
-﻿using System.Text;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text.Http
+namespace System.Text.Http.SingleSegment
 { 
     public struct HttpHeaderBuffer
     {

--- a/src/System.Text.Http/System/Text/Http/Obsolete/HttpHeaders.cs
+++ b/src/System.Text.Http/System/Text/Http/Obsolete/HttpHeaders.cs
@@ -1,21 +1,24 @@
-﻿using System.Collections;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
 using System.Collections.Generic;
 using System.Text.Utf8;
 
-namespace System.Text.Http
+namespace System.Text.Http.SingleSegment
 {
-    public struct HttpHeaders : IEnumerable<KeyValuePair<Utf8String, Utf8String>>
+    public struct HttpHeadersSingleSegment : IEnumerable<KeyValuePair<Utf8String, Utf8String>>
     {
         private readonly Utf8String _headerString;
         private int _count;
         
-        public HttpHeaders(ReadOnlySpan<byte> bytes)
+        public HttpHeadersSingleSegment(ReadOnlySpan<byte> bytes)
         {
             _headerString = new Utf8String(bytes);
             _count = -1;
         }
 
-        public HttpHeaders(Utf8String headerString)
+        public HttpHeadersSingleSegment(Utf8String headerString)
         {
             _headerString = headerString;
             _count = -1;

--- a/tests/Benchmarks/E2EPipelineNoIO.cs
+++ b/tests/Benchmarks/E2EPipelineNoIO.cs
@@ -33,7 +33,33 @@ Accept-Language: en-US,en;q=0.8,it;q=0.6,ms;q=0.4
         {
             using (iteration.StartMeasurement())
             {
-                RawInMemoryHttpServer.Run(numberOfRequests, concurrentConnections, s_genericRequest, (request, response)=> {
+                RawInMemoryHttpServer.Run(numberOfRequests, concurrentConnections, s_genericRequest, (request, response) => {
+                    var formatter = new OutputFormatter<WritableBuffer>(response, EncodingData.InvariantUtf8);
+                    formatter.Append("HTTP/1.1 200 OK");
+                    formatter.Append("\r\nContent-Length: 13");
+                    formatter.Append("\r\nContent-Type: text/plain");
+                    formatter.Format("\r\nDate: {0:R}", DateTime.UtcNow);
+                    formatter.Append("Server: System.IO.Pipelines");
+                    formatter.Append("\r\n\r\n");
+
+                    // write body
+                    formatter.Append("Hello, World!");
+                });
+            }
+        }
+    }
+
+    [Benchmark]
+    [InlineData(1000, 256)]
+    [InlineData(1000, 1024)]
+    [InlineData(1000, 4096)]
+    private static void TechEmpowerHelloWorldNoIOSingleSegmentParser(int numberOfRequests, int concurrentConnections)
+    {
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement())
+            {
+                RawInMemoryHttpServer.RunSingleSegmentParser(numberOfRequests, concurrentConnections, s_genericRequest, (request, response)=> {
                     var formatter = new OutputFormatter<WritableBuffer>(response, EncodingData.InvariantUtf8);
                     formatter.Append("HTTP/1.1 200 OK");
                     formatter.Append("\r\nContent-Length: 13");

--- a/tests/Benchmarks/Helpers/Server.cs
+++ b/tests/Benchmarks/Helpers/Server.cs
@@ -1,7 +1,12 @@
-﻿using System.Diagnostics;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers;
+using System.Diagnostics;
 using System.Text;
 using System.Text.Formatting;
 using System.Text.Http;
+using System.Text.Http.SingleSegment;
 using System.Text.Utf8;
 using System.Threading.Tasks;
 
@@ -9,7 +14,7 @@ namespace System.IO.Pipelines.Samples
 {
     public static class RawInMemoryHttpServer
     {
-        public static void Run(int numberOfRequests, int concurrentConnections, byte[] requestPayload, Action<HttpRequest, WritableBuffer> writeResponse)
+        public static void RunSingleSegmentParser(int numberOfRequests, int concurrentConnections, byte[] requestPayload, Action<HttpRequestSingleSegment, WritableBuffer> writeResponse)
         {
             var factory = new PipelineFactory();
             var listener = new FakeListener(factory, concurrentConnections);
@@ -37,7 +42,7 @@ namespace System.IO.Pipelines.Samples
                             continue;
                         }
                         // Parse the input http request
-                        HttpRequest parsedRequest = HttpRequest.Parse(requestBytes);
+                        HttpRequestSingleSegment parsedRequest = HttpRequestSingleSegment.Parse(requestBytes);
 
                         // Writing directly to pooled buffers
                         var output = connection.Output.Alloc();
@@ -68,5 +73,65 @@ namespace System.IO.Pipelines.Samples
             listener.Dispose();
             factory.Dispose();
         }
+
+        public static void Run(int numberOfRequests, int concurrentConnections, byte[] requestPayload, Action<HttpRequest, WritableBuffer> writeResponse)
+        {
+            var factory = new PipelineFactory();
+            var listener = new FakeListener(factory, concurrentConnections);
+
+            listener.OnConnection(async connection => {
+                while (true)
+                {
+                    // Wait for data
+                    var result = await connection.Input.ReadAsync();
+                    ReadableBuffer input = result.Buffer;
+
+                    try
+                    {
+                        if (input.IsEmpty && result.IsCompleted)
+                        {
+                            // No more data
+                            break;
+                        }
+
+                        var requestBytes = input.First;
+
+                        if (requestBytes.Length != 492)
+                        {
+                            continue;
+                        }
+                        // Parse the input http request
+                        HttpRequest parsedRequest = HttpRequest.Parse(new ReadOnlyBytes(requestBytes));
+
+                        // Writing directly to pooled buffers
+                        var output = connection.Output.Alloc();
+                        writeResponse(parsedRequest, output);
+                        await output.FlushAsync();
+                    }
+                    catch (Exception e)
+                    {
+                        var istr = new Utf8String(input.First.Span).ToString();
+                        Debug.WriteLine(e.Message);
+                    }
+                    finally
+                    {
+                        // Consume the input
+                        connection.Input.Advance(input.End, input.End);
+                    }
+                }
+            });
+
+            var tasks = new Task[numberOfRequests];
+            for (int i = 0; i < numberOfRequests; i++)
+            {
+                tasks[i] = listener.ExecuteRequestAsync(requestPayload);
+            }
+
+            Task.WaitAll(tasks);
+
+            listener.Dispose();
+            factory.Dispose();
+        }
+
     }
 }

--- a/tests/System.Buffers.Experimental.Tests/BytesReader.cs
+++ b/tests/System.Buffers.Experimental.Tests/BytesReader.cs
@@ -35,7 +35,7 @@ namespace System.Slices.Tests
         [Fact]
         public void MultiSegmentBytesReaderNumbers()
         {
-            ReadOnlyBytes bytes = Create(new byte[][] {
+            ReadOnlyBytes bytes = ReadOnlyBytes.Create(new byte[][] {
                 new byte[] { 0          },
                 new byte[] { 1, 2       },
                 new byte[] { 3, 4       },

--- a/tests/System.Text.Http.Tests/GivenAnHttpHeaders.cs
+++ b/tests/System.Text.Http.Tests/GivenAnHttpHeaders.cs
@@ -1,7 +1,11 @@
-﻿using System.Collections;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using FluentAssertions;
 using Xunit;
 using System.Text.Utf8;
+using System.Text.Http;
+using System.Text.Http.SingleSegment;
 
 namespace System.Text.Http.Tests
 {
@@ -21,7 +25,7 @@ namespace System.Text.Http.Tests
 
         private const string HeaderWithoutCrlf = "Host: localhost:8080";
 
-        private HttpHeaders _httpHeaders;
+        private HttpHeadersSingleSegment _httpHeaders;
 
         public GivenAnHttpHeaders()
         {
@@ -36,7 +40,7 @@ namespace System.Text.Http.Tests
                 }
             }
 
-            _httpHeaders = new HttpHeaders(headers);
+            _httpHeaders = new HttpHeadersSingleSegment(headers);
         }
 
         [Fact]
@@ -87,7 +91,7 @@ namespace System.Text.Http.Tests
         [Fact]
         public void It_parsers_Utf8String_as_well()
         {
-            var httpHeader = new HttpHeaders(new Utf8String(new UTF8Encoding().GetBytes(HeadersString)));
+            var httpHeader = new HttpHeadersSingleSegment(new Utf8String(new UTF8Encoding().GetBytes(HeadersString)));
 
             httpHeader.Count.Should().Be(8);
         }
@@ -95,7 +99,7 @@ namespace System.Text.Http.Tests
         [Fact]
         public void String_without_column_throws_ArgumentException()
         {
-            var httpHeader = new HttpHeaders(new Utf8String(new UTF8Encoding().GetBytes(HeaderWithoutColumn)));
+            var httpHeader = new HttpHeadersSingleSegment(new Utf8String(new UTF8Encoding().GetBytes(HeaderWithoutColumn)));
 
             Action action = () => { var count = httpHeader.Count; }; 
 
@@ -105,7 +109,7 @@ namespace System.Text.Http.Tests
         [Fact]
         public void String_without_carriage_return_and_line_feed_throws_ArgumentException()
         {
-            var httpHeader = new HttpHeaders(new Utf8String(new UTF8Encoding().GetBytes(HeaderWithoutCrlf)));
+            var httpHeader = new HttpHeadersSingleSegment(new Utf8String(new UTF8Encoding().GetBytes(HeaderWithoutCrlf)));
 
             Action action = () => { var count = httpHeader.Count; };
 
@@ -116,10 +120,10 @@ namespace System.Text.Http.Tests
         public void CanParseBodylessRequest()
         {
             var request = new Utf8String("GET / HTTP/1.1\r\nConnection: close\r\n\r\n").CopyBytes().Slice();
-            var parsed = HttpRequest.Parse(request);
+            var parsed = HttpRequestSingleSegment.Parse(request);
             Assert.Equal(HttpMethod.Get, parsed.RequestLine.Method);
             Assert.Equal(HttpVersion.V1_1, parsed.RequestLine.Version);
-            Assert.Equal(new Utf8String("/"), parsed.RequestLine.RequestUri);
+            Assert.Equal("/", parsed.RequestLine.RequestUri.ToString(TextEncoder.Utf8));
             Assert.Equal(1, parsed.Headers.Count);
             Assert.Equal(0, parsed.Body.Length);
         } 

--- a/tests/System.Text.Http.Tests/GivenIFormatterExtensionsForHttp.cs
+++ b/tests/System.Text.Http.Tests/GivenIFormatterExtensionsForHttp.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Utf8;
 using FluentAssertions;
 using Xunit;
+using System.Text.Http.SingleSegment;
 
 namespace System.Text.Http.Tests
 {
@@ -39,79 +40,6 @@ namespace System.Text.Http.Tests
             result.Slice().SequenceEqual(_statusLineInBytes);
             _formatter.Clear();
         }
-
-        //[Fact]
-        //public void It_has_an_extension_method_to_write_headers()
-        //{
-        //    _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
-
-        //    var result = _formatter.Buffer;
-
-        //    result.Should().ContainInOrder(_headerInBytes);
-
-        //    ArrayPool<byte>.Shared.Return(result);
-        //}
-
-        //[Fact]
-        //public void It_is_possible_to_update_the_value_of_a_header()
-        //{
-        //    var httpHeaderBuffer = 
-        //        _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
-
-        //    httpHeaderBuffer.UpdateValue("open");
-
-        //    var result = _formatter.Buffer;
-
-        //    result.Should().ContainInOrder(_updatedHeaderInBytes);
-
-        //    ArrayPool<byte>.Shared.Return(result);
-        //}
-
-        //[Fact]
-        //public void It_is_possible_to_specify_a_number_of_reserve_bytes_when_writing_the_header_and_it_is_set_to_empty_space()
-        //{
-        //    _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"), 30);
-
-        //    var result = _formatter.Buffer;
-
-        //    result.Should().ContainInOrder(_headerInBytes);
-
-        //    var filledBytesCount = 30 - _headerInBytes.Length;
-        //    var fillingArray = new byte[filledBytesCount];            
-        //    for (var i = 0; i < filledBytesCount; i++)
-        //    {
-        //        fillingArray[i] = 32;
-        //    }
-
-        //    result.Should().ContainInOrder(_headerInBytes);
-        //    result.Should().ContainInOrder(fillingArray);
-
-        //    ArrayPool<byte>.Shared.Return(result);
-        //}
-
-        //[Fact]
-        //public void It_is_possible_to_use_the_reserve_to_write_a_header_value_with_more_characters_than_originally_set()
-        //{
-        //    var httpHeaderBuffer = 
-        //        _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
-
-        //    httpHeaderBuffer.UpdateValue("18446744073709551615");
-
-        //    var result = _formatter.Buffer;
-
-        //    result.Should().ContainInOrder(Utf8Encoding.GetBytes("Connection : 18446744073709551615\r\n"));
-        //}
-
-        //[Fact]
-        //public void HttpHeaderBuffer_UpdateValue_throws_an_exception_if_the_new_value_is_bigger_than_the_buffer_space()
-        //{
-        //    var httpHeaderBuffer = 
-        //        _formatter.WriteHttpHeader(GetUtf8EncodedString("Connection"), GetUtf8EncodedString("close"));
-
-        //    Action action = () => httpHeaderBuffer.UpdateValue("close18446744073709551615a");
-
-        //    action.ShouldThrow<ArgumentException>().WithMessage("newValue");
-        //}
 
         [Fact]
         public void The_http_extension_methods_can_be_composed_to_generate_the_http_message()

--- a/tests/System.Text.Http.Tests/HttpRequestTests.cs
+++ b/tests/System.Text.Http.Tests/HttpRequestTests.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers;
+using System.Collections.Generic;
+using System.Collections.Sequences;
+using System.Text;
+using System.Text.Http;
+using System.Text.Utf8;
+using Xunit;
+
+namespace System.Slices.Tests
+{
+    public partial class HttpRequestTests
+    {
+        [Fact]
+        public void HttpReaderSingleSegment()
+        {
+            var bytes = new ReadOnlyBytes(s_requestBytes);
+            HttpRequest request = HttpRequest.Parse(bytes);
+
+            Assert.Equal("GET", request.Verb.ToString(TextEncoder.Utf8));
+            Assert.Equal("/developer/documentation/data-insertion/r-sample-http-get", request.Path.ToString(TextEncoder.Utf8));
+            Assert.Equal("HTTP/1.1", request.Version.ToString(TextEncoder.Utf8));
+            var headers = request.Headers.ToString();
+            var body = bytes.Slice(request.Body).ToString(TextEncoder.Utf8);
+            Assert.Equal("Hello World", body);
+
+            HttpHeader header;
+            var position = Position.First;
+            while (request.Headers.TryGet(ref position, out header, true))
+            {
+                string name;
+                string value;
+                header.Deconstruct(out name, out value);
+                if (name == "Connection") Assert.Equal("keep-alive", value);
+            }
+        }
+
+        [Fact]
+        public void HttpReaderMultipleSegments()
+        {
+            ReadOnlyBytes bytes = s_segmentedRequest;
+            HttpRequest request = HttpRequest.Parse(bytes);
+
+            Assert.Equal("GET", request.Verb.ToString(TextEncoder.Utf8));
+            Assert.Equal("/developer/documentation/data-insertion/r-sample-http-get", request.Path.ToString(TextEncoder.Utf8));
+            Assert.Equal("HTTP/1.1", request.Version.ToString(TextEncoder.Utf8));
+            var headers = request.Headers.ToString();
+            var body = bytes.Slice(request.Body).ToString(TextEncoder.Utf8);
+            Assert.Equal("Hello World", body);
+
+            HttpHeader header;
+            var position = new Position();
+            while (request.Headers.TryGet(ref position, out header, true))
+            {
+                string name;
+                string value;
+                header.Deconstruct(out name, out value);
+                if (name == "Connection") Assert.Equal("keep-alive", value);
+            }
+        }
+
+        #region Test Data
+        ReadOnlyBytes s_segmentedRequest = Parse(s_requestStringSegmented);
+        private static ReadOnlyBytes Parse(string text)
+        {
+            var segments = text.Split('|');
+            var buffers = new List<byte[]>();
+            foreach (var segment in segments)
+            {
+                buffers.Add(Encoding.UTF8.GetBytes(segment));
+            }
+            return ReadOnlyBytes.Create(buffers.ToArray());
+        }
+
+        static byte[] s_requestBytes = Encoding.UTF8.GetBytes(@"GET /developer/documentation/data-insertion/r-sample-http-get HTTP/1.1
+Host: marketing.adobe.com
+Connection: keep-alive
+Cache-Control: max-age=0
+Upgrade-Insecure-Requests: 1
+User-Agent: corfxlab_pipleline
+
+Hello World");
+
+        static string s_requestStringSegmented = @"GE|T /developer/documen|tation/data-insertion/r-sample-http-get HT|TP/1.1
+Host: marketing.adobe.com
+Connection: keep-alive
+Cache-Control: max-age=0
+Upgrade-Insecure-Requests: 1
+User-Agent: corfxlab_pipleline
+
+Hello World";
+        #endregion
+    }
+}


### PR DESCRIPTION
The existing HTTP parser (HttpRequest.Parse) cannot parse payloads arriving in multiple buffers.
This change adds the ability to parse requests arriving in multiple-buffers. It uses BytesReader added yesterday to parse the HTTP payload.

The old single segment parser was moved to System.Text.Http.SingleSegment. I will remove it completely later.