### PR TITLE
EphemeralBuffers for Windows and Unix, where the memory won't be page…

### DIFF
--- a/src/System.Buffers.Experimental/Interop/Unix/Interop.Libraries.cs
+++ b/src/System.Buffers.Experimental/Interop/Unix/Interop.Libraries.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+internal static partial class Interop
+{
+    internal static partial class Libraries
+    {
+        internal const string SystemNative = "System.Native";
+    }
+}

--- a/src/System.Buffers.Experimental/Interop/Unix/System.Native/Interop.MLock.cs
+++ b/src/System.Buffers.Experimental/Interop/Unix/System.Native/Interop.MLock.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MLock", SetLastError = true)]
+        internal static extern int MLock(IntPtr addr, ulong len);
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MUnlock", SetLastError = true)]
+        internal static extern int MUnlock(IntPtr addr, ulong len);
+    }
+}

--- a/src/System.Buffers.Experimental/Interop/Unix/System.Native/Interop.MMap.cs
+++ b/src/System.Buffers.Experimental/Interop/Unix/System.Native/Interop.MMap.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+
+    internal static partial class Sys
+    {
+        [Flags]
+        internal enum MemoryMappedProtections
+        {
+            PROT_NONE = 0x0,
+            PROT_READ = 0x1,
+            PROT_WRITE = 0x2,
+            PROT_EXEC = 0x4
+        }
+
+        [Flags]
+        internal enum MemoryMappedFlags
+        {
+            MAP_SHARED = 0x01,
+            MAP_PRIVATE = 0x02,
+            MAP_ANONYMOUS = 0x10,
+        }
+
+        // NOTE: Shim returns null pointer on failure, not non-null MAP_FAILED sentinel.
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MMap", SetLastError = true)]
+        internal static extern IntPtr MMap(
+            IntPtr addr, ulong len, 
+            MemoryMappedProtections prot, MemoryMappedFlags flags,
+            IntPtr fd, long offset);
+    }
+}

--- a/src/System.Buffers.Experimental/Interop/Unix/System.Native/Interop.MUnmap.cs
+++ b/src/System.Buffers.Experimental/Interop/Unix/System.Native/Interop.MUnmap.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MUnmap", SetLastError = true)]
+        internal static extern int MUnmap(IntPtr addr, ulong len);
+    }
+}

--- a/src/System.Buffers.Experimental/Interop/Unix/System.Native/Interop.MemSet.cs
+++ b/src/System.Buffers.Experimental/Interop/Unix/System.Native/Interop.MemSet.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MemSet")]
+        internal static extern unsafe void* MemSet(void *s, int c, UIntPtr n);
+    }
+}

--- a/src/System.Buffers.Experimental/Interop/Unix/System.Native/Interop.SysConf.cs
+++ b/src/System.Buffers.Experimental/Interop/Unix/System.Native/Interop.SysConf.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        internal enum SysConfName
+        {
+            _SC_CLK_TCK = 1,
+            _SC_PAGESIZE = 2,
+            _SC_NPROCESSORS_ONLN = 3,
+        }
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SysConf", SetLastError = true)]
+        internal static extern long SysConf(SysConfName name);
+    }
+}

--- a/src/System.Buffers.Experimental/Interop/Unix/Windows/Interop.Libraries.cs
+++ b/src/System.Buffers.Experimental/Interop/Unix/Windows/Interop.Libraries.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+internal static partial class Interop
+{ 
+    internal static partial class Libraries
+    {
+        internal const string Kernel32 = "Kernel32.dll";
+    }
+}

--- a/src/System.Buffers.Experimental/Interop/Unix/Windows/Kernel32/Interop.GetSystemInfo.cs
+++ b/src/System.Buffers.Experimental/Interop/Unix/Windows/Kernel32/Interop.GetSystemInfo.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32)]
+        internal extern static void GetSystemInfo(out SYSTEM_INFO lpSystemInfo);
+    }
+}

