### PR TITLE
Optimized Memory<T> Access

### DIFF
--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -15,11 +15,7 @@ namespace System
         int _index;
         int _length;
 
-        internal Memory(OwnedMemory<T> owner, long id)
-            : this(owner, id, 0, owner.GetSpanInternal(id).Length)
-        { }
-
-        private Memory(OwnedMemory<T> owner, long id, int index, int length)
+        internal Memory(OwnedMemory<T> owner, long id, int index, int length)
         {
             _owner = owner;
             _id = id;
@@ -53,7 +49,7 @@ namespace System
             return new Memory<T>(_owner, _id, _index + index, length);
         }
 
-        public Span<T> Span => _owner.GetSpanInternal(_id).Slice(_index, _length);
+        public Span<T> Span => _owner.GetSpanInternal(_id, _index, _length);
 
         public DisposableReservation<T> Reserve() => new DisposableReservation<T>(_owner, _id);
 

--- a/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
@@ -14,10 +14,6 @@ namespace System
         int _index;
         int _length;
 
-        internal ReadOnlyMemory(OwnedMemory<T> owner, long id)
-            : this(owner, id, 0, owner.GetSpanInternal(id).Length)
-        { }
-
         internal ReadOnlyMemory(OwnedMemory<T> owner, long id, int index, int length)
         {
             _owner = owner;
@@ -47,7 +43,7 @@ namespace System
             return new ReadOnlyMemory<T>(_owner, _id, _index + index, length);
         }
 
-        public ReadOnlySpan<T> Span => _owner.GetSpanInternal(_id).Slice(_index, _length);
+        public ReadOnlySpan<T> Span => _owner.GetSpanInternal(_id, _index, _length);
 
         public DisposableReservation<T> Reserve()
         {

--- a/tests/System.Buffers.Experimental.Tests/BytesReader.cs
+++ b/tests/System.Buffers.Experimental.Tests/BytesReader.cs
@@ -10,7 +10,7 @@ namespace System.Slices.Tests
 {
     public partial class ReadOnlyBytesTests
     {
-        [Fact(Skip = "[VS2017] Error: The active Test Run was aborted.")]
+        [Fact]
         public void SingleSegmentBytesReader()
         {
             ReadOnlyBytes bytes = Create("AB CD#EF&&");


### PR DESCRIPTION
At the standup today, we talked about how accessing Span from Memory from Memory from OwnedMemory shows in profiles. I spent some thine looking at what we do in these code paths, and there are some obvious inefficiencies.  

a) Getting Span from Memory first creates a full Span for the OwnedMemory and then slices the Span to get Span corresponding to Memory's subrange. This change eliminates this slicing.
b) Getting Memory from OwnedMemory is done by passing OwnedMemory to Memory ctor. The ctor then gets Span out of OwnedMemory to determine the length of itself. This change eliminates the need to get the Span by calling a different Memory ctor that explicitly takes length parameter.

Unfortunately I cannot compare perf wins as out perf benchmarks for pipelines (Benchmarks.dll) are currently broken. I will try to fix the benchmarks and amend this PR.

cc: @davidfowl, @pakrym, @shiftylogic, @ahsonkhan