### PR TITLE
Experiment to enable delayed disposal

### DIFF
--- a/src/System.Slices/System/Buffers/BloomFilter.cs
+++ b/src/System.Slices/System/Buffers/BloomFilter.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+
+namespace System.Runtime {
+    
+    // Naive Bloom filter
+    // Should really adapt, and alter mapping so false conflicts go away.
+    // This should be sufficient for initial prototyping.
+    public class BloomFilter {
+
+        private byte [] bits;
+
+        public BloomFilter() {
+            bits = new byte[0x100 >> 3];
+        }
+
+        public void Clear() {
+            for (int i = 0; i < bits.Length; i++) {
+                bits[i] = 0;
+            }
+        } 
+
+        public void Add(Object o) {
+            var i = o.GetHashCode();
+            for (int k = 0; k < 4; k++) {
+                int ibit  = i & 0x7;
+                int ibyte = (i & 0xff) >> 3;
+                bits[ibyte] |= (byte)(1 << ibit);
+                i >>= 8; 
+            }
+        }
+
+        public bool DoesNotContain(Object o) {
+            var i = o.GetHashCode();
+            for (int k = 0; k < 4; k++) {
+                int ibit  = i & 0x7;
+                int ibyte = (i & 0xff) >> 3;
+                if((bits[ibyte] & (byte)(1 << ibit)) == 0) return true;
+                i >>= 8; 
+            }
+            return false;
+        }
+    }
+}

--- a/src/System.Slices/System/Buffers/DelayedDisposer.cs
+++ b/src/System.Slices/System/Buffers/DelayedDisposer.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System;
+
+namespace System.Runtime {
+
+    public class DelayedDisposer {
+
+        [ThreadStatic]
+        static DelayedDisposeBuffer t_toBeDisposed;
+
+        static public void Add (IDisposable d) {
+            t_toBeDisposed.Enqueue (d);
+        }
+
+        static public void Flush () {
+            t_toBeDisposed.EnsureInitialized ();
+            t_toBeDisposed.Drain ();
+        }
+
+        struct DelayedDisposeBuffer {
+            // This buffer fills from the top (_buffer.Length-1). 
+            // _freespace represents the index of the highest used element. 
+            // When the buffer is full, _freespace == 0.
+            // When the buffer is uninitialized, _freespace == 0. i.e.  _buffer == null => _freespace == 0 
+            // These means that the initialialization of thread static can be 
+            // put on slow path of when the buffer is full, so we only require a single test on the fast path.  
+            int _freeSpace;
+            IDisposable[] _buffer;
+
+            private DelayedDisposeBuffer (int size) {
+                this._buffer = new IDisposable[size];
+                this._freeSpace = _buffer.Length;
+            }
+
+            bool IsFullOrUninitialized () {
+                return _freeSpace == 0;
+            }
+
+            public bool EnsureInitialized () {
+                if (_buffer == null) {
+                    this = new DelayedDisposeBuffer (32);
+                    return false;
+                }
+                return true;
+            }
+
+            private void EnsureLargeEnough () {
+                if (_freeSpace < _buffer.Length * 0.75) {
+                    var newSize = (int) (_buffer.Length / 0.75) + 4;
+                    var newDisposableBuffer = new DelayedDisposeBuffer (newSize);
+                    for (int i = _buffer.Length - 1; i >= _freeSpace; i--) {
+                        newDisposableBuffer.Enqueue (_buffer[i]);
+                    }
+                    this = newDisposableBuffer;
+                }
+            }
+
+            public BloomFilter Drain () {
+                var referenced = ReferenceCounter.GetMaybeReferenced ();
+                int newFreeSpace = _buffer.Length;
+                for (int i = _buffer.Length - 1; i >= _freeSpace; i--) {
+                    if (referenced.DoesNotContain (_buffer[i])) {
+                        _buffer[i].Dispose ();
+                        _buffer[i] = null;
+                    } else {
+                        _buffer[--newFreeSpace] = _buffer[i];
+                    }
+                }
+                _freeSpace = newFreeSpace;
+
+                EnsureLargeEnough ();
+
+                return referenced;
+            }
+
+            public void Enqueue (IDisposable t) {
+                if (IsFullOrUninitialized () && EnsureInitialized()) {
+                    // Was actually full
+                    BloomFilter referenced = Drain ();
+                    if (referenced.DoesNotContain (t)) {
+                        t.Dispose ();
+                        return;
+                    }
+                }
+                _freeSpace--;
+                _buffer[_freeSpace] = t;
+            }
+        }
+    }
+}

