### PR TITLE
Finalizer issue with OwnedNativeMemory

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/OwnedMemory.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/OwnedMemory.cs
@@ -23,7 +23,7 @@ namespace System.Buffers
 
         ~OwnedNativeMemory()
         {
-            Dispose();
+            Dispose(false);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/System.Slices/System/Buffers/OwnedMemory.cs
+++ b/src/System.Slices/System/Buffers/OwnedMemory.cs
@@ -107,14 +107,16 @@ namespace System.Buffers
             Interlocked.Exchange(ref _id,  FreedId);
             if (HasOutstandingReferences) throw new InvalidOperationException("outstanding references detected.");
             Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        { 
+            _id = FreedId;
             _array = null;
             _pointer = IntPtr.Zero;
             _length = 0;
             _arrayIndex = 0;
         }
-
-        protected virtual void Dispose(bool disposing)
-        { }
 
         public bool IsDisposed => Id == FreedId;
 

--- a/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
@@ -7,7 +7,7 @@ namespace System.Slices.Tests
 {
     public class MemoryTests
     {
-        [Fact(Skip = "flaky")]
+        [Fact]
         public void SimpleTestS()
         {            
             using(var owned = new OwnedNativeMemory(1024)) {
@@ -43,7 +43,7 @@ namespace System.Slices.Tests
             }
         }
 
-        [Fact(Skip = "flaky")]
+        [Fact]
         public void NativeMemoryLifetime()
         {
             Memory<byte> copyStoredForLater;
@@ -81,7 +81,7 @@ namespace System.Slices.Tests
             });
         }
 
-        [Fact(Skip = "flaky")]
+        [Fact]
         public unsafe void PinnedArrayMemoryLifetime()
         {
             Memory<byte> copyStoredForLater;


### PR DESCRIPTION
The finalizer could fail if the object had got into a bad state due
to Reservation having been leaked. This occured in the test due
to trying to dispose an object while having reservations. This is
a possible fix, but it may be better to decide on how finalization
and Dispose should interact.

There are a few questions about the right error model:
* Should we raise an error if a Release is on an object that has been 
  attempted to be freed? Or should that succeed.  Currently, if fails, 
  but I think this might be a bad idea. 
* Should finalization of an object potentially raise an exception if it 
  has effectively been leaked?

@KrzysztofCwalina @joshfree @davidfowl 
