### PR TITLE
Moved optimized ASCII encoder to System.Text.Primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,6 +260,7 @@ scripts/PerfHarness/*.csv
 scripts/PerfHarness/*.xml
 scripts/PerfHarness/*.md
 scripts/PerfHarness/*.etl
+scripts/PerfHarness/results/
 BenchmarkDotNet.Artifacts/
 BDN.Generated/
 binaries/

--- a/scripts/PerfHarness/run.bat
+++ b/scripts/PerfHarness/run.bat
@@ -1,0 +1,1 @@
+dotnet run -c Release -- --perf:outputdir results --perf:typenames %1

--- a/src/System.IO.Pipelines.Text.Primitives/ReadableBufferExtensions.cs
+++ b/src/System.IO.Pipelines.Text.Primitives/ReadableBufferExtensions.cs
@@ -151,6 +151,7 @@ namespace System.IO.Pipelines.Text.Primitives
             return value;
         }
 
+        [Obsolete("Use System.Text.PrimitiveEncoder.DecodeAscii method")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe static string GetAsciiString(this Span<byte> span)
         {

--- a/src/System.Text.Primitives/System/Text/Encoding/Ascii/PrimitiveEncoder_ascii.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Ascii/PrimitiveEncoder_ascii.cs
@@ -1,0 +1,129 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace System.Text
+{
+    public static partial class PrimitiveEncoder
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string DecodeAscii(this ReadOnlySpan<byte> bytes)
+        {
+            var len = bytes.Length;
+            if (len == 0) {
+                return string.Empty;
+            }
+
+            var result = new string('\0', len);
+
+            unsafe
+            {
+                fixed (char* destination = result)
+                fixed (byte* source = &bytes.DangerousGetPinnableReference()) {
+                    if (!TryGetAsciiString(source, destination, len)) {
+                        ThrowArgumentException();
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string DecodeAscii(this Span<byte> bytes)
+        {
+            var len = bytes.Length;
+            if (len == 0) {
+                return string.Empty;
+            }
+
+            var result = new string('\0', len);
+
+            unsafe
+            {
+                fixed (char* destination = result)
+                fixed (byte* source = &bytes.DangerousGetPinnableReference()) {
+                    if (!TryGetAsciiString(source, destination, len)) {
+                        ThrowArgumentException();
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        static void ThrowArgumentException()
+        {
+            throw new ArgumentException();
+        }
+
+        static unsafe bool TryGetAsciiString(byte* input, char* output, int count)
+        {
+            var i = 0;
+
+            int isValid = 0;
+            while (i < count - 11) {
+                isValid = isValid | *input | *(input + 1) | *(input + 2) |
+                    *(input + 3) | *(input + 4) | *(input + 5) | *(input + 6) |
+                    *(input + 7) | *(input + 8) | *(input + 9) | *(input + 10) |
+                    *(input + 11);
+
+                i += 12;
+                *(output) = (char)*(input);
+                *(output + 1) = (char)*(input + 1);
+                *(output + 2) = (char)*(input + 2);
+                *(output + 3) = (char)*(input + 3);
+                *(output + 4) = (char)*(input + 4);
+                *(output + 5) = (char)*(input + 5);
+                *(output + 6) = (char)*(input + 6);
+                *(output + 7) = (char)*(input + 7);
+                *(output + 8) = (char)*(input + 8);
+                *(output + 9) = (char)*(input + 9);
+                *(output + 10) = (char)*(input + 10);
+                *(output + 11) = (char)*(input + 11);
+                output += 12;
+                input += 12;
+            }
+            if (i < count - 5) {
+                isValid = isValid | *input | *(input + 1) | *(input + 2) |
+                    *(input + 3) | *(input + 4) | *(input + 5);
+
+                i += 6;
+                *(output) = (char)*(input);
+                *(output + 1) = (char)*(input + 1);
+                *(output + 2) = (char)*(input + 2);
+                *(output + 3) = (char)*(input + 3);
+                *(output + 4) = (char)*(input + 4);
+                *(output + 5) = (char)*(input + 5);
+                output += 6;
+                input += 6;
+            }
+            if (i < count - 3) {
+                isValid = isValid | *input | *(input + 1) | *(input + 2) |
+                    *(input + 3);
+
+                i += 4;
+                *(output) = (char)*(input);
+                *(output + 1) = (char)*(input + 1);
+                *(output + 2) = (char)*(input + 2);
+                *(output + 3) = (char)*(input + 3);
+                output += 4;
+                input += 4;
+            }
+
+            while (i < count) {
+                isValid = isValid | *input;
+
+                i++;
+                *output = (char)*input;
+                output++;
+                input++;
+            }
+
+            return isValid <= 127;
+        }     
+    }
+}

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\..\src\System.IO.Pipelines.Text.Primitives\System.IO.Pipelines.Text.Primitives.csproj" />
     <ProjectReference Include="..\..\src\System.IO.Pipelines\System.IO.Pipelines.csproj" />
     <ProjectReference Include="..\..\src\System.Text.Formatting\System.Text.Formatting.csproj" />
+    <ProjectReference Include="..\..\src\System.Text.Primitives\System.Text.Primitives.csproj" />
     <ProjectReference Include="..\..\src\System.Text.Http\System.Text.Http.csproj" />
     <ProjectReference Include="..\..\src\System.Text.Json\System.Text.Json.csproj" />
   </ItemGroup>

--- a/tests/Benchmarks/GetAsciiStringBench.cs
+++ b/tests/Benchmarks/GetAsciiStringBench.cs
@@ -1,27 +1,66 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
+
 using Xunit;
 using Microsoft.Xunit.Performance;
 using System;
-
 using System.Text;
-using System.IO.Pipelines.Text.Primitives;
 
-public class GetAsciiStringBench
+public class AsciiDecodingBench
 {
     [Benchmark(InnerIterationCount = 1000000)]
     [InlineData("/plaintext")]
     [InlineData("text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7")]
-    public static int GetAsciiString(string text)
+    public static int AsciiToStringPrimitives(string text)
     {
         string str;
         int len = 0;
-        var bytes = (Span<byte>)Encoding.ASCII.GetBytes(text);
+        var bytes = (ReadOnlySpan<byte>)Encoding.ASCII.GetBytes(text);
         foreach (var iteration in Benchmark.Iterations) {
             using (iteration.StartMeasurement()) {
-                for (int i = 0; i < Benchmark.InnerIterationCount; i++) { 
-                    str = bytes.GetAsciiString();
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++) {
+                    str = bytes.DecodeAscii();
+                    len += str.Length;
+                }
+            }
+        }
+        return len;
+    }
+
+    [Benchmark(InnerIterationCount = 1000000)]
+    [InlineData("/plaintext")]
+    [InlineData("text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7")]
+    public static int AsciiToStringClr(string text)
+    {
+        string str;
+        int len = 0;
+        var bytes = Encoding.ASCII.GetBytes(text);
+        foreach (var iteration in Benchmark.Iterations) {
+            using (iteration.StartMeasurement()) {
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++) {
+                    str = Encoding.ASCII.GetString(bytes);
+                    len += str.Length;
+                }
+            }
+        }
+        return len;
+    }
+
+    [Benchmark(InnerIterationCount = 1000000)]
+    [InlineData("/plaintext")]
+    [InlineData("text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7")]
+    public static int Utf8ToStringTextEncoder(string text)
+    {
+        string str;
+        int len = 0;
+        var bytes = (ReadOnlySpan<byte>)Encoding.ASCII.GetBytes(text);
+        foreach (var iteration in Benchmark.Iterations) {
+            using (iteration.StartMeasurement()) {
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++) {
+                    if (!TextEncoder.Utf8.TryDecode(bytes, out str, out var consumed)) {
+                        throw new Exception();
+                    }
                     len += str.Length;
                 }
             }

--- a/tests/System.Text.Primitives.Tests/Encoding/PrimitiveEncoderTests_ascii.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/PrimitiveEncoderTests_ascii.cs
@@ -1,0 +1,53 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+using Xunit;
+
+namespace System.Text.Ascii.Tests
+{
+    public class PrimitiveEncoderTestsAscii
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("Hello World")]
+        public void DecodeAsciiToStringBasics(string original)
+        {
+            var encoded = (Span<byte>)System.Text.Encoding.ASCII.GetBytes(original);
+            var decoded = encoded.DecodeAscii();
+            Assert.Equal(original, decoded);
+        }
+
+        [Fact]
+        public void DecodeAsciiWorksOnAllAsciiChars()
+        {
+            for (int index = 0; index < 100; index++) {
+                var encoded = (Span<byte>)new byte[100];
+                for (int encodedByte = 0; encodedByte < 128; encodedByte++) {
+                    encoded[index] = (byte)encodedByte;
+                    var result = encoded.DecodeAscii();
+                }
+            }
+        }
+
+        [Fact]
+        public void DecodeAsciiToStringFailsOnNonAscii()
+        {
+            for (int index = 0; index < 100; index++) {
+                var encoded = (Span<byte>)new byte[100];
+                for (int encodedByte = 128; encodedByte < 256; encodedByte++) {
+                    encoded[0] = (byte)encodedByte;
+                    bool exception = false;
+                    try {
+                        var result = encoded.DecodeAscii();
+                    }
+                    catch(ArgumentException) {
+                        exception = true;
+                    }
+                    Assert.True(exception);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I tried to make it into a TryDecode method, but it was 5% slower for some strings.
Maybe we can try one more time once we have Kestrel benchmarks at goal and stable.

cc: @shiftylogic, @davidfowl, @ahsonkhan 

Also, i tried to make it into a nested PrimitiveEncoder.Ascii class, but we don't support extension methods on nested types. 