### PR TITLE
Improve pipe throughput

### DIFF
--- a/src/System.IO.Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/Pipe.cs
@@ -561,9 +561,7 @@ namespace System.IO.Pipelines
                 else
                 {
                     // Reading commit head shared with writer
-
                     readEnd = new ReadCursor(_commitHead, _commitHeadIndex);
-
                 }
 
                 _readingState.Begin(ExceptionResource.AlreadyReading);

--- a/src/System.IO.Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/Pipe.cs
@@ -404,7 +404,7 @@ namespace System.IO.Pipelines
             int consumedBytes = 0;
             if (!consumed.IsDefault)
             {
-                consumedBytes = ReadCursor.GetLength(_readHead, _readHead.Start, consumed.Segment, consumed.Index);
+                consumedBytes = new ReadCursor(_readHead).GetLength(consumed);
 
                 returnStart = _readHead;
                 returnEnd = consumed.Segment;

--- a/tests/System.IO.Pipelines.Performance.Tests/Program.cs
+++ b/tests/System.IO.Pipelines.Performance.Tests/Program.cs
@@ -9,12 +9,6 @@ namespace System.IO.Pipelines.Performance.Tests
     {
         public static void Main(string[] args)
         {
-            //var p = new PipeThroughput();
-            //p.Setup();
-            //for (int i = 0; i < 100000; i++)
-            //{
-            //    p.ParseLiveAspNetInline();
-            //}
             var options = (uint[])Enum.GetValues(typeof(BenchmarkType));
             BenchmarkType type;
             if (args.Length != 1 || !Enum.TryParse(args[0], out type))

--- a/tests/System.IO.Pipelines.Performance.Tests/Program.cs
+++ b/tests/System.IO.Pipelines.Performance.Tests/Program.cs
@@ -9,14 +9,20 @@ namespace System.IO.Pipelines.Performance.Tests
     {
         public static void Main(string[] args)
         {
-            var options = (uint[]) Enum.GetValues(typeof(BenchmarkType));
+            //var p = new PipeThroughput();
+            //p.Setup();
+            //for (int i = 0; i < 100000; i++)
+            //{
+            //    p.ParseLiveAspNetInline();
+            //}
+            var options = (uint[])Enum.GetValues(typeof(BenchmarkType));
             BenchmarkType type;
             if (args.Length != 1 || !Enum.TryParse(args[0], out type))
             {
                 Console.WriteLine($"Please add benchmark to run as parameter:");
                 for (var i = 0; i < options.Length; i++)
                 {
-                    Console.WriteLine($"  {((BenchmarkType) options[i]).ToString()}");
+                    Console.WriteLine($"  {((BenchmarkType)options[i]).ToString()}");
                 }
 
                 return;
@@ -31,7 +37,7 @@ namespace System.IO.Pipelines.Performance.Tests
             {
                 BenchmarkRunner.Run<Enumerators>();
             }
-            if (type.HasFlag(BenchmarkType.Throughtput))
+            if (type.HasFlag(BenchmarkType.Throughput))
             {
                 BenchmarkRunner.Run<PipeThroughput>();
             }
@@ -46,7 +52,7 @@ namespace System.IO.Pipelines.Performance.Tests
     public enum BenchmarkType : uint
     {
         Enumerators = 1,
-        Throughtput = 2,
+        Throughput = 2,
         ReadCursorOperations = 4,
         All = uint.MaxValue
     }


### PR DESCRIPTION
1. Expand locks instead of interlocked
2. Avoid double locking
3. Inline `Read` so we don't copy big struct around