### PR TITLE
Remove the single char variant of TryEncode from TextEncoder

### DIFF
--- a/src/System.Text.Formatting/System/Text/Formatting/IOutputExtensions.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/IOutputExtensions.cs
@@ -84,10 +84,19 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, char value, EncodingData encoding) where TFormatter : IOutput
         {
+            int consumed;
             int bytesWritten;
-            if (!encoding.TextEncoder.TryEncode(value, formatter.Buffer, out bytesWritten)) {
-                return false;
+
+            unsafe
+            {
+                ReadOnlySpan<char> charSpan = new ReadOnlySpan<char>(&value, 1);
+
+                if (!encoding.TextEncoder.TryEncode(charSpan, formatter.Buffer, out consumed, out bytesWritten))
+                {
+                    return false;
+                }
             }
+
             formatter.Advance(bytesWritten);
             return true;
         }

--- a/src/System.Text.Formatting/System/Text/Formatting/ITextOutputExtensions.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/ITextOutputExtensions.cs
@@ -170,10 +170,19 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, char value) where TFormatter : ITextOutput
         {
+            int consumed;
             int bytesWritten;
-            if (!formatter.Encoding.TextEncoder.TryEncode(value, formatter.Buffer, out bytesWritten)) {
-                return false;
+
+            unsafe
+            {
+                ReadOnlySpan<char> charSpan = new ReadOnlySpan<char>(&value, 1);
+
+                if (!formatter.Encoding.TextEncoder.TryEncode(charSpan, formatter.Buffer, out consumed, out bytesWritten))
+                {
+                    return false;
+                }
             }
+
             formatter.Advance(bytesWritten);
             return true;
         }

--- a/src/System.Text.Json.Dynamic/System/Text/Json/JsonDynamicObject.cs
+++ b/src/System.Text.Json.Dynamic/System/Text/Json/JsonDynamicObject.cs
@@ -335,7 +335,7 @@ namespace System.Text.Json
     static class Utf8StringExtensions
     {
         private static readonly char[] EncodingChars = new char[] { '"' };
-        private static readonly ReadOnlySpan<char> QuoteSpan = new ReadOnlySpan<char>(EncodingChars, 4, 1);
+        private static readonly ReadOnlySpan<char> QuoteSpan = new ReadOnlySpan<char>(EncodingChars, 0, 1);
 
         // TODO: this should be properly implemented 
         // currently it handles formatting to UTF8 only.

--- a/src/System.Text.Json.Dynamic/project.json
+++ b/src/System.Text.Json.Dynamic/project.json
@@ -17,6 +17,7 @@
     "requireLicenseAcceptance": true
   },
   "buildOptions": {
+    "allowUnsafe": true,
     "keyFile": "../../tools/Key.snk",
     "compile": {
       "include": [ "System/**/*.cs" ],

--- a/src/System.Text.Primitives/System/Text/Formatting/PrimitiveFormatter_uuid.cs
+++ b/src/System.Text.Primitives/System/Text/Formatting/PrimitiveFormatter_uuid.cs
@@ -145,12 +145,20 @@ namespace System.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static bool TryWriteChar(char character, Span<byte> buffer, ref int bytesWritten, EncodingData encoding)
         {
+            int consumed;
             int written;
-            if (!encoding.TextEncoder.TryEncode(character, buffer.Slice(bytesWritten), out written))
+
+            unsafe
             {
-                bytesWritten = 0;
-                return false;
+                ReadOnlySpan<char> charSpan = new ReadOnlySpan<char>(&character, 1);
+
+                if (!encoding.TextEncoder.TryEncode(charSpan, buffer.Slice(bytesWritten), out consumed, out written))
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
             }
+
             bytesWritten += written;
             return true;
         }

--- a/src/System.Text.Primitives/System/Text/TextEncoding.cs
+++ b/src/System.Text.Primitives/System/Text/TextEncoding.cs
@@ -160,34 +160,5 @@ namespace System.Text {
         public abstract bool TryEncode(string text, Span<byte> encodedBytes, out int bytesWritten);
 
         #endregion Encode Methods
-
-        #region Extensions / helpers
-
-        /// <summary>
-        /// Encode a single UTF-16 character into a byte sequence that is relative to the concrete TextEncoder being called.
-        /// 
-        /// NOTE: This code will not work in the case where the character being encoded is a surrogate and another character is
-        ///       needed to complete encoding.
-        /// </summary>
-        /// <param name="value">The character to encode.</param>
-        /// <param name="data">A buffer to write the encoded sequence of bytes.</param>
-        /// <param name="bytesWritten">An output parameter to capture the number of bytes written to <paramref name="data"/>.</param>
-        /// <returns>
-        /// True if successfully able to encode the character and there was enough buffer space to write the sequence of
-        /// bytes, else false.
-        /// </returns>
-        public bool TryEncode(char value, Span<byte> data, out int bytesWritten)
-        {
-            // TODO: This might be better as an extension method.
-            unsafe
-            {
-                var stackSpan = new ReadOnlySpan<char>(&value, 1);
-
-                int consumed;
-                return TryEncode(stackSpan, data, out consumed, out bytesWritten);
-            }
-        }
-
-        #endregion Extensions / helpers
     }
 }

--- a/tests/System.Text.Formatting.Tests/CustomTypeFormatting.cs
+++ b/tests/System.Text.Formatting.Tests/CustomTypeFormatting.cs
@@ -21,8 +21,10 @@ namespace System.Text.Formatting.Tests
 
         public bool TryFormat(Span<byte> buffer, out int bytesWritten, TextFormat format, EncodingData encoding)
         {
-            if (!PrimitiveFormatter.TryFormat(_age, buffer, out bytesWritten, format, encoding)) return false;
-
+            if (!PrimitiveFormatter.TryFormat(_age, buffer, out bytesWritten, format, encoding))
+            {
+                return false;
+            }
 
             char symbol = _inMonths ? 'm' : 'y';
             int consumed;
@@ -31,7 +33,10 @@ namespace System.Text.Formatting.Tests
             unsafe
             {
                 ReadOnlySpan<char> symbolSpan = new ReadOnlySpan<char>(&symbol, 1);
-                if (!encoding.TextEncoder.TryEncode(symbolSpan, buffer.Slice(bytesWritten), out consumed, out symbolBytes)) return false;
+                if (!encoding.TextEncoder.TryEncode(symbolSpan, buffer.Slice(bytesWritten), out consumed, out symbolBytes))
+                {
+                    return false;
+                }
             }
 
             bytesWritten += symbolBytes;
@@ -53,7 +58,8 @@ namespace System.Text.Formatting.Tests
         {
             byte[] buffer = new byte[1024];
             MemoryStream stream = new MemoryStream(buffer);
-            using(var writer = new StreamFormatter(stream, pool)) {
+            using (var writer = new StreamFormatter(stream, pool))
+            {
                 writer.Append(new Age(56));
                 writer.Append(new Age(14, inMonths: true));
 
@@ -67,7 +73,8 @@ namespace System.Text.Formatting.Tests
         {
             byte[] buffer = new byte[1024];
             MemoryStream stream = new MemoryStream(buffer);
-            using(var writer = new StreamFormatter(stream, EncodingData.InvariantUtf8, pool)) {
+            using (var writer = new StreamFormatter(stream, EncodingData.InvariantUtf8, pool))
+            {
                 writer.Append(new Age(56));
                 writer.Append(new Age(14, inMonths: true));
                 var writtenText = Encoding.UTF8.GetString(buffer, 0, (int)stream.Position);

--- a/tests/System.Text.Formatting.Tests/CustomTypeFormatting.cs
+++ b/tests/System.Text.Formatting.Tests/CustomTypeFormatting.cs
@@ -25,8 +25,14 @@ namespace System.Text.Formatting.Tests
 
 
             char symbol = _inMonths ? 'm' : 'y';
+            int consumed;
             int symbolBytes;
-            if (!encoding.TextEncoder.TryEncode(symbol, buffer.Slice(bytesWritten), out symbolBytes)) return false;
+
+            unsafe
+            {
+                ReadOnlySpan<char> symbolSpan = new ReadOnlySpan<char>(&symbol, 1);
+                if (!encoding.TextEncoder.TryEncode(symbolSpan, buffer.Slice(bytesWritten), out consumed, out symbolBytes)) return false;
+            }
 
             bytesWritten += symbolBytes;
             return true;


### PR DESCRIPTION
Removing this variant force people to think about whether they really want to encode a single character. We could consider an extension method outside System.Text.Primitives core code base. For now, most of the users were in prototypes, tests, or somewhere that wrapping the "unsafe" portion was easy.