### PR TITLE
Added SIMD-based IndexOf

### DIFF
--- a/scripts/PerfHarness/PerfHarness.csproj
+++ b/scripts/PerfHarness/PerfHarness.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>PerfHarness</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/System.Buffers.Experimental/System.Buffers.Experimental.csproj
+++ b/src/System.Buffers.Experimental/System.Buffers.Experimental.csproj
@@ -13,5 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Buffers" Version="4.3.0" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <AssemblyOriginatorKeyFile>../../tools/test_key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/tests/Benchmarks/IndexOf.cs
+++ b/tests/Benchmarks/IndexOf.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Xunit.Performance;
+using System;
+using System.Buffers;
+using System.Numerics;
+using System.Text;
+
+public class IndexOfBench
+{
+    static int s_bufferLength = 1000;
+    static byte[] s_buffer = new byte[s_bufferLength];
+    static int s_loops = 1000;
+
+    static IndexOfBench() 
+    {
+        s_buffer[s_bufferLength - 100] = 255;
+    }
+
+    [Benchmark]
+    static int SpanIndexOf()
+    {
+        Span<byte> buffer = s_buffer;
+        int index = 0;
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement())
+            {
+                for(int i=0; i<s_loops; i++) {
+                    index += buffer.IndexOf(255);
+                }
+            }
+        }
+        return index;
+    }
+
+    [Benchmark]
+    static int VectorizedIndexOf()
+    {
+        if(!Vector.IsHardwareAccelerated) return 0;
+
+        Span<byte> buffer = s_buffer;
+        int index = 0;
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement())
+            {
+                for(int i=0; i<s_loops; i++) {
+                    index += buffer.IndexOfVectorized(255);
+                }
+            }
+        }
+        return index;
+    }
+}
+

--- a/tests/System.Buffers.Experimental.Tests/VectorizedOperations.cs
+++ b/tests/System.Buffers.Experimental.Tests/VectorizedOperations.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Buffers;
+using Xunit;
+
+namespace System.Buffers.Tests
+{
+    public class VectorizedOperationsTests
+    {
+        [Fact]
+        public void SpanIndexOf()
+        {
+            int len = 10000;
+            byte[] buffer = new byte[len];
+            buffer[0] = 1;
+            buffer[len / 2] = 2;
+            buffer[len - 1] = 3;
+
+            Span<byte> span = buffer;
+            Assert.Equal(0, span.IndexOfVectorized(1));
+            Assert.Equal(len/2, span.IndexOfVectorized(2));
+            Assert.Equal(len-1, span.IndexOfVectorized(3));
+            Assert.Equal(-1, span.IndexOfVectorized(4));
+        }
+
+        [Fact]
+        public void ReadOnlySpanIndexOf()
+        {
+            int len = 10000;
+            byte[] buffer = new byte[len];
+            buffer[0] = 1;
+            buffer[len / 2] = 2;
+            buffer[len - 1] = 3;
+
+            ReadOnlySpan<byte> span = buffer;
+            Assert.Equal(0, span.IndexOfVectorized(1));
+            Assert.Equal(len/2, span.IndexOfVectorized(2));
+            Assert.Equal(len-1, span.IndexOfVectorized(3));
+            Assert.Equal(-1, span.IndexOfVectorized(4));
+        }
+
+        [Fact]
+        public void EmptySpanIndexOf()
+        {
+            int len = 0;
+            byte[] buffer = new byte[len];
+            Span<byte> span = buffer;
+            Assert.Equal(-1, span.IndexOfVectorized(4));
+        }
+
+        [Fact]
+        public void EmptyReadOnlySpanIndexOf()
+        {
+            int len = 10000;
+            byte[] buffer = new byte[len];
+            buffer[0] = 1;
+            buffer[len / 2] = 2;
+            buffer[len - 1] = 3;
+
+            ReadOnlySpan<byte> span = buffer;
+            Assert.Equal(-1, span.IndexOfVectorized(4));
+        }
+    }
+}

--- a/tests/System.Text.Formatting.Tests/System.Text.Formatting.Tests.csproj
+++ b/tests/System.Text.Formatting.Tests/System.Text.Formatting.Tests.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170125-04" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />
   </ItemGroup>


### PR DESCRIPTION
IndexOf is very commonly used in parsers. This PR is the first stab at implementing vectorized IndexOf operating over Span<T>. 

I added a simple benchmark, and it shows that vectorized IndexOf is ~3x faster than the sequential IndexOf for searching items far into the buffer. It is significantly slower if the searched for item is at index 0. The break even point is around index 30.

Test Name            /                            Average	[time]
IndexOfBench.VectorizedIndexOf	  0.091765931	
IndexOfBench.SpanIndexOf	          0.29441888	

Note, that I tried to implement a hybrid algorithm, i.e. sequential for indexes 0-32 and then vectorized. Unfortunately the overhead of the branch, slicing, etc. was so high that it almost nullified the gains for indexes 0-30 and then made perf slightly worse for other indexes. I might play with this idea a bit more later.

One more thing, there is a small different between Span and ReadOnlySpan IndexOfVectorized implementations. Span has the GetItem method that returns a by ref (i.e. no copy). ReadOnlySpan does not and so I have to use the indexer (which copies a large vector). @jaredpar, are we getting readonly by refs soon? It would be a great match for ReadOnlySpan.

cc: @ahsonkhan, @shiftylogic, @vancem, @jkotas, @joshfree, @benaadams, @davidfowl, @sivarv