### PR TITLE
Some pipelines cleanup

### DIFF
--- a/src/System.IO.Pipelines.Extensions/System.IO.Pipelines.Extensions.csproj
+++ b/src/System.IO.Pipelines.Extensions/System.IO.Pipelines.Extensions.csproj
@@ -10,4 +10,7 @@
     <ProjectReference Include="..\System.Binary\System.Binary.csproj" />
     <ProjectReference Include="..\System.IO.Pipelines\System.IO.Pipelines.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
+  </ItemGroup>
 </Project>

--- a/src/System.IO.Pipelines.Networking.Libuv/UvThread.cs
+++ b/src/System.IO.Pipelines.Networking.Libuv/UvThread.cs
@@ -121,7 +121,14 @@ namespace System.IO.Pipelines.Networking.Libuv
 
                 _postHandle.Send();
 
-                _thread.Join();
+                // REVIEW: Make it configurable
+                if (!_thread.Join(5000))
+                {
+                    if (Thread.CurrentThread.ManagedThreadId == _thread.ManagedThreadId)
+                    {
+                        throw new InvalidOperationException("Can't unwind on the loop thread");
+                    }
+                }
 
                 // REVIEW: Can you restart the thread?
             }

--- a/src/System.IO.Pipelines/PipeOptions.cs
+++ b/src/System.IO.Pipelines/PipeOptions.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace System.IO.Pipelines
 {
     public class PipeOptions

--- a/src/System.IO.Pipelines/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/System.IO.Pipelines.csproj
@@ -11,7 +11,4 @@
     <ProjectReference Include="..\System.Buffers.Primitives\System.Buffers.Primitives.csproj" />
     <ProjectReference Include="..\System.Collections.Sequences\System.Collections.Sequences.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
-  </ItemGroup>
 </Project>

--- a/src/System.IO.Pipelines/Testing/BufferUtilities.cs
+++ b/src/System.IO.Pipelines/Testing/BufferUtilities.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
-using System.Linq;
 using System.Text;
 
 namespace System.IO.Pipelines.Testing
@@ -12,10 +11,11 @@ namespace System.IO.Pipelines.Testing
     {
         public static ReadableBuffer CreateBuffer(params byte[][] inputs)
         {
-            if (inputs == null || !inputs.Any())
+            if (inputs == null || inputs.Length == 0)
             {
                 throw new InvalidOperationException();
             }
+
             var i = 0;
 
             BufferSegment last = null;
@@ -55,12 +55,22 @@ namespace System.IO.Pipelines.Testing
 
         public static ReadableBuffer CreateBuffer(params string[] inputs)
         {
-            return CreateBuffer(inputs.Select(i => Encoding.UTF8.GetBytes(i)).ToArray());
+            var buffers = new byte[inputs.Length][];
+            for (int i = 0; i < inputs.Length; i++)
+            {
+                buffers[i] = Encoding.UTF8.GetBytes(inputs[i]);
+            }
+            return CreateBuffer(buffers);
         }
 
         public static ReadableBuffer CreateBuffer(params int[] inputs)
         {
-            return CreateBuffer(inputs.Select(i => new byte[i]).ToArray());
+            var buffers = new byte[inputs.Length][];
+            for (int i = 0; i < inputs.Length; i++)
+            {
+                buffers[i] = new byte[inputs[i]];
+            }
+            return CreateBuffer(buffers);
         }
     }
 }

--- a/tests/System.IO.Pipelines.Tests/SocketsFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/SocketsFacts.cs
@@ -224,7 +224,8 @@ namespace System.IO.Pipelines.Tests
             connection.Output.Complete();
             watch.Stop();
 
-            return Tuple.Create(sendCount, replyCount, (int)watch.ElapsedMilliseconds);
+            // Task.Run here so that we're not on the UV thread when we complete
+            return await Task.Run(() => Tuple.Create(sendCount, replyCount, (int)watch.ElapsedMilliseconds));
 
         }
 


### PR DESCRIPTION
- Remove System.Linq dependency
- Remove dependency on ValueTask in the core API
- Throw error from UvThread.Stop if we're blocking the
uv thread trying to unwind.
- Fix the SocketsFacts so we don't end up on the libuv
thread in the test after PingClient