### PR TITLE
Remove TryGetPointer call from UvTcpConnection

### DIFF
--- a/src/System.IO.Pipelines.Networking.Libuv/UvTcpConnection.cs
+++ b/src/System.IO.Pipelines.Networking.Libuv/UvTcpConnection.cs
@@ -191,7 +191,6 @@ namespace System.IO.Pipelines.Networking.Libuv
                 var inputBuffer = _inputBuffer.Value;
 
                 _inputBuffer = null;
-                _inputBufferPin = null;
 
                 inputBuffer.Advance(readCount);
                 inputBuffer.Commit();

--- a/src/System.IO.Pipelines.Networking.Libuv/UvTcpConnection.cs
+++ b/src/System.IO.Pipelines.Networking.Libuv/UvTcpConnection.cs
@@ -1,12 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading.Tasks;
-using System.IO.Pipelines.Networking.Libuv.Interop;
 using System.Buffers;
+using System.IO.Pipelines.Networking.Libuv.Interop;
+using System.Threading.Tasks;
 
 namespace System.IO.Pipelines.Networking.Libuv
 {


### PR DESCRIPTION
Following the discussion in #1298

This is a really simple code change to remove the call to `TryGetPointer` in `UvTcpConnection`. It looks like the semantics are _similar_, but I don't think I'm fully following where that memory comes from and when it gets cleaned up, so want to make sure I'm not missing something important.

It probably also has a slight performance penalty.

I don't expect this is correct yet, just a starting point. Once this one's sorted I'll look at the RIO impl.