### PR TITLE
Fixed issue with ReadableBufferReader reporting incorrect cursor

### DIFF
--- a/src/System.IO.Pipelines/MemoryEnumerator.cs
+++ b/src/System.IO.Pipelines/MemoryEnumerator.cs
@@ -25,8 +25,6 @@ namespace System.IO.Pipelines
         /// </summary>
         public Memory<byte> Current => _current;
 
-        internal BufferSegment CurrentSegment => _segmentEnumerator.Current.Segment;
-
         /// <summary>
         /// Moves to the next <see cref="Memory{Byte}"/> in the <see cref="ReadableBuffer"/>
         /// </summary>

--- a/tests/System.IO.Pipelines.Tests/ReadableBufferReaderFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/ReadableBufferReaderFacts.cs
@@ -190,6 +190,17 @@ namespace System.IO.Pipelines.Tests
             var expected = slice == int.MaxValue ? readableBuffer.End : readableBuffer.Slice(slice).Start;
             Assert.Equal(expected, reader.Cursor);
         }
+
+        [Fact]
+        public void SlicingBufferReturnsCorrectCursor()
+        {
+            var buffer = ReadableBuffer.Create(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 }, 0, 10);
+            var sliced = buffer.Slice(2);
+
+            var reader = new ReadableBufferReader(sliced);
+            Assert.Equal(sliced.Start, reader.Cursor);
+            Assert.Equal(2, reader.Peek());
+        }
     }
 
 }


### PR DESCRIPTION
- Use SegmentEnumerator instead of MemoryEnumerator in
the ReadableBufferReader
- Slice Span instead of Memory
- Renamed _currentMemory to _currentSpan

Fixes #1261

/cc @shiftylogic 