### PR TITLE
ReadableBuffer ctor tweaks

### DIFF
--- a/src/System.IO.Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/BufferSegment.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Buffers;
 using System.Diagnostics;
 using System.Text;
@@ -38,13 +37,19 @@ namespace System.IO.Pipelines
         /// </summary>
         private readonly OwnedMemory<byte> _buffer;
 
+        /// <summary>
+        /// Should never be assigned to. Cannot be made readonly directly otherwise functions Slice etc will make a defensive copy.
+        /// In future this may be able to be changed to a "readonly ref" and Merged with `Memory`
+        /// </summary>
+        internal Memory<byte> ReadOnlyMemory;
+
         public BufferSegment(OwnedMemory<byte> buffer)
         {
             _buffer = buffer;
             Start = 0;
             End = 0;
 
-            Memory = _buffer.Memory;
+            ReadOnlyMemory = _buffer.Memory;
             _buffer.AddReference();
         }
 
@@ -63,11 +68,11 @@ namespace System.IO.Pipelines
                 _buffer = unowned.MakeCopy(start, end - start, out Start, out End);
             }
 
-            Memory = _buffer.Memory;
+            ReadOnlyMemory = _buffer.Memory;
             _buffer.AddReference();
         }
 
-        public readonly Memory<byte> Memory;
+        public Memory<byte> Memory => ReadOnlyMemory;
 
         /// <summary>
         /// If true, data should not be written into the backing block after the End offset. Data between start and end should never be modified

--- a/src/System.IO.Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/BufferSegment.cs
@@ -36,7 +36,7 @@ namespace System.IO.Pipelines
         /// <summary>
         /// The buffer being tracked
         /// </summary>
-        private OwnedMemory<byte> _buffer;
+        private readonly OwnedMemory<byte> _buffer;
 
         public BufferSegment(OwnedMemory<byte> buffer)
         {
@@ -44,6 +44,7 @@ namespace System.IO.Pipelines
             Start = 0;
             End = 0;
 
+            Memory = _buffer.Memory;
             _buffer.AddReference();
         }
 
@@ -62,10 +63,11 @@ namespace System.IO.Pipelines
                 _buffer = unowned.MakeCopy(start, end - start, out Start, out End);
             }
 
+            Memory = _buffer.Memory;
             _buffer.AddReference();
         }
 
-        public Memory<byte> Memory => _buffer.Memory;
+        public readonly Memory<byte> Memory;
 
         /// <summary>
         /// If true, data should not be written into the backing block after the End offset. Data between start and end should never be modified

