### PR TITLE
ReadableBuffer cleanup and changes

### DIFF
--- a/samples/System.IO.Pipelines.Samples/HttpClient/LibuvHttpClientHandler.cs
+++ b/samples/System.IO.Pipelines.Samples/HttpClient/LibuvHttpClientHandler.cs
@@ -161,15 +161,12 @@ namespace System.IO.Pipelines.Samples
                             responseBuffer = responseBuffer.Slice(1);
                             if (responseBuffer.Length == 0)
                             {
-                                ch = responseBuffer.First.Span[0];
-                            }
-                            responseBuffer = responseBuffer.Slice(1);
-
-                            if (ch == -1)
-                            {
                                 break;
                             }
-                            else if (ch == '\n')
+                            ch = responseBuffer.First.Span[0];
+                            responseBuffer = responseBuffer.Slice(1);
+
+                            if (ch == '\n')
                             {
                                 consumed = responseBuffer.Start;
                                 needMoreData = false;

--- a/samples/System.IO.Pipelines.Samples/HttpClient/LibuvHttpClientHandler.cs
+++ b/samples/System.IO.Pipelines.Samples/HttpClient/LibuvHttpClientHandler.cs
@@ -147,18 +147,22 @@ namespace System.IO.Pipelines.Samples
 
                     while (!responseBuffer.IsEmpty)
                     {
-                        var ch = responseBuffer.Peek();
-
-                        if (ch == -1)
+                        if (responseBuffer.Length == 0)
                         {
                             break;
                         }
+
+                        var first = responseBuffer.First.Span;
+                        int ch = first[0];
 
                         if (ch == '\r')
                         {
                             // Check for final CRLF.
                             responseBuffer = responseBuffer.Slice(1);
-                            ch = responseBuffer.Peek();
+                            if (responseBuffer.Length == 0)
+                            {
+                                ch = responseBuffer.First.Span[0];
+                            }
                             responseBuffer = responseBuffer.Slice(1);
 
                             if (ch == -1)

--- a/samples/System.IO.Pipelines.Samples/HttpServer/RequestHeaderDictionary.cs
+++ b/samples/System.IO.Pipelines.Samples/HttpServer/RequestHeaderDictionary.cs
@@ -134,7 +134,7 @@ namespace System.IO.Pipelines.Samples.Http
                 return false;
             }
 
-            return key.Equals(buffer);
+            return key.EqualsTo(buffer);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.IO.Pipelines.Extensions/DefaultReadableBufferExtensions.cs
+++ b/src/System.IO.Pipelines.Extensions/DefaultReadableBufferExtensions.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 namespace System.IO.Pipelines
 {
-    public static class ReadableBufferExtensionsExtensions
+    public static class DefaultReadableBufferExtensions
     {
         private static readonly int VectorWidth = Vector<byte>.Count;
 
@@ -218,7 +218,7 @@ namespace System.IO.Pipelines
                 return false;
             }
 
-            return buffer.Slice(0, value.Length).Equals(value);
+            return buffer.Slice(0, value.Length).EqualsTo(value);
         }
 
         /// <summary>
@@ -226,7 +226,7 @@ namespace System.IO.Pipelines
         /// </summary>
         /// <param name="value">The <see cref="Span{Byte}"/> to compare to</param>
         /// <returns>True if the bytes are equal, false if not</returns>
-        public static bool Equals(this ReadableBuffer buffer,  Span<byte> value)
+        public static bool EqualsTo(this ReadableBuffer buffer, Span<byte> value)
         {
             if (value.Length != buffer.Length)
             {

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -33,9 +33,6 @@ namespace System.IO.Pipelines
         /// </summary>
         public bool IsSingleSpan => _start.Segment == _end.Segment;
 
-        /// <summary>
-        /// The first <see cref="Memory{Byte}"/> in the <see cref="ReadableBuffer"/>.
-        /// </summary>
         public Memory<byte> First
         {
             get
@@ -44,7 +41,7 @@ namespace System.IO.Pipelines
                 return first;
             }
         }
-
+        
         /// <summary>
         /// A cursor to the start of the <see cref="ReadableBuffer"/>.
         /// </summary>
@@ -152,21 +149,6 @@ namespace System.IO.Pipelines
 
             var begin = _start.Seek(start, _end, false);
             return new ReadableBuffer(begin, _end);
-        }
-
-        /// <summary>
-        /// Returns the first byte in the <see cref="ReadableBuffer"/>.
-        /// </summary>
-        /// <returns>-1 if the buffer is empty, the first byte otherwise.</returns>
-        public int Peek()
-        {
-            if (IsEmpty)
-            {
-                return -1;
-            }
-
-            var span = First.Span;
-            return span[0];
         }
 
         /// <summary>

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -3,8 +3,6 @@
 
 using System.Buffers;
 using System.Collections.Sequences;
-using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace System.IO.Pipelines
@@ -14,8 +12,6 @@ namespace System.IO.Pipelines
     /// </summary>
     public struct ReadableBuffer : ISequence<ReadOnlyMemory<byte>>
     {
-        private Memory<byte> _first;
-
         private ReadCursor _start;
         private ReadCursor _end;
         private int _length;
@@ -23,14 +19,14 @@ namespace System.IO.Pipelines
         /// <summary>
         /// Length of the <see cref="ReadableBuffer"/> in bytes.
         /// </summary>
-        public int Length => _length >= 0 ? _length : GetLength();
+        public int Length => _length;
 
         int? ISequence<ReadOnlyMemory<byte>>.Length => Length;
 
         /// <summary>
         /// Determines if the <see cref="ReadableBuffer"/> is empty.
         /// </summary>
-        public bool IsEmpty => _first.IsEmpty && Length == 0;
+        public bool IsEmpty => _length == 0;
 
         /// <summary>
         /// Determins if the <see cref="ReadableBuffer"/> is a single <see cref="Memory{Byte}"/>.
@@ -40,7 +36,14 @@ namespace System.IO.Pipelines
         /// <summary>
         /// The first <see cref="Memory{Byte}"/> in the <see cref="ReadableBuffer"/>.
         /// </summary>
-        public Memory<byte> First => _first;
+        public Memory<byte> First
+        {
+            get
+            {
+                _start.TryGetBuffer(_end, out Memory<byte> first);
+                return first;
+            }
+        }
 
         /// <summary>
         /// A cursor to the start of the <see cref="ReadableBuffer"/>.
@@ -56,8 +59,8 @@ namespace System.IO.Pipelines
         {
             _start = start;
             _end = end;
-            start.TryGetBuffer(end, out _first);
-            _length = -1;
+            _length = start.GetLength(_end);
+
         }
 
         private ReadableBuffer(ref ReadableBuffer buffer)
@@ -75,8 +78,6 @@ namespace System.IO.Pipelines
             _end = end;
 
             _length = buffer._length;
-
-            begin.TryGetBuffer(end, out _first);
         }
 
         /// <summary>
@@ -206,14 +207,6 @@ namespace System.IO.Pipelines
             return buffer;
         }
 
-        private int GetLength()
-        {
-            var begin = _start;
-            var length = begin.GetLength(_end);
-            _length = length;
-            return length;
-        }
-
         /// <summary>
         ///
         /// </summary>
@@ -234,52 +227,6 @@ namespace System.IO.Pipelines
         public MemoryEnumerator GetEnumerator()
         {
             return new MemoryEnumerator(_start, _end);
-        }
-
-        /// <summary>
-        /// Checks to see if the <see cref="ReadableBuffer"/> starts with the specified <see cref="Span{Byte}"/>.
-        /// </summary>
-        /// <param name="value">The <see cref="Span{Byte}"/> to compare to</param>
-        /// <returns>True if the bytes StartsWith, false if not</returns>
-        public bool StartsWith(Span<byte> value)
-        {
-            if (Length < value.Length)
-            {
-                // just nope
-                return false;
-            }
-
-            return Slice(0, value.Length).Equals(value);
-        }
-
-        /// <summary>
-        /// Checks to see if the <see cref="ReadableBuffer"/> is Equal to the specified <see cref="Span{Byte}"/>.
-        /// </summary>
-        /// <param name="value">The <see cref="Span{Byte}"/> to compare to</param>
-        /// <returns>True if the bytes are equal, false if not</returns>
-        public bool Equals(Span<byte> value)
-        {
-            if (value.Length != Length)
-            {
-                return false;
-            }
-
-            if (IsSingleSpan)
-            {
-                return First.Span.BlockEquals(value);
-            }
-
-            foreach (var memory in this)
-            {
-                var compare = value.Slice(0, memory.Length);
-                if (!memory.Span.BlockEquals(compare))
-                {
-                    return false;
-                }
-
-                value = value.Slice(memory.Length);
-            }
-            return true;
         }
 
         internal void ClearCursors()

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -56,7 +56,7 @@ namespace System.IO.Pipelines
         {
             _start = start;
             _end = end;
-            _length = start.GetLength(_end);
+            _length = start.GetLength(end);
 
         }
 

--- a/tests/System.IO.Pipelines.Tests/ReadableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/ReadableBufferFacts.cs
@@ -103,12 +103,12 @@ namespace System.IO.Pipelines.Tests
         private void EqualsDetectsDeltaForAllLocations(ReadableBuffer slice, byte[] expected, int offset, int length)
         {
             Assert.Equal(length, slice.Length);
-            Assert.True(slice.Equals(new Span<byte>(expected, offset, length)));
+            Assert.True(slice.EqualsTo(new Span<byte>(expected, offset, length)));
             // change one byte in buffer, for every position
             for (int i = 0; i < length; i++)
             {
                 expected[offset + i] ^= 42;
-                Assert.False(slice.Equals(new Span<byte>(expected, offset, length)));
+                Assert.False(slice.EqualsTo(new Span<byte>(expected, offset, length)));
                 expected[offset + i] ^= 42;
             }
         }

--- a/tests/System.IO.Pipelines.Tests/SocketsFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/SocketsFacts.cs
@@ -201,7 +201,7 @@ namespace System.IO.Pipelines.Tests
                     }
                     else
                     {
-                        havePong = inputBuffer.Equals(_ping);
+                        havePong = inputBuffer.EqualsTo(_ping);
                         if (havePong)
                         {
                             count++;
@@ -247,7 +247,7 @@ namespace System.IO.Pipelines.Tests
                 }
                 else
                 {
-                    bool isPing = inputBuffer.Equals(_ping);
+                    bool isPing = inputBuffer.EqualsTo(_ping);
                     if (isPing)
                     {
                         await connection.Output.WriteAsync(_pong);

--- a/tests/System.IO.Pipelines.Tests/WritableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/WritableBufferFacts.cs
@@ -77,7 +77,7 @@ namespace System.IO.Pipelines.Tests
                     var input = result.Buffer;
                     if (input.Length == 0) break;
 
-                    Assert.True(input.Equals(new Span<byte>(data, offset, input.Length)));
+                    Assert.True(input.EqualsTo(new Span<byte>(data, offset, input.Length)));
                     offset += input.Length;
                     pipe.Advance(input.End);
                 }
@@ -187,8 +187,8 @@ namespace System.IO.Pipelines.Tests
                 // check that looks about right
                 Assert.False(readable.IsEmpty);
                 Assert.Equal(11, readable.Length);
-                Assert.True(readable.Equals(Encoding.UTF8.GetBytes("hello world")));
-                Assert.True(readable.Slice(1, 3).Equals(Encoding.UTF8.GetBytes("ell")));
+                Assert.True(readable.EqualsTo(Encoding.UTF8.GetBytes("hello world")));
+                Assert.True(readable.Slice(1, 3).EqualsTo(Encoding.UTF8.GetBytes("ell")));
 
                 // check it all works after we write more
                 output.Append("more data", TextEncoder.Utf8);
@@ -196,14 +196,14 @@ namespace System.IO.Pipelines.Tests
                 // note that the snapshotted readable should not have changed by this
                 Assert.False(readable.IsEmpty);
                 Assert.Equal(11, readable.Length);
-                Assert.True(readable.Equals(Encoding.UTF8.GetBytes("hello world")));
-                Assert.True(readable.Slice(1, 3).Equals(Encoding.UTF8.GetBytes("ell")));
+                Assert.True(readable.EqualsTo(Encoding.UTF8.GetBytes("hello world")));
+                Assert.True(readable.Slice(1, 3).EqualsTo(Encoding.UTF8.GetBytes("ell")));
 
                 // if we fetch it again, we can see everything
                 readable = output.AsReadableBuffer();
                 Assert.False(readable.IsEmpty);
                 Assert.Equal(20, readable.Length);
-                Assert.True(readable.Equals(Encoding.UTF8.GetBytes("hello worldmore data")));
+                Assert.True(readable.EqualsTo(Encoding.UTF8.GetBytes("hello worldmore data")));
             }
         }
 


### PR DESCRIPTION
- Make first computed to save some room
- Move Equals and StartsWith to extensions

/cc @benaadams I took the computed first from https://github.com/dotnet/corefxlab/pull/1277/files