### PR TITLE
Updating xunit.perf.api package

### DIFF
--- a/scripts/PerfHarness/PerfHarness.csproj
+++ b/scripts/PerfHarness/PerfHarness.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.performance.api" Version="1.0.0-alpha-build0048" />
+    <PackageReference Include="xunit.performance.api" Version="1.0.0-alpha-build0049" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="1.0.0-alpha-experimental">
     <IncludeAssets>All</IncludeAssets>
   </PackageReference>

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170125-04" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit.performance.core" Version="1.0.0-alpha-build0048" />
+    <PackageReference Include="xunit.performance.core" Version="1.0.0-alpha-build0049" />
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>

--- a/tests/System.Binary.Base64.Tests/System.Binary.Base64.Tests.csproj
+++ b/tests/System.Binary.Base64.Tests/System.Binary.Base64.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170125-04" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit.performance.core" Version="1.0.0-alpha-build0048" />
+    <PackageReference Include="xunit.performance.core" Version="1.0.0-alpha-build0049" />
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>

--- a/tests/System.Slices.Tests/System.Slices.Tests.csproj
+++ b/tests/System.Slices.Tests/System.Slices.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170125-04" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit.performance.core" Version="1.0.0-alpha-build0048" />
+    <PackageReference Include="xunit.performance.core" Version="1.0.0-alpha-build0049" />
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>

--- a/tests/System.Text.Primitives.Performance.Tests/System.Text.Primitives.Performance.Tests.csproj
+++ b/tests/System.Text.Primitives.Performance.Tests/System.Text.Primitives.Performance.Tests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170125-04" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit.performance.core" Version="1.0.0-alpha-build0048" />
+    <PackageReference Include="xunit.performance.core" Version="1.0.0-alpha-build0049" />
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>


### PR DESCRIPTION
- only tests marked as benchmark will now run during perf testing

Example, for System.Slices.Tests:
> Running 90 Benchmarks out of 402 Xunit Facts...