### PR TITLE
Avoid unnecessary branches when fixing non-null/empty arrays

### DIFF
--- a/src/System.IO.Pipelines.Compression/Interop/Interop.zlib.Windows.cs
+++ b/src/System.IO.Pipelines.Compression/Interop/Interop.zlib.Windows.cs
@@ -54,7 +54,7 @@ namespace System.IO.Pipelines.Compression
                 int memLevel,
                 ZLibNative.CompressionStrategy strategy)
             {
-                fixed (byte* versionString = ZLibVersion)
+                fixed (byte* versionString = &ZLibVersion[0])
                 fixed (ZLibNative.ZStream* streamBytes = &stream)
                 {
                     byte* pBytes = (byte*) streamBytes;
@@ -94,7 +94,7 @@ namespace System.IO.Pipelines.Compression
                 ref ZLibNative.ZStream stream,
                 int windowBits)
             {
-                fixed (byte* versionString = ZLibVersion)
+                fixed (byte* versionString = &ZLibVersion[0])
                 fixed (ZLibNative.ZStream* streamBytes = &stream)
                 {
                     byte* pBytes = (byte*) streamBytes;

--- a/src/System.IO.Pipelines.Networking.Libuv/Interop/SockAddr.cs
+++ b/src/System.IO.Pipelines.Networking.Libuv/Interop/SockAddr.cs
@@ -85,7 +85,7 @@ namespace System.IO.Pipelines.Networking.Libuv.Interop
             {
                 // otherwise IPv6
                 var bytes = new byte[16];
-                fixed (byte* b = bytes)
+                fixed (byte* b = &bytes[0])
                 {
                     *((long*)b) = _field1;
                     *((long*)(b + 8)) = _field2;


### PR DESCRIPTION
When we know an array is not null or empty at the point where `fixed` is used, we can reduce the number of branches (and IL size of the method body) by using the address of the first element.

Based on the discussion here: https://github.com/dotnet/corefx/pull/15432#discussion_r97684916

Related:

 - https://github.com/dotnet/coreclr/pull/9115
 - https://github.com/dotnet/coreclr/pull/9188
 - https://github.com/dotnet/corefx/pull/15597
 - https://github.com/dotnet/corert/pull/2668