### PR TITLE
Various changes related to Kestrel updates

### DIFF
--- a/src/System.IO.Pipelines.Text.Primitives/ReadableBufferExtensions.cs
+++ b/src/System.IO.Pipelines.Text.Primitives/ReadableBufferExtensions.cs
@@ -86,7 +86,7 @@ namespace System.IO.Pipelines.Text.Primitives
         {
             uint value;
             int consumed;
-            if(!buffer.TryParseUInt32(out value, out consumed))
+            if (!buffer.TryParseUInt32(out value, out consumed))
             {
                 throw new InvalidOperationException("could not parse uint");
             }
@@ -109,14 +109,14 @@ namespace System.IO.Pipelines.Text.Primitives
                 ArraySegment<byte> data;
                 if (buffer.First.TryGetPointer(out pointer))
                 {
-                    if (!PrimitiveParser.InvariantUtf8.TryParseUInt64((byte*)pointer, len, out value)) 
+                    if (!PrimitiveParser.InvariantUtf8.TryParseUInt64((byte*)pointer, len, out value))
                     {
                         throw new InvalidOperationException();
                     }
                 }
                 else if (buffer.First.TryGetArray(out data))
                 {
-                    if (!PrimitiveParser.InvariantUtf8.TryParseUInt64(data.Array, out value)) 
+                    if (!PrimitiveParser.InvariantUtf8.TryParseUInt64(data.Array, out value))
                     {
                         throw new InvalidOperationException();
                     }
@@ -131,7 +131,8 @@ namespace System.IO.Pipelines.Text.Primitives
                 var data = stackalloc byte[len];
                 buffer.CopyTo(new Span<byte>(data, len));
                 addr = data;
-                if (!PrimitiveParser.InvariantUtf8.TryParseUInt64(addr, len, out value)) {
+                if (!PrimitiveParser.InvariantUtf8.TryParseUInt64(addr, len, out value))
+                {
                     throw new InvalidOperationException();
                 }
             }
@@ -139,7 +140,8 @@ namespace System.IO.Pipelines.Text.Primitives
             {
                 // Heap allocated copy to parse into array (should be rare)
                 var arr = buffer.ToArray();
-                if (!PrimitiveParser.InvariantUtf8.TryParseUInt64(arr, out value)) {
+                if (!PrimitiveParser.InvariantUtf8.TryParseUInt64(arr, out value))
+                {
                     throw new InvalidOperationException();
                 }
 
@@ -147,6 +149,31 @@ namespace System.IO.Pipelines.Text.Primitives
             }
 
             return value;
+        }
+
+        public unsafe static string GetAsciiString(this Span<byte> span)
+        {
+            if (span.IsEmpty)
+            {
+                return null;
+            }
+
+            var asciiString = new string('\0', span.Length);
+
+            fixed (char* outputStart = asciiString)
+            {
+                var output = outputStart;
+
+                fixed (byte* buffer = &span.DangerousGetPinnableReference())
+                {
+                    if (!AsciiUtilities.TryGetAsciiString(buffer, output, span.Length))
+                    {
+                        throw new InvalidOperationException();
+                    }
+                }
+            }
+
+            return asciiString;
         }
 
         /// <summary>

--- a/src/System.IO.Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/BufferSegment.cs
@@ -38,6 +38,8 @@ namespace System.IO.Pipelines
         /// </summary>
         private OwnedMemory<byte> _buffer;
 
+        private Memory<byte> _memory;
+
         public BufferSegment(OwnedMemory<byte> buffer)
         {
             _buffer = buffer;
@@ -45,6 +47,7 @@ namespace System.IO.Pipelines
             End = 0;
 
             _buffer.AddReference();
+            _memory = _buffer.Memory;
         }
 
         public BufferSegment(OwnedMemory<byte> buffer, int start, int end)
@@ -63,9 +66,10 @@ namespace System.IO.Pipelines
             }
 
             _buffer.AddReference();
+            _memory = _buffer.Memory;
         }
 
-        public Memory<byte> Memory => _buffer.Memory;
+        public Memory<byte> Memory => _memory;
 
         /// <summary>
         /// If true, data should not be written into the backing block after the End offset. Data between start and end should never be modified

