### PR TITLE
Added PinnedMemoryHandle<T> to replace TryGetPointer

### DIFF
--- a/src/System.IO.Pipelines.Compression/CompressionPipelineExtensions.cs
+++ b/src/System.IO.Pipelines.Compression/CompressionPipelineExtensions.cs
@@ -125,7 +125,7 @@ namespace System.IO.Pipelines.Compression
 
                     unsafe
                     {
-                        var handle = memory.GetPinnedMemoryHandle();
+                        var handle = memory.Pin();
                         handles.Add(handle);
                         _deflater.SetInput((IntPtr)handle.PinnedPointer, memory.Length);
                     }
@@ -135,7 +135,7 @@ namespace System.IO.Pipelines.Compression
                         unsafe
                         {
                             writerBuffer.Ensure();
-                            var handle = writerBuffer.Memory.GetPinnedMemoryHandle();
+                            var handle = writerBuffer.Memory.Pin();
                             handles.Add(handle);
                             int written = _deflater.ReadDeflateOutput((IntPtr)handle.PinnedPointer, writerBuffer.Memory.Length);
                             writerBuffer.Advance(written);
@@ -161,7 +161,7 @@ namespace System.IO.Pipelines.Compression
                     {
                         writerBuffer.Ensure();
                         var memory = writerBuffer.Memory;
-                        var handle = memory.GetPinnedMemoryHandle();
+                        var handle = memory.Pin();
                         handles.Add(handle);
                         int compressedBytes;
                         flushed = _deflater.Flush((IntPtr)handle.PinnedPointer, memory.Length, out compressedBytes);
@@ -182,7 +182,7 @@ namespace System.IO.Pipelines.Compression
                     {
                         writerBuffer.Ensure();
                         var memory = writerBuffer.Memory;
-                        var handle = memory.GetPinnedMemoryHandle();
+                        var handle = memory.Pin();
                         handles.Add(handle);
                         int compressedBytes;
                         finished = _deflater.Finish((IntPtr)handle.PinnedPointer, memory.Length, out compressedBytes);
@@ -241,12 +241,12 @@ namespace System.IO.Pipelines.Compression
                     {
                         unsafe
                         {
-                            var handle = memory.GetPinnedMemoryHandle();
+                            var handle = memory.Pin();
                             handles.Add(handle);
                             _inflater.SetInput((IntPtr)handle.PinnedPointer, memory.Length);
 
                             writerBuffer.Ensure();
-                            handle = writerBuffer.Memory.GetPinnedMemoryHandle();
+                            handle = writerBuffer.Memory.Pin();
                             handles.Add(handle);
                             int written = _inflater.Inflate((IntPtr)handle.PinnedPointer, writerBuffer.Memory.Length);
                             writerBuffer.Advance(written);

--- a/src/System.IO.Pipelines.Networking.Libuv/Interop/UvWriteReq.cs
+++ b/src/System.IO.Pipelines.Networking.Libuv/Interop/UvWriteReq.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
@@ -20,7 +20,7 @@ namespace System.IO.Pipelines.Networking.Libuv.Interop
         private object _state;
         private const int BUFFER_COUNT = 4;
 
-        private List<PinnedMemoryHandle<byte>> _handles = new List<PinnedMemoryHandle<byte>>();
+        private List<MemoryHandle> _handles = new List<MemoryHandle>();
         private List<GCHandle> _pins = new List<GCHandle>(BUFFER_COUNT + 1);
 
         private LibuvAwaitable<UvWriteReq> _awaitable = new LibuvAwaitable<UvWriteReq>();

--- a/src/System.IO.Pipelines.Networking.Libuv/Interop/UvWriteReq.cs
+++ b/src/System.IO.Pipelines.Networking.Libuv/Interop/UvWriteReq.cs
@@ -85,7 +85,7 @@ namespace System.IO.Pipelines.Networking.Libuv.Interop
                 if (nBuffers == 1)
                 {
                     var memory = buffer.First;
-                    var memoryHandle = memory.GetPinnedMemoryHandle();
+                    var memoryHandle = memory.Pin();
                     _handles.Add(memoryHandle);
                     pBuffers[0] = Libuv.buf_init((IntPtr)memoryHandle.PinnedPointer, memory.Length);
                 }
@@ -94,7 +94,7 @@ namespace System.IO.Pipelines.Networking.Libuv.Interop
                     int i = 0;
                     foreach (var memory in buffer)
                     {
-                        var memoryHandle = memory.GetPinnedMemoryHandle();
+                        var memoryHandle = memory.Pin();
                         _handles.Add(memoryHandle);
                         pBuffers[i++] = Libuv.buf_init((IntPtr)memoryHandle.PinnedPointer, memory.Length);
                     }

--- a/src/System.IO.Pipelines.Text.Primitives/ReadableBufferExtensions.cs
+++ b/src/System.IO.Pipelines.Text.Primitives/ReadableBufferExtensions.cs
@@ -105,17 +105,12 @@ namespace System.IO.Pipelines.Text.Primitives
             if (buffer.IsSingleSpan)
             {
                 // It fits!
-                var handle = buffer.First.GetPinnedMemoryHandle();
-                try
+                fixed (byte* source = &buffer.First.Span.DangerousGetPinnableReference())
                 {
-                    if (!PrimitiveParser.InvariantUtf8.TryParseUInt64((byte*)handle.PinnedPointer, len, out value))
+                    if (!PrimitiveParser.InvariantUtf8.TryParseUInt64(source, len, out value))
                     {
-                        throw new InvalidOperationException();
+                        ThrowInvalidOperation();
                     }
-                }
-                finally
-                {
-                    handle.Free();
                 }
             }
             else if (len < 128) // REVIEW: What's a good number
@@ -189,17 +184,12 @@ namespace System.IO.Pipelines.Text.Primitives
 
                 foreach (var memory in buffer)
                 {
-                    var handle = memory.GetPinnedMemoryHandle();
-                    try
+                    fixed (byte* source = &memory.Span.DangerousGetPinnableReference())
                     {
-                        if (!AsciiUtilities.TryGetAsciiString((byte*)handle.PinnedPointer, output + offset, memory.Length))
+                        if (!AsciiUtilities.TryGetAsciiString(source, output + offset, memory.Length))
                         {
-                            throw new InvalidOperationException();
+                            ThrowInvalidOperation();
                         }
-                    }
-                    finally
-                    {
-                        handle.Free();
                     }
 
                     offset += memory.Length;

--- a/src/System.Net.Libuv/System/Net/Libuv/Stream.cs
+++ b/src/System.Net.Libuv/System/Net/Libuv/Stream.cs
@@ -86,24 +86,26 @@ namespace System.Net.Libuv
             // This can work with Span<byte> because it's synchronous but we need pinning support
             EnsureNotDisposed();
 
-            void* pointer;
-            if (!data.TryGetPointer(out pointer))
-            {
-                throw new InvalidOperationException("Pointer not available");
-            }
-
-            IntPtr ptrData = (IntPtr)pointer;
+            var handle = data.GetPinnedMemoryHandle();
+            IntPtr ptrData = (IntPtr)handle.PinnedPointer;
             var length = data.Length;
 
-            if (IsUnix)
+            try
             {
-                var buffer = new UVBuffer.Unix(ptrData, (uint)length);
-                UVException.ThrowIfError(UVInterop.uv_try_write(Handle, &buffer, 1));
+                if (IsUnix)
+                {
+                    var buffer = new UVBuffer.Unix(ptrData, (uint)length);
+                    UVException.ThrowIfError(UVInterop.uv_try_write(Handle, &buffer, 1));
+                }
+                else
+                {
+                    var buffer = new UVBuffer.Windows(ptrData, (uint)length);
+                    UVException.ThrowIfError(UVInterop.uv_try_write(Handle, &buffer, 1));
+                }
             }
-            else
+            finally
             {
-                var buffer = new UVBuffer.Windows(ptrData, (uint)length);
-                UVException.ThrowIfError(UVInterop.uv_try_write(Handle, &buffer, 1));
+                handle.Free();
             }
         }
 

--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -62,6 +62,8 @@ namespace System
 
         public DisposableReservation<T> Reserve() => new DisposableReservation<T>(_owner);
 
+        public unsafe PinnedMemoryHandle<T> GetPinnedMemoryHandle() => new PinnedMemoryHandle<T>(_owner, _index);
+
         public unsafe bool TryGetPointer(out void* pointer)
         {
             if (!_owner.TryGetPointerInternal(out pointer)) {

--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -62,7 +62,7 @@ namespace System
 
         public DisposableReservation<T> Reserve() => new DisposableReservation<T>(_owner);
 
-        public unsafe MemoryHandle GetPinnedMemoryHandle() => MemoryHandle.Create(_owner, _index);
+        public unsafe MemoryHandle Pin() => MemoryHandle.Create(_owner, _index);
 
         public unsafe bool TryGetPointer(out void* pointer)
         {

--- a/src/System.Slices/System/Buffers/Memory.cs
+++ b/src/System.Slices/System/Buffers/Memory.cs
@@ -62,7 +62,7 @@ namespace System
 
         public DisposableReservation<T> Reserve() => new DisposableReservation<T>(_owner);
 
-        public unsafe PinnedMemoryHandle<T> GetPinnedMemoryHandle() => new PinnedMemoryHandle<T>(_owner, _index);
+        public unsafe MemoryHandle GetPinnedMemoryHandle() => MemoryHandle.Create(_owner, _index);
 
         public unsafe bool TryGetPointer(out void* pointer)
         {

--- a/src/System.Slices/System/Buffers/PinnedMemoryHandle.cs
+++ b/src/System.Slices/System/Buffers/PinnedMemoryHandle.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    public unsafe struct PinnedMemoryHandle<T>
+    {
+        readonly OwnedMemory<T> _owner;
+        readonly GCHandle _handle;
+        readonly void* _pointer;
+
+        internal PinnedMemoryHandle(OwnedMemory<T> owner, int index)
+        {
+            _owner = owner;
+            if (_owner.TryGetPointerInternal(out _pointer))
+            {
+                _pointer = Memory<T>.Add(_pointer, index);
+            }
+            else
+            {
+                ArraySegment<T> buffer;
+                if (_owner.TryGetArrayInternal(out buffer))
+                {
+                    _handle = GCHandle.Alloc(buffer.Array, GCHandleType.Pinned);
+                    _pointer = Memory<T>.Add((void*)_handle.AddrOfPinnedObject(), buffer.Offset + index);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Memory cannot be pinned");
+                }
+            }
+
+            _owner.AddReference();
+        }
+
+        public void* PinnedPointer
+        {
+            get
+            {
+                return _pointer;
+            }
+        }
+
+        public void Free()
+        {
+            if (_handle.IsAllocated)
+            {
+                _handle.Free();
+            }
+
+            _owner.Release();
+        }
+    }
+}

--- a/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
@@ -59,7 +59,7 @@ namespace System
             return _owner.Memory.Reserve();
         }
 
-        public unsafe PinnedMemoryHandle<T> GetPinnedMemoryHandle() => new PinnedMemoryHandle<T>(_owner, _index);
+        public unsafe MemoryHandle GetPinnedMemoryHandle() => MemoryHandle.Create(_owner, _index);
    
         public unsafe bool TryGetPointer(out void* pointer)
         {

--- a/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
@@ -58,6 +58,8 @@ namespace System
         {
             return _owner.Memory.Reserve();
         }
+
+        public unsafe PinnedMemoryHandle<T> GetPinnedMemoryHandle() => new PinnedMemoryHandle<T>(_owner, _index);
    
         public unsafe bool TryGetPointer(out void* pointer)
         {

--- a/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Slices/System/Buffers/ReadOnlyMemory.cs
@@ -59,7 +59,7 @@ namespace System
             return _owner.Memory.Reserve();
         }
 
-        public unsafe MemoryHandle GetPinnedMemoryHandle() => MemoryHandle.Create(_owner, _index);
+        public unsafe MemoryHandle Pin() => MemoryHandle.Create(_owner, _index);
    
         public unsafe bool TryGetPointer(out void* pointer)
         {


### PR DESCRIPTION
Proposal to address issue #1287 

- Added API (similar to `GCHandle`) for scoped access to internal pointers of `Memory<T>` and `ReadOnlyMemory<T>`.
- Partially ported to the new `GetPinnedMemoryHandle` API.

CC @KrzysztofCwalina @davidfowl @jkotas @mjp41 