### PR TITLE
Await writes so natural back pressure is applied

### DIFF
--- a/src/System.IO.Pipelines.Networking.Libuv/Internal/LibuvAwaitable.cs
+++ b/src/System.IO.Pipelines.Networking.Libuv/Internal/LibuvAwaitable.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using System.IO.Pipelines.Networking.Libuv.Interop;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace System.IO.Pipelines.Networking.Libuv
+{
+    public class LibuvAwaitable<TRequest> : ICriticalNotifyCompletion where TRequest : UvRequest
+    {
+        private readonly static Action CALLBACK_RAN = () => { };
+
+        private Action _callback;
+
+        private Exception _exception;
+
+        private int _status;
+
+        public static Action<TRequest, int, object> Callback = (req, status, state) =>
+        {
+            var awaitable = (LibuvAwaitable<TRequest>)state;
+
+            Exception exception;
+            req.Libuv.Check(status, out exception);
+            awaitable._exception = exception;
+            awaitable._status = status;
+
+            var continuation = Interlocked.Exchange(ref awaitable._callback, CALLBACK_RAN);
+
+            continuation?.Invoke();
+        };
+
+        public LibuvAwaitable<TRequest> GetAwaiter() => this;
+        public bool IsCompleted => _callback == CALLBACK_RAN;
+
+        public int GetResult()
+        {
+            var exception = _exception;
+            var status = _status;
+
+            // Reset the awaitable state
+            _exception = null;
+            _status = 0;
+            _callback = null;
+
+            if (exception != null)
+            {
+                throw exception;
+            }
+
+            return status;
+        }
+
+        public void OnCompleted(Action continuation)
+        {
+            if (_callback == CALLBACK_RAN ||
+                Interlocked.CompareExchange(ref _callback, continuation, null) == CALLBACK_RAN)
+            {
+                Task.Run(continuation);
+            }
+        }
+
+        public void UnsafeOnCompleted(Action continuation)
+        {
+            OnCompleted(continuation);
+        }
+    }
+}


### PR DESCRIPTION
Not 100% sure about the perf throughput of this change yet, various a bit on my machine. It also reduces writing in parallel but that can be brought back by not awaiting the task. We can also have a maximum concurrency level if we want to restrict the amount of outstanding writes (like Kestrel does).

/cc @halter73 @pakrym @benaadams 