### PR TITLE
Adding Span IndexOf that takes an index and count

### DIFF
--- a/src/System.Slices/System/SpanExtensions.cs
+++ b/src/System.Slices/System/SpanExtensions.cs
@@ -43,27 +43,7 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOf(this Span<byte> span, int index, int count, byte value)
         {
-            int spanLength = span.Length;
-            if (index >= spanLength || count == 0)
-            {
-                return -1;
-            }
-
-            int length = Math.Min(count, spanLength - index);
-
-            var retVal = SpanExtensions.IndexOf(span.Slice(index, length), value);
-            return retVal == -1 ? retVal : index + retVal;
-
-            /*ref byte searchSpace = ref span.DangerousGetPinnableReference();
-            Unsafe.Add(ref searchSpace, index);
-
-            return IndexOf(ref searchSpace, value, index, count, span.Length);*/
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf2(this Span<byte> span, int index, int count, byte value)
-        {
-            return IndexOf(ref span.DangerousGetPinnableReference(), value, index, count, span.Length);
+            return IndexOfHelper(ref span.DangerousGetPinnableReference(), index, count, value, span.Length);
         }
 
         /// <summary>
@@ -76,39 +56,17 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOf(this ReadOnlySpan<byte> span, int index, int count, byte value)
         {
-            int spanLength = span.Length;
+            return IndexOfHelper(ref span.DangerousGetPinnableReference(), index, count, value, span.Length);
+        }
+
+        private static int IndexOfHelper(ref byte searchSpace, int index, int count, byte value, int spanLength)
+        {
             if (index >= spanLength || count == 0)
             {
                 return -1;
             }
 
-            int length = Math.Min(count, spanLength - index);
-
-            var retVal = SpanExtensions.IndexOf(span.Slice(index, length), value);
-            return retVal == -1 ? retVal : index + retVal;
-
-            /*ref byte searchSpace = ref span.DangerousGetPinnableReference();
-            Unsafe.Add(ref searchSpace, index);
-
-            return IndexOf(ref searchSpace, value, index, count, span.Length);*/
-        }
-
-        private static int IndexOf(ref byte searchSpace, byte value, int startIndex, int count, int spanLength)
-        {
-            Debug.Assert(count >= 0);
-            Debug.Assert(spanLength >= 0);
-            Debug.Assert(startIndex >= 0);
-
-            int index = startIndex;
-
-            if (startIndex >= spanLength || count == 0)
-            {
-                return -1;
-            }
-
-            int remainingLength = Math.Min(count, spanLength - startIndex);
-
-            Unsafe.Add(ref searchSpace, startIndex);
+            int remainingLength = Math.Min(count, spanLength - index);
 
             while (remainingLength >= 8)
             {

--- a/src/System.Slices/System/SpanExtensions.cs
+++ b/src/System.Slices/System/SpanExtensions.cs
@@ -12,35 +12,148 @@ namespace System
     /// </summary>
     public static partial class SpanExtensionsLabs
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool StartsWith(this ReadOnlySpan<byte> bytes, ReadOnlySpan<byte> slice)
         {
-            if (slice.Length > bytes.Length)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < slice.Length; i++)
-            {
-                if (bytes[i] != slice[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            int length = slice.Length;
+            return bytes.Length >= length && (length == 0 || bytes.Slice(0, length).SequenceEqual(slice));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool StartsWith<T>(this ReadOnlySpan<T> items, ReadOnlySpan<T> slice)
             where T : struct, IEquatable<T>
         {
-            if (slice.Length > items.Length) return false;
-            return items.Slice(0, slice.Length).SequenceEqual(slice);
+            int length = slice.Length;
+            return items.Length >= length && (length == 0 || items.Slice(0, length).SequenceEqual(slice));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOf(this ReadOnlyMemory<byte> memory, ReadOnlySpan<byte> values)
         {
             return SpanExtensions.IndexOf(memory.Span, values);
+        }
+
+        /// <summary>
+        /// Searches for the specified value starting at the specified index and returns the index of its first occurrence. If not found, returns -1. 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="index">The index within the span from where to start the search.</param>
+        /// <param name="count">The number of bytes to search starting from the index.</param>
+        /// <param name="value">The value to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf(this Span<byte> span, int index, int count, byte value)
+        {
+            int spanLength = span.Length;
+            if (index >= spanLength || count == 0)
+            {
+                return -1;
+            }
+
+            int length = Math.Min(count, spanLength - index);
+
+            var retVal = SpanExtensions.IndexOf(span.Slice(index, length), value);
+            return retVal == -1 ? retVal : index + retVal;
+
+            /*ref byte searchSpace = ref span.DangerousGetPinnableReference();
+            Unsafe.Add(ref searchSpace, index);
+
+            return IndexOf(ref searchSpace, value, index, count, span.Length);*/
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf2(this Span<byte> span, int index, int count, byte value)
+        {
+            return IndexOf(ref span.DangerousGetPinnableReference(), value, index, count, span.Length);
+        }
+
+        /// <summary>
+        /// Searches for the specified value starting at the specified index and returns the index of its first occurrence. If not found, returns -1. 
+        /// </summary>
+        /// <param name="span">The span to search.</param>
+        /// <param name="index">The index within the span from where to start the search.</param>
+        /// <param name="count">The number of bytes to search starting from the index.</param>
+        /// <param name="value">The value to search for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int IndexOf(this ReadOnlySpan<byte> span, int index, int count, byte value)
+        {
+            int spanLength = span.Length;
+            if (index >= spanLength || count == 0)
+            {
+                return -1;
+            }
+
+            int length = Math.Min(count, spanLength - index);
+
+            var retVal = SpanExtensions.IndexOf(span.Slice(index, length), value);
+            return retVal == -1 ? retVal : index + retVal;
+
+            /*ref byte searchSpace = ref span.DangerousGetPinnableReference();
+            Unsafe.Add(ref searchSpace, index);
+
+            return IndexOf(ref searchSpace, value, index, count, span.Length);*/
+        }
+
+        private static int IndexOf(ref byte searchSpace, byte value, int startIndex, int count, int spanLength)
+        {
+            Debug.Assert(count >= 0);
+            Debug.Assert(spanLength >= 0);
+            Debug.Assert(startIndex >= 0);
+
+            int index = startIndex;
+
+            if (startIndex >= spanLength || count == 0)
+            {
+                return -1;
+            }
+
+            int remainingLength = Math.Min(count, spanLength - startIndex);
+
+            Unsafe.Add(ref searchSpace, startIndex);
+
+            while (remainingLength >= 8)
+            {
+                if (value == Unsafe.Add(ref searchSpace, ++index))
+                    return index;
+                if (value == Unsafe.Add(ref searchSpace, ++index))
+                    return index;
+                if (value == Unsafe.Add(ref searchSpace, ++index))
+                    return index;
+                if (value == Unsafe.Add(ref searchSpace, ++index))
+                    return index;
+                if (value == Unsafe.Add(ref searchSpace, ++index))
+                    return index;
+                if (value == Unsafe.Add(ref searchSpace, ++index))
+                    return index;
+                if (value == Unsafe.Add(ref searchSpace, ++index))
+                    return index;
+                if (value == Unsafe.Add(ref searchSpace, ++index))
+                    return index;
+
+                remainingLength -= 8;
+            }
+
+            while (remainingLength >= 4)
+            {
+                if (value == Unsafe.Add(ref searchSpace, ++index))
+                    return index;
+                if (value == Unsafe.Add(ref searchSpace, ++index))
+                    return index;
+                if (value == Unsafe.Add(ref searchSpace, ++index))
+                    return index;
+                if (value == Unsafe.Add(ref searchSpace, ++index))
+                    return index;
+
+                remainingLength -= 4;
+            }
+
+            while (remainingLength > 0)
+            {
+                if (value == Unsafe.Add(ref searchSpace, ++index))
+                    return index;
+
+                remainingLength--;
+            }
+            return -1;
         }
     }
 }

--- a/src/System.Slices/System/SpanExtensions.cs
+++ b/src/System.Slices/System/SpanExtensions.cs
@@ -41,9 +41,9 @@ namespace System
         /// <param name="count">The number of bytes to search starting from the index.</param>
         /// <param name="value">The value to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this Span<byte> span, byte value, int index, int count)
+        public static int IndexOf(this Span<byte> span, byte value, int startIndex, int count)
         {
-            return IndexOfHelper(ref span.DangerousGetPinnableReference(), index, count, value, span.Length);
+            return IndexOfHelper(ref span.DangerousGetPinnableReference(), startIndex, count, value, span.Length);
         }
 
         /// <summary>
@@ -54,21 +54,17 @@ namespace System
         /// <param name="count">The number of bytes to search starting from the index.</param>
         /// <param name="value">The value to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this ReadOnlySpan<byte> span, byte value, int index, int count)
+        public static int IndexOf(this ReadOnlySpan<byte> span, byte value, int startIndex, int count)
         {
-            return IndexOfHelper(ref span.DangerousGetPinnableReference(), index, count, value, span.Length);
+            return IndexOfHelper(ref span.DangerousGetPinnableReference(), startIndex, count, value, span.Length);
         }
 
-        private static int IndexOfHelper(ref byte searchSpace, int index, int count, byte value, int spanLength)
+        private static int IndexOfHelper(ref byte searchSpace, int startIndex, int count, byte value, int length)
         {
-            if (index >= spanLength || count == 0)
-            {
-                return -1;
-            }
+            Debug.Assert(length >= 0);
 
-            int remainingLength = Math.Min(count, spanLength - index);
-
-            index--;
+            int index = startIndex - 1;
+            int remainingLength = Math.Min(count, length - startIndex);
             while (remainingLength >= 8)
             {
                 if (value == Unsafe.Add(ref searchSpace, ++index))

--- a/src/System.Slices/System/SpanExtensions.cs
+++ b/src/System.Slices/System/SpanExtensions.cs
@@ -41,7 +41,7 @@ namespace System
         /// <param name="count">The number of bytes to search starting from the index.</param>
         /// <param name="value">The value to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this Span<byte> span, int index, int count, byte value)
+        public static int IndexOf(this Span<byte> span, byte value, int index, int count)
         {
             return IndexOfHelper(ref span.DangerousGetPinnableReference(), index, count, value, span.Length);
         }
@@ -54,7 +54,7 @@ namespace System
         /// <param name="count">The number of bytes to search starting from the index.</param>
         /// <param name="value">The value to search for.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this ReadOnlySpan<byte> span, int index, int count, byte value)
+        public static int IndexOf(this ReadOnlySpan<byte> span, byte value, int index, int count)
         {
             return IndexOfHelper(ref span.DangerousGetPinnableReference(), index, count, value, span.Length);
         }

--- a/src/System.Slices/System/SpanExtensions.cs
+++ b/src/System.Slices/System/SpanExtensions.cs
@@ -68,6 +68,7 @@ namespace System
 
             int remainingLength = Math.Min(count, spanLength - index);
 
+            index--;
             while (remainingLength >= 8)
             {
                 if (value == Unsafe.Add(ref searchSpace, ++index))

--- a/src/System.Slices/System/SpanExtensions_text.cs
+++ b/src/System.Slices/System/SpanExtensions_text.cs
@@ -106,22 +106,11 @@ namespace System
         {
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool StartsWith(this ReadOnlySpan<char> str, ReadOnlySpan<char> value)
         {
-            if (value.Length > str.Length)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < value.Length; i++)
-            {
-                if (str[i] != value[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            int length = value.Length;
+            return str.Length >= length && (length == 0 || str.Slice(0, length).SequenceEqual(value));
         }
     }
 }

--- a/tests/System.Slices.Tests/BasicUnitTests.cs
+++ b/tests/System.Slices.Tests/BasicUnitTests.cs
@@ -290,5 +290,399 @@ namespace System.Slices.Tests
             object[] array = new string[10];
             Assert.Throws<ArrayTypeMismatchException>(() => { var slice = new Span<object>(array, 0, 10); });
         }
+
+        #region ReadOnlySpanStartsWithByte
+        [Fact]
+        public static void ZeroLengthStartsWith_Byte()
+        {
+            byte[] a = { 4, 5, 6 };
+            ReadOnlySpan<byte> bytes = new ReadOnlySpan<byte>(a);
+            ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(a, 2, 0);
+            Assert.True(bytes.StartsWith(slice));
+        }
+
+        [Fact]
+        public static void StartsWithNoMatchEmptySpan_Byte()
+        {
+            byte[] a = { 4, 5, 6 };
+            byte[] b = { 1, 2, 3 };
+            ReadOnlySpan<byte> bytes = new ReadOnlySpan<byte>(a, 0, 0);
+            ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(b, 0, 1);
+            Assert.False(bytes.StartsWith(slice));
+        }
+
+        [Fact]
+        public static void StartsWithMatchEmptySpans_Byte()
+        {
+            byte[] a = { 4, 5, 6 };
+            byte[] b = { 1, 2, 3 };
+            ReadOnlySpan<byte> bytes = new ReadOnlySpan<byte>(a, 0, 0);
+            ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(b, 0, 0);
+            Assert.True(bytes.StartsWith(slice));
+        }
+
+        [Fact]
+        public static void SameSpanStartsWith_Byte()
+        {
+            byte[] a = { 4, 5, 6 };
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+            Assert.True(span.StartsWith(span));
+        }
+
+        [Fact]
+        public static void SameSpanValuesStartsWith_Byte()
+        {
+            byte[] a = { 4, 5, 6 };
+            ReadOnlySpan<byte> bytes = new ReadOnlySpan<byte>(a);
+            ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(a);
+            Assert.True(bytes.StartsWith(slice));
+        }
+
+        [Fact]
+        public static void LengthMismatchStartsWith_Byte()
+        {
+            byte[] a = { 4, 5, 6 };
+            ReadOnlySpan<byte> bytes = new ReadOnlySpan<byte>(a, 0, 2);
+            ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(a);
+            Assert.False(bytes.StartsWith(slice));
+        }
+
+        [Fact]
+        public static void StartsWithMatch_Byte()
+        {
+            byte[] a = { 4, 5, 6 };
+            ReadOnlySpan<byte> bytes = new ReadOnlySpan<byte>(a);
+            ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(a, 0, 1);
+            Assert.True(bytes.StartsWith(slice));
+        }
+
+        [Fact]
+        public static void StartsWithNoMatch_Byte()
+        {
+            byte[] a = { 4, 5, 6 };
+            byte[] b = { 1, 2, 3 };
+            ReadOnlySpan<byte> bytes = new ReadOnlySpan<byte>(a);
+            ReadOnlySpan<byte> slice = new ReadOnlySpan<byte>(b, 0, 1);
+            Assert.False(bytes.StartsWith(slice));
+        }
+        #endregion
+
+        #region ReadOnlySpanStartsWithChar
+        [Fact]
+        public static void ZeroLengthStartsWith_Char()
+        {
+            char[] a = { '4', '5', '6' };
+            ReadOnlySpan<char> str = new ReadOnlySpan<char>(a);
+            ReadOnlySpan<char> value = new ReadOnlySpan<char>(a, 2, 0);
+            Assert.True(str.StartsWith(value));
+        }
+
+        [Fact]
+        public static void StartsWithNoMatchEmptySpan_Char()
+        {
+            char[] a = { '4', '5', '6' };
+            char[] b = { '1', '2', '3' };
+            ReadOnlySpan<char> str = new ReadOnlySpan<char>(a, 0, 0);
+            ReadOnlySpan<char> value = new ReadOnlySpan<char>(b, 0, 1);
+            Assert.False(str.StartsWith(value));
+        }
+
+        [Fact]
+        public static void StartsWithMatchEmptySpans_Char()
+        {
+            char[] a = { '4', '5', '6' };
+            char[] b = { '1', '2', '3' };
+            ReadOnlySpan<char> str = new ReadOnlySpan<char>(a, 0, 0);
+            ReadOnlySpan<char> value = new ReadOnlySpan<char>(b, 0, 0);
+            Assert.True(str.StartsWith(value));
+        }
+
+        [Fact]
+        public static void SameSpanStartsWith_Char()
+        {
+            char[] a = { '4', '5', '6' };
+            ReadOnlySpan<char> span = new ReadOnlySpan<char>(a);
+            Assert.True(span.StartsWith(span));
+        }
+
+        [Fact]
+        public static void SameSpanValuesStartsWith_Char()
+        {
+            char[] a = { '4', '5', '6' };
+            ReadOnlySpan<char> str = new ReadOnlySpan<char>(a);
+            ReadOnlySpan<char> value = new ReadOnlySpan<char>(a);
+            Assert.True(str.StartsWith(value));
+        }
+
+        [Fact]
+        public static void LengthMismatchStartsWith_Char()
+        {
+            char[] a = { '4', '5', '6' };
+            ReadOnlySpan<char> str = new ReadOnlySpan<char>(a, 0, 2);
+            ReadOnlySpan<char> value = new ReadOnlySpan<char>(a);
+            Assert.False(str.StartsWith(value));
+        }
+
+        [Fact]
+        public static void StartsWithMatch_Char()
+        {
+            char[] a = { '4', '5', '6' };
+            ReadOnlySpan<char> str = new ReadOnlySpan<char>(a);
+            ReadOnlySpan<char> value = new ReadOnlySpan<char>(a, 0, 1);
+            Assert.True(str.StartsWith(value));
+        }
+
+        [Fact]
+        public static void StartsWithNoMatch_Char()
+        {
+            char[] a = { '4', '5', '6' };
+            char[] b = { '1', '2', '3' };
+            ReadOnlySpan<char> str = new ReadOnlySpan<char>(a);
+            ReadOnlySpan<char> value = new ReadOnlySpan<char>(b, 0, 1);
+            Assert.False(str.StartsWith(value));
+        }
+        #endregion
+
+        #region ReadOnlySpanStartsWith<T>
+        [Fact]
+        public static void ZeroLengthStartsWith()
+        {
+            int[] a = { 4, 5, 6 };
+            ReadOnlySpan<int> items = new ReadOnlySpan<int>(a);
+            ReadOnlySpan<int> slice = new ReadOnlySpan<int>(a, 2, 0);
+            Assert.True(items.StartsWith(slice));
+        }
+
+        [Fact]
+        public static void StartsWithNoMatchEmptySpan()
+        {
+            int[] a = { 4, 5, 6 };
+            int[] b = { 1, 2, 3 };
+            ReadOnlySpan<int> items = new ReadOnlySpan<int>(a, 0, 0);
+            ReadOnlySpan<int> slice = new ReadOnlySpan<int>(b, 0, 1);
+            Assert.False(items.StartsWith(slice));
+        }
+
+        [Fact]
+        public static void StartsWithMatchEmptySpans()
+        {
+            int[] a = { 4, 5, 6 };
+            int[] b = { 1, 2, 3 };
+            ReadOnlySpan<int> items = new ReadOnlySpan<int>(a, 0, 0);
+            ReadOnlySpan<int> slice = new ReadOnlySpan<int>(b, 0, 0);
+            Assert.True(items.StartsWith(slice));
+        }
+
+        [Fact]
+        public static void SameSpanStartsWith()
+        {
+            int[] a = { 4, 5, 6 };
+            ReadOnlySpan<int> span = new ReadOnlySpan<int>(a);
+            Assert.True(span.StartsWith(span));
+        }
+
+        [Fact]
+        public static void SameSpanValuesStartsWith()
+        {
+            int[] a = { 4, 5, 6 };
+            ReadOnlySpan<int> items = new ReadOnlySpan<int>(a);
+            ReadOnlySpan<int> slice = new ReadOnlySpan<int>(a);
+            Assert.True(items.StartsWith(slice));
+        }
+
+        [Fact]
+        public static void LengthMismatchStartsWith()
+        {
+            int[] a = { 4, 5, 6 };
+            ReadOnlySpan<int> items = new ReadOnlySpan<int>(a, 0, 2);
+            ReadOnlySpan<int> slice = new ReadOnlySpan<int>(a);
+            Assert.False(items.StartsWith(slice));
+        }
+
+        [Fact]
+        public static void StartsWithMatch()
+        {
+            int[] a = { 4, 5, 6 };
+            ReadOnlySpan<int> items = new ReadOnlySpan<int>(a);
+            ReadOnlySpan<int> slice = new ReadOnlySpan<int>(a, 0, 1);
+            Assert.True(items.StartsWith(slice));
+        }
+
+        [Fact]
+        public static void StartsWithNoMatch()
+        {
+            int[] a = { 4, 5, 6 };
+            int[] b = { 1, 2, 3 };
+            ReadOnlySpan<int> items = new ReadOnlySpan<int>(a);
+            ReadOnlySpan<int> slice = new ReadOnlySpan<int>(b, 0, 1);
+            Assert.False(items.StartsWith(slice));
+        }
+        #endregion
+
+        #region SpanIndexOfByte
+        [Fact]
+        public static void TestMatchWithIndexAndCount_Byte()
+        {
+            int length = 100;
+            byte[] a = new byte[length];
+            a[50] = 99;
+            Span<byte> span = new Span<byte>(a);
+
+            int idx = span.IndexOf(45, 10, 99);
+            Assert.Equal(50, idx);
+        }
+
+        [Fact]
+        public static void TestMatchWithIndexAndCountGreaterThanLength_Byte()
+        {
+            int length = 100;
+            byte[] a = new byte[length];
+            a[50] = 99;
+            Span<byte> span = new Span<byte>(a);
+
+            int idx = span.IndexOf(45, 75, 99);
+            Assert.Equal(50, idx);
+        }
+
+        [Fact]
+        public static void TestMatchWithCountGreaterThanLength_Byte()
+        {
+            int length = 100;
+            byte[] a = new byte[length];
+            a[50] = 99;
+            Span<byte> span = new Span<byte>(a);
+
+            int idx = span.IndexOf(0, 105, 99);
+            Assert.Equal(50, idx);
+        }
+
+        [Fact]
+        public static void TestNoMatchWithCountGreaterThanLength_Byte()
+        {
+            int length = 100;
+            byte[] a = new byte[length];
+            a[50] = 99;
+            Span<byte> span = new Span<byte>(a);
+
+            int idx = span.IndexOf(0, 105, 5);
+            Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void TestNoMatchWithIndexAndCount_Byte()
+        {
+            int length = 100;
+            byte[] a = new byte[length];
+            a[50] = 99;
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+            int idx = span.IndexOf(45, 3, 99);
+            Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void StartIndexTooLargeIndexOf_Byte()
+        {
+            int length = 100;
+            byte[] a = new byte[length];
+            a[50] = 99;
+            Span<byte> span = new Span<byte>(a);
+            int idx = span.IndexOf(length + 1, 10, 99);
+            Assert.Equal(-1, idx);
+        }
+
+        public static void ZeroCountIndexOf_Byte()
+        {
+            int length = 100;
+            byte[] a = new byte[length];
+            a[50] = 99;
+            Span<byte> span = new Span<byte>(a);
+            int idx = span.IndexOf(0, 0, 99);
+            Assert.Equal(-1, idx);
+        }
+        #endregion
+
+        #region ReadOnlySpanIndexOfByte
+        [Fact]
+        public static void TestMatchWithIndexAndCountReadOnly_Byte()
+        {
+            int length = 100;
+            byte[] a = new byte[length];
+            a[50] = 99;
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+            int idx = span.IndexOf(45, 10, 99);
+            Assert.Equal(50, idx);
+        }
+
+        [Fact]
+        public static void TestMatchWithIndexAndCountGreaterThanLengthReadOnly_Byte()
+        {
+            int length = 100;
+            byte[] a = new byte[length];
+            a[50] = 99;
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+            int idx = span.IndexOf(45, 75, 99);
+            Assert.Equal(50, idx);
+        }
+
+        [Fact]
+        public static void TestMatchWithCountGreaterThanLengthReadOnly_Byte()
+        {
+            int length = 100;
+            byte[] a = new byte[length];
+            a[50] = 99;
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+            int idx = span.IndexOf(0, 105, 99);
+            Assert.Equal(50, idx);
+        }
+
+        [Fact]
+        public static void TestNoMatchWithCountGreaterThanLengthReadOnly_Byte()
+        {
+            int length = 100;
+            byte[] a = new byte[length];
+            a[50] = 99;
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+            int idx = span.IndexOf(0, 105, 5);
+            Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void TestNoMatchWithIndexAndCountReadOnly_Byte()
+        {
+            int length = 100;
+            byte[] a = new byte[length];
+            a[50] = 99;
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+
+            int idx = span.IndexOf(45, 3, 99);
+            Assert.Equal(-1, idx);
+        }
+
+        [Fact]
+        public static void StartIndexTooLargeIndexOfReadOnly_Byte()
+        {
+            int length = 100;
+            byte[] a = new byte[length];
+            a[50] = 99;
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+            int idx = span.IndexOf(length + 1, 10, 99);
+            Assert.Equal(-1, idx);
+        }
+
+        public static void ZeroCountIndexOfReadOnly_Byte()
+        {
+            int length = 100;
+            byte[] a = new byte[length];
+            a[50] = 99;
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+            int idx = span.IndexOf(0, 0, 99);
+            Assert.Equal(-1, idx);
+        }
+        #endregion
     }
 }

--- a/tests/System.Slices.Tests/BasicUnitTests.cs
+++ b/tests/System.Slices.Tests/BasicUnitTests.cs
@@ -520,16 +520,21 @@ namespace System.Slices.Tests
         #endregion
 
         #region SpanIndexOfByte
+
         [Fact]
         public static void TestMatchWithIndexAndCount_Byte()
         {
-            int length = 100;
-            byte[] a = new byte[length];
-            a[50] = 99;
-            Span<byte> span = new Span<byte>(a);
-
-            int idx = span.IndexOf(99, 45, 10);
-            Assert.Equal(50, idx);
+            for (int i = 1; i < 10; i++)
+            {
+                for (int j = 0; j < i; j++)
+                {
+                    byte[] a = new byte[i];
+                    a[j] = 99;
+                    ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+                    int idx = span.IndexOf(99, 0, 10);
+                    Assert.Equal(j, idx);
+                }
+            }
         }
 
         [Fact]
@@ -544,18 +549,35 @@ namespace System.Slices.Tests
             Assert.Equal(50, idx);
         }
 
-        [Fact]
-        public static void TestIndexOfComparison_Byte()
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(50)]
+        [InlineData(100)]
+        [InlineData(500)]
+        [InlineData(1000)]
+        [InlineData(5000)]
+        public static void TestIndexOfComparison_Byte(int length)
         {
-            byte[] a = new byte[1000];
-
-            for (int i = 0; i < a.Length; i++)
-            {
-                a[i] = (byte)(i + 1);
-            }
+            const byte lookupVal = 99;
+            var a = new byte[length];
+            a[length / 2] = lookupVal;
 
             var bytes = new Span<byte>(a);
-            Assert.Equal(bytes.IndexOf(255, 250, 10) - 250, bytes.Slice(250, 10).IndexOf(255));
+            int startIndex = length / 4;
+            int count = length / 2 + 1;
+
+            int actualResult = bytes.IndexOf(lookupVal, startIndex, count) - startIndex;
+            int expectedResult = bytes.Slice(startIndex, count).IndexOf(lookupVal);
+            Assert.Equal(actualResult, expectedResult);
         }
 
         [Fact]
@@ -620,13 +642,17 @@ namespace System.Slices.Tests
         [Fact]
         public static void TestMatchWithIndexAndCountReadOnly_Byte()
         {
-            int length = 100;
-            byte[] a = new byte[length];
-            a[50] = 99;
-            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
-
-            int idx = span.IndexOf(99, 45, 10);
-            Assert.Equal(50, idx);
+            for (int i = 1; i < 10; i++)
+            {
+                for (int j = 0; j < i; j++)
+                {
+                    byte[] a = new byte[i];
+                    a[j] = 99;
+                    ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
+                    int idx = span.IndexOf(99, 0, 10);
+                    Assert.Equal(j, idx);
+                }
+            }
         }
 
         [Fact]
@@ -641,18 +667,35 @@ namespace System.Slices.Tests
             Assert.Equal(50, idx);
         }
 
-        [Fact]
-        public static void TestIndexOfComparisonReadOnly_Byte()
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(50)]
+        [InlineData(100)]
+        [InlineData(500)]
+        [InlineData(1000)]
+        [InlineData(5000)]
+        public static void TestIndexOfComparisonReadOnly_Byte(int length)
         {
-            byte[] a = new byte[1000];
-
-            for (int i = 0; i < a.Length; i++)
-            {
-                a[i] = (byte)(i + 1);
-            }
+            const byte lookupVal = 99;
+            var a = new byte[length];
+            a[length / 2] = lookupVal;
 
             var bytes = new ReadOnlySpan<byte>(a);
-            Assert.Equal(bytes.IndexOf(255, 250, 10) - 250, bytes.Slice(250, 10).IndexOf(255));
+            int startIndex = length / 4;
+            int count = length / 2 + 1;
+
+            int actualResult = bytes.IndexOf(lookupVal, startIndex, count) - startIndex;
+            int expectedResult = bytes.Slice(startIndex, count).IndexOf(lookupVal);
+            Assert.Equal(actualResult, expectedResult);
         }
 
         [Fact]

--- a/tests/System.Slices.Tests/BasicUnitTests.cs
+++ b/tests/System.Slices.Tests/BasicUnitTests.cs
@@ -528,7 +528,7 @@ namespace System.Slices.Tests
             a[50] = 99;
             Span<byte> span = new Span<byte>(a);
 
-            int idx = span.IndexOf(45, 10, 99);
+            int idx = span.IndexOf(99, 45, 10);
             Assert.Equal(50, idx);
         }
 
@@ -540,12 +540,12 @@ namespace System.Slices.Tests
             a[50] = 99;
             Span<byte> span = new Span<byte>(a);
 
-            int idx = span.IndexOf(45, 75, 99);
+            int idx = span.IndexOf(99, 45, 75);
             Assert.Equal(50, idx);
         }
 
         [Fact]
-        public static void TestIndexOfComparison()
+        public static void TestIndexOfComparison_Byte()
         {
             byte[] a = new byte[1000];
 
@@ -555,7 +555,7 @@ namespace System.Slices.Tests
             }
 
             var bytes = new Span<byte>(a);
-            Assert.Equal(bytes.IndexOf(250, 10, 255) - 250, bytes.Slice(250, 10).IndexOf(255));
+            Assert.Equal(bytes.IndexOf(255, 250, 10) - 250, bytes.Slice(250, 10).IndexOf(255));
         }
 
         [Fact]
@@ -566,7 +566,7 @@ namespace System.Slices.Tests
             a[50] = 99;
             Span<byte> span = new Span<byte>(a);
 
-            int idx = span.IndexOf(0, 105, 99);
+            int idx = span.IndexOf(99, 0, 105);
             Assert.Equal(50, idx);
         }
 
@@ -578,7 +578,7 @@ namespace System.Slices.Tests
             a[50] = 99;
             Span<byte> span = new Span<byte>(a);
 
-            int idx = span.IndexOf(0, 105, 5);
+            int idx = span.IndexOf(5, 0, 105);
             Assert.Equal(-1, idx);
         }
 
@@ -590,7 +590,7 @@ namespace System.Slices.Tests
             a[50] = 99;
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
 
-            int idx = span.IndexOf(45, 3, 99);
+            int idx = span.IndexOf(99, 45, 3);
             Assert.Equal(-1, idx);
         }
 
