### PR TITLE
Fix arguments with = before :

### DIFF
--- a/corefxlab.sln
+++ b/corefxlab.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26131.1
+VisualStudioVersion = 15.0.26131.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5E7EB061-B9BC-4DA2-B5E5-859AA7C67695}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/System.CommandLine/System/CommandLine/ArgumentLexer.cs
+++ b/src/System.CommandLine/System/CommandLine/ArgumentLexer.cs
@@ -179,20 +179,16 @@ namespace System.CommandLine
 
         private static bool TrySplitNameValue(string text, out string name, out string value)
         {
-            return TrySplitNameValue(text, ':', out name, out value) ||
-                   TrySplitNameValue(text, '=', out name, out value);
-        }
-
-        private static bool TrySplitNameValue(string text, char separator, out string name, out string value)
-        {
-            var i = text.IndexOf(separator);
-            if (i >= 0)
+            for (int idx = 0; idx < text.Length; idx++)
             {
-                name = text.Substring(0, i);
-                value = text.Substring(i + 1);
-                return true;
+                char ch = text[idx];
+                if (ch == ':' || ch == '=')
+                {
+                    name = text.Substring(0, idx);
+                    value = text.Substring(idx + 1);
+                    return true;
+                }
             }
-
             name = null;
             value = null;
             return false;

--- a/tests/System.CommandLine.Tests/System/CommandLine/Tests/ArgumentLexerTests.cs
+++ b/tests/System.CommandLine.Tests/System/CommandLine/Tests/ArgumentLexerTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-
 using Xunit;
 
 namespace System.CommandLine.Tests
@@ -40,13 +39,14 @@ namespace System.CommandLine.Tests
         [Fact]
         public void Lex_OptionArguments()
         {
-            var text = "-a:va -b=vb --c vc";
+            var text = "-a:va -b=vb --c vc -d=C:bar";
             var actual = Lex(text);
             var expected = new[] {
                 new ArgumentToken("-", "a", "va"),
                 new ArgumentToken("-", "b", "vb"),
                 new ArgumentToken("--", "c", null),
-                new ArgumentToken(null, "vc", null)
+                new ArgumentToken(null, "vc", null),
+                new ArgumentToken("-", "d", "C:bar"), 
             };
 
             Assert.Equal(expected, actual);


### PR DESCRIPTION
Fixes #1164 

This fixes the issue where ':' was preferred as the option/argument separator even when there was a '=' earlier in the string.