### PR TITLE
Slim ReadableBufferReader

### DIFF
--- a/src/System.IO.Pipelines/ReadableBufferReader.cs
+++ b/src/System.IO.Pipelines/ReadableBufferReader.cs
@@ -82,6 +82,8 @@ namespace System.IO.Pipelines
 
         public int ConsumedBytes => _consumedBytes;
 
+        public int RemainingBytes => _remainingBytes;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int Peek()
         {


### PR DESCRIPTION
Now: 8 + 4 + 4 + 4 + 4 = 24 bytes + `sizeof(Span<byte>)`
Previously: 4 + 4 + 4 + (8 + 8 + 4 + 4 + (8 + 4 + 4)) = 52 bytes + `sizeof(Span<byte>)`
1 object ref rather than 3

Smaller `Skip` - faster in same span
Smaller `get Cursor`
Added zero cost `RemainingBytes` property

/cc @davidfowl @pakrym 