@@ -601,7 +601,7 @@ namespace System.Slices.Tests
             byte[] a = new byte[length];
             a[50] = 99;
             Span<byte> span = new Span<byte>(a);
-            int idx = span.IndexOf(length + 1, 10, 99);
+            int idx = span.IndexOf(99, length + 1, 10);
             Assert.Equal(-1, idx);
         }
 
@@ -611,7 +611,7 @@ namespace System.Slices.Tests
             byte[] a = new byte[length];
             a[50] = 99;
             Span<byte> span = new Span<byte>(a);
-            int idx = span.IndexOf(0, 0, 99);
+            int idx = span.IndexOf(99, 0, 0);
             Assert.Equal(-1, idx);
         }
         #endregion
@@ -625,7 +625,7 @@ namespace System.Slices.Tests
             a[50] = 99;
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
 
-            int idx = span.IndexOf(45, 10, 99);
+            int idx = span.IndexOf(99, 45, 10);
             Assert.Equal(50, idx);
         }
 
@@ -637,8 +637,22 @@ namespace System.Slices.Tests
             a[50] = 99;
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
 
-            int idx = span.IndexOf(45, 75, 99);
+            int idx = span.IndexOf(99, 45, 75);
             Assert.Equal(50, idx);
+        }
+
+        [Fact]
+        public static void TestIndexOfComparisonReadOnly_Byte()
+        {
+            byte[] a = new byte[1000];
+
+            for (int i = 0; i < a.Length; i++)
+            {
+                a[i] = (byte)(i + 1);
+            }
+
+            var bytes = new ReadOnlySpan<byte>(a);
+            Assert.Equal(bytes.IndexOf(255, 250, 10) - 250, bytes.Slice(250, 10).IndexOf(255));
         }
 
         [Fact]
