### PR TITLE
Made UnsafeUtilities internal

### DIFF
--- a/src/System.Binary/System/Binary/UnsafeUtilities.cs
+++ b/src/System.Binary/System/Binary/UnsafeUtilities.cs
@@ -9,7 +9,7 @@ namespace System.Runtime
     /// A collection of unsafe helper methods that we cannot implement in C#.
     /// NOTE: these can be used for VeryBadThings(tm), so tread with care...
     /// </summary>
-    public static class UnsafeUtilities
+    internal static class UnsafeUtilities
     {
         /// <summary>
         /// Reverses a primitive value - performs an endianness swap


### PR DESCRIPTION
Now that all Read<T>/Write<T> methods are in System.Binary, we can make UnsafeUtilities internal