### PR TITLE
Basic implementation of vectorized TryIndicesOf

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -246,6 +246,7 @@ namespace System.Buffers
 
         private unsafe static bool TryIndicesOf(ref byte searchSpace, byte value, int length, Span<int> indices, out int numberOfIndices)
         {
+            var result = false;
             numberOfIndices = 0;
 
             fixed (byte* pSearchSpace = &searchSpace)
@@ -319,6 +320,7 @@ namespace System.Buffers
                     }
 
                     // No Matches
+                    result = true;
                     break;
 
             exitFixed:;
@@ -328,7 +330,7 @@ namespace System.Buffers
                 }
             }
 
-            return numberOfIndices > 0;
+            return result && numberOfIndices < indices.Length;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -218,7 +218,118 @@ namespace System.Buffers
         exitFixed:;
                 return offset;
             }
+        }
 
+        public static bool TryIndicesOf(this Span<byte> buffer, byte value, Span<int> indices, out int numberOfIndices)
+        {
+            var length = buffer.Length;
+            if (length == 0 || indices.Length == 0)
+            {
+                numberOfIndices = 0;
+                return false;
+            }
+
+            return TryIndicesOf(ref buffer.DangerousGetPinnableReference(), value, length, indices, out numberOfIndices);
+        }
+
+        public static bool IndicesOf(this ReadOnlySpan<byte> buffer, byte value, Span<int> indices, out int numberOfIndices)
+        {
+            var length = buffer.Length;
+            if (length == 0 || indices.Length == 0)
+            {
+                numberOfIndices = 0;
+                return false;
+            }
+
+            return TryIndicesOf(ref buffer.DangerousGetPinnableReference(), value, length, indices, out numberOfIndices);
+        }
+
+
+        private unsafe static bool TryIndicesOf(ref byte searchSpace, byte value, int length, Span<int> indices, out int numberOfIndices)
+        {
+            numberOfIndices = 0;
+
+            fixed (byte* pSearchSpace = &searchSpace)
+            {
+                var searchStart = pSearchSpace;
+                var offset = 0;
+
+                while (true)
+                {
+                    if (Vector.IsHardwareAccelerated)
+                    {
+                        // Check Vector lengths
+                        if (length - Vector<byte>.Count >= offset)
+                        {
+                            Vector<byte> values = GetVector(value);
+                            do
+                            {
+                                var vFlaggedMatches = Vector.Equals(Unsafe.Read<Vector<byte>>(searchStart + offset), values);
+                                if (!vFlaggedMatches.Equals(Vector<byte>.Zero))
+                                {
+                                    // Found match, reuse Vector values to keep register pressure low
+                                    values = vFlaggedMatches;
+                                    break;
+                                }
+
+                                offset += Vector<byte>.Count;
+                            } while (length - Vector<byte>.Count >= offset);
+
+                            // Found match? Perform secondary search outside out of loop, so above loop body is small
+                            if (length - Vector<byte>.Count >= offset)
+                            {
+                                // Find offset of first match
+                                offset += LocateFirstFoundByte(values);
+                                // goto rather than inline return to keep function smaller
+                                goto exitFixed;
+                            }
+                        }
+                    }
+
+                    ulong flaggedMatches = 0;
+                    // Check ulong length
+                    while (length - sizeof(ulong) >= offset)
+                    {
+                        flaggedMatches = SetLowBitsForByteMatch(*(ulong*)(searchStart + offset), value);
+                        if (flaggedMatches != 0)
+                        {
+                            // Found match
+                            break;
+                        }
+
+                        offset += sizeof(ulong);
+                    }
+
+                    // Found match? Perform secondary search outside out of loop, so above loop body is small
+                    if (length - sizeof(ulong) >= offset)
+                    {
+                        // Find offset of first match
+                        offset += LocateFirstFoundByte(flaggedMatches);
+                        // goto rather than inline return to keep function smaller
+                        goto exitFixed;
+                    }
+
+                    // Haven't found match, scan through remaining
+                    for (; offset < length; offset++)
+                    {
+                        if (*(searchStart + offset) == value)
+                        {
+                            // goto rather than inline return to keep loop body small
+                            goto exitFixed;
+                        }
+                    }
+
+                    // No Matches
+                    break;
+
+            exitFixed:;
+                    indices[numberOfIndices++] = offset++;
+                    if (numberOfIndices >= indices.Length)
+                        break;
+                }
+            }
+
+            return numberOfIndices > 0;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -232,7 +232,7 @@ namespace System.Buffers
             return TryIndicesOf(ref buffer.DangerousGetPinnableReference(), value, length, indices, out numberOfIndices);
         }
 
-        public static bool IndicesOf(this ReadOnlySpan<byte> buffer, byte value, Span<int> indices, out int numberOfIndices)
+        public static bool TryIndicesOf(this ReadOnlySpan<byte> buffer, byte value, Span<int> indices, out int numberOfIndices)
         {
             var length = buffer.Length;
             if (length == 0 || indices.Length == 0)
@@ -243,7 +243,6 @@ namespace System.Buffers
 
             return TryIndicesOf(ref buffer.DangerousGetPinnableReference(), value, length, indices, out numberOfIndices);
         }