@@ -649,7 +663,7 @@ namespace System.Slices.Tests
             a[50] = 99;
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
 
-            int idx = span.IndexOf(0, 105, 99);
+            int idx = span.IndexOf(99, 0, 105);
             Assert.Equal(50, idx);
         }
 
@@ -661,7 +675,7 @@ namespace System.Slices.Tests
             a[50] = 99;
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
 
-            int idx = span.IndexOf(0, 105, 5);
+            int idx = span.IndexOf(5, 0, 105);
             Assert.Equal(-1, idx);
         }
 
@@ -673,7 +687,7 @@ namespace System.Slices.Tests
             a[50] = 99;
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
 
-            int idx = span.IndexOf(45, 3, 99);
+            int idx = span.IndexOf(99, 45, 3);
             Assert.Equal(-1, idx);
         }
 
@@ -684,7 +698,7 @@ namespace System.Slices.Tests
             byte[] a = new byte[length];
             a[50] = 99;
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
-            int idx = span.IndexOf(length + 1, 10, 99);
+            int idx = span.IndexOf(99, length + 1, 10);
             Assert.Equal(-1, idx);
         }
 
@@ -694,7 +708,7 @@ namespace System.Slices.Tests
             byte[] a = new byte[length];
             a[50] = 99;
             ReadOnlySpan<byte> span = new ReadOnlySpan<byte>(a);