--- a/src/System.IO.Pipelines/ReadCursor.cs
+++ b/src/System.IO.Pipelines/ReadCursor.cs
@@ -176,12 +176,11 @@ namespace System.IO.Pipelines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool TryGetBuffer(ReadCursor end, out Memory<byte> data, out ReadCursor cursor)
+        internal bool TryGetBuffer(ReadCursor end, out Memory<byte> data)
         {
             if (IsDefault)
             {
                 data = Memory<byte>.Empty;
-                cursor = this;
                 return false;
             }
 
@@ -195,21 +194,19 @@ namespace System.IO.Pipelines
                 if (following > 0)
                 {
                     data = segment.Memory.Slice(index, following);
-                    cursor = new ReadCursor(segment, index + following);
                     return true;
                 }
 
                 data = Memory<byte>.Empty;
-                cursor = this;
                 return false;
             }
             else
             {
-                return TryGetBufferMultiBlock(end, out data, out cursor);
+                return TryGetBufferMultiBlock(end, out data);
             }
         }
 
-        private bool TryGetBufferMultiBlock(ReadCursor end, out Memory<byte> data, out ReadCursor cursor)
+        private bool TryGetBufferMultiBlock(ReadCursor end, out Memory<byte> data)
         {
             var segment = _segment;
             var index = _index;
@@ -242,7 +239,6 @@ namespace System.IO.Pipelines
                 if (wasLastSegment)
                 {
                     data = Memory<byte>.Empty;
-                    cursor = this;
                     return false;
                 }
                 else
@@ -253,7 +249,6 @@ namespace System.IO.Pipelines
             }
 
             data = segment.Memory.Slice(index, following);
-            cursor = new ReadCursor(segment, index + following);
             return true;
         }
 

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -31,7 +31,7 @@ namespace System.IO.Pipelines
         /// <summary>
         /// Determines if the <see cref="ReadableBuffer"/> is empty.
         /// </summary>
-        public bool IsEmpty => _first.IsEmpty && Length == 0;
+        public bool IsEmpty => _start == _end;
 
         /// <summary>
         /// Determins if the <see cref="ReadableBuffer"/> is a single <see cref="Memory{Byte}"/>.
@@ -57,11 +57,7 @@ namespace System.IO.Pipelines
         {
             _start = start;
             _end = end;
-            if (!end.IsEnd && !end.GreaterOrEqual(start))
-            {
-                throw new ArgumentException("End should be greater or equal to start");
-            }
-            start.TryGetBuffer(end, out _first, out start);
+            start.TryGetBuffer(end, out _first);
             _length = -1;
         }
 
@@ -81,7 +77,7 @@ namespace System.IO.Pipelines
 
             _length = buffer._length;
 
-            begin.TryGetBuffer(end, out _first, out begin);
+            begin.TryGetBuffer(end, out _first);
         }
 
         /// <summary>

--- a/src/System.IO.Pipelines/ReadableBufferReader.cs
+++ b/src/System.IO.Pipelines/ReadableBufferReader.cs
@@ -26,22 +26,12 @@ namespace System.IO.Pipelines
             _overallIndex = 0;
             _enumerator = new MemoryEnumerator(start, end);
             _currentMemory = default(Span<byte>);
-            while (_enumerator.MoveNext())
-            {
-                if (!_enumerator.Current.IsEmpty)
-                {
-                    _currentMemory = _enumerator.Current.Span;
-                    return;
-                }
-            }
-            _end = true;
+            MoveNext();
         }
 
         public bool End => _end;
 
         public int Index => _overallIndex;
-
-        public Span<byte> Span => _currentMemory;
 
         public ReadCursor Cursor
         {
@@ -86,15 +76,17 @@ namespace System.IO.Pipelines
 
         private void MoveNext()
         {
-            if (_enumerator.MoveNext() && !_enumerator.Current.IsEmpty)
+            while (_enumerator.MoveNext())
             {
-                _currentMemory = _enumerator.Current.Span;
-                _index = 0;
+                if (!_enumerator.Current.IsEmpty)
+                {
+                    _currentMemory = _enumerator.Current.Span;
+                    _index = 0;
+                    return;
+                }
             }
-            else
-            {
-                _end = true;
-            }
+
+            _end = true;
         }
 
         public void Skip(int length)

--- a/src/System.IO.Pipelines/ThrowHelper.cs
+++ b/src/System.IO.Pipelines/ThrowHelper.cs
@@ -9,7 +9,6 @@ namespace System.IO.Pipelines
 {
     internal class ThrowHelper
     {
-
         public static void ThrowArgumentOutOfRangeException(ExceptionArgument argument)
         {
             throw GetArgumentOutOfRangeException(argument);


### PR DESCRIPTION
- Added GetAsciiString extension method on `Span<byte>`
- Store the `Memory<byte>` on BufferSegment
- Removed unused read cursor out param on TryGetBuffer
- Remove bounds check from internal readable buffer ctor
- Fixed Cursor property on ReadableBufferReader
- Added ReadableBufferReader.Skip

/cc @benaadams @halter73 @pakrym 