### PR TITLE
Renaming ReadOnlySpanExtensions to SpanExtensions

### DIFF
--- a/src/System.Slices/System/SpanExtensions.cs
+++ b/src/System.Slices/System/SpanExtensions.cs
@@ -40,7 +40,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOf(this ReadOnlyMemory<byte> memory, ReadOnlySpan<byte> values)
         {
-            return ReadOnlySpanExtensions.IndexOf(memory.Span, values);
+            return SpanExtensions.IndexOf(memory.Span, values);
         }
     }
 }

--- a/src/System.Slices/System/SpanExtensions_comparisons.cs
+++ b/src/System.Slices/System/SpanExtensions_comparisons.cs
@@ -132,7 +132,7 @@ namespace System
         {
             return first.Length >= 512
                 ? MemoryEqual(first, second)
-                : ReadOnlySpanExtensions.SequenceEqual<short>(first, second);
+                : SpanExtensions.SequenceEqual<short>(first, second);
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace System
         {
             return first.Length >= 256
                 ? MemoryEqual(first, second)
-                : ReadOnlySpanExtensions.SequenceEqual(first, second);
+                : SpanExtensions.SequenceEqual(first, second);
         }
 
         /// <summary>
@@ -180,7 +180,7 @@ namespace System
         {
             return first.Length >= 256
                 ? MemoryEqual(first, second)
-                : ReadOnlySpanExtensions.SequenceEqual(first, second);
+                : SpanExtensions.SequenceEqual(first, second);
         }
 
         /// <summary>
@@ -244,7 +244,7 @@ namespace System
                 return SequenceEqual(Cast<T, short>(first), Cast<U, short>(second));
             }
 
-            return ReadOnlySpanExtensions.SequenceEqual(Cast<T, byte>(first), Cast<U, byte>(second));
+            return SpanExtensions.SequenceEqual(Cast<T, byte>(first), Cast<U, byte>(second));
         }
     }
 }

--- a/src/System.Slices/System/SpanExtensions_text.cs
+++ b/src/System.Slices/System/SpanExtensions_text.cs
@@ -49,7 +49,7 @@ namespace System
 
         public static int IndexOf(this ReadOnlySpan<char> str, string value)
         {
-            return ReadOnlySpanExtensions.IndexOf(str, value.Slice());
+            return SpanExtensions.IndexOf(str, value.Slice());
         }
 
         public static int IndexOfAny(this ReadOnlySpan<char> str, params char[] values)

--- a/src/System.Text.Http/System/Text/Http/Obsolete/HttpHeaderBuffer.cs
+++ b/src/System.Text.Http/System/Text/Http/Obsolete/HttpHeaderBuffer.cs
@@ -59,7 +59,7 @@ namespace System.Text.Http.SingleSegment
         internal static ReadOnlySpan<byte> SliceTo(this ReadOnlySpan<byte> buffer, int start, byte terminator, out int consumedBytes)
         {
             var slice = buffer.Slice(start);
-            var index = ReadOnlySpanExtensions.IndexOf(slice, terminator);
+            var index = System.SpanExtensions.IndexOf(slice, terminator);
             if (index == -1) {
                 consumedBytes = 0;
                 return Span<byte>.Empty;
@@ -89,7 +89,7 @@ namespace System.Text.Http.SingleSegment
             while (true)
             {
                 var slice = buffer.Slice(start + offset);
-                var index = ReadOnlySpanExtensions.IndexOf(slice, terminatorFirst);
+                var index = System.SpanExtensions.IndexOf(slice, terminatorFirst);
                 if (index == -1 || index == slice.Length - 1)
                 {
                     consumedBytes = 0;


### PR DESCRIPTION
~~I am surprised CI has been passing so far given I get build failures locally without this change.~~

**Edit:** I am getting these errors locally since I am using the new version of System.Memory package which contains the changes. Since this package isn't published to myget, the CI does not use the new version (and the old version doesn't have this change).

For example:
System\SpanExtensions_text.cs(52,20): error CS0103: The name 'ReadOnlySpanExtensions' does not exist in the current context [C:\Users\ahkha\Documents\GitHub\Fork\corefxlab\src\System.Slices\System.Slices.csproj]