-            int idx = span.IndexOf(0, 0, 99);
+            int idx = span.IndexOf(99, 0, 0);
             Assert.Equal(-1, idx);
         }
         #endregion

--- a/tests/System.Slices.Tests/BasicUnitTests.cs
+++ b/tests/System.Slices.Tests/BasicUnitTests.cs
@@ -545,6 +545,20 @@ namespace System.Slices.Tests
         }
 
         [Fact]
+        public static void TestIndexOfComparison()
+        {
+            byte[] a = new byte[1000];
+
+            for (int i = 0; i < a.Length; i++)
+            {
+                a[i] = (byte)(i + 1);
+            }
+
+            var bytes = new Span<byte>(a);
+            Assert.Equal(bytes.IndexOf(250, 10, 255) - 250, bytes.Slice(250, 10).IndexOf(255));
+        }
+
+        [Fact]
         public static void TestMatchWithCountGreaterThanLength_Byte()
         {
             int length = 100;

--- a/tests/System.Slices.Tests/MemoryTests.cs
+++ b/tests/System.Slices.Tests/MemoryTests.cs
@@ -163,7 +163,7 @@ namespace System.Slices.Tests
                                        ReferenceCountingMethod.ReferenceCounter));
 
 
-        [MemberData(nameof(ReservationPerformanceData))]
+        /*[MemberData(nameof(ReservationPerformanceData))]
         [Benchmark]
         public void ReservationPerformance(int number, int size, int threads, ReferenceCountingMethod m)
         {
@@ -205,7 +205,7 @@ namespace System.Slices.Tests
             });
 
             ReferenceCountingSettings.OwnedMemory = o;
-        }
+        }*/
 
         [Fact]
         public unsafe void ReferenceCounting()

