### PR TITLE
Faster seek implementation using span.IndexOfVectorized

### DIFF
--- a/src/System.IO.Pipelines/MemoryEnumerator.cs
+++ b/src/System.IO.Pipelines/MemoryEnumerator.cs
@@ -27,6 +27,8 @@ namespace System.IO.Pipelines
 
         internal BufferSegment CurrentSegment => _segmentEnumerator.Current.Segment;
 
+        internal int CurrentSegmentStartIndex => _segmentEnumerator.Current.Start;
+
         /// <summary>
         /// Moves to the next <see cref="Memory{Byte}"/> in the <see cref="ReadableBuffer"/>
         /// </summary>

--- a/src/System.IO.Pipelines/MemoryEnumerator.cs
+++ b/src/System.IO.Pipelines/MemoryEnumerator.cs
@@ -27,8 +27,6 @@ namespace System.IO.Pipelines
 
         internal BufferSegment CurrentSegment => _segmentEnumerator.Current.Segment;
 
-        internal int CurrentSegmentStartIndex => _segmentEnumerator.Current.Start;
-
         /// <summary>
         /// Moves to the next <see cref="Memory{Byte}"/> in the <see cref="ReadableBuffer"/>
         /// </summary>

--- a/src/System.IO.Pipelines/ReadCursorOperations.cs
+++ b/src/System.IO.Pipelines/ReadCursorOperations.cs
@@ -10,15 +10,17 @@ namespace System.IO.Pipelines
     {
         public static int Seek(ReadCursor begin, ReadCursor end, out ReadCursor result, byte byte0)
         {
-            var enumerator = new MemoryEnumerator(begin, end);
+            var enumerator = new SegmentEnumerator(begin, end);
             while (enumerator.MoveNext())
             {
-                var span = enumerator.Current.Span;
-                var segment = enumerator.CurrentSegment;
+                var segmentPart = enumerator.Current;
+                var segment = segmentPart.Segment;
+                var span = segment.Memory.Span.Slice(segmentPart.Start, segmentPart.Length);
+
                 int index = span.IndexOfVectorized(byte0);
                 if (index != -1)
                 {
-                    result = new ReadCursor(segment, enumerator.CurrentSegmentStartIndex + index);
+                    result = new ReadCursor(segment, segmentPart.Start + index);
                     return span[index];
                 }
             }
@@ -29,11 +31,12 @@ namespace System.IO.Pipelines
 
         public static int Seek(ReadCursor begin, ReadCursor end, out ReadCursor result, byte byte0, byte byte1)
         {
-            var enumerator = new MemoryEnumerator(begin, end);
+            var enumerator = new SegmentEnumerator(begin, end);
             while (enumerator.MoveNext())
             {
-                var span = enumerator.Current.Span;
-                var segment = enumerator.CurrentSegment;
+                var segmentPart = enumerator.Current;
+                var segment = segmentPart.Segment;
+                var span = segment.Memory.Span.Slice(segmentPart.Start, segmentPart.Length);
 
                 int index1 = span.IndexOfVectorized(byte0);
                 int index2 = span.IndexOfVectorized(byte1);
@@ -41,7 +44,7 @@ namespace System.IO.Pipelines
                 var index = MinIndex(index1, index2);
                 if (index != -1)
                 {
-                    result = new ReadCursor(segment, enumerator.CurrentSegmentStartIndex + index);
+                    result = new ReadCursor(segment, segmentPart.Start + index);
                     return span[index];
                 }
             }
@@ -52,11 +55,12 @@ namespace System.IO.Pipelines
 
         public static int Seek(ReadCursor begin, ReadCursor end, out ReadCursor result, byte byte0, byte byte1, byte byte2)
         {
-            var enumerator = new MemoryEnumerator(begin, end);
+            var enumerator = new SegmentEnumerator(begin, end);
             while (enumerator.MoveNext())
             {
-                var span = enumerator.Current.Span;
-                var segment = enumerator.CurrentSegment;
+                var segmentPart = enumerator.Current;
+                var segment = segmentPart.Segment;
+                var span = segment.Memory.Span.Slice(segmentPart.Start, segmentPart.Length);
 
                 int index1 = span.IndexOfVectorized(byte0);
                 int index2 = span.IndexOfVectorized(byte1);
@@ -66,7 +70,7 @@ namespace System.IO.Pipelines
 
                 if (index != -1)
                 {
-                    result = new ReadCursor(segment, enumerator.CurrentSegmentStartIndex + index);
+                    result = new ReadCursor(segment, segmentPart.Start + index);
                     return span[index];
                 }
             }

--- a/src/System.IO.Pipelines/ReadCursorOperations.cs
+++ b/src/System.IO.Pipelines/ReadCursorOperations.cs
@@ -2,371 +2,85 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
-using System.Numerics;
-using System.Runtime.CompilerServices;
+using System.Buffers;
 
 namespace System.IO.Pipelines
 {
     public static class ReadCursorOperations
     {
-        private const ulong _xorPowerOfTwoToHighByte = (0x07ul |
-                                                        0x06ul << 8 |
-                                                        0x05ul << 16 |
-                                                        0x04ul << 24 |
-                                                        0x03ul << 32 |
-                                                        0x02ul << 40 |
-                                                        0x01ul << 48) + 1;
-
-        private static readonly int _vectorSpan = Vector<byte>.Count;
-
         public static unsafe int Seek(ReadCursor begin, ReadCursor end, out ReadCursor result, byte byte0)
         {
+            var enumerator = new MemoryEnumerator(begin, end);
+            while (enumerator.MoveNext())
+            {
+                var span = enumerator.Current.Span;
+                var segment = enumerator.CurrentSegment;
+                int index = span.IndexOfVectorized(byte0);
+                if (index != -1)
+                {
+                    result = new ReadCursor(segment, enumerator.CurrentSegmentStartIndex + index);
+                    return span[index];
+                }
+            }
+
             result = end;
-            var block = begin.Segment;
-            if (block == null)
-            {
-                return -1;
-            }
-
-            var index = begin.Index;
-            var wasLastBlock = block.Next == null;
-            var following = block.End - index;
-
-            while (true)
-            {
-                while (following == 0)
-                {
-                    if ((block == end.Segment && index >= end.Index) ||
-                        wasLastBlock)
-                    {
-                        return -1;
-                    }
-
-                    block = block.Next;
-                    index = block.Start;
-                    wasLastBlock = block.Next == null;
-                    following = block.End - index;
-                }
-                ArraySegment<byte> array;
-                var getArrayResult = block.Memory.TryGetArray(out array);
-                Debug.Assert(getArrayResult);
-
-                while (following > 0)
-                {
-                    // Need unit tests to test Vector path
-#if !DEBUG
-                    // Check will be Jitted away https://github.com/dotnet/coreclr/issues/1079
-                    if (Vector.IsHardwareAccelerated)
-                    {
-#endif
-                    if (following >= _vectorSpan)
-                    {
-                        var byte0Equals = Vector.Equals(new Vector<byte>(array.Array, array.Offset + index), GetVector(byte0));
-
-                        if (byte0Equals.Equals(Vector<byte>.Zero))
-                        {
-                            if (block == end.Segment && index + _vectorSpan > end.Index)
-                            {
-                                return -1;
-                            }
-
-                            following -= _vectorSpan;
-                            index += _vectorSpan;
-                            continue;
-                        }
-
-                        var byteIndex = LocateFirstFoundByte(byte0Equals);
-
-                        if (block == end.Segment && index + byteIndex >= end.Index)
-                        {
-                            // Ensure iterator is left at limit position
-                            return -1;
-                        }
-
-                        result = new ReadCursor(block, index + byteIndex);
-                        return byte0;
-                    }
-                    // Need unit tests to test Vector path
-#if !DEBUG
-                    }
-#endif
-                    fixed (byte* pCurrentFixed = array.Array)
-                    {
-                        var pCurrent = pCurrentFixed + array.Offset + index;
-
-                        var pEnd = block == end.Segment ? pCurrentFixed + array.Offset + end.Index : pCurrent + following;
-                        while (pCurrent < pEnd)
-                        {
-                            if (*pCurrent == byte0)
-                            {
-                                result = new ReadCursor(block, index);
-                                return byte0;
-                            }
-                            pCurrent++;
-                            index++;
-                        }
-                    }
-                    following = 0;
-                    break;
-                }
-            }
+            return -1;
         }
 
         public static unsafe int Seek(ReadCursor begin, ReadCursor end, out ReadCursor result, byte byte0, byte byte1)
         {
+            // use address of ushort rather than stackalloc as the inliner won't inline functions with stackalloc
+            ushort twoBytes;
+            byte* byteArray = (byte*)&twoBytes;
+            byteArray[0] = byte0;
+            byteArray[1] = byte1;
+            var targets = new Span<byte>(byteArray, 2);
+            var enumerator = new MemoryEnumerator(begin, end);
+            while (enumerator.MoveNext())
+            {
+                var span = enumerator.Current.Span;
+                var segment = enumerator.CurrentSegment;
+
+                // TODO: Vectorize
+                int index = span.IndexOf(targets);
+                if (index != -1)
+                {
+                    result = new ReadCursor(segment, enumerator.CurrentSegmentStartIndex + index);
+                    return span[index];
+                }
+            }
+
             result = end;
-            var block = begin.Segment;
-            if (block == null)
-            {
-                return -1;
-            }
-
-            var index = begin.Index;
-            var wasLastBlock = block.Next == null;
-            var following = block.End - index;
-            int byteIndex = int.MaxValue;
-
-            while (true)
-            {
-                while (following == 0)
-                {
-                    if ((block == end.Segment && index >= end.Index) ||
-                        wasLastBlock)
-                    {
-                        return -1;
-                    }
-                    block = block.Next;
-                    index = block.Start;
-                    wasLastBlock = block.Next == null;
-                    following = block.End - index;
-                }
-                ArraySegment<byte> array;
-                var getArrayResult = block.Memory.TryGetArray(out array);
-                Debug.Assert(getArrayResult);
-
-                while (following > 0)
-                {
-
-                    // Need unit tests to test Vector path
-#if !DEBUG
-                    // Check will be Jitted away https://github.com/dotnet/coreclr/issues/1079
-                    if (Vector.IsHardwareAccelerated)
-                    {
-#endif
-                    if (following >= _vectorSpan)
-                    {
-                        var data = new Vector<byte>(array.Array, index + array.Offset);
-
-                        var byteEquals = Vector.Equals(data, GetVector(byte0));
-                        byteEquals = Vector.ConditionalSelect(byteEquals, byteEquals, Vector.Equals(data, GetVector(byte1)));
-
-                        if (!byteEquals.Equals(Vector<byte>.Zero))
-                        {
-                            byteIndex = LocateFirstFoundByte(byteEquals);
-                        }
-
-                        if (byteIndex == int.MaxValue)
-                        {
-                            following -= _vectorSpan;
-                            index += _vectorSpan;
-
-                            if (block == end.Segment && index >= end.Index)
-                            {
-                                return -1;
-                            }
-
-                            continue;
-                        }
-
-                        if (block == end.Segment && index + byteIndex >= end.Index)
-                        {
-                            // Ensure iterator is left at limit position
-                            return -1;
-                        }
-
-                        result = new ReadCursor(block, index + byteIndex);
-                        return array.Array[array.Offset + index + byteIndex];
-                    }
-                    // Need unit tests to test Vector path
-#if !DEBUG
-                    }
-#endif
-                    fixed (byte* pCurrentFixed = array.Array)
-                    {
-                        var pCurrent = pCurrentFixed + array.Offset + index;
-
-                        var pEnd = block == end.Segment ? pCurrentFixed + array.Offset + end.Index : pCurrent + following;
-                        while (pCurrent < pEnd)
-                        {
-                            if (*pCurrent == byte0)
-                            {
-                                result = new ReadCursor(block, index);
-                                return byte0;
-                            }
-                            if (*pCurrent == byte1)
-                            {
-                                result = new ReadCursor(block, index);
-                                return byte1;
-                            }
-                            pCurrent++;
-                            index++;
-                        }
-                    }
-
-                    following = 0;
-                    break;
-                }
-            }
+            return -1;
         }
 
         public static unsafe int Seek(ReadCursor begin, ReadCursor end, out ReadCursor result, byte byte0, byte byte1, byte byte2)
         {
+            // use address of uint rather than stackalloc as the inliner won't inline functions with stackalloc
+            uint fourBytes;
+            byte* byteArray = (byte*)&fourBytes;
+            byteArray[0] = byte0;
+            byteArray[1] = byte1;
+            byteArray[2] = byte2;
+
+            var targets = new Span<byte>(byteArray, 3);
+            var enumerator = new MemoryEnumerator(begin, end);
+            while (enumerator.MoveNext())
+            {
+                var span = enumerator.Current.Span;
+                var segment = enumerator.CurrentSegment;
+
+                // TODO: Vectorize
+                int index = span.IndexOf(targets);
+                if (index != -1)
+                {
+                    result = new ReadCursor(segment, enumerator.CurrentSegmentStartIndex + index);
+                    return span[index];
+                }
+            }
+
             result = end;
-            var block = begin.Segment;
-            if (block == null)
-            {
-                return -1;
-            }
-
-            var index = begin.Index;
-            var wasLastBlock = block.Next == null;
-            var following = block.End - index;
-            int byteIndex = int.MaxValue;
-
-            while (true)
-            {
-                while (following == 0)
-                {
-                    if ((block == end.Segment && index >= end.Index) ||
-                        wasLastBlock)
-                    {
-                        return -1;
-                    }
-                    block = block.Next;
-                    index = block.Start;
-                    wasLastBlock = block.Next == null;
-                    following = block.End - index;
-                }
-                ArraySegment<byte> array;
-                var getArrayResult = block.Memory.TryGetArray(out array);
-                Debug.Assert(getArrayResult);
-
-                while (following > 0)
-                {
-                    // Need unit tests to test Vector path
-#if !DEBUG
-                    // Check will be Jitted away https://github.com/dotnet/coreclr/issues/1079
-                    if (Vector.IsHardwareAccelerated)
-                    {
-#endif
-                    if (following >= _vectorSpan)
-                    {
-                        var data = new Vector<byte>(array.Array, array.Offset + index);
-
-                        var byteEquals = Vector.Equals(data, GetVector(byte0));
-                        byteEquals = Vector.ConditionalSelect(byteEquals, byteEquals, Vector.Equals(data, GetVector(byte1)));
-                        byteEquals = Vector.ConditionalSelect(byteEquals, byteEquals, Vector.Equals(data, GetVector(byte2)));
-
-                        if (!byteEquals.Equals(Vector<byte>.Zero))
-                        {
-                            byteIndex = LocateFirstFoundByte(byteEquals);
-                        }
-
-                        if (byteIndex == int.MaxValue)
-                        {
-                            following -= _vectorSpan;
-                            index += _vectorSpan;
-
-                            if (block == end.Segment && index >= end.Index)
-                            {
-                                return -1;
-                            }
-
-                            continue;
-                        }
-
-                        if (block == end.Segment && index + byteIndex >= end.Index)
-                        {
-                            // Ensure iterator is left at limit position
-                            return -1;
-                        }
-
-                        result = new ReadCursor(block, index + byteIndex);
-                        return array.Array[array.Offset + index + byteIndex];
-                    }
-                    // Need unit tests to test Vector path
-#if !DEBUG
-                    }
-#endif
-
-                    fixed (byte* pCurrentFixed = array.Array)
-                    {
-                        var pCurrent = pCurrentFixed + array.Offset + index;
-
-                        var pEnd = block == end.Segment ? pCurrentFixed + array.Offset + end.Index : pCurrent + following;
-                        while (pCurrent < pEnd)
-                        {
-                            if (*pCurrent == byte0)
-                            {
-                                result = new ReadCursor(block, index);
-                                return byte0;
-                            }
-                            if (*pCurrent == byte1)
-                            {
-                                result = new ReadCursor(block, index);
-                                return byte1;
-                            }
-                            if (*pCurrent == byte2)
-                            {
-                                result = new ReadCursor(block, index);
-                                return byte2;
-                            }
-                            pCurrent++;
-                            index++;
-                        }
-                    }
-                    following = 0;
-                    break;
-                }
-            }
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector<byte> GetVector(byte vectorByte)
-        {
-            // Vector<byte> .ctor doesn't become an intrinsic due to detection issue
-            // However this does cause it to become an intrinsic (with additional multiply and reg->reg copy)
-            // https://github.com/dotnet/coreclr/issues/7459#issuecomment-253965670
-            return Vector.AsVectorByte(new Vector<uint>(vectorByte * 0x01010101u));
-        }
-
-        /// <summary>
-        /// Locate the first of the found bytes
-        /// </summary>
-        /// <param  name="byteEquals"></param >
-        /// <returns>The first index of the result vector</returns>
-        // Force inlining (64 IL bytes, 91 bytes asm) Issue: https://github.com/dotnet/coreclr/issues/7386
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int LocateFirstFoundByte(Vector<byte> byteEquals)
-        {
-            var vector64 = Vector.AsVectorUInt64(byteEquals);
-            ulong longValue = 0;
-            var i = 0;
-            // Pattern unrolled by jit https://github.com/dotnet/coreclr/pull/8001
-            for (; i < Vector<ulong>.Count; i++)
-            {
-                longValue = vector64[i];
-                if (longValue == 0) continue;
-                break;
-            }
-
-            // Flag least significant power of two bit
-            var powerOfTwoFlag = (longValue ^ (longValue - 1));
-            // Shift all powers of two into the high byte and extract
-            var foundByteIndex = (int)((powerOfTwoFlag * _xorPowerOfTwoToHighByte) >> 57);
-            // Single LEA instruction with jitted const (using function result)
-            return i * 8 + foundByteIndex;
+            return -1;
         }
     }
 }

--- a/src/System.IO.Pipelines/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/System.IO.Pipelines.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\System.Slices\System.Slices.csproj" />
     <ProjectReference Include="..\System.Binary\System.Binary.csproj" />
     <ProjectReference Include="..\System.Collections.Sequences\System.Collections.Sequences.csproj" />
+    <ProjectReference Include="..\System.Buffers.Experimental\System.Buffers.Experimental.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Buffers" Version="4.3.0" />

--- a/tests/System.IO.Pipelines.Performance.Tests/ReadCursorOperationsThroughput.cs
+++ b/tests/System.IO.Pipelines.Performance.Tests/ReadCursorOperationsThroughput.cs
@@ -10,7 +10,7 @@ namespace System.IO.Pipelines.Performance.Tests
     [Config(typeof(CoreConfig))]
     public class ReadCursorOperationsThroughput
     {
-        private const int InnerLoopCount = 512;
+        private const int InnerLoopCount = 1024;
 
         private const string plaintextRequest = "GET /plaintext HTTP/1.1\r\nHost: www.example.com\r\n\r\n";
 
@@ -34,7 +34,7 @@ namespace System.IO.Pipelines.Performance.Tests
         public void Setup()
         {
             var liveaspnetRequestBytes = Encoding.UTF8.GetBytes(liveaspnetRequest);
-            var pipelinedRequests = string.Join("", Enumerable.Repeat(plaintextRequest, 16));
+            var pipelinedRequests = string.Concat(Enumerable.Repeat(plaintextRequest, 16));
             _plainTextPipelinedBuffer = ReadableBuffer.Create(Encoding.UTF8.GetBytes(pipelinedRequests));
             _plainTextBuffer = ReadableBuffer.Create(Encoding.UTF8.GetBytes(plaintextRequest));
             _liveAspNetBuffer = ReadableBuffer.Create(liveaspnetRequestBytes);
@@ -70,13 +70,13 @@ namespace System.IO.Pipelines.Performance.Tests
             FindAllNewLines(_plainTextPipelinedBuffer);
         }
 
-        [Benchmark(OperationsPerInvoke = InnerLoopCount)]
+        // [Benchmark(OperationsPerInvoke = InnerLoopCount)]
         public void SeekLiveAspNet()
         {
             FindAllNewLines(_liveAspNetBuffer);
         }
 
-        [Benchmark(OperationsPerInvoke = InnerLoopCount)]
+        // [Benchmark(OperationsPerInvoke = InnerLoopCount)]
         public void SeekLiveAspNetMultiBuffer()
         {
             FindAllNewLines(_liveAspNetMultiBuffer);

--- a/tests/System.IO.Pipelines.Performance.Tests/ReadCursorOperationsThroughput.cs
+++ b/tests/System.IO.Pipelines.Performance.Tests/ReadCursorOperationsThroughput.cs
@@ -70,13 +70,13 @@ namespace System.IO.Pipelines.Performance.Tests
             FindAllNewLines(_plainTextPipelinedBuffer);
         }
 
-        // [Benchmark(OperationsPerInvoke = InnerLoopCount)]
+        [Benchmark(OperationsPerInvoke = InnerLoopCount)]
         public void SeekLiveAspNet()
         {
             FindAllNewLines(_liveAspNetBuffer);
         }
 
-        // [Benchmark(OperationsPerInvoke = InnerLoopCount)]
+        [Benchmark(OperationsPerInvoke = InnerLoopCount)]
         public void SeekLiveAspNetMultiBuffer()
         {
             FindAllNewLines(_liveAspNetMultiBuffer);


### PR DESCRIPTION
There's likely a gain and a loss here since we're using the `MemoryEnumerator` to look at the data. Will measure the differences.