### PR TITLE
Renamed several types in System.Buffers.Primitives 

### DIFF
--- a/samples/LibuvWithNonAllocatingFormatters/Program.cs
+++ b/samples/LibuvWithNonAllocatingFormatters/Program.cs
@@ -95,8 +95,8 @@ namespace LibuvWithNonAllocatingFormatters
                     }
 
                     var segment = formatter.Formatted;
-                    using (var memory = new OwnedPinnedArray<byte>(segment.Array)) {
-                        connection.TryWrite(memory.Memory.Slice(segment.Offset, segment.Count));
+                    using (var memory = new OwnedPinnedBuffer<byte>(segment.Array)) {
+                        connection.TryWrite(memory.Buffer.Slice(segment.Offset, segment.Count));
                         connection.Dispose();
                     }
                 };

--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
@@ -8,7 +8,7 @@ using System.Collections.Sequences;
 
 namespace Microsoft.Net.Http
 {
-    class OwnedBuffer : OwnedMemory<byte>, IMemoryList<byte>, IReadOnlyMemoryList<byte>
+    class OwnedBuffer : OwnedBuffer<byte>, IBufferList<byte>, IReadOnlyBufferList<byte>
     {
         public const int DefaultBufferSize = 1024;
         internal OwnedBuffer _next;
@@ -25,42 +25,42 @@ namespace Microsoft.Net.Http
         {
         }
 
-        public Memory<byte> First => Memory;
+        public Buffer<byte> First => Buffer;
 
-        public IMemoryList<byte> Rest => _next;
+        public IBufferList<byte> Rest => _next;
 
         public int WrittenByteCount => _written;
 
-        ReadOnlyMemory<byte> IReadOnlyMemoryList<byte>.First => Memory;
+        ReadOnlyBuffer<byte> IReadOnlyBufferList<byte>.First => Buffer;
 
-        IReadOnlyMemoryList<byte> IReadOnlyMemoryList<byte>.Rest => _next;
+        IReadOnlyBufferList<byte> IReadOnlyBufferList<byte>.Rest => _next;
 
-        // TODO: maybe these should be renamed to no conflict with OwnedMemory<T>.Length?
-        int? ISequence<Memory<byte>>.Length => null;
-        int? ISequence<ReadOnlyMemory<byte>>.Length => null;
+        // TODO: maybe these should be renamed to no conflict with OwnedBuffer<T>.Length?
+        int? ISequence<Buffer<byte>>.Length => null;
+        int? ISequence<ReadOnlyBuffer<byte>>.Length => null;
 
         public int CopyTo(Span<byte> buffer)
         {
             if (buffer.Length > _written) {
-                Memory.Slice(0, _written).CopyTo(buffer);
+                Buffer.Slice(0, _written).CopyTo(buffer);
                 return _next.CopyTo(buffer.Slice(_written));
             }
 
-            Memory.Slice(0, buffer.Length).CopyTo(buffer);
+            Buffer.Slice(0, buffer.Length).CopyTo(buffer);
             return buffer.Length;
         }
 
-        public bool TryGet(ref Position position, out Memory<byte> item, bool advance = true)
+        public bool TryGet(ref Position position, out Buffer<byte> item, bool advance = true)
         {
             if (position == Position.First) {
-                item = Memory.Slice(0, _written);
+                item = Buffer.Slice(0, _written);
                 if (advance) { position.IntegerPosition++; position.ObjectPosition = _next; }
                 return true;
             }
-            else if (position.ObjectPosition == null) { item = default(Memory<byte>); return false; }
+            else if (position.ObjectPosition == null) { item = default(Buffer<byte>); return false; }
 
             var sequence = (OwnedBuffer)position.ObjectPosition;
-            item = sequence.Memory.Slice(0, _written);
+            item = sequence.Buffer.Slice(0, _written);
             if (advance) {
                 if (position == Position.First) {
                     position.ObjectPosition = _next;
@@ -73,17 +73,17 @@ namespace Microsoft.Net.Http
             return true;
         }
 
-        public bool TryGet(ref Position position, out ReadOnlyMemory<byte> item, bool advance = true)
+        public bool TryGet(ref Position position, out ReadOnlyBuffer<byte> item, bool advance = true)
         {
             if (position == Position.First) {
-                item = Memory.Slice(0, _written);
+                item = Buffer.Slice(0, _written);
                 if (advance) { position.IntegerPosition++; position.ObjectPosition = _next; }
                 return true;
             }
-            else if (position.ObjectPosition == null) { item = default(ReadOnlyMemory<byte>); return false; }
+            else if (position.ObjectPosition == null) { item = default(ReadOnlyBuffer<byte>); return false; }
 
             var sequence = (OwnedBuffer)position.ObjectPosition;
-            item = sequence.Memory.Slice(0, _written);
+            item = sequence.Buffer.Slice(0, _written);
             if (advance) {
                 if (position == Position.First) {
                     position.ObjectPosition = _next;

--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/ReadWriteBytes.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/ReadWriteBytes.cs
@@ -7,48 +7,48 @@ using System.Runtime.CompilerServices;
 
 namespace System.Buffers
 {
-    public interface IMemoryList<T> : ISequence<Memory<T>>
+    public interface IBufferList<T> : ISequence<Buffer<T>>
     {
         int CopyTo(Span<T> buffer);
-        Memory<T> First { get; }
-        IMemoryList<T> Rest { get; }
+        Buffer<T> First { get; }
+        IBufferList<T> Rest { get; }
     }
 
     /// <summary>
     ///  Multi-segment buffer
     /// </summary>
-    public struct ReadWriteBytes : IMemoryList<byte>
+    public struct ReadWriteBytes : IBufferList<byte>
     {
-        Memory<byte> _first;
-        IMemoryList<byte> _rest;
+        Buffer<byte> _first;
+        IBufferList<byte> _rest;
         int _length;
 
-        static readonly ReadWriteBytes s_empty = new ReadWriteBytes(Memory<byte>.Empty);
+        static readonly ReadWriteBytes s_empty = new ReadWriteBytes(Buffer<byte>.Empty);
 
-        public ReadWriteBytes(Memory<byte> first, IMemoryList<byte> rest, int length)
+        public ReadWriteBytes(Buffer<byte> first, IBufferList<byte> rest, int length)
         {
             _rest = rest;
             _first = first;
             _length = length;
         }
 
-        public ReadWriteBytes(Memory<byte> first, IMemoryList<byte> rest) :
+        public ReadWriteBytes(Buffer<byte> first, IBufferList<byte> rest) :
             this(first, rest, Unspecified)
         { }
 
-        public ReadWriteBytes(Memory<byte> memory) :
-            this(memory, null, memory.Length)
+        public ReadWriteBytes(Buffer<byte> buffer) :
+            this(buffer, null, buffer.Length)
         { }
 
-        public ReadWriteBytes(IMemoryList<byte> segments, int length) :
+        public ReadWriteBytes(IBufferList<byte> segments, int length) :
             this(segments.First, segments.Rest, length)
         { }
 
-        public ReadWriteBytes(IMemoryList<byte> segments) :
+        public ReadWriteBytes(IBufferList<byte> segments) :
             this(segments.First, segments.Rest, Unspecified)
         { }
 
-        public bool TryGet(ref Position position, out Memory<byte> value, bool advance = true)
+        public bool TryGet(ref Position position, out Buffer<byte> value, bool advance = true)
         {
             if (position == Position.First)
             {
@@ -62,10 +62,10 @@ namespace System.Buffers
                 return true;
             }
 
-            var rest = position.ObjectPosition as IMemoryList<byte>;
+            var rest = position.ObjectPosition as IBufferList<byte>;
             if (rest == null)
             {
-                value = default(Memory<byte>);
+                value = default(Buffer<byte>);
                 return false;
             }
 
@@ -85,9 +85,9 @@ namespace System.Buffers
             return true;
         }
 
-        public Memory<Byte> First => _first;
+        public Buffer<byte> First => _first;
 
-        public IMemoryList<byte> Rest => _rest;
+        public IBufferList<byte> Rest => _rest;
 
         public int? Length
         {
@@ -147,7 +147,7 @@ namespace System.Buffers
             {
                 if (First.Length == index && length == 0)
                 {
-                    return new ReadWriteBytes(Memory<byte>.Empty);
+                    return new ReadWriteBytes(Buffer<byte>.Empty);
                 }
                 else
                 {
@@ -171,7 +171,7 @@ namespace System.Buffers
             if (_rest != null)
             {
                 Position position = new Position();
-                Memory<byte> segment;
+                Buffer<byte> segment;
                 while (_rest.TryGet(ref position, out segment))
                 {
                     length += segment.Length;
@@ -184,11 +184,11 @@ namespace System.Buffers
         // and knowing the length is not needed in amy operations, e.g. slicing small section of the front.
         const int Unspecified = -1;
 
-        class MemoryListNode : IMemoryList<byte>
+        class BufferListNode : IBufferList<byte>
         {
-            internal Memory<byte> _first;
-            internal MemoryListNode _rest;
-            public Memory<byte> First => _first;
+            internal Buffer<byte> _first;
+            internal BufferListNode _rest;
+            public Buffer<byte> First => _first;
 
             public int? Length
             {
@@ -197,13 +197,13 @@ namespace System.Buffers
                 }
             }
 
-            public IMemoryList<byte> Rest => _rest;
+            public IBufferList<byte> Rest => _rest;
 
             public int CopyTo(Span<byte> buffer)
             {
                 int copied = 0;
                 var position = Position.First;
-                Memory<byte> segment;
+                Buffer<byte> segment;
                 var free = buffer;
                 while (TryGet(ref position, out segment, true))
                 {
@@ -223,7 +223,7 @@ namespace System.Buffers
                 return copied;
             }
 
-            public bool TryGet(ref Position position, out Memory<byte> item, bool advance = true)
+            public bool TryGet(ref Position position, out Buffer<byte> item, bool advance = true)
             {
                 if (position == Position.First)
                 {
@@ -231,9 +231,9 @@ namespace System.Buffers
                     if (advance) { position.IntegerPosition++; position.ObjectPosition = _rest; }
                     return true;
                 }
-                else if (position.ObjectPosition == null) { item = default(Memory<byte>); return false; }
+                else if (position.ObjectPosition == null) { item = default(Buffer<byte>); return false; }
 
-                var sequence = (MemoryListNode)position.ObjectPosition;
+                var sequence = (BufferListNode)position.ObjectPosition;
                 item = sequence._first;
                 if (advance)
                 {
@@ -253,18 +253,18 @@ namespace System.Buffers
 
         public static ReadWriteBytes Create(params byte[][] buffers)
         {
-            MemoryListNode first = null;
-            MemoryListNode current = null;
+            BufferListNode first = null;
+            BufferListNode current = null;
             foreach (var buffer in buffers)
             {
                 if (first == null)
                 {
-                    current = new MemoryListNode();
+                    current = new BufferListNode();
                     first = current;
                 }
                 else
                 {
-                    current._rest = new MemoryListNode();
+                    current._rest = new BufferListNode();
                     current = current._rest;
                 }
                 current._first = buffer;

--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/TcpServer.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/TcpServer.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Net.Sockets
             }
         }
 
-        public int Send(ReadOnlyMemory<byte> buffer)
+        public int Send(ReadOnlyBuffer<byte> buffer)
         {
             return Send(buffer.Span);
         }
@@ -202,7 +202,7 @@ namespace Microsoft.Net.Sockets
             }
         }
 
-        public int Receive(Memory<byte> buffer)
+        public int Receive(Buffer<byte> buffer)
         {
             return Receive(buffer.Span);
         }

--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -9,21 +9,21 @@ namespace System.Buffers
 {
     public static class BufferExtensions
     {
-        public static ReadOnlySpan<byte> ToSpan<T>(this T memorySequence) where T : ISequence<ReadOnlyMemory<byte>>
+        public static ReadOnlySpan<byte> ToSpan<T>(this T bufferSequence) where T : ISequence<ReadOnlyBuffer<byte>>
         {
             Position position = Position.First;
-            ReadOnlyMemory<byte> memory;
-            ResizableArray<byte> array = new ResizableArray<byte>(memorySequence.Length.GetValueOrDefault(1024)); 
-            while (memorySequence.TryGet(ref position, out memory))
+            ReadOnlyBuffer<byte> buffer;
+            ResizableArray<byte> array = new ResizableArray<byte>(bufferSequence.Length.GetValueOrDefault(1024)); 
+            while (bufferSequence.TryGet(ref position, out buffer))
             {
-                array.AddAll(memory.Span);
+                array.AddAll(buffer.Span);
             }
             array.Resize(array.Count);
             return array.Items.Slice(0, array.Count);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this IReadOnlyMemoryList<byte> sequence, ReadOnlySpan<byte> value)
+        public static int IndexOf(this IReadOnlyBufferList<byte> sequence, ReadOnlySpan<byte> value)
         {
             var first = sequence.First.Span;
             var index = first.IndexOf(value);
@@ -35,7 +35,7 @@ namespace System.Buffers
             return IndexOfStraddling(first, sequence.Rest, value);
         }
 
-        public static int IndexOf(this IReadOnlyMemoryList<byte> sequence, byte value)
+        public static int IndexOf(this IReadOnlyBufferList<byte> sequence, byte value)
         {
             var first = sequence.First.Span;
             var index = first.IndexOf(value);
@@ -53,7 +53,7 @@ namespace System.Buffers
         // TODO (pri 3): I am pretty sure this whole routine can be written much better
 
         // searches values that potentially straddle between first and rest
-        internal static int IndexOfStraddling(this ReadOnlySpan<byte> first, IReadOnlyMemoryList<byte> rest, ReadOnlySpan<byte> value)
+        internal static int IndexOfStraddling(this ReadOnlySpan<byte> first, IReadOnlyBufferList<byte> rest, ReadOnlySpan<byte> value)
         {
             Debug.Assert(rest != null);
 
@@ -119,9 +119,9 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this ReadOnlyMemory<byte> memory, ReadOnlySpan<byte> values)
+        public static int IndexOf(this ReadOnlyBuffer<byte> buffer, ReadOnlySpan<byte> values)
         {
-            return SpanExtensions.IndexOf(memory.Span, values);
+            return SpanExtensions.IndexOf(buffer.Span, values);
         }
     }
 }

--- a/src/System.Buffers.Experimental/System/Buffers/BytesReader.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BytesReader.cs
@@ -15,7 +15,7 @@ namespace System.Buffers
         ReadOnlyBytes _unreadSegments;
         int _index; // index relative to the begining of bytes passed to the constructor
 
-        ReadOnlyMemory<byte> _currentSegment;
+        ReadOnlyBuffer<byte> _currentSegment;
         int _currentSegmentIndex;
         
         public BytesReader(ReadOnlyBytes bytes, TextEncoder encoder)
@@ -27,7 +27,7 @@ namespace System.Buffers
             _index = 0;
         }
 
-        public BytesReader(ReadOnlyMemory<byte> bytes, TextEncoder encoder)
+        public BytesReader(ReadOnlyBuffer<byte> bytes, TextEncoder encoder)
         {
             _unreadSegments = new ReadOnlyBytes(bytes);
             _currentSegment = bytes;
@@ -36,16 +36,16 @@ namespace System.Buffers
             _index = 0;
         }
 
-        public BytesReader(ReadOnlyMemory<byte> bytes) : this(bytes, TextEncoder.Utf8)
+        public BytesReader(ReadOnlyBuffer<byte> bytes) : this(bytes, TextEncoder.Utf8)
         { }
 
         public BytesReader(ReadOnlyBytes bytes) : this(bytes, TextEncoder.Utf8)
         { }
 
-        public BytesReader(IReadOnlyMemoryList<byte> bytes) : this(bytes, TextEncoder.Utf8)
+        public BytesReader(IReadOnlyBufferList<byte> bytes) : this(bytes, TextEncoder.Utf8)
         { }
 
-        public BytesReader(IReadOnlyMemoryList<byte> bytes, TextEncoder encoder) : this(new ReadOnlyBytes(bytes))
+        public BytesReader(IReadOnlyBufferList<byte> bytes, TextEncoder encoder) : this(new ReadOnlyBytes(bytes))
         { }
 
         public byte Peek() => _currentSegment.Span[_currentSegmentIndex];
@@ -182,7 +182,7 @@ namespace System.Buffers
                 if (newSegments == null && toAdvance == 0)
                 {
                     _unreadSegments = ReadOnlyBytes.Empty;
-                    _currentSegment = ReadOnlyMemory<byte>.Empty;
+                    _currentSegment = ReadOnlyBuffer<byte>.Empty;
                     _currentSegmentIndex = 0;
                     return;
                 }
@@ -210,7 +210,7 @@ namespace System.Buffers
             }
         }
 
-        int IndexOf(IReadOnlyMemoryList<byte> sequence, byte value)
+        int IndexOf(IReadOnlyBufferList<byte> sequence, byte value)
         {
             if (sequence == null) return -1;
             var first = sequence.First;

--- a/src/System.Buffers.Experimental/System/Buffers/IReadOnlyMemoryList.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/IReadOnlyMemoryList.cs
@@ -5,11 +5,11 @@ using System;
 using System.Collections.Sequences;
 
 namespace System.Buffers {
-    public interface IReadOnlyMemoryList<T> : ISequence<ReadOnlyMemory<T>>
+    public interface IReadOnlyBufferList<T> : ISequence<ReadOnlyBuffer<T>>
     {
         int CopyTo(Span<T> buffer);
-        ReadOnlyMemory<T> First { get; }
+        ReadOnlyBuffer<T> First { get; }
 
-        IReadOnlyMemoryList<T> Rest { get; }
+        IReadOnlyBufferList<T> Rest { get; }
     }
 }

--- a/src/System.Buffers.Experimental/System/Buffers/NativeBufferPool.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/NativeBufferPool.cs
@@ -39,7 +39,7 @@ namespace System.Buffers.Pools
             Marshal.FreeHGlobal(_memory);
         }
 
-        public override OwnedMemory<byte> Rent(int numberOfBytes)
+        public override OwnedBuffer<byte> Rent(int numberOfBytes)
         {
             if (numberOfBytes < 1) throw new ArgumentOutOfRangeException(nameof(numberOfBytes));
             if (numberOfBytes > _bufferSize) new NotSupportedException();
@@ -77,7 +77,7 @@ namespace System.Buffers.Pools
             }
         }
 
-        internal sealed class BufferManager : OwnedMemory<byte>
+        internal sealed class BufferManager : OwnedBuffer<byte>
         {
             private readonly NativeBufferPool _pool;
 

--- a/src/System.Buffers.Experimental/System/Buffers/OwnedNativeMemory.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/OwnedNativeMemory.cs
@@ -5,14 +5,14 @@ using System.Runtime.InteropServices;
 
 namespace System.Buffers
 {
-    public class OwnedNativeMemory : OwnedMemory<byte>
+    public class OwnedNativeBuffer : OwnedBuffer<byte>
     {
-        public OwnedNativeMemory(int length) : this(length, Marshal.AllocHGlobal(length))
+        public OwnedNativeBuffer(int length) : this(length, Marshal.AllocHGlobal(length))
         { }
 
-        public OwnedNativeMemory(int length, IntPtr address) : base(null, 0, length, address) { }
+        public OwnedNativeBuffer(int length, IntPtr address) : base(null, 0, length, address) { }
 
-        public static implicit operator IntPtr(OwnedNativeMemory owner)
+        public static implicit operator IntPtr(OwnedNativeBuffer owner)
         {
             unsafe
             {
@@ -20,7 +20,7 @@ namespace System.Buffers
             }
         }
 
-        ~OwnedNativeMemory()
+        ~OwnedNativeBuffer()
         {
             Dispose(false);
         }

--- a/src/System.Buffers.Experimental/System/Buffers/OwnedPinnedArray.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/OwnedPinnedArray.cs
@@ -6,12 +6,12 @@ using System.Runtime.InteropServices;
 
 namespace System.Buffers
 {
-    // This is to support secnarios today covered by Memory<T> in corefxlab
-    public class OwnedPinnedArray<T> : OwnedMemory<T>
+    // This is to support secnarios today covered by Buffer<T> in corefxlab
+    public class OwnedPinnedBuffer<T> : OwnedBuffer<T>
     {
         private GCHandle _handle;
 
-        public unsafe OwnedPinnedArray(T[] array, void* pointer, GCHandle handle = default(GCHandle)) :
+        public unsafe OwnedPinnedBuffer(T[] array, void* pointer, GCHandle handle = default(GCHandle)) :
             base(array, 0, array.Length, new IntPtr(pointer))
         {
             var computedPointer = new IntPtr(Unsafe.AsPointer(ref Array[0]));
@@ -22,28 +22,28 @@ namespace System.Buffers
             _handle = handle;
         }
 
-        public unsafe OwnedPinnedArray(T[] array) : this(array, GCHandle.Alloc(array, GCHandleType.Pinned))
+        public unsafe OwnedPinnedBuffer(T[] array) : this(array, GCHandle.Alloc(array, GCHandleType.Pinned))
         { }
 
-        private OwnedPinnedArray(T[] array, GCHandle handle) : base(array, 0, array.Length, handle.AddrOfPinnedObject())
+        private OwnedPinnedBuffer(T[] array, GCHandle handle) : base(array, 0, array.Length, handle.AddrOfPinnedObject())
         {
             _handle = handle;
         }
 
-        public static implicit operator OwnedPinnedArray<T>(T[] array)
+        public static implicit operator OwnedPinnedBuffer<T>(T[] array)
         {
-            return new OwnedPinnedArray<T>(array);
+            return new OwnedPinnedBuffer<T>(array);
         }
 
         public new unsafe byte* Pointer => (byte*)base.Pointer.ToPointer();
         public new T[] Array => base.Array;
 
-        public unsafe static implicit operator IntPtr(OwnedPinnedArray<T> owner)
+        public unsafe static implicit operator IntPtr(OwnedPinnedBuffer<T> owner)
         {
             return new IntPtr(owner.Pointer);
         }
 
-        public static implicit operator T[] (OwnedPinnedArray<T> owner)
+        public static implicit operator T[] (OwnedPinnedBuffer<T> owner)
         {
             return owner.Array;
         }

--- a/src/System.Buffers.Primitives/System/Buffers/BufferPool.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/BufferPool.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Buffers.Pools
+using System.Buffers.Pools;
+
+namespace System.Buffers
 {
     public abstract class BufferPool : IDisposable
     {
-        public abstract OwnedMemory<byte> Rent(int minimumBufferSize);
+        public static BufferPool Default => ManagedBufferPool.Shared;
+
+        public abstract OwnedBuffer<byte> Rent(int minimumBufferSize);
 
         public void Dispose()
         {

--- a/src/System.Buffers.Primitives/System/Buffers/ManagedBufferPool.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ManagedBufferPool.cs
@@ -3,9 +3,9 @@
 
 namespace System.Buffers.Pools
 {
-    public sealed class ManagedBufferPool : BufferPool
+    internal sealed class ManagedBufferPool : BufferPool
     {
-        static ManagedBufferPool s_shared = new ManagedBufferPool();
+        readonly static ManagedBufferPool s_shared = new ManagedBufferPool();
 
         public static ManagedBufferPool Shared
         {
@@ -15,7 +15,7 @@ namespace System.Buffers.Pools
             }
         }
 
-        public override OwnedMemory<byte> Rent(int minimumBufferSize)
+        public override OwnedBuffer<byte> Rent(int minimumBufferSize)
         {
             return new ArrayPoolMemory(minimumBufferSize);
         }
@@ -24,7 +24,7 @@ namespace System.Buffers.Pools
         {
         }
 
-        private class ArrayPoolMemory : OwnedMemory<byte>
+        private class ArrayPoolMemory : OwnedBuffer<byte>
         {
             public ArrayPoolMemory(int size) : base(ArrayPool<byte>.Shared.Rent(size))
             {

--- a/src/System.Buffers.Primitives/System/Buffers/Memory.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Memory.cs
@@ -9,60 +9,60 @@ using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Text;
 
-namespace System
+namespace System.Buffers
 {
-    [DebuggerTypeProxy(typeof(MemoryDebuggerView<>))]
-    public struct Memory<T> : IEquatable<Memory<T>>, IEquatable<ReadOnlyMemory<T>>
+    [DebuggerTypeProxy(typeof(BufferDebuggerView<>))]
+    public struct Buffer<T> : IEquatable<Buffer<T>>, IEquatable<ReadOnlyBuffer<T>>
     {
-        readonly OwnedMemory<T> _owner;
+        readonly OwnedBuffer<T> _owner;
         readonly int _index;
         readonly int _length;
 
-        internal Memory(OwnedMemory<T> owner, int length)
+        internal Buffer(OwnedBuffer<T> owner, int length)
         {
             _owner = owner;
             _index = 0;
             _length = length;
         }
 
-        private Memory(OwnedMemory<T> owner, int index, int length)
+        private Buffer(OwnedBuffer<T> owner, int index, int length)
         {
             _owner = owner;
             _index = index;
             _length = length;
         }
 
-        public static implicit operator ReadOnlyMemory<T>(Memory<T> memory)
+        public static implicit operator ReadOnlyBuffer<T>(Buffer<T> buffer)
         {
-            return new ReadOnlyMemory<T>(memory._owner, memory._index, memory._length);
+            return new ReadOnlyBuffer<T>(buffer._owner, buffer._index, buffer._length);
         }
 
-        public static implicit operator Memory<T>(T[] array)
+        public static implicit operator Buffer<T>(T[] array)
         {
             var owner = new OwnedArray<T>(array);
-            return owner.Memory;
+            return owner.Buffer;
         }
 
-        public static Memory<T> Empty { get; } = OwnerEmptyMemory<T>.Shared.Memory;
+        public static Buffer<T> Empty { get; } = OwnerEmptyMemory<T>.Shared.Buffer;
 
         public int Length => _length;
 
         public bool IsEmpty => Length == 0;
 
-        public Memory<T> Slice(int index)
+        public Buffer<T> Slice(int index)
         {
-            return new Memory<T>(_owner, _index + index, _length - index);
+            return new Buffer<T>(_owner, _index + index, _length - index);
         }
-        public Memory<T> Slice(int index, int length)
+        public Buffer<T> Slice(int index, int length)
         {
-            return new Memory<T>(_owner, _index + index, length);
+            return new Buffer<T>(_owner, _index + index, length);
         }
 
         public Span<T> Span => _owner.GetSpanInternal(_index, _length);
 
         public DisposableReservation<T> Reserve() => new DisposableReservation<T>(_owner);
 
-        public unsafe MemoryHandle Pin() => MemoryHandle.Create(_owner, _index);
+        public unsafe BufferHandle Pin() => BufferHandle.Create(_owner, _index);
 
         public unsafe bool TryGetPointer(out void* pointer)
         {
@@ -97,45 +97,45 @@ namespace System
             Span.CopyTo(span);
         }
 
-        public void CopyTo(Memory<T> memory)
+        public void CopyTo(Buffer<T> buffer)
         {
-            Span.CopyTo(memory.Span);
+            Span.CopyTo(buffer.Span);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj)
         {
-            if(!(obj is Memory<T>)) {
+            if(!(obj is Buffer<T>)) {
                 return false;
             }
 
-            var other = (Memory<T>)obj;
+            var other = (Buffer<T>)obj;
             return Equals(other);
         }
-        public bool Equals(Memory<T> other)
+        public bool Equals(Buffer<T> other)
         {
             return
                 _owner == other._owner &&
                 _index == other._index &&
                 _length == other._length;
         }
-        public bool Equals(ReadOnlyMemory<T> other)
+        public bool Equals(ReadOnlyBuffer<T> other)
         {
             return other.Equals(this);
         }
-        public static bool operator==(Memory<T> left, Memory<T> right)
+        public static bool operator==(Buffer<T> left, Buffer<T> right)
         {
             return left.Equals(right);
         }
-        public static bool operator!=(Memory<T> left, Memory<T> right)
+        public static bool operator!=(Buffer<T> left, Buffer<T> right)
         {
             return !left.Equals(right);
         }
-        public static bool operator ==(Memory<T> left, ReadOnlyMemory<T> right)
+        public static bool operator ==(Buffer<T> left, ReadOnlyBuffer<T> right)
         {
             return left.Equals(right);
         }
-        public static bool operator !=(Memory<T> left, ReadOnlyMemory<T> right)
+        public static bool operator !=(Buffer<T> left, ReadOnlyBuffer<T> right)
         {
             return !left.Equals(right);
         }

--- a/src/System.Buffers.Primitives/System/Buffers/MemoryHandle.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/MemoryHandle.cs
@@ -6,19 +6,19 @@ using System.Runtime.InteropServices;
 
 namespace System.Buffers
 {
-    public unsafe struct MemoryHandle
+    public unsafe struct BufferHandle
     {
         IKnown _owner;
         GCHandle _handle;
         void* _pointer;
 
-        internal static MemoryHandle Create<T>(OwnedMemory<T> owner, int index)
+        internal static BufferHandle Create<T>(OwnedBuffer<T> owner, int index)
         {
             void* pointer;
             GCHandle handle;
             if (owner.TryGetPointerInternal(out pointer))
             {
-                pointer = Memory<T>.Add(pointer, index);
+                pointer = Buffer<T>.Add(pointer, index);
             }
             else
             {
@@ -26,7 +26,7 @@ namespace System.Buffers
                 if (owner.TryGetArrayInternal(out buffer))
                 {
                     handle = GCHandle.Alloc(buffer.Array, GCHandleType.Pinned);
-                    pointer = Memory<T>.Add((void*)handle.AddrOfPinnedObject(), buffer.Offset + index);
+                    pointer = Buffer<T>.Add((void*)handle.AddrOfPinnedObject(), buffer.Offset + index);
                 }
                 else
                 {
@@ -36,7 +36,7 @@ namespace System.Buffers
 
             owner.AddReference();
 
-            return new MemoryHandle {
+            return new BufferHandle {
                 _owner = owner,
                 _handle = handle,
                 _pointer = pointer

--- a/src/System.Buffers.Primitives/System/Buffers/OwnedArray.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/OwnedArray.cs
@@ -3,7 +3,7 @@
 
 namespace System.Buffers
 {
-    public sealed class OwnedArray<T> : OwnedMemory<T>
+    internal sealed class OwnedArray<T> : OwnedBuffer<T>
     {
         public new T[] Array => base.Array;
 
@@ -30,10 +30,10 @@ namespace System.Buffers
         { }
     }
 
-    internal class OwnerEmptyMemory<T> : OwnedMemory<T>
+    internal class OwnerEmptyMemory<T> : OwnedBuffer<T>
     {
         readonly static T[] s_empty = new T[0];
-        public readonly static OwnedMemory<T> Shared = new OwnerEmptyMemory<T>();
+        public readonly static OwnedBuffer<T> Shared = new OwnerEmptyMemory<T>();
 
         public OwnerEmptyMemory() : base(s_empty, 0, 0) { }
 

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyMemory.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyMemory.cs
@@ -8,65 +8,65 @@ using System.Diagnostics;
 using System.Runtime;
 using System.Text;
 
-namespace System
+namespace System.Buffers
 {
-    [DebuggerTypeProxy(typeof(ReadOnlyMemoryDebuggerView<>))]
-    public struct ReadOnlyMemory<T> : IEquatable<ReadOnlyMemory<T>>, IEquatable<Memory<T>>
+    [DebuggerTypeProxy(typeof(ReadOnlyBufferDebuggerView<>))]
+    public struct ReadOnlyBuffer<T> : IEquatable<ReadOnlyBuffer<T>>, IEquatable<Buffer<T>>
     {
-        readonly OwnedMemory<T> _owner;
+        readonly OwnedBuffer<T> _owner;
         readonly int _index;
         readonly int _length;
 
-        internal ReadOnlyMemory(OwnedMemory<T> owner, int length)
+        internal ReadOnlyBuffer(OwnedBuffer<T> owner, int length)
         {
             _owner = owner;
             _index = 0;
             _length = length;
         }
 
-        internal ReadOnlyMemory(OwnedMemory<T> owner,int index, int length)
+        internal ReadOnlyBuffer(OwnedBuffer<T> owner,int index, int length)
         {
             _owner = owner;
             _index = index;
             _length = length;
         }
 
-        public static implicit operator ReadOnlyMemory<T>(T[] array)
+        public static implicit operator ReadOnlyBuffer<T>(T[] array)
         {
             var owner = new OwnedArray<T>(array);
-            return owner.Memory;
+            return owner.Buffer;
         }
 
-        public static ReadOnlyMemory<T> Empty { get; } = OwnerEmptyMemory<T>.Shared.Memory;
+        public static ReadOnlyBuffer<T> Empty { get; } = OwnerEmptyMemory<T>.Shared.Buffer;
 
         public int Length => _length;
 
         public bool IsEmpty => Length == 0;
 
-        public ReadOnlyMemory<T> Slice(int index)
+        public ReadOnlyBuffer<T> Slice(int index)
         {
-            return new ReadOnlyMemory<T>(_owner, _index + index, _length - index);
+            return new ReadOnlyBuffer<T>(_owner, _index + index, _length - index);
         }
-        public ReadOnlyMemory<T> Slice(int index, int length)
+        public ReadOnlyBuffer<T> Slice(int index, int length)
         {
-            return new ReadOnlyMemory<T>(_owner, _index + index, length);
+            return new ReadOnlyBuffer<T>(_owner, _index + index, length);
         }
 
         public ReadOnlySpan<T> Span => _owner.GetSpanInternal(_index, _length);
 
         public DisposableReservation<T> Reserve()
         {
-            return _owner.Memory.Reserve();
+            return _owner.Buffer.Reserve();
         }
 
-        public unsafe MemoryHandle Pin() => MemoryHandle.Create(_owner, _index);
+        public unsafe BufferHandle Pin() => BufferHandle.Create(_owner, _index);
    
         public unsafe bool TryGetPointer(out void* pointer)
         {
             if (!_owner.TryGetPointerInternal(out pointer)) {
                 return false;
             }
-            pointer = Memory<T>.Add(pointer, _index);
+            pointer = Buffer<T>.Add(pointer, _index);
             return true;
         }
 
@@ -89,27 +89,27 @@ namespace System
             Span.CopyTo(span);
         }
 
-        public void CopyTo(Memory<T> memory)
+        public void CopyTo(Buffer<T> buffer)
         {
-            Span.CopyTo(memory.Span);
+            Span.CopyTo(buffer.Span);
         }
 
         public override bool Equals(object obj)
         {
-            if (!(obj is Memory<T>)) {
+            if (!(obj is Buffer<T>)) {
                 return false;
             }
 
-            var other = (Memory<T>)obj;
+            var other = (Buffer<T>)obj;
             return Equals(other);
         }
 
-        public bool Equals(Memory<T> other)
+        public bool Equals(Buffer<T> other)
         {
-            return Equals((ReadOnlyMemory<T>)other);
+            return Equals((ReadOnlyBuffer<T>)other);
         }
 
-        public bool Equals(ReadOnlyMemory<T> other)
+        public bool Equals(ReadOnlyBuffer<T> other)
         {
             return
                 _owner == other._owner &&
@@ -117,20 +117,20 @@ namespace System
                 _length == other._length;
         }
 
-        public static bool operator ==(ReadOnlyMemory<T> left, Memory<T> right)
+        public static bool operator ==(ReadOnlyBuffer<T> left, Buffer<T> right)
         {
             return left.Equals(right);
         }
-        public static bool operator !=(ReadOnlyMemory<T> left, Memory<T> right)
+        public static bool operator !=(ReadOnlyBuffer<T> left, Buffer<T> right)
         {
             return left.Equals(right);
         }
 
-        public static bool operator ==(ReadOnlyMemory<T> left, ReadOnlyMemory<T> right)
+        public static bool operator ==(ReadOnlyBuffer<T> left, ReadOnlyBuffer<T> right)
         {
             return left.Equals(right);
         }
-        public static bool operator !=(ReadOnlyMemory<T> left, ReadOnlyMemory<T> right)
+        public static bool operator !=(ReadOnlyBuffer<T> left, ReadOnlyBuffer<T> right)
         {
             return left.Equals(right);
         }

--- a/src/System.Buffers.Primitives/System/Runtime/DebuggerViews.cs
+++ b/src/System.Buffers.Primitives/System/Runtime/DebuggerViews.cs
@@ -1,42 +1,43 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
 using System.Diagnostics;
 
 namespace System.Runtime
 {
-    internal class MemoryDebuggerView<T>
+    internal class BufferDebuggerView<T>
     {
-        private ReadOnlyMemory<T> _memory;
+        private ReadOnlyBuffer<T> _buffer;
 
-        public MemoryDebuggerView(Memory<T> memory)
+        public BufferDebuggerView(Buffer<T> buffer)
         {
-            _memory = memory;
+            _buffer = buffer;
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         public T[] Items
         {
             get {
-                return _memory.ToArray();
+                return _buffer.ToArray();
             }
         }
     }
 
-    internal class ReadOnlyMemoryDebuggerView<T>
+    internal class ReadOnlyBufferDebuggerView<T>
     {
-        private ReadOnlyMemory<T> _memory;
+        private ReadOnlyBuffer<T> _buffer;
 
-        public ReadOnlyMemoryDebuggerView(ReadOnlyMemory<T> memory)
+        public ReadOnlyBufferDebuggerView(ReadOnlyBuffer<T> buffer)
         {
-            _memory = memory;
+            _buffer = buffer;
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
         public T[] Items
         {
             get {
-                return _memory.ToArray();
+                return _buffer.ToArray();
             }
         }
     }

--- a/src/System.IO.Pipelines.Extensions/ReadWriteExtensions.cs
+++ b/src/System.IO.Pipelines.Extensions/ReadWriteExtensions.cs
@@ -78,7 +78,7 @@ namespace System.IO.Pipelines
         {
             int len = Unsafe.SizeOf<T>();
             buffer.Ensure(len);
-            buffer.Memory.Span.WriteBigEndian(value);
+            buffer.Buffer.Span.WriteBigEndian(value);
             buffer.Advance(len);
         }
 
@@ -90,7 +90,7 @@ namespace System.IO.Pipelines
         {
             int len = Unsafe.SizeOf<T>();
             buffer.Ensure(len);
-            buffer.Memory.Span.WriteLittleEndian(value);
+            buffer.Buffer.Span.WriteLittleEndian(value);
             buffer.Advance(len);
         }
     }

--- a/src/System.IO.Pipelines.Extensions/StreamExtensions.cs
+++ b/src/System.IO.Pipelines.Extensions/StreamExtensions.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Buffers.Pools;
+using System.Buffers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,7 +16,7 @@ namespace System.IO.Pipelines
         /// <returns></returns>
         public static IPipeWriter AsPipelineWriter(this Stream stream)
         {
-            return (stream as IPipeWriter) ?? stream.AsPipelineWriter(ManagedBufferPool.Shared);
+            return (stream as IPipeWriter) ?? stream.AsPipelineWriter(BufferPool.Default);
         }
 
         /// <summary>
@@ -106,7 +106,7 @@ namespace System.IO.Pipelines
             }
         }
 
-        private static async Task WriteToStream(Stream stream, Memory<byte> memory)
+        private static async Task WriteToStream(Stream stream, Buffer<byte> memory)
         {
             ArraySegment<byte> data;
             if (memory.TryGetArray(out data))

--- a/src/System.IO.Pipelines.Extensions/UnownedBufferReader.cs
+++ b/src/System.IO.Pipelines.Extensions/UnownedBufferReader.cs
@@ -93,7 +93,7 @@ namespace System.IO.Pipelines
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         // Called by the WRITER
-        public async Task WriteAsync(OwnedMemory<byte> buffer, CancellationToken cancellationToken)
+        public async Task WriteAsync(OwnedBuffer<byte> buffer, CancellationToken cancellationToken)
         {
             // If Writing has stopped, why is the caller writing??
             if (Writing.Status != TaskStatus.WaitingForActivation)
@@ -119,7 +119,7 @@ namespace System.IO.Pipelines
                 // Allocate a new segment to hold the buffer being written.
                 using (var segment = new BufferSegment(buffer))
                 {
-                    segment.End = buffer.Memory.Length;
+                    segment.End = buffer.Buffer.Length;
 
                     if (_head == null || _head.ReadableBytes == 0)
                     {

--- a/src/System.IO.Pipelines.File/FileReader.cs
+++ b/src/System.IO.Pipelines.File/FileReader.cs
@@ -112,9 +112,9 @@ namespace System.IO.Pipelines.File
             public unsafe void Read()
             {
                 var buffer = Writer.Alloc(2048);
-                fixed (byte* source = &buffer.Memory.Span.DangerousGetPinnableReference())
+                fixed (byte* source = &buffer.Buffer.Span.DangerousGetPinnableReference())
                 {
-                    var count = buffer.Memory.Length;
+                    var count = buffer.Buffer.Length;
 
                     var overlapped = ThreadPoolBoundHandle.AllocateNativeOverlapped(PreAllocatedOverlapped);
                     overlapped->OffsetLow = Offset;

--- a/src/System.IO.Pipelines.Networking.Libuv/Interop/UvWriteReq.cs
+++ b/src/System.IO.Pipelines.Networking.Libuv/Interop/UvWriteReq.cs
@@ -20,7 +20,7 @@ namespace System.IO.Pipelines.Networking.Libuv.Interop
         private object _state;
         private const int BUFFER_COUNT = 4;
 
-        private List<MemoryHandle> _handles = new List<MemoryHandle>();
+        private List<BufferHandle> _handles = new List<BufferHandle>();
         private List<GCHandle> _pins = new List<GCHandle>(BUFFER_COUNT + 1);
 
         private LibuvAwaitable<UvWriteReq> _awaitable = new LibuvAwaitable<UvWriteReq>();

--- a/src/System.IO.Pipelines.Networking.Libuv/UvTcpConnection.cs
+++ b/src/System.IO.Pipelines.Networking.Libuv/UvTcpConnection.cs
@@ -22,7 +22,7 @@ namespace System.IO.Pipelines.Networking.Libuv
 
         private Task _sendingTask;
         private WritableBuffer? _inputBuffer;
-        private MemoryHandle _inputBufferPin;
+        private BufferHandle _inputBufferPin;
 
         public UvTcpConnection(UvThread thread, UvTcpHandle handle)
         {
@@ -242,10 +242,10 @@ namespace System.IO.Pipelines.Networking.Libuv
             var inputBuffer = _input.Writer.Alloc(2048);
             _inputBuffer = inputBuffer;
 
-            var pinnedHandle = inputBuffer.Memory.Pin();
+            var pinnedHandle = inputBuffer.Buffer.Pin();
             _inputBufferPin = pinnedHandle;
 
-            return handle.Libuv.buf_init((IntPtr)pinnedHandle.PinnedPointer, inputBuffer.Memory.Length);
+            return handle.Libuv.buf_init((IntPtr)pinnedHandle.PinnedPointer, inputBuffer.Buffer.Length);
         }
     }
 }

--- a/src/System.IO.Pipelines.Networking.Sockets/SocketConnection.cs
+++ b/src/System.IO.Pipelines.Networking.Sockets/SocketConnection.cs
@@ -380,7 +380,7 @@ namespace System.IO.Pipelines.Networking.Sockets
                         while (Socket.Available != 0 && buffer.BytesWritten < FlushInputEveryBytes)
                         {
                             buffer.Ensure(); // ask for *something*, then use whatever is available (usually much much more)
-                            SetBuffer(buffer.Memory, args);
+                            SetBuffer(buffer.Buffer, args);
                             // await async for the io work to be completed
                             await Socket.ReceiveSignalAsync(args);
 
@@ -607,7 +607,7 @@ namespace System.IO.Pipelines.Networking.Sockets
         }
 
         // unsafe+async not good friends
-        private unsafe void SetBuffer(Memory<byte> memory, SocketAsyncEventArgs args, int ignore = 0)
+        private unsafe void SetBuffer(Buffer<byte> memory, SocketAsyncEventArgs args, int ignore = 0)
         {
             ArraySegment<byte> segment;
             if (!memory.TryGetArray(out segment))

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/RioTcpConnection.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/RioTcpConnection.cs
@@ -64,7 +64,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
         private void ProcessReceives()
         {
             _buffer = _input.Writer.Alloc(2048);
-            var receiveBufferSeg = GetSegmentFromMemory(_buffer.Memory);
+            var receiveBufferSeg = GetSegmentFromMemory(_buffer.Buffer);
 
             if (!_rio.RioReceive(_requestQueue, ref receiveBufferSeg, 1, RioReceiveFlags.None, 0))
             {
@@ -111,7 +111,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
             _output.Reader.Complete();
         }
 
-        private Task SendAsync(Memory<byte> memory, bool endOfMessage)
+        private Task SendAsync(Buffer<byte> memory, bool endOfMessage)
         {
             if (!IsReadyToSend)
             {
@@ -130,7 +130,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
             return _completedTask;
         }
 
-        private async Task SendAsyncAwaited(Memory<byte> memory, bool endOfMessage)
+        private async Task SendAsyncAwaited(Buffer<byte> memory, bool endOfMessage)
         {
             await ReadyToSend;
 
@@ -219,7 +219,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
             _buffer.FlushAsync();
         }
 
-        private unsafe RioBufferSegment GetSegmentFromMemory(Memory<byte> memory)
+        private unsafe RioBufferSegment GetSegmentFromMemory(Buffer<byte> memory)
         {
             void* pointer;
             if (!memory.TryGetPointer(out pointer))

--- a/src/System.IO.Pipelines.Text.Primitives/PipelineTextOutput.cs
+++ b/src/System.IO.Pipelines.Text.Primitives/PipelineTextOutput.cs
@@ -30,7 +30,7 @@ namespace System.IO.Pipelines.Text.Primitives
             {
                 EnsureBuffer();
 
-                return _writableBuffer.Memory.Span;
+                return _writableBuffer.Buffer.Span;
             }
         }
 

--- a/src/System.IO.Pipelines/MemoryEnumerator.cs
+++ b/src/System.IO.Pipelines/MemoryEnumerator.cs
@@ -1,43 +1,45 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
+
 namespace System.IO.Pipelines
 {
     /// <summary>
     /// An enumerator over the <see cref="ReadableBuffer"/>
     /// </summary>
-    public struct MemoryEnumerator
+    public struct BufferEnumerator
     {
         private SegmentEnumerator _segmentEnumerator;
-        private Memory<byte> _current;
+        private Buffer<byte> _current;
 
         /// <summary>
         /// 
         /// </summary>
-        public MemoryEnumerator(ReadCursor start, ReadCursor end)
+        public BufferEnumerator(ReadCursor start, ReadCursor end)
         {
             _segmentEnumerator = new SegmentEnumerator(start, end);
-            _current = default(Memory<byte>);
+            _current = default(Buffer<byte>);
         }
 
         /// <summary>
-        /// The current <see cref="Memory{Byte}"/>
+        /// The current <see cref="Buffer{Byte}"/>
         /// </summary>
-        public Memory<byte> Current => _current;
+        public Buffer<byte> Current => _current;
 
         /// <summary>
-        /// Moves to the next <see cref="Memory{Byte}"/> in the <see cref="ReadableBuffer"/>
+        /// Moves to the next <see cref="Buffer{Byte}"/> in the <see cref="ReadableBuffer"/>
         /// </summary>
         /// <returns></returns>
         public bool MoveNext()
         {
             if (!_segmentEnumerator.MoveNext())
             {
-                _current = Memory<byte>.Empty;
+                _current = Buffer<byte>.Empty;
                 return false;
             }
             var current = _segmentEnumerator.Current;
-            _current = current.Segment.Memory.Slice(current.Start, current.Length);
+            _current = current.Segment.Buffer.Slice(current.Start, current.Length);
 
             return true;
         }

--- a/src/System.IO.Pipelines/MemoryPool.cs
+++ b/src/System.IO.Pipelines/MemoryPool.cs
@@ -68,7 +68,7 @@ namespace System.IO.Pipelines
 
         private Action<MemoryPoolSlab> _slabDeallocationCallback;
 
-        public override OwnedMemory<byte> Rent(int size)
+        public override OwnedBuffer<byte> Rent(int size)
         {
             if (size > _blockLength)
             {

--- a/src/System.IO.Pipelines/MemoryPoolBlock.cs
+++ b/src/System.IO.Pipelines/MemoryPoolBlock.cs
@@ -10,7 +10,7 @@ namespace System.IO.Pipelines
     /// Block tracking object used by the byte buffer memory pool. A slab is a large allocation which is divided into smaller blocks. The
     /// individual blocks are then treated as independent array segments.
     /// </summary>
-    public class MemoryPoolBlock : OwnedMemory<byte>
+    public class MemoryPoolBlock : OwnedBuffer<byte>
     {
         private readonly int _offset;
         private readonly int _length;
@@ -84,7 +84,7 @@ namespace System.IO.Pipelines
         public override string ToString()
         {
             var builder = new StringBuilder();
-            SpanExtensions.AppendAsLiteral(Memory.Span, builder);
+            SpanExtensions.AppendAsLiteral(Buffer.Span, builder);
             return builder.ToString();
         }
 

--- a/src/System.IO.Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/Pipe.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Buffers.Pools;
+using System.Buffers;
 using System.Diagnostics;
 
 namespace System.IO.Pipelines
@@ -88,7 +88,7 @@ namespace System.IO.Pipelines
             _writerAwaitable = new PipeAwaitable(completed: true);
         }
 
-        internal Memory<byte> Memory => _writingHead?.Memory.Slice(_writingHead.End, _writingHead.WritableBytes) ?? Memory<byte>.Empty;
+        internal Buffer<byte> Buffer => _writingHead?.Buffer.Slice(_writingHead.End, _writingHead.WritableBytes) ?? Buffer<byte>.Empty;
 
         /// <summary>
         /// Allocates memory from the pipeline to write into.
@@ -300,7 +300,7 @@ namespace System.IO.Pipelines
                 Debug.Assert(!_writingHead.ReadOnly);
                 Debug.Assert(_writingHead.Next == null);
 
-                var buffer = _writingHead.Memory;
+                var buffer = _writingHead.Buffer;
                 var bufferIndex = _writingHead.End + bytesWritten;
 
                 Debug.Assert(bufferIndex <= buffer.Length);

--- a/src/System.IO.Pipelines/PipeFactory.cs
+++ b/src/System.IO.Pipelines/PipeFactory.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Buffers.Pools;
+using System.Buffers;
 
 namespace System.IO.Pipelines
 {

--- a/src/System.IO.Pipelines/ReadCursor.cs
+++ b/src/System.IO.Pipelines/ReadCursor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -186,11 +187,11 @@ namespace System.IO.Pipelines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool TryGetBuffer(ReadCursor end, out Memory<byte> data)
+        internal bool TryGetBuffer(ReadCursor end, out Buffer<byte> data)
         {
             if (IsDefault)
             {
-                data = Memory<byte>.Empty;
+                data = Buffer<byte>.Empty;
                 return false;
             }
 
@@ -203,11 +204,11 @@ namespace System.IO.Pipelines
 
                 if (following > 0)
                 {
-                    data = segment.Memory.Slice(index, following);
+                    data = segment.Buffer.Slice(index, following);
                     return true;
                 }
 
-                data = Memory<byte>.Empty;
+                data = Buffer<byte>.Empty;
                 return false;
             }
             else
@@ -216,7 +217,7 @@ namespace System.IO.Pipelines
             }
         }
 
-        private bool TryGetBufferMultiBlock(ReadCursor end, out Memory<byte> data)
+        private bool TryGetBufferMultiBlock(ReadCursor end, out Buffer<byte> data)
         {
             var segment = _segment;
             var index = _index;
@@ -248,7 +249,7 @@ namespace System.IO.Pipelines
 
                 if (wasLastSegment)
                 {
-                    data = Memory<byte>.Empty;
+                    data = Buffer<byte>.Empty;
                     return false;
                 }
                 else
@@ -258,7 +259,7 @@ namespace System.IO.Pipelines
                 }
             }
 
-            data = segment.Memory.Slice(index, following);
+            data = segment.Buffer.Slice(index, following);
             return true;
         }
 
@@ -270,7 +271,7 @@ namespace System.IO.Pipelines
             }
 
             var sb = new StringBuilder();
-            Span<byte> span = Segment.Memory.Span.Slice(Index, Segment.End - Index);
+            Span<byte> span = Segment.Buffer.Span.Slice(Index, Segment.End - Index);
             SpanExtensions.AppendAsLiteral(span, sb);
             return sb.ToString();
         }

--- a/src/System.IO.Pipelines/ReadCursorOperations.cs
+++ b/src/System.IO.Pipelines/ReadCursorOperations.cs
@@ -15,7 +15,7 @@ namespace System.IO.Pipelines
             {
                 var segmentPart = enumerator.Current;
                 var segment = segmentPart.Segment;
-                var span = segment.Memory.Span.Slice(segmentPart.Start, segmentPart.Length);
+                var span = segment.Buffer.Span.Slice(segmentPart.Start, segmentPart.Length);
 
                 int index = span.IndexOf(byte0);
                 if (index != -1)
@@ -36,7 +36,7 @@ namespace System.IO.Pipelines
             {
                 var segmentPart = enumerator.Current;
                 var segment = segmentPart.Segment;
-                var span = segment.Memory.Span.Slice(segmentPart.Start, segmentPart.Length);
+                var span = segment.Buffer.Span.Slice(segmentPart.Start, segmentPart.Length);
 
                 int index = span.IndexOf(byte0, byte1);
 
@@ -58,7 +58,7 @@ namespace System.IO.Pipelines
             {
                 var segmentPart = enumerator.Current;
                 var segment = segmentPart.Segment;
-                var span = segment.Memory.Span.Slice(segmentPart.Start, segmentPart.Length);
+                var span = segment.Buffer.Span.Slice(segmentPart.Start, segmentPart.Length);
 
                 int index = span.IndexOf(byte0, byte1, byte2);
 

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -10,7 +10,7 @@ namespace System.IO.Pipelines
     /// <summary>
     /// Represents a buffer that can read a sequential series of bytes.
     /// </summary>
-    public struct ReadableBuffer : ISequence<ReadOnlyMemory<byte>>
+    public struct ReadableBuffer : ISequence<ReadOnlyBuffer<byte>>
     {
         private ReadCursor _start;
         private ReadCursor _end;
@@ -21,7 +21,7 @@ namespace System.IO.Pipelines
         /// </summary>
         public int Length => _length;
 
-        int? ISequence<ReadOnlyMemory<byte>>.Length => Length;
+        int? ISequence<ReadOnlyBuffer<byte>>.Length => Length;
 
         /// <summary>
         /// Determines if the <see cref="ReadableBuffer"/> is empty.
@@ -29,15 +29,15 @@ namespace System.IO.Pipelines
         public bool IsEmpty => _length == 0;
 
         /// <summary>
-        /// Determins if the <see cref="ReadableBuffer"/> is a single <see cref="Memory{Byte}"/>.
+        /// Determins if the <see cref="ReadableBuffer"/> is a single <see cref="Buffer{Byte}"/>.
         /// </summary>
         public bool IsSingleSpan => _start.Segment == _end.Segment;
 
-        public Memory<byte> First
+        public Buffer<byte> First
         {
             get
             {
-                _start.TryGetBuffer(_end, out Memory<byte> first);
+                _start.TryGetBuffer(_end, out Buffer<byte> first);
                 return first;
             }
         }
@@ -172,10 +172,10 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.destination);
             }
 
-            foreach (var memory in this)
+            foreach (var buffer in this)
             {
-                memory.Span.CopyTo(destination);
-                destination = destination.Slice(memory.Length);
+                buffer.Span.CopyTo(destination);
+                destination = destination.Slice(buffer.Length);
             }
         }
 
@@ -196,9 +196,9 @@ namespace System.IO.Pipelines
         public override string ToString()
         {
             var sb = new StringBuilder();
-            foreach (var memory in this)
+            foreach (var buffer in this)
             {
-                SpanExtensions.AppendAsLiteral(memory.Span, sb);
+                SpanExtensions.AppendAsLiteral(buffer.Span, sb);
             }
             return sb.ToString();
         }
@@ -206,9 +206,9 @@ namespace System.IO.Pipelines
         /// <summary>
         /// Returns an enumerator over the <see cref="ReadableBuffer"/>
         /// </summary>
-        public MemoryEnumerator GetEnumerator()
+        public BufferEnumerator GetEnumerator()
         {
-            return new MemoryEnumerator(_start, _end);
+            return new BufferEnumerator(_start, _end);
         }
 
         internal void ClearCursors()
@@ -250,14 +250,14 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
             }
 
-            var buffer = new OwnedArray<byte>(data);
+            OwnedBuffer<byte> buffer = data;
             var segment = new BufferSegment(buffer);
             segment.Start = offset;
             segment.End = offset + length;
             return new ReadableBuffer(new ReadCursor(segment, offset), new ReadCursor(segment, offset + length));
         }
 
-        bool ISequence<ReadOnlyMemory<byte>>.TryGet(ref Position position, out ReadOnlyMemory<byte> item, bool advance)
+        bool ISequence<ReadOnlyBuffer<byte>>.TryGet(ref Position position, out ReadOnlyBuffer<byte> item, bool advance)
         {
             if (position == Position.First)
             {
@@ -278,7 +278,7 @@ namespace System.IO.Pipelines
             }
             else if (position == Position.AfterLast)
             {
-                item = default(ReadOnlyMemory<byte>);
+                item = default(ReadOnlyBuffer<byte>);
                 return false;
             }
 
@@ -293,11 +293,11 @@ namespace System.IO.Pipelines
             }
             if (currentSegment == _end.Segment)
             {
-                item = currentSegment.Memory.Slice(currentSegment.Start, _end.Index - currentSegment.Start);
+                item = currentSegment.Buffer.Slice(currentSegment.Start, _end.Index - currentSegment.Start);
             }
             else
             {
-                item = currentSegment.Memory.Slice(currentSegment.Start, currentSegment.End - currentSegment.Start);
+                item = currentSegment.Buffer.Slice(currentSegment.Start, currentSegment.End - currentSegment.Start);
             }
             return true;
         }

--- a/src/System.IO.Pipelines/ReadableBufferReader.cs
+++ b/src/System.IO.Pipelines/ReadableBufferReader.cs
@@ -90,7 +90,7 @@ namespace System.IO.Pipelines
                 var length = part.Length;
                 if (length != 0)
                 {
-                    _currentSpan = part.Segment.Memory.Span.Slice(part.Start, length);
+                    _currentSpan = part.Segment.Buffer.Span.Slice(part.Start, length);
                     _index = 0;
                     return;
                 }

--- a/src/System.IO.Pipelines/SegmentEnumerator.cs
+++ b/src/System.IO.Pipelines/SegmentEnumerator.cs
@@ -27,12 +27,12 @@ namespace System.IO.Pipelines
         }
 
         /// <summary>
-        /// The current <see cref="Memory{Byte}"/>
+        /// The current <see cref="Buffer{Byte}"/>
         /// </summary>
         public SegmentPart Current => _current;
 
         /// <summary>
-        /// Moves to the next <see cref="Memory{Byte}"/> in the <see cref="ReadableBuffer"/>
+        /// Moves to the next <see cref="Buffer{Byte}"/> in the <see cref="ReadableBuffer"/>
         /// </summary>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.IO.Pipelines/Testing/BufferUtilities.cs
+++ b/src/System.IO.Pipelines/Testing/BufferUtilities.cs
@@ -34,9 +34,9 @@ namespace System.IO.Pipelines.Testing
                     chars[dataOffset + j] = s[j];
                 }
 
-                // Create a segment that has offset relative to the OwnedMemory and OwnedMemory itself has offset relative to array
-                var ownedMemory = new OwnedArray<byte>(new ArraySegment<byte>(chars, memoryOffset, length * 3));
-                var current = new BufferSegment(ownedMemory, length, length * 2);
+                // Create a segment that has offset relative to the OwnedBuffer and OwnedBuffer itself has offset relative to array
+                var ownedBuffer = OwnedBuffer<byte>.Create(new ArraySegment<byte>(chars, memoryOffset, length * 3));
+                var current = new BufferSegment(ownedBuffer, length, length * 2);
                 if (first == null)
                 {
                     first = current;

--- a/src/System.IO.Pipelines/UnownedBuffer.cs
+++ b/src/System.IO.Pipelines/UnownedBuffer.cs
@@ -9,7 +9,7 @@ namespace System.IO.Pipelines
     /// <summary>
     /// Represents a buffer that is owned by an external component.
     /// </summary>
-    public class UnownedBuffer : OwnedMemory<byte>
+    public class UnownedBuffer : OwnedBuffer<byte>
     {
         private ArraySegment<byte> _buffer;
 
@@ -18,14 +18,14 @@ namespace System.IO.Pipelines
             _buffer = buffer;
         }
 
-        public OwnedMemory<byte> MakeCopy(int offset, int length, out int newStart, out int newEnd)
+        public OwnedBuffer<byte> MakeCopy(int offset, int length, out int newStart, out int newEnd)
         {
             // Copy to a new Owned Buffer.
             var buffer = new byte[length];
-            Buffer.BlockCopy(_buffer.Array, _buffer.Offset + offset, buffer, 0, length);
+            System.Buffer.BlockCopy(_buffer.Array, _buffer.Offset + offset, buffer, 0, length);
             newStart = 0;
             newEnd = length;
-            return new OwnedArray<byte>(buffer);
+            return buffer;
         }
     }
 }

--- a/src/System.IO.Pipelines/WritableBuffer.cs
+++ b/src/System.IO.Pipelines/WritableBuffer.cs
@@ -20,20 +20,20 @@ namespace System.IO.Pipelines
         /// <summary>
         /// Available memory.
         /// </summary>
-        public Memory<byte> Memory => _pipe.Memory;
+        public Buffer<byte> Buffer => _pipe.Buffer;
 
         /// <summary>
         /// Returns the number of bytes currently written and uncommitted.
         /// </summary>
         public int BytesWritten => AsReadableBuffer().Length;
 
-        Span<byte> IOutput.Buffer => Memory.Span;
+        Span<byte> IOutput.Buffer => Buffer.Span;
 
         void IOutput.Enlarge(int desiredBufferLength) => Ensure(NewSize(desiredBufferLength));
 
         private int NewSize(int desiredBufferLength)
         {
-            var currentSize = Memory.Length;
+            var currentSize = Buffer.Length;
             if(desiredBufferLength == 0) {
                 if (currentSize <= 0) return 256;
                 else return currentSize * 2;
@@ -55,7 +55,7 @@ namespace System.IO.Pipelines
         /// </summary>
         /// <param name="count">number of bytes</param>
         /// <remarks>
-        /// Used when writing to <see cref="Memory"/> directly. 
+        /// Used when writing to <see cref="Buffer"/> directly. 
         /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">
         /// More requested than underlying <see cref="IBufferPool"/> can allocate in a contiguous block.
@@ -78,7 +78,7 @@ namespace System.IO.Pipelines
         /// Moves forward the underlying <see cref="IPipeWriter"/>'s write cursor but does not commit the data.
         /// </summary>
         /// <param name="bytesWritten">number of bytes to be marked as written.</param>
-        /// <remarks>Forwards the start of available <see cref="Memory"/> by <paramref name="bytesWritten"/>.</remarks>
+        /// <remarks>Forwards the start of available <see cref="Buffer"/> by <paramref name="bytesWritten"/>.</remarks>
         /// <exception cref="ArgumentException"><paramref name="bytesWritten"/> is larger than the current data available data.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="bytesWritten"/> is negative.</exception>
         public void Advance(int bytesWritten)

--- a/src/System.IO.Pipelines/WritableBufferExtensions.cs
+++ b/src/System.IO.Pipelines/WritableBufferExtensions.cs
@@ -15,15 +15,15 @@ namespace System.IO.Pipelines
         /// <param name="source">The <see cref="Span{Byte}"/> to write</param>
         public static void Write(this WritableBuffer buffer, ReadOnlySpan<byte> source)
         {
-            if (buffer.Memory.IsEmpty)
+            if (buffer.Buffer.IsEmpty)
             {
                 buffer.Ensure();
             }
 
             // Fast path, try copying to the available memory directly
-            if (source.Length <= buffer.Memory.Length)
+            if (source.Length <= buffer.Buffer.Length)
             {
-                source.CopyTo(buffer.Memory.Span);
+                source.CopyTo(buffer.Buffer.Span);
                 buffer.Advance(source.Length);
                 return;
             }
@@ -33,7 +33,7 @@ namespace System.IO.Pipelines
 
             while (remaining > 0)
             {
-                var writable = Math.Min(remaining, buffer.Memory.Length);
+                var writable = Math.Min(remaining, buffer.Buffer.Length);
 
                 buffer.Ensure(writable);
 
@@ -42,7 +42,7 @@ namespace System.IO.Pipelines
                     continue;
                 }
 
-                source.Slice(offset, writable).CopyTo(buffer.Memory.Span);
+                source.Slice(offset, writable).CopyTo(buffer.Buffer.Span);
 
                 remaining -= writable;
                 offset += writable;

--- a/src/System.Net.Libuv/System/Net/Libuv/Stream.cs
+++ b/src/System.Net.Libuv/System/Net/Libuv/Stream.cs
@@ -31,7 +31,7 @@ namespace System.Net.Libuv
             }
         }
 
-        public event Action<Memory<byte>> ReadCompleted;
+        public event Action<Buffer<byte>> ReadCompleted;
         public event Action EndOfStream;
 
         public unsafe void TryWrite(byte[] data)
@@ -81,7 +81,7 @@ namespace System.Net.Libuv
             }
         }
 
-        public unsafe void TryWrite(Memory<byte> data)
+        public unsafe void TryWrite(Buffer<byte> data)
         {
             // This can work with Span<byte> because it's synchronous but we need pinning support
             EnsureNotDisposed();
@@ -144,8 +144,8 @@ namespace System.Net.Libuv
             }
             else
             {
-                using (var owned = new OwnedNativeMemory((int)bytesRead, buffer.Buffer)) {
-                    OnReadCompleted(owned.Memory);
+                using (var owned = new OwnedNativeBuffer((int)bytesRead, buffer.Buffer)) {
+                    OnReadCompleted(owned.Buffer);
                     //buffer.Dispose(); // TODO: owned memory frees the memory. this is bad; need to fix
                 }
             }
@@ -174,14 +174,14 @@ namespace System.Net.Libuv
             }
             else
             {
-                using (var owned = new OwnedNativeMemory((int)bytesRead, buffer.Buffer)) {
-                    OnReadCompleted(owned.Memory);
+                using (var owned = new OwnedNativeBuffer((int)bytesRead, buffer.Buffer)) {
+                    OnReadCompleted(owned.Buffer);
                     //buffer.Dispose(); // TODO: owned memory frees the memory. this is bad; need to fix
                 }
             }
         }
 
-        void OnReadCompleted(Memory<byte> bytesRead)
+        void OnReadCompleted(Buffer<byte> bytesRead)
         {
             if (ReadCompleted != null)
             {

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/SequenceFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/SequenceFormatter.cs
@@ -9,15 +9,15 @@ namespace System.Text.Formatting
 {
     public static class SequenceFormatterExtensions
     {
-        public static SequenceFormatter<TSequence> CreateFormatter<TSequence>(this TSequence sequence, TextEncoder encoder = default(TextEncoder)) where TSequence : ISequence<Memory<byte>>
+        public static SequenceFormatter<TSequence> CreateFormatter<TSequence>(this TSequence sequence, TextEncoder encoder = default(TextEncoder)) where TSequence : ISequence<Buffer<byte>>
         {
             return new SequenceFormatter<TSequence>(sequence, encoder);
         }
     }
 
-    public class SequenceFormatter<TSequence> : ITextOutput where TSequence : ISequence<Memory<byte>>
+    public class SequenceFormatter<TSequence> : ITextOutput where TSequence : ISequence<Buffer<byte>>
     {
-        ISequence<Memory<byte>> _buffers;
+        ISequence<Buffer<byte>> _buffers;
         TextEncoder _encoder;
 
         Position _currentPosition = Position.First;
@@ -40,17 +40,17 @@ namespace System.Text.Formatting
             }
         }
 
-        private Memory<byte> Current { 
+        private Buffer<byte> Current { 
             get {
-                Memory<byte> result;
+                Buffer<byte> result;
                 if (!_buffers.TryGet(ref _currentPosition, out result, advance: false)) { throw new InvalidOperationException(); }
                 return result;
             }
         }
-        private Memory<byte> Previous
+        private Buffer<byte> Previous
         {
             get {
-                Memory<byte> result;
+                Buffer<byte> result;
                 if (!_buffers.TryGet(ref _previousPosition, out result, advance: false)) { throw new InvalidOperationException(); }
                 return result;
             }
@@ -68,7 +68,7 @@ namespace System.Text.Formatting
             _previousPosition = _currentPosition;
             _previousWrittenBytes = _currentWrittenBytes;
 
-            Memory<byte> span;
+            Buffer<byte> span;
             if (!_buffers.TryGet(ref _currentPosition, out span)) {
                 throw new InvalidOperationException();
             }

--- a/src/System.Text.Formatting/System/Text/Parsing/SequenceParser.cs
+++ b/src/System.Text.Formatting/System/Text/Parsing/SequenceParser.cs
@@ -11,15 +11,15 @@ namespace System.Text.Parsing
     {
         const int StackBufferSize = 128;
 
-        public static bool TryParseUInt64<T>(this T memorySequence, out ulong value, out int consumed) where T : ISequence<ReadOnlyMemory<byte>>
+        public static bool TryParseUInt64<T>(this T bufferSequence, out ulong value, out int consumed) where T : ISequence<ReadOnlyBuffer<byte>>
         {
             value = default(uint);
             consumed = default(int);
             Position position = Position.First;
 
             // Fetch the first segment
-            ReadOnlyMemory<byte> first;
-            if (!memorySequence.TryGet(ref position, out first)) {
+            ReadOnlyBuffer<byte> first;
+            if (!bufferSequence.TryGet(ref position, out first)) {
                 return false;
             }
 
@@ -30,8 +30,8 @@ namespace System.Text.Parsing
             }
 
             // Apparently the we need data from the second segment to succesfully parse, and so fetch the second segment.
-            ReadOnlyMemory<byte> second;
-            if (!memorySequence.TryGet(ref position, out second)) {
+            ReadOnlyBuffer<byte> second;
+            if (!bufferSequence.TryGet(ref position, out second)) {
                 // if there is no second segment and the first parsed succesfully, return the result of the parsing.
                 if (parsed) return true;
                 return false;
@@ -52,9 +52,9 @@ namespace System.Text.Parsing
                     second.CopyTo(free);
                     free = free.Slice(second.Length);
 
-                    ReadOnlyMemory<byte> next;
+                    ReadOnlyBuffer<byte> next;
                     while (free.Length > 0) {
-                        if (memorySequence.TryGet(ref position, out next)) {
+                        if (bufferSequence.TryGet(ref position, out next)) {
                             if (next.Length > free.Length) next = next.Slice(0, free.Length);
                             next.CopyTo(free);
                             free = free.Slice(next.Length);
@@ -77,22 +77,22 @@ namespace System.Text.Parsing
 
             // for invariant culture, we should never reach this point, as invariant uint text is never longer than 127 bytes. 
             // I left this code here, as we will need it for custom cultures and possibly when we shrink the stack allocated buffer.
-            combinedSpan = memorySequence.ToSpan();
+            combinedSpan = bufferSequence.ToSpan();
             if (!PrimitiveParser.InvariantUtf8.TryParseUInt64(first.Span, out value, out consumed)) {
                 return false;
             }
             return true;
         }
 
-        public static bool TryParseUInt32<T>(this T memorySequence, out uint value, out int consumed) where T : ISequence<ReadOnlyMemory<byte>>
+        public static bool TryParseUInt32<T>(this T bufferSequence, out uint value, out int consumed) where T : ISequence<ReadOnlyBuffer<byte>>
         {
             value = default(uint);
             consumed = default(int);
             Position position = Position.First;
 
             // Fetch the first segment
-            ReadOnlyMemory<byte> first;
-            if (!memorySequence.TryGet(ref position, out first)) {
+            ReadOnlyBuffer<byte> first;
+            if (!bufferSequence.TryGet(ref position, out first)) {
                 return false;
             }
 
@@ -103,8 +103,8 @@ namespace System.Text.Parsing
             }
 
             // Apparently the we need data from the second segment to succesfully parse, and so fetch the second segment.
-            ReadOnlyMemory<byte> second;
-            if (!memorySequence.TryGet(ref position, out second)) {
+            ReadOnlyBuffer<byte> second;
+            if (!bufferSequence.TryGet(ref position, out second)) {
                 // if there is no second segment and the first parsed succesfully, return the result of the parsing.
                 if (parsed) return true;
                 return false;
@@ -125,9 +125,9 @@ namespace System.Text.Parsing
                     second.CopyTo(free);
                     free = free.Slice(second.Length);
 
-                    ReadOnlyMemory<byte> next;
+                    ReadOnlyBuffer<byte> next;
                     while (free.Length > 0) {
-                        if (memorySequence.TryGet(ref position, out next)) {
+                        if (bufferSequence.TryGet(ref position, out next)) {
                             if (next.Length > free.Length) next = next.Slice(0, free.Length);
                             next.CopyTo(free);
                             free = free.Slice(next.Length);
@@ -150,7 +150,7 @@ namespace System.Text.Parsing
 
             // for invariant culture, we should never reach this point, as invariant uint text is never longer than 127 bytes. 
             // I left this code here, as we will need it for custom cultures and possibly when we shrink the stack allocated buffer.
-            combinedSpan = memorySequence.ToSpan();
+            combinedSpan = bufferSequence.ToSpan();
             if (!PrimitiveParser.InvariantUtf8.TryParseUInt32(combinedSpan, out value, out consumed)) {
                 return false;
             }

--- a/src/System.Text.Http/System/Text/Http/HttpRequest.cs
+++ b/src/System.Text.Http/System/Text/Http/HttpRequest.cs
@@ -12,7 +12,7 @@ namespace System.Text.Http
     {
         public HttpMethod Method;
         public HttpVersion Version;
-        public Memory<byte> RequestUri;
+        public Buffer<byte> RequestUri;
 
         public override string ToString()
         {
@@ -152,7 +152,7 @@ namespace System.Text.Http
             return ToString(bytes.Value, encoder);
         }
 
-        public static string ToString(this Memory<byte> bytes, TextEncoder encoder)
+        public static string ToString(this Buffer<byte> bytes, TextEncoder encoder)
         {
             if (encoder.Encoding == TextEncoder.EncodingName.Utf8)
             {
@@ -170,7 +170,7 @@ namespace System.Text.Http
             if (encoder.Encoding == TextEncoder.EncodingName.Utf8)
             {
                 var position = Position.First;
-                ReadOnlyMemory<byte> segment;
+                ReadOnlyBuffer<byte> segment;
                 while (bytes.TryGet(ref position, out segment, true))
                 {
                     sb.Append(new Utf8String(segment.Span));
@@ -195,7 +195,7 @@ namespace System.Text.Http
             if (encoder.Encoding == TextEncoder.EncodingName.Utf8)
             {
                 var position = Position.First;
-                ReadOnlyMemory<byte> segment;
+                ReadOnlyBuffer<byte> segment;
                 while (bytes.TryGet(ref position, out segment, true))
                 {
                     sb.Append(new Utf8String(segment.Span));

--- a/src/System.Text.Json/System/Text/Json/JsonParseObject.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonParseObject.cs
@@ -11,7 +11,7 @@ namespace System.Text.Json
     public struct JsonObject : IDisposable
     {
         private BufferPool _pool;
-        private OwnedMemory<byte> _dbMemory;
+        private OwnedBuffer<byte> _dbMemory;
         private ReadOnlySpan<byte> _db; 
         private ReadOnlySpan<byte> _values;
 
@@ -29,7 +29,7 @@ namespace System.Text.Json
             return result;
         }
 
-        internal JsonObject(ReadOnlySpan<byte> values, ReadOnlySpan<byte> db, BufferPool pool = null, OwnedMemory<byte> dbMemory = null)
+        internal JsonObject(ReadOnlySpan<byte> values, ReadOnlySpan<byte> db, BufferPool pool = null, OwnedBuffer<byte> dbMemory = null)
         {
             _db = db;
             _values = values;

--- a/src/System.Text.Json/System/Text/Json/JsonParser.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonParser.cs
@@ -37,7 +37,7 @@ namespace System.Text.Json
 
     internal struct TwoStacks
     {
-        Memory<byte> _memory;
+        Buffer<byte> _memory;
         int topOfStackObj;
         int topOfStackArr;
         int capacity;
@@ -54,7 +54,7 @@ namespace System.Text.Json
             }
         }
 
-        public TwoStacks(Memory<byte> db)
+        public TwoStacks(Buffer<byte> db)
         {
             _memory = db;
             topOfStackObj = _memory.Length;
@@ -102,7 +102,7 @@ namespace System.Text.Json
             return value;
         }
 
-        internal void Resize(Memory<byte> newStackMemory)
+        internal void Resize(Buffer<byte> newStackMemory)
         {
             _memory.Slice(0, Math.Max(objectStackCount, arrayStackCount) * 8).Span.CopyTo(newStackMemory.Span);
             _memory = newStackMemory;
@@ -111,10 +111,10 @@ namespace System.Text.Json
 
     internal struct JsonParser
     {
-        private Memory<byte> _db;
+        private Buffer<byte> _db;
         private ReadOnlySpan<byte> _values; // TODO: this should be ReadOnlyMemory<byte>
-        private Memory<byte> _scratchMemory;
-        private OwnedMemory<byte> _scratchManager;
+        private Buffer<byte> _scratchMemory;
+        private OwnedBuffer<byte> _scratchManager;
         BufferPool _pool;
         TwoStacks _stack;
 
@@ -144,9 +144,9 @@ namespace System.Text.Json
         public JsonObject Parse(ReadOnlySpan<byte> utf8Json, BufferPool pool = null)
         {
             _pool = pool;
-            if (_pool == null) _pool = ManagedBufferPool.Shared;
+            if (_pool == null) _pool = BufferPool.Default;
             _scratchManager = _pool.Rent(utf8Json.Length * 4);
-            _scratchMemory = _scratchManager.Memory;
+            _scratchMemory = _scratchManager.Buffer;
 
             int dbLength = _scratchMemory.Length / 2;
             _db = _scratchMemory.Slice(0, dbLength);
@@ -219,11 +219,11 @@ namespace System.Text.Json
             var newScratch = _pool.Rent(_scratchMemory.Length * 2);
             int dbLength = newScratch.Length / 2;
 
-            var newDb = newScratch.Memory.Slice(0, dbLength);
+            var newDb = newScratch.Buffer.Slice(0, dbLength);
             _db.Slice(0, _valuesIndex).Span.CopyTo(newDb.Span);
             _db = newDb;
 
-            var newStackMemory = newScratch.Memory.Slice(dbLength);
+            var newStackMemory = newScratch.Buffer.Slice(dbLength);
             _stack.Resize(newStackMemory);
             _scratchManager.Dispose();
             _scratchManager = newScratch;

--- a/tests/System.Buffers.Experimental.Tests/BytesReader.cs
+++ b/tests/System.Buffers.Experimental.Tests/BytesReader.cs
@@ -173,7 +173,7 @@ namespace System.Slices.Tests
             if (encoder.Encoding == TextEncoder.EncodingName.Utf8)
             {
                 var position = Position.First;
-                ReadOnlyMemory<byte> segment;
+                ReadOnlyBuffer<byte> segment;
                 while (bytes.TryGet(ref position, out segment))
                 {
                     sb.Append(new Utf8String(segment.Span));

--- a/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
@@ -10,12 +10,12 @@ namespace System.Slices.Tests
         [Fact]
         public void SimpleTestS()
         {            
-            using(var owned = new OwnedNativeMemory(1024)) {
+            using(var owned = new OwnedNativeBuffer(1024)) {
                 var span = owned.Span;
                 span[10] = 10;
                 unsafe { Assert.Equal(10, owned.Pointer[10]); }
 
-                var memory = owned.Memory;
+                var memory = owned.Buffer;
                 var array = memory.ToArray();
                 Assert.Equal(owned.Length, array.Length);
                 Assert.Equal(10, array[10]);
@@ -25,14 +25,14 @@ namespace System.Slices.Tests
                 Assert.Equal(10, copy[0]);
             }
 
-            using (OwnedPinnedArray<byte> owned = new byte[1024]) {
+            using (OwnedPinnedBuffer<byte> owned = new byte[1024]) {
                 var span = owned.Span;
                 span[10] = 10;
                 Assert.Equal(10, owned.Array[10]);
 
                 unsafe { Assert.Equal(10, owned.Pointer[10]); }
 
-                var memory = owned.Memory;
+                var memory = owned.Buffer;
                 var array = memory.ToArray();
                 Assert.Equal(owned.Length, array.Length);
                 Assert.Equal(10, array[10]);
@@ -46,7 +46,7 @@ namespace System.Slices.Tests
         [Fact]
         public void NativeMemoryLifetime()
         {
-            var owner = new OwnedNativeMemory(1024);
+            var owner = new OwnedNativeBuffer(1024);
             TestLifetime(owner);
         }
 
@@ -55,17 +55,17 @@ namespace System.Slices.Tests
         {
             var bytes = new byte[1024];
             fixed (byte* pBytes = bytes) {
-                var owner = new OwnedPinnedArray<byte>(bytes, pBytes);
+                var owner = new OwnedPinnedBuffer<byte>(bytes, pBytes);
                 TestLifetime(owner);            
             }
         }
 
-        static void TestLifetime(OwnedMemory<byte> owned)
+        static void TestLifetime(OwnedBuffer<byte> owned)
         {
-            Memory<byte> copyStoredForLater;
+            Buffer<byte> copyStoredForLater;
             try {
-                Memory<byte> memory = owned.Memory;
-                Memory<byte> memorySlice = memory.Slice(10);
+                Buffer<byte> memory = owned.Buffer;
+                Buffer<byte> memorySlice = memory.Slice(10);
                 copyStoredForLater = memorySlice;
                 var r = memorySlice.Reserve();
                 try {

--- a/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
@@ -13,7 +13,7 @@ namespace System.Slices.Tests
         [Fact]
         public void SingleSegmentBasics()
         {
-            ReadOnlyMemory<byte> buffer = new byte[] { 1, 2, 3, 4, 5, 6 };
+            ReadOnlyBuffer<byte> buffer = new byte[] { 1, 2, 3, 4, 5, 6 };
             var bytes = new ReadOnlyBytes(buffer);
             var sliced  = bytes.Slice(1, 3);
             var span = sliced.First.Span;
@@ -46,7 +46,7 @@ namespace System.Slices.Tests
         public void SingleSegmentSlicing()
         {
             var array = new byte[] { 0, 1, 2, 3, 4, 5, 6 };
-            ReadOnlyMemory<byte> buffer = array;
+            ReadOnlyBuffer<byte> buffer = array;
             var bytes = new ReadOnlyBytes(buffer);
 
             ReadOnlyBytes sliced = bytes;
@@ -83,7 +83,7 @@ namespace System.Slices.Tests
         public void SingleSegmentCopyToKnownLength()
         {
             var array = new byte[] { 0, 1, 2, 3, 4, 5, 6 };
-            ReadOnlyMemory<byte> buffer = array;
+            ReadOnlyBuffer<byte> buffer = array;
             var bytes = new ReadOnlyBytes(buffer, null, array.Length);
 
             { // copy to equal
@@ -116,7 +116,7 @@ namespace System.Slices.Tests
         public void SingleSegmentCopyToUnknownLength()
         {
             var array = new byte[] { 0, 1, 2, 3, 4, 5, 6 };
-            ReadOnlyMemory<byte> buffer = array;
+            ReadOnlyBuffer<byte> buffer = array;
             var bytes = new ReadOnlyBytes(buffer, null, -1);
 
             { // copy to equal
@@ -232,7 +232,7 @@ namespace System.Slices.Tests
             var bytes = new ReadOnlyBytes(buffer);
             var position = new Position();
             int length = 0;
-            ReadOnlyMemory<byte> segment;
+            ReadOnlyBuffer<byte> segment;
             while (bytes.TryGet(ref position, out segment))
             {
                 length += segment.Length;
@@ -258,7 +258,7 @@ namespace System.Slices.Tests
                 multibytes = multibytes.Slice(i);
                 var position = new Position();
                 var length = 0;
-                ReadOnlyMemory<byte> segment;
+                ReadOnlyBuffer<byte> segment;
                 while (multibytes.TryGet(ref position, out segment))
                 {
                     length += segment.Length;
@@ -276,7 +276,7 @@ namespace System.Slices.Tests
                 multibytes = multibytes.Slice(0, i);
                 var position = new Position();
                 var length = 0;
-                ReadOnlyMemory<byte> segment;
+                ReadOnlyBuffer<byte> segment;
                 while (multibytes.TryGet(ref position, out segment))
                 {
                     length += segment.Length;

--- a/tests/System.IO.Pipelines.Performance.Tests/Enumerators.cs
+++ b/tests/System.IO.Pipelines.Performance.Tests/Enumerators.cs
@@ -22,7 +22,7 @@ namespace System.IO.Pipelines.Performance.Tests
         {
             for (int i = 0; i < InnerLoopCount; i++)
             {
-                var enumerator = new MemoryEnumerator(_readableBuffer.Start, _readableBuffer.End);
+                var enumerator = new BufferEnumerator(_readableBuffer.Start, _readableBuffer.End);
                 while (enumerator.MoveNext())
                 {
                     var memory = enumerator.Current;

--- a/tests/System.IO.Pipelines.Tests/PipelineReaderWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/PipelineReaderWriterFacts.cs
@@ -40,7 +40,7 @@ namespace System.IO.Pipelines.Tests
             // Fill the block with stuff leaving 5 bytes at the end
             var buffer = _pipe.Writer.Alloc(1);
 
-            var len = buffer.Memory.Length;
+            var len = buffer.Buffer.Length;
             // Fill the buffer with garbage
             //     block 1       ->    block2
             // [padding..hello]  ->  [  world   ]
@@ -401,7 +401,7 @@ namespace System.IO.Pipelines.Tests
             Assert.False(buffer.IsSingleSpan);
             var helloBuffer = buffer.Slice(blockSize - 5);
             Assert.False(helloBuffer.IsSingleSpan);
-            var memory = new List<Memory<byte>>();
+            var memory = new List<Buffer<byte>>();
             foreach (var m in helloBuffer)
             {
                 memory.Add(m);
@@ -579,7 +579,7 @@ namespace System.IO.Pipelines.Tests
         {
             private DisposeTrackingOwnedMemory _memory = new DisposeTrackingOwnedMemory(new byte[1]);
 
-            public override OwnedMemory<byte> Rent(int size)
+            public override OwnedBuffer<byte> Rent(int size)
             {
                 return _memory;
             }
@@ -591,7 +591,7 @@ namespace System.IO.Pipelines.Tests
 
             }
 
-            private class DisposeTrackingOwnedMemory : OwnedMemory<byte>
+            private class DisposeTrackingOwnedMemory : OwnedBuffer<byte>
             {
                 public DisposeTrackingOwnedMemory(byte[] array) : base(array)
                 {

--- a/tests/System.IO.Pipelines.Tests/PipelineWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/PipelineWriterFacts.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 using System.IO.Pipelines.Text.Primitives;
 using Xunit;
 using System.Text.Formatting;
-using System.Buffers.Pools;
+using System.Buffers;
 
 namespace System.IO.Pipelines.Tests
 {
@@ -112,7 +112,7 @@ namespace System.IO.Pipelines.Tests
 
         private class MyCustomStream : Stream, IPipeWriter
         {
-            private readonly Pipe _pipe = new Pipe(ManagedBufferPool.Shared);
+            private readonly Pipe _pipe = new Pipe(BufferPool.Default);
 
             public override bool CanRead => true;
 

--- a/tests/System.IO.Pipelines.Tests/ReadableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/ReadableBufferFacts.cs
@@ -216,7 +216,7 @@ namespace System.IO.Pipelines.Tests
         {
             byte huntValue = (byte)~emptyValue;
 
-            var handles = new List<MemoryHandle>();
+            var handles = new List<BufferHandle>();
 
             // we're going to fully index the final locations of the buffer, so that we
             // can mutate etc in constant time
@@ -251,7 +251,7 @@ namespace System.IO.Pipelines.Tests
             handles.Clear();
         }
 
-        private static unsafe byte*[] BuildPointerIndex(ref ReadableBuffer readBuffer, List<MemoryHandle> handles)
+        private static unsafe byte*[] BuildPointerIndex(ref ReadableBuffer readBuffer, List<BufferHandle> handles)
         {
 
             byte*[] addresses = new byte*[readBuffer.Length];
@@ -514,9 +514,9 @@ namespace System.IO.Pipelines.Tests
 
                 {
                     // empty buffer
-                    var readable = output.AsReadableBuffer() as ISequence<ReadOnlyMemory<byte>>;
+                    var readable = output.AsReadableBuffer() as ISequence<ReadOnlyBuffer<byte>>;
                     var position = Position.First;
-                    ReadOnlyMemory<byte> memory;
+                    ReadOnlyBuffer<byte> memory;
                     int spanCount = 0;
                     while (readable.TryGet(ref position, out memory))
                     {
@@ -527,9 +527,9 @@ namespace System.IO.Pipelines.Tests
                 }
 
                 {
-                    var readable = BufferUtilities.CreateBuffer(new byte[] { 1 }, new byte[] { 2, 2 }, new byte[] { 3, 3, 3 }) as ISequence<ReadOnlyMemory<byte>>;
+                    var readable = BufferUtilities.CreateBuffer(new byte[] { 1 }, new byte[] { 2, 2 }, new byte[] { 3, 3, 3 }) as ISequence<ReadOnlyBuffer<byte>>;
                     var position = Position.First;
-                    ReadOnlyMemory<byte> memory;
+                    ReadOnlyBuffer<byte> memory;
                     int spanCount = 0;
                     while (readable.TryGet(ref position, out memory))
                     {

--- a/tests/System.IO.Pipelines.Tests/UnownedBufferReaderFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/UnownedBufferReaderFacts.cs
@@ -3,8 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Buffers.Pools;
-using System.IO;
+using System.Buffers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -269,7 +268,7 @@ namespace System.IO.Pipelines.Tests
 
             var reader = stream.AsPipelineReader();
 
-            var data = Memory<byte>.Empty;
+            var data = Buffer<byte>.Empty;
 
             while (true)
             {
@@ -558,7 +557,7 @@ namespace System.IO.Pipelines.Tests
 
         private class StreamAndPipeReader : Stream, IPipeReader
         {
-            private readonly Pipe _pipe = new Pipe(ManagedBufferPool.Shared);
+            private readonly Pipe _pipe = new Pipe(BufferPool.Default);
 
             public override bool CanRead => true;
 

--- a/tests/System.IO.Pipelines.Tests/WritableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/WritableBufferFacts.cs
@@ -66,7 +66,7 @@ namespace System.IO.Pipelines.Tests
 
                 var output = pipe.Writer.Alloc();
                 output.Write(data);
-                var foo = output.Memory.IsEmpty; // trying to see if .Memory breaks
+                var foo = output.Buffer.IsEmpty; // trying to see if .Memory breaks
                 await output.FlushAsync();
                 pipe.Writer.Complete();
 
@@ -101,7 +101,7 @@ namespace System.IO.Pipelines.Tests
 
                 var output = pipe.Writer.Alloc();
                 output.Append(data, TextEncoder.Utf8);
-                var foo = output.Memory.IsEmpty; // trying to see if .Memory breaks
+                var foo = output.Buffer.IsEmpty; // trying to see if .Memory breaks
                 await output.FlushAsync();
                 pipe.Writer.Complete();
 
@@ -136,7 +136,7 @@ namespace System.IO.Pipelines.Tests
 
                 var output = pipe.Writer.Alloc();
                 output.Append(data, TextEncoder.Utf8);
-                var foo = output.Memory.IsEmpty; // trying to see if .Memory breaks
+                var foo = output.Buffer.IsEmpty; // trying to see if .Memory breaks
                 await output.FlushAsync();
                 pipe.Writer.Complete();
 

--- a/tests/System.Text.Formatting.Tests/SequenceFormatterTests.cs
+++ b/tests/System.Text.Formatting.Tests/SequenceFormatterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
 using System.Collections.Sequences;
 using Xunit;
 
@@ -11,7 +12,7 @@ namespace System.Text.Formatting.Tests
         [Fact]
         public void SequenceFormatterBasics()
         {
-            var list = new ArrayList<Memory<byte>>();
+            var list = new ArrayList<Buffer<byte>>();
             list.Add(new byte[10]);
             list.Add(new byte[10]);
             list.Add(new byte[10]);

--- a/tests/System.Text.Formatting.Tests/SequenceTests.cs
+++ b/tests/System.Text.Formatting.Tests/SequenceTests.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers;
 using System.Collections.Sequences;
 using System.Text.Utf8;
 using Xunit;
@@ -45,9 +47,9 @@ namespace System.Text.Parsing.Tests
             Assert.Equal(expectedConsumed, consumed);
         }
 
-        static ArrayList<ReadOnlyMemory<byte>> ToUtf8Buffers(params string[] segments)
+        static ArrayList<ReadOnlyBuffer<byte>> ToUtf8Buffers(params string[] segments)
         {
-            var buffers = new ArrayList<ReadOnlyMemory<byte>>();
+            var buffers = new ArrayList<ReadOnlyBuffer<byte>>();
             foreach (var segment in segments) {
                 buffers.Add(new Utf8String(segment).Bytes.ToArray());
             }


### PR DESCRIPTION
Renamed:
- Memory\<T\> to Buffer\<T\>
- ReadOnlyMemory\<T\> to ReadOnlyBuffer\<T\>
- MemoryHandle to BufferHandle
- OwnedMemory\<T\> to Memory\<T\>

Moved all the types to System.Buffers namespace
Move BufferPool to System.Buffers

Made the following types internal:
- OwnedArray\<T\>: use OwnedBuffer\<T\> cast and Create method to create buffers over T[] and ArraySegment\<T\>
- ManagedBufferPool: use BufferPool.Default

The names might not be final, but I think they move us closer to where we want to be