### PR TITLE
Rename IndexOf overloads to IndexOfAny

### DIFF
--- a/src/System.Buffers.Primitives/System/SpanExtensions.cs
+++ b/src/System.Buffers.Primitives/System/SpanExtensions.cs
@@ -43,19 +43,19 @@ namespace System
             return SequentialIndexOf(ref span.DangerousGetPinnableReference(), value, span.Length);
         }
 
-        public unsafe static int IndexOf(this Span<byte> buffer, byte value0, byte value1)
+        public unsafe static int IndexOfAny(this Span<byte> buffer, byte value0, byte value1)
         {
             fixed (byte* pSearchSpace = &buffer.DangerousGetPinnableReference())
             {
-                return IndexOf(pSearchSpace, buffer.Length, value0, value1);
+                return IndexOfAny(pSearchSpace, buffer.Length, value0, value1);
             }
         }
 
-        public unsafe static int IndexOf(this Span<byte> buffer, byte value0, byte value1, byte value2)
+        public unsafe static int IndexOfAny(this Span<byte> buffer, byte value0, byte value1, byte value2)
         {
             fixed (byte* pSearchSpace = &buffer.DangerousGetPinnableReference())
             {
-                return IndexOf(pSearchSpace, buffer.Length, value0, value1, value2);
+                return IndexOfAny(pSearchSpace, buffer.Length, value0, value1, value2);
             }
         }
 
@@ -64,19 +64,19 @@ namespace System
             return SequentialIndexOf(ref span.DangerousGetPinnableReference(), value, span.Length);
         }
 
-        public unsafe static int IndexOf(this ReadOnlySpan<byte> buffer, byte value0, byte value1)
+        public unsafe static int IndexOfAny(this ReadOnlySpan<byte> buffer, byte value0, byte value1)
         {
             fixed (byte* pSearchSpace = &buffer.DangerousGetPinnableReference())
             {
-                return IndexOf(pSearchSpace, buffer.Length, value0, value1);
+                return IndexOfAny(pSearchSpace, buffer.Length, value0, value1);
             }
         }
 
-        public unsafe static int IndexOf(this ReadOnlySpan<byte> buffer, byte value0, byte value1, byte value2)
+        public unsafe static int IndexOfAny(this ReadOnlySpan<byte> buffer, byte value0, byte value1, byte value2)
         {
             fixed (byte* pSearchSpace = &buffer.DangerousGetPinnableReference())
             {
-                return IndexOf(pSearchSpace, buffer.Length, value0, value1, value2);
+                return IndexOfAny(pSearchSpace, buffer.Length, value0, value1, value2);
             }
         }
 
@@ -153,7 +153,7 @@ namespace System
             return (int)(byte*)(index + 7);
         }
 
-        private static unsafe int IndexOf(byte* searchSpace, int length, byte value0, byte value1)
+        private static unsafe int IndexOfAny(byte* searchSpace, int length, byte value0, byte value1)
         {
             var offset = 0;
             // If length < vector length the jump over Vector dominates the search; as the Vector section is quite chunky
@@ -226,7 +226,7 @@ namespace System
             return offset;
         }
 
-        private static unsafe int IndexOf(byte* searchSpace, int length, byte value0, byte value1, byte value2)
+        private static unsafe int IndexOfAny(byte* searchSpace, int length, byte value0, byte value1, byte value2)
         {
             var offset = 0;
             // If length < vector length the jump over Vector dominates the search; as the Vector section is quite chunky

--- a/src/System.IO.Pipelines/ReadCursorOperations.cs
+++ b/src/System.IO.Pipelines/ReadCursorOperations.cs
@@ -38,7 +38,7 @@ namespace System.IO.Pipelines
                 var segment = segmentPart.Segment;
                 var span = segment.Buffer.Span.Slice(segmentPart.Start, segmentPart.Length);
 
-                int index = span.IndexOf(byte0, byte1);
+                int index = span.IndexOfAny(byte0, byte1);
 
                 if (index != -1)
                 {
@@ -60,7 +60,7 @@ namespace System.IO.Pipelines
                 var segment = segmentPart.Segment;
                 var span = segment.Buffer.Span.Slice(segmentPart.Start, segmentPart.Length);
 
-                int index = span.IndexOf(byte0, byte1, byte2);
+                int index = span.IndexOfAny(byte0, byte1, byte2);
 
                 if (index != -1)
                 {


### PR DESCRIPTION
To reflect what they do more correctly

Resolves https://github.com/dotnet/corefxlab/issues/1352

/cc @ahsonkhan 