### PR TITLE
Improvements to ReadOnlyBytes

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/ReadOnlyBytes.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/ReadOnlyBytes.cs
@@ -107,10 +107,16 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlyBytes Slice(int index, int length)
         {
+            if(length==0) return ReadOnlyBytes.Empty;
+
             var first = First;
             if (first.Length >= length + index)
             {
-                return new ReadOnlyBytes(first.Slice(index, length));
+                var slice = first.Slice(index, length);
+                if(slice.Length > 0) {
+                    return new ReadOnlyBytes(first.Slice(index, length));
+                }
+                return ReadOnlyBytes.Empty;
             }
             if (first.Length > index)
             {
@@ -129,9 +135,20 @@ namespace System.Buffers
             else {
                 var first = First;
                 if (first.Length > index) {
-                    return new ReadOnlyBytes(first.Slice(index), _rest);
+                    var slice = first.Slice(index);
+                    if(slice.Length > 0 || _rest!=null) {
+                        return new ReadOnlyBytes(slice, _rest);
+                    }
+                    return ReadOnlyBytes.Empty;
                 }
-                return new ReadOnlyBytes(_rest).Slice(index - first.Length);
+
+                var toSlice = index - first.Length;
+                if (_rest == null && toSlice == 0) return Empty;
+                var rest = new ReadOnlyBytes(_rest);
+                if(toSlice > 0) {
+                    rest = rest.Slice(toSlice);
+                }
+                return rest;
             }
         }
 

--- a/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
@@ -21,6 +21,44 @@ namespace System.Slices.Tests
         }
 
         [Fact]
+        public void SingleSegmentSlicing()
+        {
+            var array = new byte[] { 0, 1, 2, 3, 4, 5, 6 };
+            ReadOnlyMemory<byte> buffer = array;
+            var bytes = new ReadOnlyBytes(buffer);
+
+            ReadOnlyBytes sliced = bytes;
+            ReadOnlySpan<byte> span;
+            for(int i=1; i<=array.Length; i++) {
+                sliced  = bytes.Slice(i);
+                span = sliced.First.Span;
+                Assert.Equal(array.Length - i, span.Length);
+                if(i!=array.Length) Assert.Equal(i, span[0]);
+            }
+            Assert.Equal(0, span.Length);
+        }
+
+        [Fact]
+        public void MultiSegmentSlicing()
+        {
+            var array1 = new byte[] { 0, 1 };
+            var array2 = new byte[] { 2, 3 };
+            var totalLenght = array1.Length + array2.Length;
+            ReadOnlyBytes bytes = ReadOnlyBytes.Create(array1, array2);
+
+            ReadOnlyBytes sliced = bytes;
+            ReadOnlySpan<byte> span;
+            for(int i=1; i<=totalLenght; i++) {
+                sliced  = bytes.Slice(i);
+                span = sliced.First.Span;
+                Assert.Equal(totalLenght - i, sliced.ComputeLength());
+                if(i!=totalLenght) Assert.Equal(i, span[0]);
+            }
+            Assert.Equal(0, span.Length);
+        }
+
+
+        [Fact]
         public void ReadOnlyBytesEnumeration()
         {
             var buffer = new byte[] { 1, 2, 3, 4, 5, 6 };


### PR DESCRIPTION
cc: @shiftylogic, @ahsonkhan, @davidfowl 

Added more through tests for slicing
Found a bug and fixed it
Optimized slicing to empty ROBs