--- a/src/System.Buffers.Experimental/Interop/Unix/Windows/Kernel32/Interop.MemOptions.cs
+++ b/src/System.Buffers.Experimental/Interop/Unix/Windows/Kernel32/Interop.MemOptions.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        internal partial class MemOptions
+        {
+            internal const int MEM_COMMIT = 0x1000;
+            internal const int MEM_RESERVE = 0x2000;
+        }
+
+        internal const int INVALID_FILE_SIZE = -1;
+
+        internal partial class PageOptions
+        {
+            internal const int PAGE_READWRITE = 0x04;
+            internal const int PAGE_READONLY = 0x02;
+            internal const int PAGE_WRITECOPY = 0x08;
+            internal const int PAGE_EXECUTE_READ = 0x20;
+            internal const int PAGE_EXECUTE_READWRITE = 0x40;
+        }
+
+        internal partial class FileMapOptions
+        {
+            internal const int FILE_MAP_COPY = 0x0001;
+            internal const int FILE_MAP_WRITE = 0x0002;
+            internal const int FILE_MAP_READ = 0x0004;
+            internal const int FILE_MAP_EXECUTE = 0x0020;
+        }
+
+    }
+}

--- a/src/System.Buffers.Experimental/Interop/Unix/Windows/Kernel32/Interop.RtlZeroMemory.cs
+++ b/src/System.Buffers.Experimental/Interop/Unix/Windows/Kernel32/Interop.RtlZeroMemory.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32)]
+        internal extern static void RtlZeroMemory(IntPtr ptr, UIntPtr cnt);
+    }
+}

--- a/src/System.Buffers.Experimental/Interop/Unix/Windows/Kernel32/Interop.SYSTEM_INFO.cs
+++ b/src/System.Buffers.Experimental/Interop/Unix/Windows/Kernel32/Interop.SYSTEM_INFO.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SYSTEM_INFO
+        {
+            internal ushort wProcessorArchitecture;
+            internal ushort wReserved;
+            internal int dwPageSize;
+            internal IntPtr lpMinimumApplicationAddress;
+            internal IntPtr lpMaximumApplicationAddress;
+            internal IntPtr dwActiveProcessorMask;
+            internal int dwNumberOfProcessors;
+            internal int dwProcessorType;
+            internal int dwAllocationGranularity;
+            internal short wProcessorLevel;
+            internal short wProcessorRevision;
+        }
+
+        internal enum ProcessorArchitecture : ushort
+        {
+            Processor_Architecture_INTEL = 0,
+            Processor_Architecture_ARM = 5,
+            Processor_Architecture_IA64 = 6,
+            Processor_Architecture_AMD64 = 9,
+            Processor_Architecture_ARM64 = 12,
+            Processor_Architecture_UNKNOWN = 0xFFFF
+        }
+    }
+}

--- a/src/System.Buffers.Experimental/Interop/Unix/Windows/Kernel32/Interop.VirtualAlloc.cs
+++ b/src/System.Buffers.Experimental/Interop/Unix/Windows/Kernel32/Interop.VirtualAlloc.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, EntryPoint = "VirtualAlloc", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal extern static IntPtr VirtualAlloc(IntPtr lpAddress, UIntPtr dwSize, int flAllocationType, int flProtect);
+    }
+}

--- a/src/System.Buffers.Experimental/Interop/Unix/Windows/Kernel32/Interop.VirtualFree.cs
+++ b/src/System.Buffers.Experimental/Interop/Unix/Windows/Kernel32/Interop.VirtualFree.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
+        internal extern static bool VirtualFree(IntPtr lpAddress, UIntPtr dwSize, int dwFreeType);
+    }
+}

--- a/src/System.Buffers.Experimental/Interop/Unix/Windows/Kernel32/Interop.VirtualLock.cs
+++ b/src/System.Buffers.Experimental/Interop/Unix/Windows/Kernel32/Interop.VirtualLock.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class Kernel32
+    {
+        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
+        internal extern static bool VirtualLock(IntPtr lpAddress, UIntPtr dwSize);
+    }
+}

