### PR TITLE
Remove 16 bytes from BufferSegment

### DIFF
--- a/src/System.IO.Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/BufferSegment.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Buffers;
 using System.Diagnostics;
 using System.Text;
@@ -36,9 +35,7 @@ namespace System.IO.Pipelines
         /// <summary>
         /// The buffer being tracked
         /// </summary>
-        private OwnedMemory<byte> _buffer;
-
-        private Memory<byte> _memory;
+        private readonly OwnedMemory<byte> _buffer;
 
         public BufferSegment(OwnedMemory<byte> buffer)
         {
@@ -47,7 +44,6 @@ namespace System.IO.Pipelines
             End = 0;
 
             _buffer.AddReference();
-            _memory = _buffer.Memory;
         }
 
         public BufferSegment(OwnedMemory<byte> buffer, int start, int end)
@@ -66,10 +62,9 @@ namespace System.IO.Pipelines
             }
 
             _buffer.AddReference();
-            _memory = _buffer.Memory;
         }
 
-        public Memory<byte> Memory => _memory;
+        public Memory<byte> Memory => _buffer.Memory;
 
         /// <summary>
         /// If true, data should not be written into the backing block after the End offset. Data between start and end should never be modified


### PR DESCRIPTION
Not sure caching memory here does much? Always calling it once and stashing, vs calling very light .ctor on use and inlining it?

/cc @davidfowl 