### PR TITLE
Removed Writing task from IPipelineWriter

### DIFF
--- a/src/System.IO.Pipelines.File/FileReader.cs
+++ b/src/System.IO.Pipelines.File/FileReader.cs
@@ -59,7 +59,7 @@ namespace System.IO.Pipelines.File
             buffer.Advance((int)numBytes);
             var awaitable = buffer.FlushAsync();
 
-            if (numBytes == 0 || operation.Writer.Writing.IsCompleted)
+            if (numBytes == 0)
             {
                 operation.Writer.Complete();
 
@@ -68,6 +68,7 @@ namespace System.IO.Pipelines.File
             }
             else if (awaitable.IsCompleted)
             {
+                // No back pressure being applied to continue reading
                 operation.Read();
             }
             else
@@ -82,6 +83,12 @@ namespace System.IO.Pipelines.File
             if (await awaitable)
             {
                 operation.Read();
+            }
+            else
+            {
+                operation.Writer.Complete();
+
+                operation.Dispose();
             }
         }
 

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/RioTcpConnection.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/RioTcpConnection.cs
@@ -201,7 +201,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
 
         public void ReceiveBeginComplete(uint bytesTransferred)
         {
-            if (bytesTransferred == 0 || _input.Writing.IsCompleted)
+            if (bytesTransferred == 0)
             {
                 _input.CompleteWriter();
             }
@@ -222,7 +222,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
         private unsafe RioBufferSegment GetSegmentFromMemory(Memory<byte> memory)
         {
             void* pointer;
-            if(!memory.TryGetPointer(out pointer))
+            if (!memory.TryGetPointer(out pointer))
             {
                 throw new InvalidOperationException("Memory needs to be pinned");
             }

--- a/src/System.IO.Pipelines/IPipelineWriter.cs
+++ b/src/System.IO.Pipelines/IPipelineWriter.cs
@@ -12,15 +12,6 @@ namespace System.IO.Pipelines
     public interface IPipelineWriter
     {
         /// <summary>
-        /// Gets a task that completes when no more data will be read from the pipeline.
-        /// </summary>
-        /// <remarks>
-        /// This task indicates the consumer has completed and will not read anymore data.
-        /// When this task is triggered, the producer should stop producing data.
-        /// </remarks>
-        Task Writing { get; }
-
-        /// <summary>
         /// Allocates memory from the pipeline to write into.
         /// </summary>
         /// <param name="minimumSize">The minimum size buffer to allocate</param>

--- a/src/System.IO.Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/Pipe.cs
@@ -117,7 +117,7 @@ namespace System.IO.Pipelines
         /// This task indicates the consumer has completed and will not read anymore data.
         /// When this task is triggered, the producer should stop producing data.
         /// </remarks>
-        public Task Writing => _writingTcs.Task;
+        private Task Writing => _writingTcs.Task;
 
         internal Memory<byte> Memory => _writingHead?.Memory.Slice(_writingHead.End, _writingHead.WritableBytes) ?? Memory<byte>.Empty;
 

--- a/src/System.IO.Pipelines/PipelineWriter.cs
+++ b/src/System.IO.Pipelines/PipelineWriter.cs
@@ -19,8 +19,6 @@ namespace System.IO.Pipelines
 
         protected abstract Task WriteAsync(ReadableBuffer buffer);
 
-        public Task Writing => _pipe.Writing;
-
         public WritableBuffer Alloc(int minimumSize = 0) => _pipe.Alloc(minimumSize);
 
         public void Complete(Exception exception = null) => _pipe.CompleteWriter(exception);

--- a/tests/System.IO.Pipelines.Tests/PipelineWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/PipelineWriterFacts.cs
@@ -136,8 +136,6 @@ namespace System.IO.Pipelines.Tests
                 }
             }
 
-            public Task Writing => _pipe.Writing;
-
             public WritableBuffer Alloc(int minimumSize = 0)
             {
                 return _pipe.Alloc(minimumSize);


### PR DESCRIPTION
- For better symmetry between reading and writing, the Writing
task was removed IPipelineWriter.
- FlushAsync returns a bool when awaited which the producer can use to
stop producing. False means the consumer is complete.

/cc @benaadams 