### PR TITLE
Added some APIs to HTTP parser

### DIFF
--- a/src/System.Text.Http/System/Text/Http/HttpRequest.cs
+++ b/src/System.Text.Http/System/Text/Http/HttpRequest.cs
@@ -35,10 +35,10 @@ namespace System.Text.Http
         public ReadOnlyBytes Verb => Bytes.Slice(_verb);
         public ReadOnlyBytes Path => Bytes.Slice(_path);
         public ReadOnlyBytes Version => Bytes.Slice(_version);
-
         public HttpHeaders Headers => _headers;
-
-        public int Body => _bodyIndex;
+        public ReadOnlyBytes Body => Bytes.Slice(_bodyIndex);
+        
+        public int BodyIndex => _bodyIndex;
 
         public static HttpRequest Parse(ReadOnlyBytes bytes)
         {

--- a/tests/System.Text.Http.Tests/HttpRequestTests.cs
+++ b/tests/System.Text.Http.Tests/HttpRequestTests.cs
@@ -23,7 +23,7 @@ namespace System.Slices.Tests
             Assert.Equal("/developer/documentation/data-insertion/r-sample-http-get", request.Path.ToString(TextEncoder.Utf8));
             Assert.Equal("HTTP/1.1", request.Version.ToString(TextEncoder.Utf8));
             var headers = request.Headers.ToString();
-            var body = bytes.Slice(request.Body).ToString(TextEncoder.Utf8);
+            var body = bytes.Slice(request.BodyIndex).ToString(TextEncoder.Utf8);
             Assert.Equal("Hello World", body);
 
             HttpHeader header;
@@ -47,7 +47,7 @@ namespace System.Slices.Tests
             Assert.Equal("/developer/documentation/data-insertion/r-sample-http-get", request.Path.ToString(TextEncoder.Utf8));
             Assert.Equal("HTTP/1.1", request.Version.ToString(TextEncoder.Utf8));
             var headers = request.Headers.ToString();
-            var body = bytes.Slice(request.Body).ToString(TextEncoder.Utf8);
+            var body = bytes.Slice(request.BodyIndex).ToString(TextEncoder.Utf8);
             Assert.Equal("Hello World", body);
 
             HttpHeader header;


### PR DESCRIPTION
I am porting samples to new multi-segment parsers and I discovered some APIs missing.
I need them to finish the port.