### PR TITLE
improved performance of Memory.get_Empty

### DIFF
--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -43,7 +43,7 @@ namespace System
             return owner.Memory;
         }
 
-        public static Memory<T> Empty => OwnerEmptyMemory<T>.Shared.Memory;
+        public static Memory<T> Empty { get; } = OwnerEmptyMemory<T>.Shared.Memory;
 
         public int Length => _length;
 

--- a/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
@@ -37,7 +37,7 @@ namespace System
             return owner.Memory;
         }
 
-        public static ReadOnlyMemory<T> Empty => Memory<T>.Empty;
+        public static ReadOnlyMemory<T> Empty { get; } = OwnerEmptyMemory<T>.Shared.Memory;
 
         public int Length => _length;
 


### PR DESCRIPTION
I reran the benchmarks several times and consistently ParsePlaintext improves but ParsePipelinedPlaintext degrades a bit. Possibly it's because my "before" is not really before this change but rather after my previous change (removal of ID). Possibly some changes to that got merged separately changed the baseline.  I would redo the baseline for more complex change, but I think this is a clear improvement, so I think we should just merge. Any other opinions?

#### Before
```
                   Method |       Mean |    StdDev |     Median | Scaled | Scaled-StdDev |        RPS | Allocated |
------------------------- |----------- |---------- |----------- |------- |-------------- |----------- |---------- |
           ParsePlaintext |  1.9474 us | 0.0695 us |  1.9281 us |   1.00 |          0.00 | 513,500.72 |     105 B |
  ParsePipelinedPlaintext |  1.6893 us | 0.0513 us |  1.6757 us |   0.87 |          0.04 | 591,974.34 |     105 B |
          ParseLiveAspNet |  9.1254 us | 0.2620 us |  9.2597 us |   4.69 |          0.21 | 109,583.94 |    1.1 kB |
 ParsePipelinedLiveAspNet | 10.1330 us | 0.1856 us | 10.2064 us |   5.21 |          0.21 |  98,687.41 |    1.1 kB |
             ParseUnicode | 14.3673 us | 0.5455 us | 14.4018 us |   7.39 |          0.38 |  69,602.74 |   1.94 kB |
    ParseUnicodePipelined | 16.1511 us | 0.3173 us | 16.1940 us |   8.30 |          0.33 |  61,915.45 |   1.94 kB |
```

#### After
```
                   Method |       Mean |    StdDev |     Median | Scaled | Scaled-StdDev |        RPS | Allocated |
------------------------- |----------- |---------- |----------- |------- |-------------- |----------- |---------- |
           ParsePlaintext |  1.9145 us | 0.0544 us |  1.9459 us |   1.00 |          0.00 | 522,330.49 |     105 B |
  ParsePipelinedPlaintext |  1.7103 us | 0.0459 us |  1.7365 us |   0.89 |          0.03 | 584,699.61 |     105 B |
          ParseLiveAspNet |  9.2185 us | 0.2146 us |  9.3227 us |   4.82 |          0.17 | 108,477.11 |    1.1 kB |
 ParsePipelinedLiveAspNet | 10.3602 us | 0.2725 us | 10.3802 us |   5.42 |          0.21 |  96,523.00 |    1.1 kB |
             ParseUnicode | 15.2175 us | 0.4898 us | 15.0674 us |   7.95 |          0.34 |  65,713.75 |   1.94 kB |
    ParseUnicodePipelined | 16.2008 us | 0.3531 us | 16.1448 us |   8.47 |          0.30 |  61,725.23 |   1.94 kB |
```