### PR TITLE
Added more seek tests for newlines

### DIFF
--- a/tests/System.IO.Pipelines.Performance.Tests/ReadCursorOperationsThroughput.cs
+++ b/tests/System.IO.Pipelines.Performance.Tests/ReadCursorOperationsThroughput.cs
@@ -116,9 +116,17 @@ namespace System.IO.Pipelines.Performance.Tests
             while (!reader.End)
             {
                 var span = reader.Span;
+
+                // Trim the start if we have an index
+                if (reader.Index > 0)
+                {
+                    span = span.Slice(reader.Index);
+                }
+
                 while (span.Length > 0)
                 {
                     var length = span.IndexOfVectorized((byte)'\n');
+                    var skip = length;
 
                     if (length == -1)
                     {
@@ -131,14 +139,16 @@ namespace System.IO.Pipelines.Performance.Tests
                         }
 
                         length = span.Length;
+                        skip = buffer.Slice(current, found).Length + 1;
                     }
                     else
                     {
                         length += 1;
+                        skip = length;
                     }
 
                     span = span.Slice(length);
-                    reader.Skip(length);
+                    reader.Skip(skip);
                 }
             }
         }

--- a/tests/System.IO.Pipelines.Performance.Tests/ReadCursorOperationsThroughput.cs
+++ b/tests/System.IO.Pipelines.Performance.Tests/ReadCursorOperationsThroughput.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO.Pipelines.Testing;
 using System.IO.Pipelines.Tests;
@@ -66,9 +67,21 @@ namespace System.IO.Pipelines.Performance.Tests
         }
 
         [Benchmark(OperationsPerInvoke = InnerLoopCount)]
+        public void SeekPlainTextReadableBufferReader()
+        {
+            FindAllNewLinesReadableBufferReader(_plainTextBuffer);
+        }
+
+        [Benchmark(OperationsPerInvoke = InnerLoopCount)]
         public void SeekPlainTextPipelined()
         {
             FindAllNewLines(_plainTextPipelinedBuffer);
+        }
+
+        [Benchmark(OperationsPerInvoke = InnerLoopCount)]
+        public void SeekPlainTextPipelinedReadableBufferReader()
+        {
+            FindAllNewLinesReadableBufferReader(_plainTextPipelinedBuffer);
         }
 
         [Benchmark(OperationsPerInvoke = InnerLoopCount)]
@@ -81,6 +94,53 @@ namespace System.IO.Pipelines.Performance.Tests
         public void SeekLiveAspNetMultiBuffer()
         {
             FindAllNewLines(_liveAspNetMultiBuffer);
+        }
+
+        [Benchmark(OperationsPerInvoke = InnerLoopCount)]
+        public void SeekLiveAspNetReadableBufferReader()
+        {
+            FindAllNewLinesReadableBufferReader(_liveAspNetBuffer);
+        }
+
+        [Benchmark(OperationsPerInvoke = InnerLoopCount)]
+        public void SeekLiveAspNetMultiBufferReadableBufferReader()
+        {
+            FindAllNewLinesReadableBufferReader(_liveAspNetMultiBuffer);
+        }
+
+        private static void FindAllNewLinesReadableBufferReader(ReadableBuffer buffer)
+        {
+            var reader = new ReadableBufferReader(buffer);
+            var end = buffer.End;
+
+            while (!reader.End)
+            {
+                var span = reader.Span;
+                while (span.Length > 0)
+                {
+                    var length = span.IndexOfVectorized((byte)'\n');
+
+                    if (length == -1)
+                    {
+                        var current = reader.Cursor;
+
+                        if (ReadCursorOperations.Seek(current, end, out var found, (byte)'\n') == -1)
+                        {
+                            // We're done
+                            return;
+                        }
+
+                        length = span.Length;
+                    }
+                    else
+                    {
+                        length += 1;
+                    }
+
+                    span = span.Slice(length);
+                    reader.Skip(length);
+                }
+            }
         }
 
         private static void FindAllNewLines(ReadableBuffer buffer)


### PR DESCRIPTION
Perf tests to show the patterns we're using in kestrel to traverse a `ReadableBuffer`:

|                                       Method |      Mean |    StdErr |    StdDev |    Median |              RPS |
|--------------------------------------------- |---------- |---------- |---------- |---------- |----------------- |
|                                SeekPlainText | 0.2854 ns | 0.0029 ns | 0.0160 ns | 0.2868 ns | 3,504,029,261.31 |
|            SeekPlainTextReadableBufferReader | 0.1547 ns | 0.0014 ns | 0.0075 ns | 0.1534 ns | 6,462,042,969.75 |
|                       SeekPlainTextPipelined | 3.7484 ns | 0.0977 ns | 0.5352 ns | 3.5305 ns |   266,779,616.57 |
|   SeekPlainTextPipelinedReadableBufferReader | 1.4455 ns | 0.0614 ns | 0.3360 ns | 1.3614 ns |   691,821,417.11 |
|                               SeekLiveAspNet | 0.9759 ns | 0.0223 ns | 0.1219 ns | 0.9136 ns | 1,024,650,662.02 |
|                    SeekLiveAspNetMultiBuffer | 1.6948 ns | 0.0649 ns | 0.3556 ns | 1.5812 ns |   590,048,195.27 |
|           SeekLiveAspNetReadableBufferReader | 0.4726 ns | 0.0199 ns | 0.1090 ns | 0.4319 ns | 2,116,113,409.41 |
|SeekLiveAspNetMultiBufferReadableBufferReader | 0.8311 ns | 0.0189 ns | 0.1034 ns | 0.8100 ns | 1,203,191,969.31 |