--- a/src/System.IO.Pipelines/EmptyByteMemory.cs
+++ b/src/System.IO.Pipelines/EmptyByteMemory.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace System.IO.Pipelines
+{
+
+    internal class EmptyByteMemory : OwnedMemory<byte>
+    {
+        private static OwnedMemory<byte> s_ownedMemory;
+
+        public static void EnsureInitalized()
+        {
+            if (s_ownedMemory == null)
+            {
+                Initalize();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void Initalize()
+        {
+            s_ownedMemory = new EmptyByteMemory();
+            ReadOnlyEmpty = s_ownedMemory.Memory;
+        }
+
+        /// <summary>
+        /// Should never be assigned to. Cannot be made readonly directly otherwise functions Slice etc will make a defensive copy.
+        /// In future this may be able to be changed to a "readonly ref"
+        /// </summary>
+        public static Memory<byte> ReadOnlyEmpty;
+
+        private EmptyByteMemory() : base(new byte[0], 0, 0) { }
+
+        protected override void Dispose(bool disposing)
+        { }
+    }
+}

--- a/src/System.IO.Pipelines/MemoryEnumerator.cs
+++ b/src/System.IO.Pipelines/MemoryEnumerator.cs
@@ -17,7 +17,7 @@ namespace System.IO.Pipelines
         public MemoryEnumerator(ReadCursor start, ReadCursor end)
         {
             _segmentEnumerator = new SegmentEnumerator(start, end);
-            _current = Memory<byte>.Empty;
+            _current = EmptyByteMemory.ReadOnlyEmpty;
         }
 
         /// <summary>
@@ -35,11 +35,11 @@ namespace System.IO.Pipelines
         {
             if (!_segmentEnumerator.MoveNext())
             {
-                _current = Memory<byte>.Empty;
+                _current = EmptyByteMemory.ReadOnlyEmpty;
                 return false;
             }
             var current = _segmentEnumerator.Current;
-            _current = current.Segment.Memory.Slice(current.Start, current.Length);
+            _current = current.Segment.ReadOnlyMemory.Slice(current.Start, current.Length);
 
             return true;
         }

--- a/src/System.IO.Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/Pipe.cs
@@ -50,6 +50,7 @@ namespace System.IO.Pipelines
         /// <param name="options"></param>
         public Pipe(IBufferPool pool, PipeOptions options = null)
         {
+            EmptyByteMemory.EnsureInitalized();
             if (pool == null)
             {
                 throw new ArgumentNullException(nameof(pool));
@@ -80,7 +81,7 @@ namespace System.IO.Pipelines
             _writerAwaitable = new PipeAwaitable(options.WriterScheduler ?? InlineScheduler.Default, completed: true);
         }
 
-        internal Memory<byte> Memory => _writingHead?.Memory.Slice(_writingHead.End, _writingHead.WritableBytes) ?? Memory<byte>.Empty;
+        internal Memory<byte> Memory => _writingHead?.ReadOnlyMemory.Slice(_writingHead.End, _writingHead.WritableBytes) ?? EmptyByteMemory.ReadOnlyEmpty;
 
         /// <summary>
         /// Allocates memory from the pipeline to write into.
@@ -285,7 +286,7 @@ namespace System.IO.Pipelines
                 Debug.Assert(!_writingHead.ReadOnly);
                 Debug.Assert(_writingHead.Next == null);
 
-                var buffer = _writingHead.Memory;
+                var buffer = _writingHead.ReadOnlyMemory;
                 var bufferIndex = _writingHead.End + bytesWritten;
 
                 Debug.Assert(bufferIndex <= buffer.Length);

--- a/src/System.IO.Pipelines/ReadCursor.cs
+++ b/src/System.IO.Pipelines/ReadCursor.cs
@@ -8,6 +8,8 @@ namespace System.IO.Pipelines
 {
     public struct ReadCursor : IEquatable<ReadCursor>
     {
+        private static readonly Memory<byte> _emptyMemory = Memory<byte>.Empty;
+
         private BufferSegment _segment;
         private int _index;
 
@@ -180,7 +182,7 @@ namespace System.IO.Pipelines
         {
             if (IsDefault)
             {
-                data = Memory<byte>.Empty;
+                data = _emptyMemory;
                 return false;
             }
 
@@ -197,7 +199,7 @@ namespace System.IO.Pipelines
                     return true;
                 }
 
-                data = Memory<byte>.Empty;
+                data = _emptyMemory;
                 return false;
             }
             else
@@ -211,7 +213,7 @@ namespace System.IO.Pipelines
         {
             if (IsDefault)
             {
-                data = Memory<byte>.Empty;
+                data = _emptyMemory;
                 cursor = this;
                 return false;
             }
@@ -230,7 +232,7 @@ namespace System.IO.Pipelines
                     return true;
                 }
 
-                data = Memory<byte>.Empty;
+                data = _emptyMemory;
                 cursor = this;
                 return false;
             }
@@ -272,7 +274,7 @@ namespace System.IO.Pipelines
 
                 if (wasLastSegment)
                 {
-                    data = Memory<byte>.Empty;
+                    data = _emptyMemory;
                     return false;
                 }
                 else
@@ -318,7 +320,7 @@ namespace System.IO.Pipelines
 
                 if (wasLastSegment)
                 {
-                    data = Memory<byte>.Empty;
+                    data = _emptyMemory;
                     cursor = this;
                     return false;
                 }

--- a/src/System.IO.Pipelines/ReadCursor.cs
+++ b/src/System.IO.Pipelines/ReadCursor.cs
@@ -186,11 +186,11 @@ namespace System.IO.Pipelines
                 var following = end.Index - index;
                 if (segment != null && following > 0)
                 {
-                    data = segment.Memory.Slice(index, following);
+                    data = segment.ReadOnlyMemory.Slice(index, following);
                 }
                 else
                 {
-                    data = Memory<byte>.Empty;
+                    data = EmptyByteMemory.ReadOnlyEmpty;
                 }
 
                 return !data.IsEmpty;
@@ -231,7 +231,7 @@ namespace System.IO.Pipelines
 
                 if (wasLastSegment)
                 {
-                    data = Memory<byte>.Empty;
+                    data = EmptyByteMemory.ReadOnlyEmpty;
                     return false;
                 }
                 else
@@ -241,7 +241,7 @@ namespace System.IO.Pipelines
                 }
             }
 
-            data = segment.Memory.Slice(index, following);
+            data = segment.ReadOnlyMemory.Slice(index, following);
             return true;
         }
 
@@ -253,7 +253,7 @@ namespace System.IO.Pipelines
             }
 
             var sb = new StringBuilder();