--- a/tests/System.Slices.Tests/MemoryTests.cs
+++ b/tests/System.Slices.Tests/MemoryTests.cs
@@ -163,7 +163,7 @@ namespace System.Slices.Tests
                                        ReferenceCountingMethod.ReferenceCounter));
 
 
-        /*[MemberData(nameof(ReservationPerformanceData))]
+        [MemberData(nameof(ReservationPerformanceData))]
         [Benchmark]
         public void ReservationPerformance(int number, int size, int threads, ReferenceCountingMethod m)
         {
@@ -205,7 +205,7 @@ namespace System.Slices.Tests
             });
 
             ReferenceCountingSettings.OwnedMemory = o;
-        }*/
+        }
 
         [Fact]
         public unsafe void ReferenceCounting()

--- a/tests/System.Slices.Tests/PerformanceTests.cs
+++ b/tests/System.Slices.Tests/PerformanceTests.cs
@@ -68,7 +68,7 @@ namespace System.Slices.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        int result = bytes.IndexOf(250, 10, 255);
+                        int result = bytes.IndexOf(255, 250, 10);
                     }
                 }
             }

--- a/tests/System.Slices.Tests/PerformanceTests.cs
+++ b/tests/System.Slices.Tests/PerformanceTests.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.Slices.Tests
+{
+    public class PerformanceTests
+    {
+        /*[Benchmark(InnerIterationCount = 100000)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(50)]
+        [InlineData(100)]
+        [InlineData(500)]
+        [InlineData(1000)]
+        [InlineData(5000)]
+        public void SpanStartsWith(int length)
+        {
+            byte[] a = new byte[length];
+            byte[] b = {1, 2, 3, 4, 5};
+
+            for (int i = 0; i < a.Length; i++)
+            {
+                a[i] = (byte)(i + 1);
+            }
+
+            var bytes = new ReadOnlySpan<byte>(a);
+            var slice = new ReadOnlySpan<byte>(b, 0, Math.Min(length, b.Length));
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        bool result = bytes.StartsWith(slice);
+                    }
+                }
+            }
+        }*/
+
+        [Benchmark(InnerIterationCount = 100000)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(50)]
+        [InlineData(100)]
+        [InlineData(500)]
+        [InlineData(1000)]
+        [InlineData(5000)]
+        public void SpanIndexOf(int length)
+        {
+            byte[] a = new byte[length];
+
+            for (int i = 0; i < a.Length; i++)
+            {
+                a[i] = (byte)(i + 1);
+            }
+
+            var bytes = new Span<byte>(a);
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        //int result = bytes.IndexOf(0, length, 1);
+                        int result = bytes.IndexOf2(0, length, 1);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/System.Slices.Tests/PerformanceTests.cs
+++ b/tests/System.Slices.Tests/PerformanceTests.cs
@@ -81,8 +81,7 @@ namespace System.Slices.Tests
 
             bytes = new Span<byte>(a);
         }
-
-        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        
         private static byte[] GetArray(int length)
         {
             var rand = new Random(42);
@@ -98,23 +97,26 @@ namespace System.Slices.Tests
             }
             return a;
         }
-
-        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        
         private static void TestBenchIndexOf(Span<byte> bytes, int startIndex, int count)
         {
-            bytes.IndexOf(LookupVal, startIndex, count);
+            var temp = bytes.IndexOf(LookupVal, startIndex, count);
+            if (temp == -1)
+            {
+                Console.WriteLine(temp);
+            }
         }
-
-        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        
         private static void TestBenchSlice(Span<byte> bytes, int startIndex, int count)
         {
-            bytes.Slice(startIndex, count).IndexOf(LookupVal);
+            var temp = bytes.Slice(startIndex, count).IndexOf(LookupVal);
+            if (temp == -1)
+            {
+                Console.WriteLine(temp);
+            }
         }
 
         [Benchmark(InnerIterationCount = 1000000)]
-        [InlineData(1)]
-        [InlineData(10)]
-        [InlineData(100)]
         [InlineData(1000)]
         public static void SpanIndexOfWithIndexAndCountComparisonValueAtEnd(int length)
         {
@@ -133,9 +135,6 @@ namespace System.Slices.Tests
         }
 
         [Benchmark(InnerIterationCount = 1000000)]
-        [InlineData(1)]
-        [InlineData(10)]
-        [InlineData(100)]
         [InlineData(1000)]
         public static void SpanIndexOfWithSliceComparisonValueAtEnd(int length)
         {
@@ -154,9 +153,6 @@ namespace System.Slices.Tests
         }
 
         [Benchmark(InnerIterationCount = 10000000)]
-        [InlineData(1)]
-        [InlineData(10)]
-        [InlineData(100)]
         [InlineData(1000)]
         public static void SpanIndexOfWithIndexAndCountComparisonValueAtStart(int length)
         {
@@ -175,9 +171,6 @@ namespace System.Slices.Tests
         }
 
         [Benchmark(InnerIterationCount = 10000000)]
-        [InlineData(1)]
-        [InlineData(10)]
-        [InlineData(100)]
         [InlineData(1000)]
         public static void SpanIndexOfWithSliceComparisonValueAtStart(int length)
         {
@@ -196,9 +189,6 @@ namespace System.Slices.Tests
         }
 
         [Benchmark(InnerIterationCount = 1000000)]
-        [InlineData(1)]
-        [InlineData(10)]
-        [InlineData(100)]
         [InlineData(1000)]
         public static void SpanIndexOfWithIndexAndCountComparisonValueInMiddle(int length)
         {
@@ -217,9 +207,6 @@ namespace System.Slices.Tests
         }
 
         [Benchmark(InnerIterationCount = 1000000)]
-        [InlineData(1)]
-        [InlineData(10)]
-        [InlineData(100)]
         [InlineData(1000)]
         public static void SpanIndexOfWithSliceComparisonValueInMiddle(int length)
         {

--- a/tests/System.Slices.Tests/PerformanceTests.cs
+++ b/tests/System.Slices.Tests/PerformanceTests.cs
@@ -92,7 +92,7 @@ namespace System.Slices.Tests
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         private static void TestBenchSlice(Span<byte> bytes, int startIndex, int count)
         {
-            _sResult += bytes.IndexOf(LookupVal, startIndex, count);
+            _sResult += bytes.Slice(startIndex, count).IndexOf(LookupVal);
         }
 
         [Benchmark(InnerIterationCount = 100000)]

--- a/tests/System.Slices.Tests/PerformanceTests.cs
+++ b/tests/System.Slices.Tests/PerformanceTests.cs
@@ -49,18 +49,32 @@ namespace System.Slices.Tests
             }
         }
 