--- a/src/System.Buffers.Experimental/System/Buffers/EphemeralBufferUnix.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/EphemeralBufferUnix.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using static Interop.Sys;
+
+namespace System.Buffers.Experimental.System.Buffers
+{
+    public class EphemeralBufferUnix
+    {
+        private IntPtr _memory;
+        private int _bufferCount;
+        private int _bufferSize;
+        private ConcurrentQueue<SecureMemory> _buffers = new ConcurrentQueue<SecureMemory>();
+        private long _totalAllocated;
+        private byte[] _emptyData;
+
+        public EphemeralBufferUnix(int bufferSize, int bufferCount)
+        {
+            if (bufferSize < 1) throw new ArgumentOutOfRangeException(nameof(bufferSize));
+            if (bufferCount < 1) throw new ArgumentOutOfRangeException(nameof(bufferSize));
+
+            var pageSize = SysConf(SysConfName._SC_PAGESIZE);
+            if (pageSize < 0)
+            {
+                ThrowHelper.ThrowInvalidOperationException();
+            }
+            _emptyData = new byte[bufferSize];
+            var pages = (int)Math.Ceiling((bufferCount * bufferSize) / (double)pageSize);
+            _totalAllocated = pages * pageSize;
+            _bufferCount = (int)_totalAllocated / bufferSize;
+            _bufferSize = bufferSize;
+            _memory = MMap(IntPtr.Zero, (ulong)_totalAllocated, MemoryMappedProtections.PROT_READ | MemoryMappedProtections.PROT_WRITE, MemoryMappedFlags.MAP_PRIVATE | MemoryMappedFlags.MAP_ANONYMOUS, new IntPtr(-1), 0);
+            if (_memory.ToInt64() < 0)
+            {
+                ThrowHelper.ThrowInvalidOperationException();
+            }
+            if (MLock(_memory, (ulong)_totalAllocated) < 0)
+            {
+                ThrowHelper.ThrowInvalidOperationException();
+            }
+
+            for (var i = 0; i < _totalAllocated; i += bufferSize)
+            {
+                var mem = new SecureMemory(IntPtr.Add(_memory, i), bufferSize);
+                _buffers.Enqueue(mem);
+            }
+        }
+
+        sealed class SecureMemory : OwnedMemory<byte>
+        {
+            public SecureMemory(IntPtr memory, int length) : base(null, 0, length, memory)
+            { }
+            internal bool Rented;
+            public new IntPtr Pointer => base.Pointer;
+        }
+
+        public unsafe void Dispose()
+        {
+            MemSet((void*)_memory, 0, (UIntPtr)_totalAllocated);
+            if (MUnmap(_memory, (ulong)_totalAllocated) < 0)
+            {
+                Debug.Assert(false,"Didn't let go of the memory");
+            }
+            GC.SuppressFinalize(this);
+        }
+
+        ~EphemeralBufferUnix()
+        {
+            Dispose();
+        }
+    }
+}

--- a/src/System.Buffers.Experimental/System/Buffers/EphemeralBufferUnix.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/EphemeralBufferUnix.cs
@@ -13,7 +13,7 @@ namespace System.Buffers.Experimental.System.Buffers
         private IntPtr _memory;
         private int _bufferCount;
         private int _bufferSize;
-        private ConcurrentQueue<SecureMemory> _buffers = new ConcurrentQueue<SecureMemory>();
+        private ConcurrentQueue<EphemeralMemory> _buffers = new ConcurrentQueue<EphemeralMemory>();
         private long _totalAllocated;
         private byte[] _emptyData;
 
@@ -44,14 +44,14 @@ namespace System.Buffers.Experimental.System.Buffers
 
             for (var i = 0; i < _totalAllocated; i += bufferSize)
             {
-                var mem = new SecureMemory(IntPtr.Add(_memory, i), bufferSize);
+                var mem = new EphemeralMemory(IntPtr.Add(_memory, i), bufferSize);
                 _buffers.Enqueue(mem);
             }
         }
 
