### PR TITLE
Stream To Pipe Unit tests and Bugfix ref #1217

### DIFF
--- a/samples/System.IO.Pipelines.Samples/HttpServer/HttpRequestStream.cs
+++ b/samples/System.IO.Pipelines.Samples/HttpServer/HttpRequestStream.cs
@@ -145,7 +145,7 @@ namespace System.IO.Pipelines.Samples.Http
 #endif
         public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
-            return _connection.Input.CopyToAsync(destination, bufferSize, cancellationToken);
+            return _connection.Input.CopyToEndAsync(destination, bufferSize, cancellationToken);
         }
 
     }

--- a/src/System.IO.Pipelines/PipelineConnectionExtensions.cs
+++ b/src/System.IO.Pipelines/PipelineConnectionExtensions.cs
@@ -81,41 +81,54 @@ namespace System.IO.Pipelines
         {
             try
             {
-                await input.CopyToAsync(stream, bufferSize, cancellationToken);
+                // TODO: Use bufferSize argument
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    var result = await input.ReadAsync();
+                    var inputBuffer = result.Buffer;
+                    try
+                    {
+                        if (inputBuffer.IsEmpty && result.IsCompleted)
+                        {
+                            input.Complete();
+                            return;
+                        }
+
+                        await inputBuffer.CopyToAsync(stream);
+                    }
+                    finally
+                    {
+                        input.Advance(inputBuffer.End);
+                    }
+                }
             }
             catch (Exception ex)
             {
                 input.Complete(ex);
-                return;
             }
-            return;
         }
 
         public static Task CopyToAsync(this IPipeReader input, Stream stream)
         {
-            return input.CopyToAsync(stream, 4096, CancellationToken.None);
+            return input.CopyToAsync(stream, 4096);
         }
 
-        public static async Task CopyToAsync(this IPipeReader input, Stream stream, int bufferSize, CancellationToken cancellationToken)
+        public static async Task CopyToAsync(this IPipeReader input, Stream stream, int bufferSize)
         {
-            // TODO: Use bufferSize argument
-            while (!cancellationToken.IsCancellationRequested)
+            var result = await input.ReadAsync();
+            var inputBuffer = result.Buffer;
+            try
             {
-                var result = await input.ReadAsync();
-                var inputBuffer = result.Buffer;
-                try
+                if (inputBuffer.IsEmpty && result.IsCompleted)
                 {
-                    if (inputBuffer.IsEmpty && result.IsCompleted)
-                    {
-                        return;
-                    }
+                    return;
+                }
 
-                    await inputBuffer.CopyToAsync(stream);
-                }
-                finally
-                {
-                    input.Advance(inputBuffer.End);
-                }
+                await inputBuffer.CopyToAsync(stream);
+            }
+            finally
+            {
+                input.Advance(inputBuffer.End);
             }
         }
 

--- a/src/System.IO.Pipelines/PipelineConnectionStream.cs
+++ b/src/System.IO.Pipelines/PipelineConnectionStream.cs
@@ -183,7 +183,7 @@ namespace System.IO.Pipelines
 #endif
         public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
-            return _connection.Input.CopyToAsync(destination, bufferSize, cancellationToken);
+            return _connection.Input.CopyToEndAsync(destination, bufferSize, cancellationToken);
         }
 
         protected override void Dispose(bool disposing)

--- a/tests/System.IO.Pipelines.Tests/PipeToStreamFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/PipeToStreamFacts.cs
@@ -26,12 +26,12 @@ namespace System.IO.Pipelines.Tests
                 {
                     var reader = pipe.Reader.ReadAsync();
                 });
-                Assert.Equal<byte>(buffer, stream.ToArray());
+                Assert.Equal(buffer, stream.ToArray());
             }
         }
 
         [Fact]
-        public async Task CopyFromPipeToEndThrow()
+        public async Task CopyFromPipeToEndObserveStreamThrow()
         {
             var buffer = new byte[1000];
             (new Random()).NextBytes(buffer);
@@ -50,7 +50,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public async Task CopyFromPipeNoEndThrow()
+        public async Task CopyFromPipeObserveStreamThrow()
         {
             var buffer = new byte[1000];
             (new Random()).NextBytes(buffer);
@@ -99,13 +99,13 @@ namespace System.IO.Pipelines.Tests
                 var reader = await pipe.Reader.ReadAsync();
 
                 Assert.True(reader.IsCompleted);
-                Assert.Equal<byte>(buffer, reader.Buffer.ToArray());
+                Assert.Equal(buffer, reader.Buffer.ToArray());
                 pipe.Reader.Advance(reader.Buffer.End);
             }
         }
 
         [Fact]
-        public async Task CopyFromStreamToEndThrow()
+        public async Task CopyFromStreamToEndObserveStreamThrow()
         {
             using (var pipeFactory = new PipeFactory())
             using (var stream = new FakeExceptionStream())
@@ -121,7 +121,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
-        public async Task CopyFromStreamNoEndThrow()
+        public async Task CopyFromStreamNoEndObserveStreamThrow()
         {
             using (var pipeFactory = new PipeFactory())
             using (var stream = new FakeExceptionStream())
@@ -147,7 +147,7 @@ namespace System.IO.Pipelines.Tests
                 var reader = await pipe.Reader.ReadAsync();
 
                 Assert.False(reader.IsCompleted);
-                Assert.Equal<byte>(buffer, reader.Buffer.ToArray());
+                Assert.Equal(buffer, reader.Buffer.ToArray());
                 pipe.Reader.Advance(reader.Buffer.End);
             }
         }