--- a/tests/System.Slices.Tests/BloomFilterTests.cs
+++ b/tests/System.Slices.Tests/BloomFilterTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Runtime;
+using Xunit;
+
+namespace System.Slices.Tests
+{
+    public class BloomFilterTests
+    {
+        
+        [Fact]
+        public void AddMayContain()
+        {
+            for (int p = 0; p < 30; p++) {
+                var array = new object[30];
+                for (int i = 0; i < array.Length; i++) {
+                    array[i] = new object();
+                }
+                
+                var b = new BloomFilter();
+                
+                for (int i = 0; i < array.Length; i++) {
+                    b.Add(array[i]);
+                    for (int j = 0; j <= i; j++) {
+                        Assert.False(b.DoesNotContain(array[j]));
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void ClearTest()
+        {
+            for (int p = 0; p < 30; p++) {
+                var array = new object[30];
+                for (int i = 0; i < array.Length; i++) {
+                    array[i] = new object();
+                }
+                
+                var b = new BloomFilter();
+                
+                for (int i = 0; i < array.Length; i++) {
+                    b.Add(array[i]);
+                }
+
+                b.Clear();
+
+                for (int i = 0; i < array.Length; i++) {
+                    Assert.True(b.DoesNotContain(array[i]));
+                }
+            }
+        }
+    }
+}

--- a/tests/System.Slices.Tests/DelayedDisposerTests.cs
+++ b/tests/System.Slices.Tests/DelayedDisposerTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Runtime;
+using Xunit;
+
+namespace System.Slices.Tests {
+    class DisposeCount : IDisposable {
+        public int disposedCount = 0;
+
+        public DisposeCount () { }
+
+        public void Dispose () {
+            disposedCount++;
+        }
+    }
+
+    public class DelayedDisposerTests {
+
+        [Fact]
+        public void BasicTest () {
+            DisposeCount[] array = new DisposeCount[1000];
+
+            for (int i = 0; i < array.Length; i++) {
+                array[i] = new DisposeCount ();
+            }
+
+            for (int i = 0; i < array.Length; i++) {
+                DelayedDisposer.Add (array[i]);
+            }
+
+            // Make sure there is something that hasn't been 
+            // disposed, so we can test flush.
+            bool anyLeft = false;
+            for (int i = 0; i < array.Length; i++) {
+                anyLeft |= array[i].disposedCount == 0;
+            }
+
+            // Add something, so that we can check flush
+            int n = 0;
+            while (!anyLeft) {
+                if (anyLeft) break;
+                array[0] = new DisposeCount ();
+                DelayedDisposer.Add (array[0]);
+                anyLeft = array[0].disposedCount == 0;
+                n++;
+                if (n == 100) {
+                    // Clearly not very Delayed
+                    break;
+                }
+            }
+
+            DelayedDisposer.Flush ();
+
+            for (int i = 0; i < array.Length; i++) {
+                Assert.True (array[i].disposedCount == 1, "Failed! Index " + i);
+            }
+        }
+
+        [Fact]
+        public void ReferencedTest () {
+            DisposeCount[] array = new DisposeCount[1000];
+
+            for (int i = 0; i < array.Length; i++) {
+                array[i] = new DisposeCount ();
+                ReferenceCounter.AddReference (array[i]);
+            }
+
+            for (int i = 0; i < array.Length; i++) {
+                DelayedDisposer.Add (array[i]);
+            }
+
+            //Nothing should be removed
+            for (int i = 0; i < array.Length; i++) {
+                Assert.True (array[i].disposedCount == 0, "Element should not have been reclaimed: index " + i);
+            }
+
+            for (int i = 1; i < array.Length; i += 2) {
+                ReferenceCounter.Release (array[i]);
+            }
+
+            DelayedDisposer.Flush ();
+
+            for (int i = 0; i < array.Length; i++) {
+                if (i % 2 == 0) {
+                    Assert.True (array[i].disposedCount == 0, "Element should not have been reclaimed: index " + i);
+                }
+            }
+
+            for (int i = 0; i < array.Length; i += 2) {
+                ReferenceCounter.Release (array[i]);
+            }
+
+            DelayedDisposer.Flush ();
+
+            for (int i = 0; i < array.Length; i++) {
+                Assert.True (array[i].disposedCount == 1, "Element should have been reclaimed: index " + i);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Accessing the `ReferenceCounter` for every single `Dispose` could be expensive.

We make `ReferenceCounter` able to return a `BloomFilter` that over-approximates the elements that are referenced.  This means that a single scan of all the thread local state can enable many items to be disposed.

The `DelayedDisposer` class then wraps up this approach by batching up multiple `Dispose` calls, and checking the `BloomFilter` when it has sufficient items to continue.

Currently, there are two weaknesses
*  `BloomFilter` is very naive. It just takes bytes from the hashcode to calculate the different hashes. It does not adapt to the number of elements it is storing. 
* `DelayedDisposer` does not shrink back its window of elements if it is no longer necessary to be so large.

cc @KrzysztofCwalina @jkotas @davidfowl 