### PR TITLE
Reduce implied param passing

### DIFF
--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -19,7 +19,15 @@ namespace System
         readonly int _index;
         readonly int _length;
 
-        internal Memory(OwnedMemory<T> owner, int id, int index, int length)
+        internal Memory(OwnedMemory<T> owner, int index, int length)
+        {
+            _owner = owner;
+            _id = owner.Id;
+            _index = index;
+            _length = length;
+        }
+
+        private Memory(OwnedMemory<T> owner, int id, int index, int length)
         {
             _owner = owner;
             _id = id;

--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -19,11 +19,11 @@ namespace System
         readonly int _index;
         readonly int _length;
 
-        internal Memory(OwnedMemory<T> owner, int index, int length)
+        internal Memory(OwnedMemory<T> owner, int length)
         {
             _owner = owner;
             _id = owner.Id;
-            _index = index;
+            _index = 0;
             _length = length;
         }
 

--- a/src/System.Slices/System/Buffers/OwnedMemory.cs
+++ b/src/System.Slices/System/Buffers/OwnedMemory.cs
@@ -26,7 +26,7 @@ namespace System.Buffers
 
         public int Length => _length;
 
-        protected int Id => _id;
+        internal int Id => _id;
         protected T[] Array => _array;
         protected IntPtr Pointer => _pointer;
         protected int Offset => _arrayIndex;
@@ -49,8 +49,8 @@ namespace System.Buffers
             Initialize(array, arrayOffset, length, pointer);
         }
 
-        public Memory<T> Memory => new Memory<T>(this, Id, 0, Length);
-        public ReadOnlyMemory<T> ReadOnlyMemory => new ReadOnlyMemory<T>(this, Id, 0, Length);
+        public Memory<T> Memory => new Memory<T>(this, 0, Length);
+        public ReadOnlyMemory<T> ReadOnlyMemory => new ReadOnlyMemory<T>(this, 0, Length);
 
         public Span<T> Span
         {

--- a/src/System.Slices/System/Buffers/OwnedMemory.cs
+++ b/src/System.Slices/System/Buffers/OwnedMemory.cs
@@ -49,8 +49,8 @@ namespace System.Buffers
             Initialize(array, arrayOffset, length, pointer);
         }
 
-        public Memory<T> Memory => new Memory<T>(this, 0, Length);
-        public ReadOnlyMemory<T> ReadOnlyMemory => new ReadOnlyMemory<T>(this, 0, Length);
+        public Memory<T> Memory => new Memory<T>(this, Length);
+        public ReadOnlyMemory<T> ReadOnlyMemory => new ReadOnlyMemory<T>(this, Length);
 
         public Span<T> Span
         {

--- a/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
@@ -18,11 +18,11 @@ namespace System
         readonly int _index;
         readonly int _length;
 
-        internal ReadOnlyMemory(OwnedMemory<T> owner, int index, int length)
+        internal ReadOnlyMemory(OwnedMemory<T> owner, int length)
         {
             _owner = owner;
             _id = owner.Id;
-            _index = index;
+            _index = 0;
             _length = length;
         }
 

--- a/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
@@ -18,6 +18,14 @@ namespace System
         readonly int _index;
         readonly int _length;
 
+        internal ReadOnlyMemory(OwnedMemory<T> owner, int index, int length)
+        {
+            _owner = owner;
+            _id = owner.Id;
+            _index = index;
+            _length = length;
+        }
+
         internal ReadOnlyMemory(OwnedMemory<T> owner, int id, int index, int length)
         {
             _owner = owner;


### PR DESCRIPTION
Change causes `OwnedMemory``1.get_Memory` to evaporate from the stack traces

4th param for instance call is passed via stack rather than reg; so cut memory op by looking it up later, rather than precall; and spilling a param to stack; `0` is also implied by this .`ctor` so doesn't need to be passed.

(this `RCX`, owner `RDX`, id `R8`, index `R9`, length `stack`) 
=> (this `RCX`, owner `RDX`, length `R8`) 

It is an extremely hot function

![](https://aoa.blob.core.windows.net/aspnet/ownedMemory.png)