### PR TITLE
Expand locking in GetResult methods

### DIFF
--- a/src/System.IO.Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/Pipe.cs
@@ -557,14 +557,17 @@ namespace System.IO.Pipelines
 
         ReadResult IReadableBufferAwaiter.GetResult()
         {
-            GetResult(ref _readerAwaitable,
-                ref _writerCompletion,
-                out bool isCancelled,
-                out bool isCompleted);
+            bool isCancelled;
+            bool isCompleted;
 
             ReadableBuffer buffer;
             lock (_sync)
             {
+                GetResult(ref _readerAwaitable,
+                    ref _writerCompletion,
+                    out isCancelled,
+                    out isCompleted);
+
                 ReadCursor readEnd;
                 // No need to read end if there is no head
                 var head = _readHead;
@@ -592,11 +595,14 @@ namespace System.IO.Pipelines
 
         FlushResult IWritableBufferAwaiter.GetResult()
         {
-            GetResult(ref _writerAwaitable,
-                ref _readerCompletion,
-                out bool isCancelled,
-                out bool isCompleted);
-            return new FlushResult(isCancelled, isCompleted);
+            lock (_sync)
+            {
+                GetResult(ref _writerAwaitable,
+                    ref _readerCompletion,
+                    out bool isCancelled,
+                    out bool isCompleted);
+                return new FlushResult(isCancelled, isCompleted);
+            }
         }
 
         void IWritableBufferAwaiter.OnCompleted(Action continuation)


### PR DESCRIPTION
`GetResult` calls `ObserveCancellation` that modifies state. Decreases performance but we need it.

Before:
```
                  Method |        Mean |    StdErr |     StdDev |          RPS |
------------------------ |------------ |---------- |----------- |------------- |
 ParseLiveAspNetTwoTasks | 291.2868 ns | 2.0583 ns | 11.2738 ns | 3,433,043.01 |
   ParseLiveAspNetInline | 204.2358 ns | 2.8546 ns | 15.6355 ns | 4,896,300.75 |

```

After:

```
                  Method |        Mean |    StdErr |     StdDev |          RPS |
------------------------ |------------ |---------- |----------- |------------- |
 ParseLiveAspNetTwoTasks | 326.4556 ns | 3.3105 ns | 18.1321 ns | 3,063,203.49 |
   ParseLiveAspNetInline | 237.0526 ns | 3.8329 ns | 20.9937 ns | 4,218,472.53 |
```

@davidfowl 