--- a/tests/System.IO.Pipelines.Tests/PipeToStreamFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/PipeToStreamFacts.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Pipelines.Tests
+{
+    public class PipeToStreamFacts
+    {
+        [Fact]
+        public async Task CopyFromPipeToEnd()
+        {
+            var buffer = new byte[1000];
+            (new Random()).NextBytes(buffer);
+            using (var pipeFactory = new PipeFactory())
+            using (var stream = new MemoryStream())
+            {
+                var pipe = pipeFactory.Create();
+                await pipe.Writer.WriteAsync(buffer);
+                pipe.Writer.Complete();
+                await pipe.Reader.CopyToEndAsync(stream);
+
+                Assert.Throws<InvalidOperationException>(() =>
+                {
+                    var reader = pipe.Reader.ReadAsync();
+                });
+                Assert.Equal<byte>(buffer, stream.ToArray());
+            }
+        }
+
+        [Fact]
+        public async Task CopyFromPipeToEndThrow()
+        {
+            var buffer = new byte[1000];
+            (new Random()).NextBytes(buffer);
+            using (var pipeFactory = new PipeFactory())
+            using (var stream = new FakeExceptionStream())
+            {
+                var pipe = pipeFactory.Create();
+                await pipe.Writer.WriteAsync(buffer);
+                pipe.Writer.Complete();
+                await pipe.Reader.CopyToEndAsync(stream);
+                await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                {
+                    var reader = await pipe.Reader.ReadAsync();
+                });
+            }
+        }
+
+        [Fact]
+        public async Task CopyFromPipeNoEndThrow()
+        {
+            var buffer = new byte[1000];
+            (new Random()).NextBytes(buffer);
+            using (var pipeFactory = new PipeFactory())
+            using (var stream = new FakeExceptionStream())
+            {
+                var pipe = pipeFactory.Create();
+                await pipe.Writer.WriteAsync(buffer);
+                pipe.Writer.Complete();
+
+                await Assert.ThrowsAsync<IOException>(async () =>
+                {
+                    await pipe.Reader.CopyToAsync(stream);
+                });
+            }
+        }
+
+        [Fact]
+        public async Task CopyFromPipeNoEnd()
+        {
+            var buffer = new byte[1000];
+            (new Random()).NextBytes(buffer);
+            using (var pipeFactory = new PipeFactory())
+            using (var stream = new MemoryStream())
+            {
+                var pipe = pipeFactory.Create();
+                await pipe.Writer.WriteAsync(buffer);
+                await pipe.Reader.CopyToAsync(stream);
+                var reader = pipe.Reader.ReadAsync();
+
+                Assert.False(reader.IsCompleted);
+                Assert.Equal<byte>(buffer, stream.ToArray());
+            }
+        }
+
+        [Fact]
+        public async Task CopyFromStreamToEnd()
+        {
+            var buffer = new byte[1000];
+            (new Random()).NextBytes(buffer);
+            using (var pipeFactory = new PipeFactory())
+            using (var stream = new MemoryStream(buffer))
+            {
+                var pipe = pipeFactory.Create();
+                await stream.CopyToEndAsync(pipe.Writer);
+                var reader = await pipe.Reader.ReadAsync();
+
+                Assert.True(reader.IsCompleted);
+                Assert.Equal<byte>(buffer, reader.Buffer.ToArray());
+                pipe.Reader.Advance(reader.Buffer.End);
+            }
+        }
+
+        [Fact]
+        public async Task CopyFromStreamToEndThrow()
+        {
+            using (var pipeFactory = new PipeFactory())
+            using (var stream = new FakeExceptionStream())
+            {
+                var pipe = pipeFactory.Create();
+                await stream.CopyToEndAsync(pipe.Writer);
+
+                await Assert.ThrowsAsync<IOException>(async () =>
+                {
+                    var reader = await pipe.Reader.ReadAsync();
+                });
+            }
+        }
+
+        [Fact]
+        public async Task CopyFromStreamNoEndThrow()
+        {
+            using (var pipeFactory = new PipeFactory())
+            using (var stream = new FakeExceptionStream())
+            {
+                var pipe = pipeFactory.Create();
+                await Assert.ThrowsAsync<IOException>(async () =>
+                {
+                    await stream.CopyToAsync(pipe.Writer);
+                });
+            }
+        }
+
+        [Fact]
+        public async Task CopyFromStreamNoEnd()
+        {
+            var buffer = new byte[1000];
+            (new Random()).NextBytes(buffer);
+            using (var pipeFactory = new PipeFactory())
+            using (var stream = new MemoryStream(buffer))
+            {
+                var pipe = pipeFactory.Create();
+                await stream.CopyToAsync(pipe.Writer);
+                var reader = await pipe.Reader.ReadAsync();
+
+                Assert.False(reader.IsCompleted);
+                Assert.Equal<byte>(buffer, reader.Buffer.ToArray());
+                pipe.Reader.Advance(reader.Buffer.End);
+            }
+        }
+
+        private class FakeExceptionStream : MemoryStream
+        {
+            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                return Task.FromException<int>(new IOException());
+            }
+
+            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                return Task.FromException<int>(new IOException());
+            }
+        }
+    }
+}

--- a/tests/System.IO.Pipelines.Tests/PipeToStreamFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/PipeToStreamFacts.cs
@@ -30,7 +30,7 @@ namespace System.IO.Pipelines.Tests
             }
         }
 
-        [Fact]
+        [Fact] 
         public async Task CopyFromPipeToEndObserveStreamThrow()
         {
             var buffer = new byte[1000];


### PR DESCRIPTION
Doing these tests it's highlighted a mismatch in the behavior. The CopyToAsync completes the pipe however this is not the same behavior as the stream side. I think we might what to change this behavior thoughts?