### PR TITLE
Improve Vectorized IndexOf for < Vector length

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -197,8 +197,7 @@ namespace System.Buffers
                     Vector<byte> values = GetVector(value);
                     do
                     {
-                        var vData = Unsafe.Read<Vector<byte>>(searchSpace + offset);
-                        var vMatches = Vector.Equals(vData, values);
+                        var vMatches = Vector.Equals(Unsafe.Read<Vector<byte>>(searchSpace + offset), values);
                         if (!vMatches.Equals(Vector<byte>.Zero))
                         {
                             // Found match, reuse Vector values to keep register pressure low
@@ -269,8 +268,9 @@ namespace System.Buffers
                     do
                     {
                         var vData = Unsafe.Read<Vector<byte>>(searchSpace + offset);
-                        var vMatches = Vector.Equals(vData, values0);
-                        vMatches = Vector.ConditionalSelect(vMatches, vMatches, Vector.Equals(vData, values1));
+                        var vMatches = Vector.BitwiseOr(
+                                            Vector.Equals(vData, values0), 
+                                            Vector.Equals(vData, values1));
                         if (!vMatches.Equals(Vector<byte>.Zero))
                         {
                             // Found match, reuse Vector values0 to keep register pressure low
@@ -342,9 +342,11 @@ namespace System.Buffers
                     do
                     {
                         var vData = Unsafe.Read<Vector<byte>>(searchSpace + offset);
-                        var vMatches = Vector.Equals(vData, values0);
-                        vMatches = Vector.ConditionalSelect(vMatches, vMatches, Vector.Equals(vData, values1));
-                        vMatches = Vector.ConditionalSelect(vMatches, vMatches, Vector.Equals(vData, values2));
+                        var vMatches = Vector.BitwiseOr(
+                                        Vector.BitwiseOr(
+                                            Vector.Equals(vData, values0), 
+                                            Vector.Equals(vData, values1)),
+                                            Vector.Equals(vData, values2));
                         if (!vMatches.Equals(Vector<byte>.Zero))
                         {
                             // Found match, reuse Vector values0 to keep register pressure low

--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -119,105 +119,90 @@ namespace System.Buffers
             return -1;
         }
 
-        static readonly int s_longSize = Vector<ulong>.Count;
-        static readonly int s_byteSize = Vector<byte>.Count;
-
         public unsafe static int IndexOfVectorized(this Span<byte> buffer, byte value)
         {
-            var length = buffer.Length;
-            if (length == 0)
+            fixed (byte* pSearchSpace = &buffer.DangerousGetPinnableReference())
             {
-                return -1;
+                return IndexOfVectorized(pSearchSpace, value, buffer.Length);
             }
-
-            return IndexOfVectorized(ref buffer.DangerousGetPinnableReference(), value, length);
         }
 
         public unsafe static int IndexOfVectorized(this ReadOnlySpan<byte> buffer, byte value)
         {
-            var length = buffer.Length;
-            if (length == 0)
+            fixed (byte* pSearchSpace = &buffer.DangerousGetPinnableReference())
             {
-                return -1;
+                return IndexOfVectorized(pSearchSpace, value, buffer.Length);
             }
-
-            return IndexOfVectorized(ref buffer.DangerousGetPinnableReference(), value, length);
         }
 
-        private static unsafe int IndexOfVectorized(ref byte searchSpace, byte value, int length)
+        private static unsafe int IndexOfVectorized(byte* searchSpace, byte value, int length)
         {
-            fixed (byte* pSearchSpace = &searchSpace)
+            var offset = 0;
+            // If length < vector length the jump over Vector dominates the search; as the Vector section is quite chunky
+            // So do an early search and exit
+            if (length < Vector<byte>.Count)
             {
-                var searchStart = pSearchSpace;
-                var offset = 0;
-
-                if (Vector.IsHardwareAccelerated)
-                {
-                    // Check Vector lengths
-                    if (length - Vector<byte>.Count >= offset)
-                    {
-                        Vector<byte> values = GetVector(value);
-                        do
-                        {
-                            var vFlaggedMatches = Vector.Equals(Unsafe.Read<Vector<byte>>(searchStart + offset), values);
-                            if (!vFlaggedMatches.Equals(Vector<byte>.Zero))
-                            {
-                                // Found match, reuse Vector values to keep register pressure low
-                                values = vFlaggedMatches;
-                                break;
-                            }
-
-                            offset += Vector<byte>.Count;
-                        } while (length - Vector<byte>.Count >= offset);
-
-                        // Found match? Perform secondary search outside out of loop, so above loop body is small
-                        if (length - Vector<byte>.Count >= offset)
-                        {
-                            // Find offset of first match
-                            offset += LocateFirstFoundByte(values);
-                            // goto rather than inline return to keep function smaller
-                            goto exitFixed;
-                        }
-                    }
-                }
-
-                ulong flaggedMatches = 0;
-                // Check ulong length
-                while (length - sizeof(ulong) >= offset)
-                {
-                    flaggedMatches = SetLowBitsForByteMatch(*(ulong*)(searchStart + offset), value);
-                    if (flaggedMatches != 0)
-                    {
-                        // Found match
-                        break;
-                    }
-
-                    offset += sizeof(ulong);
-                }
-
-                // Found match? Perform secondary search outside out of loop, so above loop body is small
-                if (length - sizeof(ulong) >= offset)
-                {
-                    // Find offset of first match
-                    offset += LocateFirstFoundByte(flaggedMatches);
-                    // goto rather than inline return to keep function smaller
-                    goto exitFixed;
-                }
-
-                // Haven't found match, scan through remaining
                 for (; offset < length; offset++)
                 {
-                    if (*(searchStart + offset) == value)
+                    var ch = searchSpace[offset];
+                    if (ch == value)
                     {
                         // goto rather than inline return to keep loop body small
-                        goto exitFixed;
+                        goto shortExit;
                     }
                 }
-                // No Matches
+                // Not found
                 offset = -1;
-        exitFixed:;
+            shortExit:
                 return offset;
             }
+
+            if (Vector.IsHardwareAccelerated)
+            {
+                // Check Vector lengths
+                if (length - Vector<byte>.Count >= offset)
+                {
+                    Vector<byte> values = GetVector(value);
+                    do
+                    {
+                        var vData = Unsafe.Read<Vector<byte>>(searchSpace + offset);
+                        var vMatches = Vector.Equals(vData, values);
+                        if (!vMatches.Equals(Vector<byte>.Zero))
+                        {
+                            // Found match, reuse Vector values to keep register pressure low
+                            values = vMatches;
+                            break;
+                        }
+
+                        offset += Vector<byte>.Count;
+                    } while (length - Vector<byte>.Count >= offset);
+
+                    // Found match? Perform secondary search outside out of loop, so above loop body is small
+                    if (length - Vector<byte>.Count >= offset)
+                    {
+                        // Find offset of first match
+                        offset += LocateFirstFoundByte(values);
+                        // goto rather than inline return to keep function smaller
+                        goto exit;
+                    }
+                }
+            }
+
+            // Haven't found match, scan through remaining
+            for (; offset < length; offset++)
+            {
+                var ch = searchSpace[offset];
+                if (ch == value)
+                {
+                    // goto rather than inline return to keep loop body small
+                    goto exit;
+                }
+            }
+
+            // No Matches
+            offset = -1;
+        exit:
+            return offset;
         }
 
         public static bool TryIndicesOf(this Span<byte> buffer, byte value, Span<int> indices, out int numberOfIndices)

--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -123,7 +123,23 @@ namespace System.Buffers
         {
             fixed (byte* pSearchSpace = &buffer.DangerousGetPinnableReference())
             {
-                return IndexOfVectorized(pSearchSpace, value, buffer.Length);
+                return IndexOfVectorized(pSearchSpace, buffer.Length, value);
+            }
+        }
+
+        public unsafe static int IndexOfVectorized(this Span<byte> buffer, byte value0, byte value1)
+        {
+            fixed (byte* pSearchSpace = &buffer.DangerousGetPinnableReference())
+            {
+                return IndexOfVectorized(pSearchSpace, buffer.Length, value0, value1);
+            }
+        }
+
+        public unsafe static int IndexOfVectorized(this Span<byte> buffer, byte value0, byte value1, byte value2)
+        {
+            fixed (byte* pSearchSpace = &buffer.DangerousGetPinnableReference())
+            {
+                return IndexOfVectorized(pSearchSpace, buffer.Length, value0, value1, value2);
             }
         }
 
@@ -131,11 +147,27 @@ namespace System.Buffers
         {
             fixed (byte* pSearchSpace = &buffer.DangerousGetPinnableReference())
             {
-                return IndexOfVectorized(pSearchSpace, value, buffer.Length);
+                return IndexOfVectorized(pSearchSpace, buffer.Length, value);
             }
         }
 
-        private static unsafe int IndexOfVectorized(byte* searchSpace, byte value, int length)
+        public unsafe static int IndexOfVectorized(this ReadOnlySpan<byte> buffer, byte value0, byte value1)
+        {
+            fixed (byte* pSearchSpace = &buffer.DangerousGetPinnableReference())
+            {
+                return IndexOfVectorized(pSearchSpace, buffer.Length, value0, value1);
+            }
+        }
+
+        public unsafe static int IndexOfVectorized(this ReadOnlySpan<byte> buffer, byte value0, byte value1, byte value2)
+        {
+            fixed (byte* pSearchSpace = &buffer.DangerousGetPinnableReference())
+            {
+                return IndexOfVectorized(pSearchSpace, buffer.Length, value0, value1, value2);
+            }
+        }
+
+        private static unsafe int IndexOfVectorized(byte* searchSpace, int length, byte value)
         {
             var offset = 0;
             // If length < vector length the jump over Vector dominates the search; as the Vector section is quite chunky
@@ -202,6 +234,152 @@ namespace System.Buffers
             // No Matches
             offset = -1;
         exit:
+            return offset;
+        }
+
+        private static unsafe int IndexOfVectorized(byte* searchSpace, int length, byte value0, byte value1)
+        {
+            var offset = 0;
+            // If length < vector length the jump over Vector dominates the search; as the Vector section is quite chunky
+            // So do an early search and exit
+            if (length < Vector<byte>.Count)
+            {
+                for (; offset < length; offset++)
+                {
+                    var ch = searchSpace[offset];
+                    if (ch == value0 || ch == value1)
+                    {
+                        // goto rather than inline return to keep loop body small
+                        goto shortExit;
+                    }
+                }
+                // Not found
+                offset = -1;
+                shortExit:
+                return offset;
+            }
+
+            if (Vector.IsHardwareAccelerated)
+            {
+                // Check Vector lengths
+                if (length - Vector<byte>.Count >= offset)
+                {
+                    Vector<byte> values0 = GetVector(value0);
+                    Vector<byte> values1 = GetVector(value1);
+                    do
+                    {
+                        var vData = Unsafe.Read<Vector<byte>>(searchSpace + offset);
+                        var vMatches = Vector.Equals(vData, values0);
+                        vMatches = Vector.ConditionalSelect(vMatches, vMatches, Vector.Equals(vData, values1));
+                        if (!vMatches.Equals(Vector<byte>.Zero))
+                        {
+                            // Found match, reuse Vector values0 to keep register pressure low
+                            values0 = vMatches;
+                            break;
+                        }
+
+                        offset += Vector<byte>.Count;
+                    } while (length - Vector<byte>.Count >= offset);
+
+                    // Found match? Perform secondary search outside out of loop, so above loop body is small
+                    if (length - Vector<byte>.Count >= offset)
+                    {
+                        // Find offset of first match
+                        offset += LocateFirstFoundByte(values0);
+                        // goto rather than inline return to keep function smaller
+                        goto exit;
+                    }
+                }
+            }
+
+            // Haven't found match, scan through remaining
+            for (; offset < length; offset++)
+            {
+                var ch = searchSpace[offset];
+                if (ch == value0 || ch == value1)
+                {
+                    // goto rather than inline return to keep loop body small
+                    goto exit;
+                }
+            }
+
+            // No Matches
+            offset = -1;
+            exit:
+            return offset;
+        }
+
+        private static unsafe int IndexOfVectorized(byte* searchSpace, int length, byte value0, byte value1, byte value2)
+        {
+            var offset = 0;
+            // If length < vector length the jump over Vector dominates the search; as the Vector section is quite chunky
+            // So do an early search and exit
+            if (length < Vector<byte>.Count)
+            {
+                for (; offset < length; offset++)
+                {
+                    var ch = searchSpace[offset];
+                    if (ch == value0 || ch == value1 || ch == value2)
+                    {
+                        // goto rather than inline return to keep loop body small
+                        goto shortExit;
+                    }
+                }
+                // Not found
+                offset = -1;
+                shortExit:
+                return offset;
+            }
+
+            if (Vector.IsHardwareAccelerated)
+            {
+                // Check Vector lengths
+                if (length - Vector<byte>.Count >= offset)
+                {
+                    Vector<byte> values0 = GetVector(value0);
+                    Vector<byte> values1 = GetVector(value1);
+                    Vector<byte> values2 = GetVector(value2);
+                    do
+                    {
+                        var vData = Unsafe.Read<Vector<byte>>(searchSpace + offset);
+                        var vMatches = Vector.Equals(vData, values0);
+                        vMatches = Vector.ConditionalSelect(vMatches, vMatches, Vector.Equals(vData, values1));
+                        vMatches = Vector.ConditionalSelect(vMatches, vMatches, Vector.Equals(vData, values2));
+                        if (!vMatches.Equals(Vector<byte>.Zero))
+                        {
+                            // Found match, reuse Vector values0 to keep register pressure low
+                            values0 = vMatches;
+                            break;
+                        }
+
+                        offset += Vector<byte>.Count;
+                    } while (length - Vector<byte>.Count >= offset);
+
+                    // Found match? Perform secondary search outside out of loop, so above loop body is small
+                    if (length - Vector<byte>.Count >= offset)
+                    {
+                        // Find offset of first match
+                        offset += LocateFirstFoundByte(values0);
+                        // goto rather than inline return to keep function smaller
+                        goto exit;
+                    }
+                }
+            }
+
+            // Haven't found match, scan through remaining
+            for (; offset < length; offset++)
+            {
+                var ch = searchSpace[offset];
+                if (ch == value0 || ch == value1 || ch == value2)
+                {
+                    // goto rather than inline return to keep loop body small
+                    goto exit;
+                }
+            }
+
+            // No Matches
+            offset = -1;
+            exit:
             return offset;
         }
 

--- a/src/System.IO.Pipelines/ReadCursorOperations.cs
+++ b/src/System.IO.Pipelines/ReadCursorOperations.cs
@@ -38,10 +38,8 @@ namespace System.IO.Pipelines
                 var segment = segmentPart.Segment;
                 var span = segment.Memory.Span.Slice(segmentPart.Start, segmentPart.Length);
 
-                int index1 = span.IndexOfVectorized(byte0);
-                int index2 = span.IndexOfVectorized(byte1);
+                int index = span.IndexOfVectorized(byte0, byte1);
 
-                var index = MinIndex(index1, index2);
                 if (index != -1)
                 {
                     result = new ReadCursor(segment, segmentPart.Start + index);
@@ -62,11 +60,7 @@ namespace System.IO.Pipelines
                 var segment = segmentPart.Segment;
                 var span = segment.Memory.Span.Slice(segmentPart.Start, segmentPart.Length);
 
-                int index1 = span.IndexOfVectorized(byte0);
-                int index2 = span.IndexOfVectorized(byte1);
-                int index3 = span.IndexOfVectorized(byte2);
-
-                var index = MinIndex(index1, index2, index3);
+                int index = span.IndexOfVectorized(byte0, byte1, byte2);
 
                 if (index != -1)
                 {
@@ -77,23 +71,6 @@ namespace System.IO.Pipelines
 
             result = end;
             return -1;
-        }
-
-        private static int MinIndex(int v1, int v2)
-        {
-            v1 = v1 == -1 ? int.MaxValue : v1;
-            v2 = v2 == -1 ? int.MaxValue : v2;
-            var result = Math.Min(v1, v2);
-            return result == int.MaxValue ? -1 : result;
-        }
-
-        private static int MinIndex(int v1, int v2, int v3)
-        {
-            v1 = v1 == -1 ? int.MaxValue : v1;
-            v2 = v2 == -1 ? int.MaxValue : v2;
-            v3 = v3 == -1 ? int.MaxValue : v3;
-            var result = Math.Min(Math.Min(v1, v2), v3);
-            return result == int.MaxValue ? -1 : result;
         }
     }
 }


### PR DESCRIPTION
When the search space < Vector length the jump over the vector code dominates; so add an early loop for shorter lengths.

@KrzysztofCwalina I think this resolves the issue you were seeing?

/cc @davidfowl 