### PR TITLE
Removed Memory._id

### DIFF
--- a/src/System.Slices/System/Buffers/OwnedMemory.cs
+++ b/src/System.Slices/System/Buffers/OwnedMemory.cs
@@ -140,39 +140,31 @@ namespace System.Buffers
         #endregion
 
         #region Used by Memory<T>
-        void IKnown.AddReference(long id)
+        void IKnown.AddReference()
         {
             AddReference();
-            try {
-                VerifyId(id);
-            } catch (ObjectDisposedException e) {
-                Release();
-                throw e;
-            }
         }
 
-        void IKnown.Release(long id)
+        void IKnown.Release()
         {
-            VerifyId(id);
             Release();
         }
 
-        internal unsafe bool TryGetPointerInternal(long id, out void* pointer)
+        internal unsafe bool TryGetPointerInternal(out void* pointer)
         {
-            VerifyId(id);
             return TryGetPointerCore(out pointer);
         }
 
-        internal bool TryGetArrayInternal(long id, out ArraySegment<T> buffer)
+        internal bool TryGetArrayInternal(out ArraySegment<T> buffer)
         {
-            VerifyId(id);
             return TryGetArrayCore(out buffer);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal Span<T> GetSpanInternal(long id, int index, int length)
+        internal Span<T> GetSpanInternal(int index, int length)
         {
-            VerifyId(id);
+            if (IsDisposed) ThrowIdHelper();
+
             var array = Array;
             if (array != null) 
             {
@@ -226,22 +218,20 @@ namespace System.Buffers
 
     interface IKnown
     {
-        void AddReference(long id);
-        void Release(long id);
+        void AddReference();
+        void Release();
     }
 
     public struct DisposableReservation<T> : IDisposable
     {
         OwnedMemory<T> _owner;
-        long _id;
 
-        internal DisposableReservation(OwnedMemory<T> owner, long id)
+        internal DisposableReservation(OwnedMemory<T> owner)
         {
-            _id = id;
             _owner = owner;
             switch(ReferenceCountingSettings.OwnedMemory) {
                 case ReferenceCountingMethod.Interlocked:
-                    ((IKnown)_owner).AddReference(_id);
+                    ((IKnown)_owner).AddReference();
                     break;
                 case ReferenceCountingMethod.ReferenceCounter:
                     ReferenceCounter.AddReference(_owner);
@@ -257,7 +247,7 @@ namespace System.Buffers
         {
             switch (ReferenceCountingSettings.OwnedMemory) {
                 case ReferenceCountingMethod.Interlocked:
-                    ((IKnown)_owner).Release(_id);
+                    ((IKnown)_owner).Release();
                     break;
                 case ReferenceCountingMethod.ReferenceCounter:
                     ReferenceCounter.Release(_owner);

--- a/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
@@ -14,22 +14,19 @@ namespace System
     public struct ReadOnlyMemory<T> : IEquatable<ReadOnlyMemory<T>>, IEquatable<Memory<T>>
     {
         readonly OwnedMemory<T> _owner;
-        readonly int _id;
         readonly int _index;
         readonly int _length;
 
         internal ReadOnlyMemory(OwnedMemory<T> owner, int length)
         {
             _owner = owner;
-            _id = owner.Id;
             _index = 0;
             _length = length;
         }
 
-        internal ReadOnlyMemory(OwnedMemory<T> owner, int id, int index, int length)
+        internal ReadOnlyMemory(OwnedMemory<T> owner,int index, int length)
         {
             _owner = owner;
-            _id = id;
             _index = index;
             _length = length;
         }
@@ -48,14 +45,14 @@ namespace System
 
         public ReadOnlyMemory<T> Slice(int index)
         {
-            return new ReadOnlyMemory<T>(_owner, _id, _index + index, _length - index);
+            return new ReadOnlyMemory<T>(_owner, _index + index, _length - index);
         }
         public ReadOnlyMemory<T> Slice(int index, int length)
         {
-            return new ReadOnlyMemory<T>(_owner, _id, _index + index, length);
+            return new ReadOnlyMemory<T>(_owner, _index + index, length);
         }
 
-        public ReadOnlySpan<T> Span => _owner.GetSpanInternal(_id, _index, _length);
+        public ReadOnlySpan<T> Span => _owner.GetSpanInternal(_index, _length);
 
         public DisposableReservation<T> Reserve()
         {
@@ -64,7 +61,7 @@ namespace System
    
         public unsafe bool TryGetPointer(out void* pointer)
         {
-            if (!_owner.TryGetPointerInternal(_id, out pointer)) {
+            if (!_owner.TryGetPointerInternal(out pointer)) {
                 return false;
             }
             pointer = Memory<T>.Add(pointer, _index);
@@ -73,7 +70,7 @@ namespace System
 
         public unsafe bool TryGetArray(out ArraySegment<T> buffer)
         {
-            if (!_owner.TryGetArrayInternal(_id, out buffer)) {
+            if (!_owner.TryGetArrayInternal(out buffer)) {
                 return false;
             }
             buffer = new ArraySegment<T>(buffer.Array, buffer.Offset + _index, _length);
@@ -114,7 +111,6 @@ namespace System
         {
             return
                 _owner == other._owner &&
-                _id == other._id &&
                 _index == other._index &&
                 _length == other._length;
         }
@@ -140,7 +136,7 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
-            return HashingHelper.CombineHashCodes(_owner.GetHashCode(), _index.GetHashCode(), _id.GetHashCode(), _length.GetHashCode());
+            return HashingHelper.CombineHashCodes(_owner.GetHashCode(), _index.GetHashCode(), _length.GetHashCode());
         }
 
         public override string ToString()

--- a/tests/Benchmarks/IndexOf.cs
+++ b/tests/Benchmarks/IndexOf.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Xunit;
 using Microsoft.Xunit.Performance;
 using System;
 using System.Buffers;
@@ -10,18 +11,22 @@ using System.Text;
 
 public class IndexOfBench
 {
-    static int s_bufferLength = 1000;
+    static int s_bufferLength = 2000;
     static byte[] s_buffer = new byte[s_bufferLength];
     static int s_loops = 1000;
 
-    static IndexOfBench() 
-    {
-        s_buffer[s_bufferLength - 100] = 255;
-    }
-
     [Benchmark]
-    static int SpanIndexOf()
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(4)]
+    [InlineData(8)]
+    [InlineData(16)]
+    [InlineData(30)]
+    [InlineData(1000)]
+    static int SpanIndexOf(int at)
     {
+        s_buffer[at] = 255;
         Span<byte> buffer = s_buffer;
         int index = 0;
         foreach (var iteration in Benchmark.Iterations)
@@ -33,13 +38,23 @@ public class IndexOfBench
                 }
             }
         }
+        s_buffer[at] = 0;
         return index;
     }
 
     [Benchmark]
-    static int VectorizedIndexOf()
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(4)]
+    [InlineData(8)]
+    [InlineData(16)]
+    [InlineData(30)]
+    [InlineData(1000)]
+    static int VectorizedIndexOf(int at)
     {
         if(!Vector.IsHardwareAccelerated) return 0;
+        s_buffer[at] = 255;
 
         Span<byte> buffer = s_buffer;
         int index = 0;
@@ -52,6 +67,7 @@ public class IndexOfBench
                 }
             }
         }
+        s_buffer[at] = 0;
         return index;
     }
 }


### PR DESCRIPTION
We want to get to baseline performance first before adding pooling checks/diagnostics. This change:

- makes Memory<T> smaller and so passing it by value and construction cheaper
- makes get_Span, TryGetPointer, TryGetArray cheaper as they won’t have to pass the ID and do ID checks
- makes diagnosing use after return bugs harder

### Kestrel-Pipelines performance impact

#### Before (with ID)
```
                   Method |       Mean |    StdDev |     Median | Scaled | Scaled-StdDev |        RPS | Allocated |
------------------------- |----------- |---------- |----------- |------- |-------------- |----------- |---------- |
           ParsePlaintext |  2.0345 us | 0.0546 us |  2.0456 us |   1.00 |          0.00 | 491,511.89 |     105 B |
  ParsePipelinedPlaintext |  1.8487 us | 0.0524 us |  1.8607 us |   0.91 |          0.03 | 540,916.50 |     105 B |
          ParseLiveAspNet |  9.5836 us | 0.2583 us |  9.5493 us |   4.71 |          0.18 | 104,345.41 |   1.11 kB |
 ParsePipelinedLiveAspNet | 10.7971 us | 0.3896 us | 10.7426 us |   5.31 |          0.23 |  92,617.14 |   1.11 kB |
             ParseUnicode | 14.8633 us | 0.3654 us | 15.0547 us |   7.31 |          0.26 |  67,279.60 |   1.94 kB |
    ParseUnicodePipelined | 16.6655 us | 0.3759 us | 16.6712 us |   8.20 |          0.28 |  60,004.12 |   1.94 kB |
```

#### After (no ID)

```
                   Method |       Mean |    StdDev |     Median | Scaled | Scaled-StdDev |        RPS | Allocated |
------------------------- |----------- |---------- |----------- |------- |-------------- |----------- |---------- |
           ParsePlaintext |  1.9474 us | 0.0695 us |  1.9281 us |   1.00 |          0.00 | 513,500.72 |     105 B |
  ParsePipelinedPlaintext |  1.6893 us | 0.0513 us |  1.6757 us |   0.87 |          0.04 | 591,974.34 |     105 B |
          ParseLiveAspNet |  9.1254 us | 0.2620 us |  9.2597 us |   4.69 |          0.21 | 109,583.94 |    1.1 kB |
 ParsePipelinedLiveAspNet | 10.1330 us | 0.1856 us | 10.2064 us |   5.21 |          0.21 |  98,687.41 |    1.1 kB |
             ParseUnicode | 14.3673 us | 0.5455 us | 14.4018 us |   7.39 |          0.38 |  69,602.74 |   1.94 kB |
    ParseUnicodePipelined | 16.1511 us | 0.3173 us | 16.1940 us |   8.30 |          0.33 |  61,915.45 |   1.94 kB |
```