-
 
         private unsafe static bool TryIndicesOf(ref byte searchSpace, byte value, int length, Span<int> indices, out int numberOfIndices)
         {

--- a/tests/System.Buffers.Experimental.Tests/VectorizedOperations.cs
+++ b/tests/System.Buffers.Experimental.Tests/VectorizedOperations.cs
@@ -85,12 +85,12 @@ namespace System.Buffers.Tests
                 dataBytes[i] = (byte)(i % gap);
             Span<byte> data = dataBytes;
 
-            Span<int> indices = new int[dataBytes.Length / gap];
+            Span<int> indices = new int[(dataBytes.Length / gap) + 1];
 
             // Validate correctness
             int count;
             Assert.True(data.TryIndicesOf(target, indices, out count));
-            Assert.Equal(indices.Length, count);
+            Assert.Equal(indices.Length - 1, count);
 
             var idx = 0;
             var cur = 0;
@@ -110,6 +110,21 @@ namespace System.Buffers.Tests
         }
 
         [Fact]
+        public void NotFoundIndicesOf()
+        {
+            byte[] dataBytes = new byte[20];
+            for (var i = 0; i < dataBytes.Length; i++)
+                dataBytes[i] = (byte)1;
+            Span<byte> data = dataBytes;
+
+            Span<int> indices = new int[1];
+
+            int count;
+            Assert.True(data.TryIndicesOf(2, indices, out count));
+            Assert.Equal(0, count);
+        }
+
+        [Fact]
         public void PartialIndicesOf()
         {
             int gap = 8;
@@ -121,12 +136,32 @@ namespace System.Buffers.Tests
             Span<int> indices = new int[(dataBytes.Length / gap) - 5];
 
             int count;
-            Assert.True(data.TryIndicesOf(3, indices, out count));
+            Assert.False(data.TryIndicesOf(3, indices, out count));
             Assert.Equal(indices.Length, count);
 
             Span<byte> left = data.Slice(indices[count - 1]);
             Assert.True(left.TryIndicesOf(1, indices, out count));
             Assert.Equal(5, count);
+        }
+
+        [Fact]
+        public void ExactIndicesOf()
+        {
+            int gap = 8;
+            byte[] dataBytes = new byte[200];
+            for (var i = 0; i < dataBytes.Length; i++)
+                dataBytes[i] = (byte)(i % gap);
+            Span<byte> data = dataBytes;
+
+            Span<int> indices = new int[dataBytes.Length / gap];
+
+            int count;
+            Assert.False(data.TryIndicesOf(3, indices, out count));
+            Assert.Equal(indices.Length, count);
+
+            Span<byte> left = data.Slice(indices[count - 1]);
+            Assert.True(left.TryIndicesOf(1, indices, out count));
+            Assert.Equal(0, count);
         }
 
         [Fact]

--- a/tests/System.Buffers.Experimental.Tests/VectorizedOperations.cs
+++ b/tests/System.Buffers.Experimental.Tests/VectorizedOperations.cs
@@ -60,5 +60,87 @@ namespace System.Buffers.Tests
             ReadOnlySpan<byte> span = buffer;
             Assert.Equal(-1, span.IndexOfVectorized(4));
         }
+
+        [Theory]
+        [InlineData(8, 0)]
+        [InlineData(8, 1)]
+        [InlineData(8, 4)]
+        [InlineData(8, 7)]
+        [InlineData(32, 0)]
+        [InlineData(32, 1)]
+        [InlineData(32, 17)]
+        [InlineData(32, 31)]
+        [InlineData(128, 0)]
+        [InlineData(128, 1)]
+        [InlineData(128, 26)]
+        [InlineData(128, 127)]
+        [InlineData(256, 0)]
+        [InlineData(256, 1)]
+        [InlineData(256, 173)]
+        [InlineData(256, 255)]
+        public void SpanIndicesOf(int gap, byte target)
+        {
+            byte[] dataBytes = new byte[8 * 1024];
+            for (var i = 0; i < dataBytes.Length; i++)
+                dataBytes[i] = (byte)(i % gap);
+            Span<byte> data = dataBytes;
+
+            Span<int> indices = new int[dataBytes.Length / gap];
+
+            // Validate correctness
+            int count;
+            Assert.True(data.TryIndicesOf(target, indices, out count));
+            Assert.Equal(indices.Length, count);
+
+            var idx = 0;
+            var cur = 0;
+            Span<byte> sp = data;
+
+            while (true)
+            {
+                int pos = sp.IndexOf(target);
+                if (pos == -1) break;
+                Assert.True(indices.Length > idx);
+                Assert.Equal(cur + pos, indices[idx++]);
+                sp = sp.Slice(pos + 1);
+                cur += pos + 1;
+            }
+
+            Assert.Equal(idx, count);
+        }
+
+        [Fact]
+        public void PartialIndicesOf()
+        {
+            int gap = 8;
+            byte[] dataBytes = new byte[200];
+            for (var i = 0; i < dataBytes.Length; i++)
+                dataBytes[i] = (byte)(i % gap);
+            Span<byte> data = dataBytes;
+
+            Span<int> indices = new int[(dataBytes.Length / gap) - 5];
+
+            int count;
+            Assert.True(data.TryIndicesOf(3, indices, out count));
+            Assert.Equal(indices.Length, count);
+
+            Span<byte> left = data.Slice(indices[count - 1]);
+            Assert.True(left.TryIndicesOf(1, indices, out count));
+            Assert.Equal(5, count);
+        }
+
+        [Fact]
+        public void NegativeIndicesOf()
+        {
+            byte[] buffer = new byte[0];
+            Span<byte> span = buffer;
+
+            Span<int> indices = new int[1];
+            int count;
+            Assert.False(span.TryIndicesOf(4, indices, out count));
+
+            indices = new int[0];
+            Assert.False(span.TryIndicesOf(3, indices, out count));
+        }
     }
 }


### PR DESCRIPTION
Based on some simple micro-benchmarks, using TryIndicesOf vs IndexOf+Slice in a loop is anywhere from 3x faster (for finding elements 8 bytes apart) to 8x faster (for elements ~120 bytes apart).