### PR TITLE
Adding extension method Slice on string which returns ReadOnlySpan<char>

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -23,6 +23,84 @@ namespace System.Buffers
             return array.Items.Slice(0, array.Count);
         }
 
+        /// <summary>
+        /// Creates a new readonly span over the portion of the target string.
+        /// </summary>
+        /// <param name="text">The target string.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="text"/> is null.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe ReadOnlySpan<char> Slice(this string text)
+        {
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+
+            int textLength = text.Length;
+
+            if (textLength == 0) return ReadOnlySpan<char>.Empty;
+
+            fixed (char* charPointer = text)
+            {
+                return ReadOnlySpan<char>.DangerousCreate(text, ref *charPointer, textLength);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new readonly span over the portion of the target string, beginning at 'start'.
+        /// </summary>
+        /// <param name="text">The target string.</param>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="text"/> is null.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;Length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe ReadOnlySpan<char> Slice(this string text, int start)
+        {
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+
+            int textLength = text.Length;
+
+            if ((uint) start > (uint) textLength)
+                throw new ArgumentOutOfRangeException(nameof(start));
+
+            if (textLength == 0) return ReadOnlySpan<char>.Empty;
+
+            fixed (char* charPointer = text)
+            {
+                return ReadOnlySpan<char>.DangerousCreate(text, ref *(charPointer + start), textLength - start);
+            }
+        }
+
+        /// <summary>
+        /// Creates a new readonly span over the portion of the target string, beginning at <paramref name="start"/>, of given <paramref name="length"/>.
+        /// </summary>
+        /// <param name="text">The target string.</param>
+        /// <param name="start">The index at which to begin this slice.</param>
+        /// <param name="length">The number of items in the span.</param>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="text"/> is null.</exception>
+        /// <exception cref="System.ArgumentOutOfRangeException">
+        /// Thrown when the specified <paramref name="start"/> or end index is not in range (&lt;0 or &gt;=Length).
+        /// </exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe ReadOnlySpan<char> Slice(this string text, int start, int length)
+        {
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+
+            int textLength = text.Length;
+
+            if ((uint)start > (uint)textLength || (uint)length > (uint)(textLength - start))
+                throw new ArgumentOutOfRangeException(nameof(start));
+
+            if (length == 0) return ReadOnlySpan<char>.Empty;
+
+            fixed (char* charPointer = text)
+            {
+                return ReadOnlySpan<char>.DangerousCreate(text, ref *(charPointer + start), length);
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int IndexOf(this IReadOnlyBufferList<byte> sequence, ReadOnlySpan<byte> value)
         {

--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -64,7 +64,7 @@ namespace System.Buffers
             if ((uint) start > (uint) textLength)
                 throw new ArgumentOutOfRangeException(nameof(start));
 
-            if (textLength == 0) return ReadOnlySpan<char>.Empty;
+            if (textLength - start == 0) return ReadOnlySpan<char>.Empty;
 
             fixed (char* charPointer = text)
             {

--- a/tests/System.Buffers.Experimental.Tests/StringSliceTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/StringSliceTests.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using System.Runtime.CompilerServices;
+
+namespace System.Slices.Tests
+{
+    public partial class StringSliceTests
+    {
+        [Fact]
+        public static void StringSliceNullary()
+        {
+            string s = "Hello";
+            ReadOnlySpan<char> span = s.Slice();
+            char[] expected = s.ToCharArray();
+            span.Validate(expected);
+        }
+
+        [Fact]
+        public static void StringSliceInt()
+        {
+            string s = "Goodbye";
+            ReadOnlySpan<char> span = s.Slice(2);
+            char[] expected = s.Substring(2).ToCharArray();
+            span.Validate(expected);
+        }
+
+        [Fact]
+        public static void StringSliceIntPastEnd()
+        {
+            string s = "Hello";
+            ReadOnlySpan<char> span = s.Slice(s.Length);
+            Assert.Equal(0, span.Length);
+        }
+
+        [Fact]
+        public static void StringSliceIntInt()
+        {
+            string s = "Goodbye";
+            ReadOnlySpan<char> span = s.Slice(2, 4);
+            char[] expected = s.Substring(2, 4).ToCharArray();
+            span.Validate(expected);
+        }
+
+        [Fact]
+        public static void StringSliceIntIntUpToEnd()
+        {
+            string s = "Goodbye";
+            ReadOnlySpan<char> span = s.Slice(2, s.Length - 2);
+            char[] expected = s.Substring(2).ToCharArray();
+            span.Validate(expected);
+        }
+
+        [Fact]
+        public static void StringSliceIntIntPastEnd()
+        {
+            string s = "Hello";
+            ReadOnlySpan<char> span = s.Slice(s.Length, 0);
+            Assert.Equal(0, span.Length);
+        }
+
+        [Fact]
+        public static void StringSliceNullChecked()
+        {
+            string s = null;
+            Assert.Throws<ArgumentNullException>(() => s.Slice().DontBox());
+            Assert.Throws<ArgumentNullException>(() => s.Slice(0).DontBox());
+            Assert.Throws<ArgumentNullException>(() => s.Slice(0, 0).DontBox());
+        }
+
+        [Fact]
+        public static void StringSliceIntRangeChecked()
+        {
+            string s = "Hello";
+            Assert.Throws<ArgumentOutOfRangeException>(() => s.Slice(-1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => s.Slice(s.Length + 1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => s.Slice(-1, 0).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => s.Slice(0, s.Length + 1).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => s.Slice(2, s.Length + 1 - 2).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => s.Slice(s.Length + 1, 0).DontBox());
+            Assert.Throws<ArgumentOutOfRangeException>(() => s.Slice(s.Length, 1).DontBox());
+        }
+    }
+}

--- a/tests/System.Buffers.Experimental.Tests/TestHelpers.cs
+++ b/tests/System.Buffers.Experimental.Tests/TestHelpers.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System.Runtime.InteropServices;
+
+namespace System.Slices.Tests
+{
+    public static partial class StringSliceTests
+    {
+        private static void Validate<T>(this ReadOnlySpan<T> span, params T[] expected)
+        {
+            bool isValueType = default(T) != null || Nullable.GetUnderlyingType(typeof(T)) != null;
+            Assert.Equal(span.Length, expected.Length);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                T actual = span[i];
+                if (isValueType)
+                    Assert.Equal(expected[i], actual);
+                else
+                    Assert.Same(expected[i], actual);
+            }
+
+            object ignore;
+            AssertThrows<IndexOutOfRangeException, T>(span, (_span) => ignore = _span[expected.Length]);
+        }
+
+        private delegate void AssertThrowsAction<T>(ReadOnlySpan<T> span);
+
+        // Cannot use standard Assert.Throws() when testing Span - Span and closures don't get along.
+        private static void AssertThrows<E, T>(ReadOnlySpan<T> span, AssertThrowsAction<T> action) where E:Exception
+        {
+            try
+            {
+                action(span);
+                Assert.False(true, "Expected exception: " + typeof(E).GetType());
+            }
+            catch (E)
+            {
+            }
+            catch (Exception wrongException)
+            {
+                Assert.False(true, "Wrong exception thrown: Expected " + typeof(E).GetType() + ": Actual: " + wrongException.GetType());
+            }
+        }
+
+        // 
+        // The innocent looking construct:
+        //
+        //    Assert.Throws<E>( () => new Span() );
+        //
+        // generates a hidden box of the Span as the return value of the lambda. This makes the IL illegal and unloadable on 
+        // runtimes that enforce the actual Span rules (never mind that we expect never to reach the box instruction...)
+        //
+        // The workaround is to code it like this:
+        //
+        //    Assert.Throws<E>( () => new Span().DontBox() );
+        // 
+        // which turns the lambda return type back to "void" and eliminates the troublesome box instruction.
+        //
+        private static void DontBox<T>(this ReadOnlySpan<T> span)
+        {
+            // This space intentionally left blank.
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private sealed class TestClass
+        {
+            private double _d;
+            public char C0;
+            public char C1;
+            public char C2;
+            public char C3;
+            public char C4;
+        }
+    }
+}
+


### PR DESCRIPTION
Moving over from System.Memory.dll as part of #1314 / #1292.

Removed here: https://github.com/dotnet/corefx/pull/17407