-        [Benchmark(InnerIterationCount = 10000000)]
+        [Benchmark(InnerIterationCount = 100000)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(50)]
+        [InlineData(100)]
+        [InlineData(500)]
         [InlineData(1000)]
-        public void SpanIndexOfWithIndexAndCountComparison(int length)
+        [InlineData(5000)]
+        public int SpanIndexOfWithIndexAndCountComparisonValueAtEnd(int length)
         {
-            byte[] a = new byte[length];
-
-            for (int i = 0; i < a.Length; i++)
-            {
-                a[i] = (byte)(i + 1);
-            }
+            const byte lookupVal = 99;
+            var a = new byte[length];
+            a[length - 1] = lookupVal;
 
             var bytes = new Span<byte>(a);
+            int startIndex = length / 2;
+            int count = length - startIndex;
+            var result = -1;
 
             foreach (var iteration in Benchmark.Iterations)
             {
@@ -68,24 +82,40 @@ namespace System.Slices.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        int result = bytes.IndexOf(255, 250, 10);
+                        result = bytes.IndexOf(lookupVal, startIndex, count);
                     }
                 }
             }
+            Console.WriteLine(result);
+            return result;
         }
 
-        [Benchmark(InnerIterationCount = 10000000)]
+        [Benchmark(InnerIterationCount = 100000)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(50)]
+        [InlineData(100)]
+        [InlineData(500)]
         [InlineData(1000)]