-            Span<byte> span = Segment.Memory.Span.Slice(Index, Segment.End - Index);
+            Span<byte> span = Segment.ReadOnlyMemory.Span.Slice(Index, Segment.End - Index);
             SpanExtensions.AppendAsLiteral(span, sb);
             return sb.ToString();
         }

--- a/src/System.IO.Pipelines/ReadCursor.cs
+++ b/src/System.IO.Pipelines/ReadCursor.cs
@@ -176,6 +176,37 @@ namespace System.IO.Pipelines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool TryGetBuffer(ReadCursor end, out Memory<byte> data)
+        {
+            if (IsDefault)
+            {
+                data = Memory<byte>.Empty;
+                return false;
+            }
+
+            var segment = _segment;
+            var index = _index;
+
+            if (end.Segment == segment)
+            {
+                var following = end.Index - index;
+
+                if (following > 0)
+                {
+                    data = segment.Memory.Slice(index, following);
+                    return true;
+                }
+
+                data = Memory<byte>.Empty;
+                return false;
+            }
+            else
+            {
+                return TryGetBufferMultiBlock(end, out data);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool TryGetBuffer(ReadCursor end, out Memory<byte> data, out ReadCursor cursor)
         {
             if (IsDefault)
@@ -207,6 +238,52 @@ namespace System.IO.Pipelines
             {
                 return TryGetBufferMultiBlock(end, out data, out cursor);
             }
+        }
+
+        private bool TryGetBufferMultiBlock(ReadCursor end, out Memory<byte> data)
+        {
+            var segment = _segment;
+            var index = _index;
+
+            // Determine if we might attempt to copy data from segment.Next before
+            // calculating "following" so we don't risk skipping data that could
+            // be added after segment.End when we decide to copy from segment.Next.
+            // segment.End will always be advanced before segment.Next is set.
+
+            int following = 0;
+
+            while (true)
+            {
+                var wasLastSegment = segment.Next == null || end.Segment == segment;
+
+                if (end.Segment == segment)
+                {
+                    following = end.Index - index;
+                }
+                else
+                {
+                    following = segment.End - index;
+                }
+
+                if (following > 0)
+                {
+                    break;
+                }
+
+                if (wasLastSegment)
+                {
+                    data = Memory<byte>.Empty;
+                    return false;
+                }
+                else
+                {
+                    segment = segment.Next;
+                    index = segment.Start;
+                }
+            }
+
+            data = segment.Memory.Slice(index, following);
+            return true;
         }
 
         private bool TryGetBufferMultiBlock(ReadCursor end, out Memory<byte> data, out ReadCursor cursor)

--- a/src/System.IO.Pipelines/ReadCursorOperations.cs
+++ b/src/System.IO.Pipelines/ReadCursorOperations.cs
@@ -49,7 +49,7 @@ namespace System.IO.Pipelines
                     following = block.End - index;
                 }
                 ArraySegment<byte> array;
-                var getArrayResult = block.Memory.TryGetArray(out array);
+                var getArrayResult = block.ReadOnlyMemory.TryGetArray(out array);
                 Debug.Assert(getArrayResult);
 
                 while (following > 0)
@@ -142,7 +142,7 @@ namespace System.IO.Pipelines
                     following = block.End - index;
                 }
                 ArraySegment<byte> array;
-                var getArrayResult = block.Memory.TryGetArray(out array);
+                var getArrayResult = block.ReadOnlyMemory.TryGetArray(out array);
                 Debug.Assert(getArrayResult);
 
                 while (following > 0)
@@ -249,7 +249,7 @@ namespace System.IO.Pipelines
                     following = block.End - index;
                 }
                 ArraySegment<byte> array;
-                var getArrayResult = block.Memory.TryGetArray(out array);
+                var getArrayResult = block.ReadOnlyMemory.TryGetArray(out array);
                 Debug.Assert(getArrayResult);
 
                 while (following > 0)

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -490,10 +490,15 @@ namespace System.IO.Pipelines
         {
             if (data == null)
             {
-                throw new ArgumentNullException(nameof(data));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.data);
             }
 
-            return Create(data, 0, data.Length);
+            var segment = new BufferSegment(new OwnedArray<byte>(data))
+            {
+                Start = 0,
+                End = data.Length
+            };
+            return new ReadableBuffer(new ReadCursor(segment, 0), new ReadCursor(segment, data.Length));
         }
 
         /// <summary>
@@ -511,15 +516,16 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.offset);
             }
 
-            if (length < 0 || (offset + length) > data.Length)
+            if (length < 0 || data.Length - offset < length)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
             }
 