-        sealed class SecureMemory : OwnedMemory<byte>
+        sealed class EphemeralMemory : OwnedMemory<byte>
         {
-            public SecureMemory(IntPtr memory, int length) : base(null, 0, length, memory)
+            public EphemeralMemory(IntPtr memory, int length) : base(null, 0, length, memory)
             { }
             internal bool Rented;
             public new IntPtr Pointer => base.Pointer;

--- a/src/System.Buffers.Experimental/System/Buffers/EphemeralBufferWindows.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/EphemeralBufferWindows.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using static Interop.Kernel32;
+
+namespace System.Buffers.Experimental.System.Buffers
+{
+    public class EphemeralBufferWindows
+    {
+        private IntPtr _memory;
+        private int _bufferCount;
+        private int _bufferSize;
+        private ConcurrentQueue<SecureMemory> _buffers = new ConcurrentQueue<SecureMemory>();
+        private UIntPtr _totalAllocated;
+        private byte[] _emptyData;
+
+        public EphemeralBufferWindows(int bufferSize, int bufferCount)
+        {
+            if (bufferSize < 1) throw new ArgumentOutOfRangeException(nameof(bufferSize));
+            if (bufferCount < 1) throw new ArgumentOutOfRangeException(nameof(bufferSize));
+
+            _emptyData = new byte[bufferSize];
+            SYSTEM_INFO sysInfo;
+            GetSystemInfo(out sysInfo);
+            var pages = (int)Math.Ceiling((bufferCount * bufferSize) / (double)sysInfo.dwPageSize);
+            var totalAllocated = pages * sysInfo.dwPageSize;
+            _bufferCount = totalAllocated / bufferSize;
+            _bufferSize = bufferSize;
+            _totalAllocated = new UIntPtr((uint)totalAllocated);
+
+            _memory = VirtualAlloc(IntPtr.Zero, _totalAllocated, MemOptions.MEM_COMMIT | MemOptions.MEM_RESERVE, PageOptions.PAGE_READWRITE);
+            VirtualLock(_memory, _totalAllocated);
+            for (var i = 0; i < totalAllocated; i += bufferSize)
+            {
+                var mem = new SecureMemory(IntPtr.Add(_memory, i), bufferSize);
+                _buffers.Enqueue(mem);
+            }
+        }
+
+        public OwnedMemory<byte> Rent()
+        {
+            SecureMemory returnValue;
+            if (!_buffers.TryDequeue(out returnValue))
+            {
+                ThrowHelper.ThrowInvalidOperationException();
+            }
+            returnValue.Rented = true;
+            return returnValue;
+        }
+
+        public void Return(OwnedMemory<byte> buffer)
+        {
+            var buffer2 = buffer as SecureMemory;
+            if (buffer2 == null)
+            {
+                Debug.Assert(false,"Buffer was empty");
+                return;
+            }
+            Debug.Assert(buffer2.Rented, "Returning a buffer that isn't rented!");
+            if (!buffer2.Rented)
+            {
+                return;
+            }
+            buffer2.Rented = false;
+            _emptyData.CopyTo(buffer.Span);
+            _buffers.Enqueue(buffer2);
+        }
+
+        sealed class SecureMemory : OwnedMemory<byte>
+        {
+            public SecureMemory(IntPtr memory, int length) : base(null, 0, length, memory)
+            { }
+            internal bool Rented;
+            public new IntPtr Pointer => base.Pointer;
+        }
+
+        public unsafe void Dispose()
+        {
+            RtlZeroMemory(_memory, _totalAllocated);
+            VirtualFree(_memory, _totalAllocated, 0x8000);
+            GC.SuppressFinalize(this);
+        }
+
+        ~EphemeralBufferWindows()
+        {
+            Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Why ? 

Well storing perm secrets should be done on things like TPM's, however for items like session keys it is normally okay to store them unencrypted in memory. However perfect forward secrecy for instance can be badly compromised if the memory is paged out to disk, as it can hang around for a long time and is easier to attack than crossing into a processes memory space.