-        public void SpanIndexOfWithSliceComparison(int length)
+        [InlineData(5000)]
+        public int SpanIndexOfWithSliceComparisonValueAtEnd(int length)
         {
-            byte[] a = new byte[length];
-
-            for (int i = 0; i < a.Length; i++)
-            {
-                a[i] = (byte)(i + 1);
-            }
+            const byte lookupVal = 99;
+            var a = new byte[length];
+            a[length - 1] = lookupVal;
 
             var bytes = new Span<byte>(a);
+            int startIndex = length / 2;
+            int count = length - startIndex;
+            var result = -1;
 
             foreach (var iteration in Benchmark.Iterations)
             {
@@ -93,10 +123,176 @@ namespace System.Slices.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        int result = bytes.Slice(250, 10).IndexOf(255);
+                        result = bytes.Slice(startIndex, count).IndexOf(lookupVal);
                     }
                 }
             }
+            Console.WriteLine(result);
+            return result;
+        }
+
+        [Benchmark(InnerIterationCount = 100000)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(50)]
+        [InlineData(100)]
+        [InlineData(500)]
+        [InlineData(1000)]
+        [InlineData(5000)]
+        public int SpanIndexOfWithIndexAndCountComparisonValueAtStart(int length)
+        {
+            const byte lookupVal = 99;
+            var a = new byte[length];
+            a[0] = lookupVal;
+
+            var bytes = new Span<byte>(a);
+            int startIndex = 0;
+            int count = length - startIndex;
+            var result = -1;
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        result = bytes.IndexOf(lookupVal, startIndex, count);
+                    }
+                }
+            }
+            Console.WriteLine(result);
+            return result;
+        }
+
+        [Benchmark(InnerIterationCount = 100000)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(50)]
+        [InlineData(100)]
+        [InlineData(500)]
+        [InlineData(1000)]
+        [InlineData(5000)]
+        public int SpanIndexOfWithSliceComparisonValueAtStart(int length)
+        {
+            const byte lookupVal = 99;
+            var a = new byte[length];
+            a[0] = lookupVal;
+
+            var bytes = new Span<byte>(a);
+            int startIndex = 0;
+            int count = length - startIndex;
+            var result = -1;
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        result = bytes.Slice(startIndex, count).IndexOf(lookupVal);
+                    }
+                }
+            }
+            Console.WriteLine(result);
+            return result;
+        }
+
+        [Benchmark(InnerIterationCount = 100000)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(50)]
+        [InlineData(100)]
+        [InlineData(500)]
+        [InlineData(1000)]
+        [InlineData(5000)]
+        public int SpanIndexOfWithIndexAndCountComparisonValueInMiddle(int length)
+        {
+            const byte lookupVal = 99;
+            var a = new byte[length];
+            a[length / 2] = lookupVal;
+
+            var bytes = new Span<byte>(a);
+            int startIndex = length / 4;
+            int count = length / 2 + 1;
+            var result = -1;
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        result = bytes.IndexOf(lookupVal, startIndex, count);
+                    }
+                }
+            }
+            Console.WriteLine(result);
+            return result;
+        }
+
+        [Benchmark(InnerIterationCount = 100000)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        [InlineData(10)]
+        [InlineData(50)]
+        [InlineData(100)]
+        [InlineData(500)]
+        [InlineData(1000)]
+        [InlineData(5000)]
+        public int SpanIndexOfWithSliceComparisonValueInMiddle(int length)
+        {
+            const byte lookupVal = 99;
+            var a = new byte[length];
+            a[length / 2] = lookupVal;
+
+            var bytes = new Span<byte>(a);
+            int startIndex = length / 4;
+            int count = length / 2 + 1;
+            var result = -1;
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        result = bytes.Slice(startIndex, count).IndexOf(lookupVal);
+                    }
+                }
+            }
+            Console.WriteLine(result);
+            return result;
         }
     }
 }

