### PR TITLE
Faster IndexOfVectorized

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -122,103 +122,203 @@ namespace System.Buffers
         static readonly int s_longSize = Vector<ulong>.Count;
         static readonly int s_byteSize = Vector<byte>.Count;
 
-        public static int IndexOfVectorized(this Span<byte> buffer, byte value)
+        public unsafe static int IndexOfVectorized(this Span<byte> buffer, byte value)
         {
-            Debug.Assert(s_longSize == 4 || s_longSize == 2);
-
-            var byteSize = s_byteSize;
-
-            if (buffer.Length < byteSize * 2 || !Vector.IsHardwareAccelerated) return buffer.IndexOf(value);
-
-            Vector<byte> match = new Vector<byte>(value);
-            var vectors = buffer.NonPortableCast<byte, Vector<byte>>();
-            var zero = Vector<byte>.Zero;
-
-            for (int vectorIndex = 0; vectorIndex < vectors.Length; vectorIndex++)
+            var index = -1;
+            var length = buffer.Length;
+            if (length == 0)
             {
-                var vector = vectors.GetItem(vectorIndex);
-                var result = Vector.Equals(vector, match);
-                if (result != zero)
-                {
-                    var longer = Vector.AsVectorUInt64(result);
-                    Debug.Assert(s_longSize == 4 || s_longSize == 2);
-
-                    var candidate = longer[0];
-                    if (candidate != 0) return vectorIndex * byteSize + IndexOf(candidate);
-                    candidate = longer[1];
-                    if (candidate != 0) return 8 + vectorIndex * byteSize + IndexOf(candidate);
-                    if (s_longSize == 4)
-                    {
-                        candidate = longer[2];
-                        if (candidate != 0) return 16 + vectorIndex * byteSize + IndexOf(candidate);
-                        candidate = longer[3];
-                        if (candidate != 0) return 24 + vectorIndex * byteSize + IndexOf(candidate);
-                    }
-                }
+                goto exit;
             }
 
-            var processed = vectors.Length * byteSize;
-            var index = buffer.Slice(processed).IndexOf(value);
-            if (index == -1) return -1;
-            return index + processed;
+            fixed (byte* pHaystack = &buffer.DangerousGetPinnableReference())
+            {
+                var haystack = pHaystack;
+                index = 0;
+
+                if (Vector.IsHardwareAccelerated)
+                {
+                    if (length - Vector<byte>.Count >= index)
+                    {
+                        Vector<byte> needles = GetVector(value);
+                        do
+                        {
+                            var flaggedMatches = Vector.Equals(Unsafe.Read<Vector<byte>>(haystack + index), needles);
+                            if (flaggedMatches.Equals(Vector<byte>.Zero))
+                            {
+                                index += Vector<byte>.Count;
+                                continue;
+                            }
+
+                            index += LocateFirstFoundByte(flaggedMatches);
+                            goto exitFixed;
+
+                        } while (length - Vector<byte>.Count >= index);
+                    }
+                }
+
+                while (length - sizeof(ulong) >= index)
+                {
+                    var flaggedMatches = SetLowBitsForByteMatch(*(ulong*)(haystack + index), value);
+                    if (flaggedMatches == 0)
+                    {
+                        index += sizeof(ulong);
+                        continue;
+                    }
+
+                    index += LocateFirstFoundByte(flaggedMatches);
+                    goto exitFixed;
+                }
+
+                for (; index < length; index++)
+                {
+                    if (*(haystack + index) == value)
+                    {
+                        goto exitFixed;
+                    }
+                }
+                // No Matches
+                index = -1;
+                // Don't goto out of fixed block
+        exitFixed:;
+            }
+        exit:
+            return index;
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static int IndexOfVectorized(this ReadOnlySpan<byte> buffer, byte value)
+        public unsafe static int IndexOfVectorized(this ReadOnlySpan<byte> buffer, byte value)
         {
             Debug.Assert(s_longSize == 4 || s_longSize == 2);
 
-            var byteSize = s_byteSize;
-
-            if (buffer.Length < byteSize * 2 || !Vector.IsHardwareAccelerated) return buffer.IndexOf(value);
-
-            Vector<byte> match = new Vector<byte>(value);
-            var vectors = buffer.NonPortableCast<byte, Vector<byte>>();
-            var zero = Vector<byte>.Zero;
-
-            for (int vectorIndex = 0; vectorIndex < vectors.Length; vectorIndex++)
+            var index = -1;
+            var length = buffer.Length;
+            if (length == 0)
             {
-                var vector = vectors[vectorIndex];
-                var result = Vector.Equals(vector, match);
-                if (result != zero)
-                {
-                    var longer = Vector.AsVectorUInt64(result);
-                    var candidate = longer[0];
-                    if (candidate != 0) return vectorIndex * byteSize + IndexOf(candidate);
-                    candidate = longer[1];
-                    if (candidate != 0) return 8 + vectorIndex * byteSize + IndexOf(candidate);
-                    if (s_longSize == 4)
-                    {
-                        candidate = longer[2];
-                        if (candidate != 0) return 16 + vectorIndex * byteSize + IndexOf(candidate);
-                        candidate = longer[3];
-                        if (candidate != 0) return 24 + vectorIndex * byteSize + IndexOf(candidate);
-                    }
-                }
+                goto exit;
             }
 
-            var processed = vectors.Length * byteSize;
-            var index = buffer.Slice(processed).IndexOf(value);
-            if (index == -1) return -1;
-            return index + processed;
+            fixed (byte* pHaystack = &buffer.DangerousGetPinnableReference())
+            {
+                var haystack = pHaystack;
+                index = 0;
+
+                if (Vector.IsHardwareAccelerated)
+                {
+                    if (length - Vector<byte>.Count >= index)
+                    {
+                        Vector<byte> needles = GetVector(value);
+                        do
+                        {
+                            var flaggedMatches = Vector.Equals(Unsafe.Read<Vector<byte>>(haystack + index), needles);
+                            if (flaggedMatches.Equals(Vector<byte>.Zero))
+                            {
+                                index += Vector<byte>.Count;
+                                continue;
+                            }
+
+                            index += LocateFirstFoundByte(flaggedMatches);
+                            goto exitFixed;
+
+                        } while (length - Vector<byte>.Count >= index);
+                    }
+                }
+
+                while (length - sizeof(ulong) >= index)
+                {
+                    var flaggedMatches = SetLowBitsForByteMatch(*(ulong*)(haystack + index), value);
+                    if (flaggedMatches == 0)
+                    {
+                        index += sizeof(ulong);
+                        continue;
+                    }
+
+                    index += LocateFirstFoundByte(flaggedMatches);
+                    goto exitFixed;
+                }
+
+                for (; index < length; index++)
+                {
+                    if (*(haystack + index) == value)
+                    {
+                        goto exitFixed;
+                    }
+                }
+                // No Matches
+                index = -1;
+                // Don't goto out of fixed block
+        exitFixed:;
+            }
+        exit:
+            return index;
         }
 
-        // used by IndexOfVectorized
-        static int IndexOf(ulong next)
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LocateFirstFoundByte(Vector<byte> match)
         {
-            // Flag least significant power of two bit
-            var powerOfTwoFlag = (next ^ (next - 1));
-            // Shift all powers of two into the high byte and extract
-            var foundByteIndex = (int)((powerOfTwoFlag * _xorPowerOfTwoToHighByte) >> 57);
-            return foundByteIndex;
+            var vector64 = Vector.AsVectorUInt64(match);
+            ulong candidate = 0;
+            var i = 0;
+            // Pattern unrolled by jit https://github.com/dotnet/coreclr/pull/8001
+            for (; i < Vector<ulong>.Count; i++)
+            {
+                candidate = vector64[i];
+                if (candidate == 0) continue;
+                break;
+            }
+
+            // Single LEA instruction with jitted const (using function result)
+            return i * 8 + LocateFirstFoundByte(candidate);
         }
 
-        const ulong _xorPowerOfTwoToHighByte = (0x07ul |
-                                                0x06ul << 8 |
-                                                0x05ul << 16 |
-                                                0x04ul << 24 |
-                                                0x03ul << 32 |
-                                                0x02ul << 40 |
-                                                0x01ul << 48) + 1;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int LocateFirstFoundByte(ulong match)
+        {
+            unchecked
+            {
+                // Flag least significant power of two bit
+                var powerOfTwoFlag = match ^ (match - 1);
+                // Shift all powers of two into the high byte and extract
+                return (int)((powerOfTwoFlag * xorPowerOfTwoToHighByte) >> 57);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static ulong SetLowBitsForByteMatch(ulong potentialMatch, byte search)
+        {
+            unchecked
+            {
+                var flaggedValue = potentialMatch ^ (byteBroadcastToUlong * search);
+                return (
+                        (flaggedValue - byteBroadcastToUlong) &
+                        ~(flaggedValue) &
+                        filterByteHighBitsInUlong
+                       ) >> 7;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Vector<byte> GetVector(byte vectorByte)
+        {
+#if !NETCOREAPP1_2
+            // Vector<byte> .ctor doesn't become an intrinsic due to detection issue
+            // However this does cause it to become an intrinsic (with additional multiply and reg->reg copy)
+            // https://github.com/dotnet/coreclr/issues/7459#issuecomment-253965670
+            return Vector.AsVectorByte(new Vector<uint>(vectorByte * 0x01010101u));
+#else
+            return new Vector<byte>(vectorByte);
+#endif
+        }
+
+        private const ulong xorPowerOfTwoToHighByte = (0x07ul |
+                                                       0x06ul << 8 |
+                                                       0x05ul << 16 |
+                                                       0x04ul << 24 |
+                                                       0x03ul << 32 |
+                                                       0x02ul << 40 |
+                                                       0x01ul << 48) + 1;
+        private const ulong byteBroadcastToUlong = ~0UL / byte.MaxValue;
+        private const ulong filterByteHighBitsInUlong = (byteBroadcastToUlong >> 1) | (byteBroadcastToUlong << (sizeof(ulong) * 8 - 1));
     }
 }


### PR DESCRIPTION
from https://github.com/dotnet/corefx/pull/16222

Not quite sure how to interpret the benchmark results (from corefxlab\scripts\PerfHarness) but they suggest is x4.5 - x6 faster than `.IndexOf` for everything except length = 0

Likely want to verify it by someone who understands how the benchmarks work; might all be the same length and 0 is higher as its jitting