### PR TITLE
Minor changes/fixes of typos/etc.

### DIFF
--- a/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs
@@ -134,12 +134,11 @@ namespace System.Text.Utf8
                 codePoint = default(uint);
                 return false;
             }
-
-            // ROBERT: The values in the masks below look wrong. Need to validate.
+            
             switch (bytesConsumed)
             {
                 case 1:
-                    codePoint = (uint)(first & b0111_1111U);
+                    codePoint = first;
                     break;
 
                 case 2:

--- a/tests/System.Text.Primitives.Tests/Encoding/Utf8EncoderTests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/Utf8EncoderTests.cs
@@ -119,7 +119,7 @@ namespace System.Text.Utf8.Tests
         [Theory, MemberData("Encoders")]
         public void BruteTestingRoundtripEncodeDecodeAllUnicodeCodePoints(TextEncoder encoder)
         {
-            const uint maximumValidCodePoint = 5;//0x10FFFF;
+            const uint maximumValidCodePoint = 0x10FFFF;
             uint[] expectedCodePoints = new uint[maximumValidCodePoint + 1];
             for (uint i = 0; i <= maximumValidCodePoint; i++)
             {


### PR DESCRIPTION
- removed redundant op
- removed comment, correction validated
- changed back typo in test