### PR TITLE
fixes a build break

### DIFF
--- a/src/System.Text.Json/System/Text/Json/JsonParser.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonParser.cs
@@ -398,7 +398,7 @@ namespace System.Text.Json
 
         private void ParseLiteral(JsonObject.JsonValueType literal, ReadOnlySpan<byte> expected)
         {
-            if (!_values.Slice(_valuesIndex).StartsWith(expected)) {
+            if (!System.SpanExtensions.StartsWith(_values.Slice(_valuesIndex), expected)) {
                 throw new FormatException("Invalid json, tried to read " + literal.ToString());
             }
             AppendDbRow(literal, _valuesIndex, expected.Length);


### PR DESCRIPTION
Somehow we got to a place where we have StartsWith(this ReadOnlySpan\<byte\>, ReadOnlySpan\<byte\>); in both SpanExtensions and SpanExtensionsLabs.

I think @ahsonkhan's PR will fix it, but it needs to be resolved.