--- a/tests/System.Slices.Tests/PerformanceTests.cs
+++ b/tests/System.Slices.Tests/PerformanceTests.cs
@@ -8,7 +8,7 @@ namespace System.Slices.Tests
 {
     public class PerformanceTests
     {
-        /*[Benchmark(InnerIterationCount = 100000)]
+        [Benchmark(InnerIterationCount = 10000000)]
         [InlineData(1)]
         [InlineData(2)]
         [InlineData(3)]
@@ -47,25 +47,11 @@ namespace System.Slices.Tests
                     }
                 }
             }
-        }*/
+        }
 
-        [Benchmark(InnerIterationCount = 100000)]
-        [InlineData(1)]
-        [InlineData(2)]
-        [InlineData(3)]
-        [InlineData(4)]
-        [InlineData(5)]
-        [InlineData(6)]
-        [InlineData(7)]
-        [InlineData(8)]
-        [InlineData(9)]
-        [InlineData(10)]
-        [InlineData(50)]
-        [InlineData(100)]
-        [InlineData(500)]
+        [Benchmark(InnerIterationCount = 10000000)]
         [InlineData(1000)]
-        [InlineData(5000)]
-        public void SpanIndexOf(int length)
+        public void SpanIndexOfWithIndexAndCountComparison(int length)
         {
             byte[] a = new byte[length];
 
@@ -82,8 +68,32 @@ namespace System.Slices.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        //int result = bytes.IndexOf(0, length, 1);
-                        int result = bytes.IndexOf2(0, length, 1);
+                        int result = bytes.IndexOf(250, 10, 255);
+                    }
+                }
+            }
+        }
+
+        [Benchmark(InnerIterationCount = 10000000)]
+        [InlineData(1000)]
+        public void SpanIndexOfWithSliceComparison(int length)
+        {
+            byte[] a = new byte[length];
+
+            for (int i = 0; i < a.Length; i++)
+            {
+                a[i] = (byte)(i + 1);
+            }
+
+            var bytes = new Span<byte>(a);
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        int result = bytes.Slice(250, 10).IndexOf(255);
                     }
                 }
             }


### PR DESCRIPTION
- Also fixing StartsWith impl (calling SequenceEqual)

Approximately 5% performance gain calling Span IndexOf that takes an index and count versus Slice.

     Test Name                                                                                 | Metric                | Iterations |   AVERAGE |   STDEV.S |       MIN |        MAX
    :----------------------------------------------------------------------------------------- |:--------------------- |:----------:| ---------:| ---------:| ---------:| ----------:
     System.Slices.Tests.PerformanceTests.SpanIndexOfWithIndexAndCountComparison(length: 1000) | Duration              |    101     |    90.687 |    13.232 |    77.279 |    139.205
     System.Slices.Tests.PerformanceTests.SpanIndexOfWithIndexAndCountComparison(length: 1000) | Branch Mispredictions |    101     | 71984.158 | 39412.573 | 16384.000 | 2.499E+005
     System.Slices.Tests.PerformanceTests.SpanIndexOfWithIndexAndCountComparison(length: 1000) | Cache Misses          |    101     |  7705.347 |  5190.365 |     0.000 |  20480.000
     System.Slices.Tests.PerformanceTests.SpanIndexOfWithSliceComparison(length: 1000)         | Duration              |    101     |    98.103 |     8.345 |    88.652 |    127.297
     System.Slices.Tests.PerformanceTests.SpanIndexOfWithSliceComparison(length: 1000)         | Branch Mispredictions |    101     | 64724.911 | 29497.001 | 20480.000 | 1.884E+005
     System.Slices.Tests.PerformanceTests.SpanIndexOfWithSliceComparison(length: 1000)         | Cache Misses          |    101     |  8678.653 |  5771.935 |     0.000 |  28672.000

For Span.StartsWith using SequenceEqual, the break even point is around Span of size 3-4. Using SequenceEqual for span.Length > 3 gives 30%+ perf gains.

![image](https://cloud.githubusercontent.com/assets/6527137/23642182/97767b92-02ad-11e7-9a62-423aab15d888.png)