-            var buffer = new OwnedArray<byte>(data);
-            var segment = new BufferSegment(buffer);
-            segment.Start = offset;
-            segment.End = offset + length;
+            var segment = new BufferSegment(new OwnedArray<byte>(data))
+            {
+                Start = offset,
+                End = offset + length
+            };
             return new ReadableBuffer(new ReadCursor(segment, offset), new ReadCursor(segment, offset + length));
         }
 

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -560,11 +560,11 @@ namespace System.IO.Pipelines
             }
             if (currentSegment == _end.Segment)
             {
-                item = currentSegment.Memory.Slice(currentSegment.Start, _end.Index - currentSegment.Start);
+                item = currentSegment.ReadOnlyMemory.Slice(currentSegment.Start, _end.Index - currentSegment.Start);
             }
             else
             {
-                item = currentSegment.Memory.Slice(currentSegment.Start, currentSegment.End - currentSegment.Start);
+                item = currentSegment.ReadOnlyMemory.Slice(currentSegment.Start, currentSegment.End - currentSegment.Start);
             }
             return true;
         }

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -57,12 +57,13 @@ namespace System.IO.Pipelines
         {
             _start = start;
             _end = end;
+            _length = -1;
+
             if (!end.IsEnd && !end.GreaterOrEqual(start))
             {
-                throw new ArgumentException("End should be greater or equal to start");
+                ThrowHelper.ThrowArgumentException_ReadableBufferCtor();
             }
-            start.TryGetBuffer(end, out _first, out start);
-            _length = -1;
+            start.TryGetBuffer(end, out _first);
         }
 
         private ReadableBuffer(ref ReadableBuffer buffer)
@@ -78,10 +79,9 @@ namespace System.IO.Pipelines
 
             _start = begin;
             _end = end;
-
             _length = buffer._length;
 
-            begin.TryGetBuffer(end, out _first, out begin);
+            begin.TryGetBuffer(end, out _first);
         }
 
         /// <summary>

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -55,14 +55,15 @@ namespace System.IO.Pipelines
 
         internal ReadableBuffer(ReadCursor start, ReadCursor end)
         {
+            if (!end.IsEnd)
+            {
+                ThrowHelper.ThrowArgumentException_ReadableBufferCtor();
+            }
+
             _start = start;
             _end = end;
             _length = -1;
 
-            if (!end.IsEnd && !end.GreaterOrEqual(start))
-            {
-                ThrowHelper.ThrowArgumentException_ReadableBufferCtor();
-            }
             start.TryGetBuffer(end, out _first);
         }
 

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -55,7 +55,7 @@ namespace System.IO.Pipelines
 
         internal ReadableBuffer(ReadCursor start, ReadCursor end)
         {
-            if (!end.IsEnd)
+            if (!end.IsEnd && !end.GreaterOrEqual(start))
             {
                 ThrowHelper.ThrowArgumentException_ReadableBufferCtor();
             }

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -55,11 +55,6 @@ namespace System.IO.Pipelines
 
         internal ReadableBuffer(ReadCursor start, ReadCursor end)
         {
-            if (!end.IsEnd && !end.GreaterOrEqual(start))
-            {
-                ThrowHelper.ThrowArgumentException_ReadableBufferCtor();
-            }
-
             _start = start;
             _end = end;
             _length = -1;

--- a/src/System.IO.Pipelines/ThrowHelper.cs
+++ b/src/System.IO.Pipelines/ThrowHelper.cs
@@ -35,6 +35,11 @@ namespace System.IO.Pipelines
             throw GetArgumentOutOfRangeException_BufferRequestTooLarge(maxSize);
         }
 
+        internal static void ThrowArgumentException_ReadableBufferCtor()
+        {
+            throw new ArgumentException("End should be greater or equal to start");
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static ArgumentOutOfRangeException GetArgumentOutOfRangeException(ExceptionArgument argument)
         {

--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -46,7 +46,7 @@ namespace System
             return owner.Memory;
         }
 
-        public readonly static Memory<T> Empty = OwnerEmptyMemory<T>.Shared.Memory;
+        public static Memory<T> Empty => OwnerEmptyMemory<T>.Shared.Memory;
 
         public int Length => _length;
 

--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -46,7 +46,7 @@ namespace System
             return owner.Memory;
         }
 
-        public static Memory<T> Empty => OwnerEmptyMemory<T>.Shared.Memory;
+        public readonly static Memory<T> Empty = OwnerEmptyMemory<T>.Shared.Memory;
 
         public int Length => _length;
 


### PR DESCRIPTION
No point in doing extra work for an out param that is never used.

`out ReadCursor cursor` variants of `TryGetBuffer` aren't used anymore but haven't removed them

Unless they were meant to be called with a param that was later used?

/cc @davidfowl 