### PR TITLE
Update System.Time to target NET45 also

### DIFF
--- a/src/System.Time/project.json
+++ b/src/System.Time/project.json
@@ -25,12 +25,20 @@
       }
     }
   },
-  "dependencies": {
-    "NETStandard.Library": "1.6.0",
-    "System.Diagnostics.Contracts": "4.0.1",
-    "System.Xml.ReaderWriter": "4.0.11"
-  },
   "frameworks": {
-    "netstandard1.3": { }
+    "netstandard1.3": {
+      "dependencies": {
+        "System.Diagnostics.Contracts": "4.0.1",
+        "System.Diagnostics.Debug": "4.0.11",
+        "System.Resources.ResourceManager": "4.0.1",
+        "System.Text.RegularExpressions": "4.1.0",
+        "System.Xml.ReaderWriter": "4.0.11"
+      }
+    },
+    "net45": {
+      "frameworkAssemblies": {
+        "System.Xml" : "4.0.0.0"
+      }
+    }
   }
 }


### PR DESCRIPTION
This updates the `System.Time` package to include a NET45 target.  It also removes the dependency on the full `NETStandard.Library`, and instead targets the minimum versions of the specific dependencies needed.

Note that reducing to a lower netstandard version is not possible, because APIs like `IXmlSerializable` are not available until netstandard 1.3.