### PR TITLE
Improve Pipe throughput

### DIFF
--- a/src/System.IO.Pipelines/FlushResult.cs
+++ b/src/System.IO.Pipelines/FlushResult.cs
@@ -5,20 +5,16 @@ namespace System.IO.Pipelines
 {
     public struct FlushResult
     {
-        public FlushResult(bool isCancelled, bool isCompleted)
-        {
-            IsCancelled = isCancelled;
-            IsCompleted = isCompleted;
-        }
+        internal ResultFlags ResultFlags;
 
         /// <summary>
         /// True if the currrent flush was cancelled
         /// </summary>
-        public bool IsCancelled { get; }
+        public bool IsCancelled => (ResultFlags & ResultFlags.Cancelled) > 0;
 
         /// <summary>
         /// True if the <see cref="IPipeWriter"/> is complete
         /// </summary>
-        public bool IsCompleted { get; }
+        public bool IsCompleted => (ResultFlags & ResultFlags.Completed) > 0;
     }
 }

--- a/src/System.IO.Pipelines/FlushResult.cs
+++ b/src/System.IO.Pipelines/FlushResult.cs
@@ -10,11 +10,11 @@ namespace System.IO.Pipelines
         /// <summary>
         /// True if the currrent flush was cancelled
         /// </summary>
-        public bool IsCancelled => (ResultFlags & ResultFlags.Cancelled) > 0;
+        public bool IsCancelled => (ResultFlags & ResultFlags.Cancelled) != 0;
 
         /// <summary>
         /// True if the <see cref="IPipeWriter"/> is complete
         /// </summary>
-        public bool IsCompleted => (ResultFlags & ResultFlags.Completed) > 0;
+        public bool IsCompleted => (ResultFlags & ResultFlags.Completed) != 0;
     }
 }

--- a/src/System.IO.Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/Pipe.cs
@@ -575,11 +575,13 @@ namespace System.IO.Pipelines
                     result.ResultBuffer.BufferEnd.Segment = _commitHead;
                     result.ResultBuffer.BufferEnd.Index = _commitHeadIndex;
                     result.ResultBuffer.BufferLength = ReadCursor.GetLength(head, head.Start, _commitHead, _commitHeadIndex);
+
+                    result.ResultBuffer.BufferStart.Segment = head;
+                    result.ResultBuffer.BufferStart.Index = head.Start;
                 }
 
                 _readingState.Begin(ExceptionResource.AlreadyReading);
 
-                result.ResultBuffer.BufferStart.Segment = head;
             }
             return result;
         }

--- a/src/System.IO.Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/Pipe.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace System.IO.Pipelines
 {
@@ -290,6 +291,7 @@ namespace System.IO.Pipelines
             _writingHead = null;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void AdvanceWriter(int bytesWritten)
         {
             EnsureAlloc();
@@ -393,9 +395,9 @@ namespace System.IO.Pipelines
             int consumedBytes = 0;
             if (!consumed.IsDefault)
             {
-                consumedBytes = new ReadCursor(_readHead).GetLength(consumed);
-
                 returnStart = _readHead;
+                consumedBytes = ReadCursor.GetLength(returnStart, returnStart.Start, consumed.Segment, consumed.Index);
+
                 returnEnd = consumed.Segment;
                 _readHead = consumed.Segment;
                 _readHead.Start = consumed.Index;
@@ -501,22 +503,6 @@ namespace System.IO.Pipelines
             return new ReadableBufferAwaitable(this);
         }
 
-        private static void GetResult(ref PipeAwaitable awaitableState,
-            ref PipeCompletion completion,
-            out bool isCancelled,
-            out bool isCompleted)
-        {
-            if (!awaitableState.IsCompleted)
-            {
-                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.GetResultNotCompleted);
-            }
-
-            // Change the state from to be cancelled -> observed
-            isCancelled = awaitableState.ObserveCancelation();
-            isCompleted = completion.IsCompleted;
-            completion.ThrowIfFailed();
-        }
-
         private static void TrySchedule(IScheduler scheduler, Action action)
         {
             if (action != null)
@@ -563,36 +549,39 @@ namespace System.IO.Pipelines
 
         ReadResult IReadableBufferAwaiter.GetResult()
         {
-            bool isCancelled;
-            bool isCompleted;
+            if (!_readerAwaitable.IsCompleted)
+            {
+                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.GetResultNotCompleted);
+            }
 
-            ReadableBuffer buffer;
+            var result = new ReadResult();
             lock (_sync)
             {
-                GetResult(ref _readerAwaitable,
-                    ref _writerCompletion,
-                    out isCancelled,
-                    out isCompleted);
+                if (_writerCompletion.IsCompletedOrThrow())
+                {
+                    result.ResultFlags |= ResultFlags.Completed;
+                }
 
-                ReadCursor readEnd;
+                if (_readerAwaitable.ObserveCancelation())
+                {
+                    result.ResultFlags |= ResultFlags.Cancelled;
+                }
+
                 // No need to read end if there is no head
                 var head = _readHead;
-                if (head == null)
-                {
-                    readEnd = new ReadCursor(null);
-                }
-                else
+                if (head != null)
                 {
                     // Reading commit head shared with writer
-                    readEnd = new ReadCursor(_commitHead, _commitHeadIndex);
+                    result.ResultBuffer.BufferEnd.Segment = _commitHead;
+                    result.ResultBuffer.BufferEnd.Index = _commitHeadIndex;
+                    result.ResultBuffer.BufferLength = ReadCursor.GetLength(head, head.Start, _commitHead, _commitHeadIndex);
                 }
 
                 _readingState.Begin(ExceptionResource.AlreadyReading);
 
-                buffer = new ReadableBuffer(new ReadCursor(head), readEnd);
+                result.ResultBuffer.BufferStart.Segment = head;
             }
-
-            return new ReadResult(buffer, isCancelled, isCompleted);
+            return result;
         }
 
         // IWritableBufferAwaiter members
@@ -601,14 +590,25 @@ namespace System.IO.Pipelines
 
         FlushResult IWritableBufferAwaiter.GetResult()
         {
+            var result = new FlushResult();
             lock (_sync)
             {
-                GetResult(ref _writerAwaitable,
-                    ref _readerCompletion,
-                    out bool isCancelled,
-                    out bool isCompleted);
-                return new FlushResult(isCancelled, isCompleted);
+                if (!_writerAwaitable.IsCompleted)
+                {
+                    ThrowHelper.ThrowInvalidOperationException(ExceptionResource.GetResultNotCompleted);
+                }
+
+                // Change the state from to be cancelled -> observed
+                if (_writerAwaitable.ObserveCancelation())
+                {
+                    result.ResultFlags |= ResultFlags.Cancelled;
+                }
+                if (_readerCompletion.IsCompletedOrThrow())
+                {
+                    result.ResultFlags |= ResultFlags.Completed;
+                }
             }
+            return result;
         }
 
         void IWritableBufferAwaiter.OnCompleted(Action continuation)

--- a/src/System.IO.Pipelines/PipeAwaitable.cs
+++ b/src/System.IO.Pipelines/PipeAwaitable.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,6 +21,7 @@ namespace System.IO.Pipelines
             _state = completed ? _awaitableIsCompleted : _awaitableIsNotCompleted;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Action Complete()
         {
             var awaitableState = _state;
@@ -33,6 +35,7 @@ namespace System.IO.Pipelines
             return null;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Reset()
         {
             if (_state == _awaitableIsCompleted &&
@@ -81,6 +84,7 @@ namespace System.IO.Pipelines
             return Complete();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool ObserveCancelation()
         {
             if (_cancelledState == CancelledState.CancellationRequested)

--- a/src/System.IO.Pipelines/PipeCompletion.cs
+++ b/src/System.IO.Pipelines/PipeCompletion.cs
@@ -25,12 +25,17 @@ namespace System.IO.Pipelines
             Interlocked.CompareExchange(ref _exception, exception ?? _completedNoException, null);
         }
 
-        public void ThrowIfFailed()
+        public bool IsCompletedOrThrow()
         {
-            if (_exception != null && _exception != _completedNoException)
+            if (_exception != null)
             {
-                ThrowFailed();
+                if (_exception != _completedNoException)
+                {
+                    ThrowFailed();
+                }
+                return true;
             }
+            return false;
         }
 
         private void ThrowFailed()

--- a/src/System.IO.Pipelines/ReadCursor.cs
+++ b/src/System.IO.Pipelines/ReadCursor.cs
@@ -9,39 +9,35 @@ namespace System.IO.Pipelines
 {
     public struct ReadCursor : IEquatable<ReadCursor>
     {
-        private BufferSegment _segment;
-        private int _index;
+        internal BufferSegment Segment;
+        internal int Index;
 
         internal ReadCursor(BufferSegment segment)
         {
-            _segment = segment;
-            _index = segment?.Start ?? 0;
+            Segment = segment;
+            Index = segment?.Start ?? 0;
         }
 
         internal ReadCursor(BufferSegment segment, int index)
         {
-            _segment = segment;
-            _index = index;
+            Segment = segment;
+            Index = index;
         }
 
-        internal BufferSegment Segment => _segment;
-
-        internal int Index => _index;
-
-        internal bool IsDefault => _segment == null;
+        internal bool IsDefault => Segment == null;
 
         internal bool IsEnd
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                var segment = _segment;
+                var segment = Segment;
 
                 if (segment == null)
                 {
                     return true;
                 }
-                else if (_index < segment.End)
+                else if (Index < segment.End)
                 {
                     return false;
                 }
@@ -59,7 +55,7 @@ namespace System.IO.Pipelines
         [MethodImpl(MethodImplOptions.NoInlining)]
         private bool IsEndMultiSegment()
         {
-            var segment = _segment.Next;
+            var segment = Segment.Next;
             while (segment != null)
             {
                 if (segment.Start < segment.End)
@@ -78,28 +74,41 @@ namespace System.IO.Pipelines
             {
                 return 0;
             }
+            return GetLength(Segment, Index, end.Segment, end.Index);
+        }
 
-            if (_segment == end._segment)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int GetLength(
+            BufferSegment start,
+            int startIndex,
+            BufferSegment endSegment,
+            int endIndex)
+        {
+
+            if (start == endSegment)
             {
-                return end.Index - _index;
+                return endIndex - startIndex;
             }
 
-            return GetLengthMultiSegment(end);
+            return GetLengthMultiSegment(start, startIndex, endSegment, endIndex);
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private int GetLengthMultiSegment(ReadCursor end)
+        private static int GetLengthMultiSegment(BufferSegment start,
+            int startIndex,
+            BufferSegment endSegment,
+            int endIndex)
         {
-            var segment = _segment;
-            var index = _index;
+            var segment = start;
+            var index = startIndex;
             var length = 0;
             checked
             {
                 while (true)
                 {
-                    if (segment == end._segment)
+                    if (segment == endSegment)
                     {
-                        return length + end._index - index;
+                        return length + endIndex - index;
                     }
                     else if (segment.Next == null)
                     {
@@ -124,9 +133,9 @@ namespace System.IO.Pipelines
             }
 
             ReadCursor cursor;
-            if (_segment == end._segment && end._index - _index >= bytes)
+            if (Segment == end.Segment && end.Index - Index >= bytes)
             {
-                cursor = new ReadCursor(Segment, _index + bytes);
+                cursor = new ReadCursor(Segment, Index + bytes);
             }
             else
             {
@@ -195,8 +204,8 @@ namespace System.IO.Pipelines
                 return false;
             }
 
-            var segment = _segment;
-            var index = _index;
+            var segment = Segment;
+            var index = Index;
 
             if (end.Segment == segment)
             {
@@ -219,8 +228,8 @@ namespace System.IO.Pipelines
 
         private bool TryGetBufferMultiBlock(ReadCursor end, out Buffer<byte> data)
         {
-            var segment = _segment;
-            var index = _index;
+            var segment = Segment;
+            var index = Index;
 
             // Determine if we might attempt to copy data from segment.Next before
             // calculating "following" so we don't risk skipping data that could
@@ -288,7 +297,7 @@ namespace System.IO.Pipelines
 
         public bool Equals(ReadCursor other)
         {
-            return other._segment == _segment && other._index == _index;
+            return other.Segment == Segment && other.Index == Index;
         }
 
         public override bool Equals(object obj)
@@ -298,8 +307,8 @@ namespace System.IO.Pipelines
 
         public override int GetHashCode()
         {
-            var h1 = _segment?.GetHashCode() ?? 0;
-            var h2 = _index.GetHashCode();
+            var h1 = Segment?.GetHashCode() ?? 0;
+            var h2 = Index.GetHashCode();
 
             var shift5 = ((uint)h1 << 5) | ((uint)h1 >> 27);
             return ((int)shift5 + h1) ^ h2;
@@ -307,19 +316,19 @@ namespace System.IO.Pipelines
 
         internal bool GreaterOrEqual(ReadCursor other)
         {
-            if (other._segment == _segment)
+            if (other.Segment == Segment)
             {
-                return other._index <= _index;
+                return other.Index <= Index;
             }
             return IsReachable(other);
         }
 
         internal bool IsReachable(ReadCursor other)
         {
-            var current = other._segment;
+            var current = other.Segment;
             while (current != null)
             {
-                if (current == _segment)
+                if (current == Segment)
                 {
                     return true;
                 }

--- a/src/System.IO.Pipelines/ReadCursor.cs
+++ b/src/System.IO.Pipelines/ReadCursor.cs
@@ -84,7 +84,6 @@ namespace System.IO.Pipelines
             BufferSegment endSegment,
             int endIndex)
         {
-
             if (start == endSegment)
             {
                 return endIndex - startIndex;

--- a/src/System.IO.Pipelines/ReadResult.cs
+++ b/src/System.IO.Pipelines/ReadResult.cs
@@ -34,11 +34,11 @@ namespace System.IO.Pipelines
         /// <summary>
         /// True if the currrent read was cancelled
         /// </summary>
-        public bool IsCancelled => (ResultFlags & ResultFlags.Cancelled) > 0;
+        public bool IsCancelled => (ResultFlags & ResultFlags.Cancelled) != 0;
 
         /// <summary>
         /// True if the <see cref="IPipeReader"/> is complete
         /// </summary>
-        public bool IsCompleted => (ResultFlags & ResultFlags.Completed) > 0;
+        public bool IsCompleted => (ResultFlags & ResultFlags.Completed) != 0;
     }
 }

--- a/src/System.IO.Pipelines/ReadResult.cs
+++ b/src/System.IO.Pipelines/ReadResult.cs
@@ -8,26 +8,37 @@ namespace System.IO.Pipelines
     /// </summary>
     public struct ReadResult
     {
+        internal ReadableBuffer ResultBuffer;
+        internal ResultFlags ResultFlags;
+
         public ReadResult(ReadableBuffer buffer, bool isCancelled, bool isCompleted)
         {
-            Buffer = buffer;
-            IsCancelled = isCancelled;
-            IsCompleted = isCompleted;
+            ResultBuffer = buffer;
+            ResultFlags = ResultFlags.None;
+
+            if (isCompleted)
+            {
+                ResultFlags |= ResultFlags.Completed;
+            }
+            if (isCancelled)
+            {
+                ResultFlags |= ResultFlags.Cancelled;
+            }
         }
 
         /// <summary>
         /// The <see cref="ReadableBuffer"/> that was read
         /// </summary>
-        public ReadableBuffer Buffer { get; }
+        public ReadableBuffer Buffer => ResultBuffer;
 
         /// <summary>
         /// True if the currrent read was cancelled
         /// </summary>
-        public bool IsCancelled { get; }
+        public bool IsCancelled => (ResultFlags & ResultFlags.Cancelled) > 0;
 
         /// <summary>
         /// True if the <see cref="IPipeReader"/> is complete
         /// </summary>
-        public bool IsCompleted { get; }
+        public bool IsCompleted => (ResultFlags & ResultFlags.Completed) > 0;
     }
 }

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -12,56 +12,55 @@ namespace System.IO.Pipelines
     /// </summary>
     public struct ReadableBuffer : ISequence<ReadOnlyBuffer<byte>>
     {
-        private ReadCursor _start;
-        private ReadCursor _end;
-        private int _length;
+        internal ReadCursor BufferStart;
+        internal ReadCursor BufferEnd;
+        internal int BufferLength;
 
         /// <summary>
         /// Length of the <see cref="ReadableBuffer"/> in bytes.
         /// </summary>
-        public int Length => _length;
+        public int Length => BufferLength;
 
         /// <summary>
         /// Determines if the <see cref="ReadableBuffer"/> is empty.
         /// </summary>
-        public bool IsEmpty => _length == 0;
+        public bool IsEmpty => BufferLength == 0;
 
         /// <summary>
         /// Determins if the <see cref="ReadableBuffer"/> is a single <see cref="Buffer{Byte}"/>.
         /// </summary>
-        public bool IsSingleSpan => _start.Segment == _end.Segment;
+        public bool IsSingleSpan => BufferStart.Segment == BufferEnd.Segment;
 
         public Buffer<byte> First
         {
             get
             {
-                _start.TryGetBuffer(_end, out Buffer<byte> first);
+                BufferStart.TryGetBuffer(BufferEnd, out Buffer<byte> first);
                 return first;
             }
         }
-        
+
         /// <summary>
         /// A cursor to the start of the <see cref="ReadableBuffer"/>.
         /// </summary>
-        public ReadCursor Start => _start;
+        public ReadCursor Start => BufferStart;
 
         /// <summary>
         /// A cursor to the end of the <see cref="ReadableBuffer"/>
         /// </summary>
-        public ReadCursor End => _end;
+        public ReadCursor End => BufferEnd;
 
         internal ReadableBuffer(ReadCursor start, ReadCursor end)
         {
-            _start = start;
-            _end = end;
-            _length = start.GetLength(end);
-
+            BufferStart = start;
+            BufferEnd = end;
+            BufferLength = start.GetLength(end);
         }
 
         private ReadableBuffer(ref ReadableBuffer buffer)
         {
-            var begin = buffer._start;
-            var end = buffer._end;
+            var begin = buffer.BufferStart;
+            var end = buffer.BufferEnd;
 
             BufferSegment segmentTail;
             var segmentHead = BufferSegment.Clone(begin, end, out segmentTail);
@@ -69,10 +68,10 @@ namespace System.IO.Pipelines
             begin = new ReadCursor(segmentHead);
             end = new ReadCursor(segmentTail, segmentTail.End);
 
-            _start = begin;
-            _end = end;
+            BufferStart = begin;
+            BufferEnd = end;
 
-            _length = buffer._length;
+            BufferLength = buffer.BufferLength;
         }
 
         /// <summary>
@@ -82,8 +81,8 @@ namespace System.IO.Pipelines
         /// <param name="length">The length of the slice</param>
         public ReadableBuffer Slice(int start, int length)
         {
-            var begin = _start.Seek(start, _end, false);
-            var end = begin.Seek(length, _end, false);
+            var begin = BufferStart.Seek(start, BufferEnd, false);
+            var end = begin.Seek(length, BufferEnd, false);
             return Slice(begin, end);
         }
 
@@ -94,8 +93,8 @@ namespace System.IO.Pipelines
         /// <param name="end">The end (inclusive) of the slice</param>
         public ReadableBuffer Slice(int start, ReadCursor end)
         {
-            _end.BoundsCheck(end);
-            var begin = _start.Seek(start, end);
+            BufferEnd.BoundsCheck(end);
+            var begin = BufferStart.Seek(start, end);
             return Slice(begin, end);
         }
 
@@ -106,7 +105,7 @@ namespace System.IO.Pipelines
         /// <param name="end">The ending (inclusive) <see cref="ReadCursor"/> of the slice</param>
         public ReadableBuffer Slice(ReadCursor start, ReadCursor end)
         {
-            _end.BoundsCheck(end);
+            BufferEnd.BoundsCheck(end);
             end.BoundsCheck(start);
 
             return new ReadableBuffer(start, end);
@@ -119,9 +118,9 @@ namespace System.IO.Pipelines
         /// <param name="length">The length of the slice</param>
         public ReadableBuffer Slice(ReadCursor start, int length)
         {
-            _end.BoundsCheck(start);
+            BufferEnd.BoundsCheck(start);
 
-            var end = start.Seek(length, _end, false);
+            var end = start.Seek(length, BufferEnd, false);
 
             return Slice(start, end);
         }
@@ -132,9 +131,9 @@ namespace System.IO.Pipelines
         /// <param name="start">The starting (inclusive) <see cref="ReadCursor"/> at which to begin this slice.</param>
         public ReadableBuffer Slice(ReadCursor start)
         {
-            _end.BoundsCheck(start);
+            BufferEnd.BoundsCheck(start);
 
-            return new ReadableBuffer(start, _end);
+            return new ReadableBuffer(start, BufferEnd);
         }
 
         /// <summary>
@@ -145,8 +144,8 @@ namespace System.IO.Pipelines
         {
             if (start == 0) return this;
 
-            var begin = _start.Seek(start, _end, false);
-            return new ReadableBuffer(begin, _end);
+            var begin = BufferStart.Seek(start, BufferEnd, false);
+            return new ReadableBuffer(begin, BufferEnd);
         }
 
         /// <summary>
@@ -206,13 +205,13 @@ namespace System.IO.Pipelines
         /// </summary>
         public BufferEnumerator GetEnumerator()
         {
-            return new BufferEnumerator(_start, _end);
+            return new BufferEnumerator(BufferStart, BufferEnd);
         }
 
         internal void ClearCursors()
         {
-            _start = default(ReadCursor);
-            _end = default(ReadCursor);
+            BufferStart = default(ReadCursor);
+            BufferEnd = default(ReadCursor);
         }
 
         /// <summary>
@@ -263,13 +262,13 @@ namespace System.IO.Pipelines
                 item = First;
                 if (advance)
                 {
-                    if (_start.IsEnd)
+                    if (BufferStart.IsEnd)
                     {
                         position = Position.AfterLast;
                     }
                     else
                     {
-                        position.ObjectPosition = _start.Segment.Next;
+                        position.ObjectPosition = BufferStart.Segment.Next;
                     }
                 }
                 return true;
@@ -289,9 +288,9 @@ namespace System.IO.Pipelines
                     position = Position.AfterLast;
                 }
             }
-            if (currentSegment == _end.Segment)
+            if (currentSegment == BufferEnd.Segment)
             {
-                item = currentSegment.Buffer.Slice(currentSegment.Start, _end.Index - currentSegment.Start);
+                item = currentSegment.Buffer.Slice(currentSegment.Start, BufferEnd.Index - currentSegment.Start);
             }
             else
             {
@@ -306,7 +305,7 @@ namespace System.IO.Pipelines
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
             }
-            return cursor.Seek(count, _end, false);
+            return cursor.Seek(count, BufferEnd, false);
         }
     }
 }

--- a/src/System.IO.Pipelines/ResultFlags.cs
+++ b/src/System.IO.Pipelines/ResultFlags.cs
@@ -5,6 +5,6 @@ namespace System.IO.Pipelines
     {
         None = 0,
         Cancelled = 1,
-        Completed = 1 >> 2
+        Completed = 2
     }
 }

--- a/src/System.IO.Pipelines/ResultFlags.cs
+++ b/src/System.IO.Pipelines/ResultFlags.cs
@@ -1,0 +1,10 @@
+namespace System.IO.Pipelines
+{
+    [Flags]
+    internal enum ResultFlags : byte
+    {
+        None = 0,
+        Cancelled = 1,
+        Completed = 1 >> 2
+    }
+}


### PR DESCRIPTION
Before:

```
                  Method |        Mean |    StdErr |     StdDev |          RPS |
------------------------ |------------ |---------- |----------- |------------- |
 ParseLiveAspNetTwoTasks | 326.4556 ns | 3.3105 ns | 18.1321 ns | 3,063,203.49 |
   ParseLiveAspNetInline | 237.0526 ns | 3.8329 ns | 20.9937 ns | 4,218,472.53 |
```

After:
```
                 Method |        Mean |    StdErr |     StdDev |          RPS |
------------------------ |------------ |---------- |----------- |------------- |
 ParseLiveAspNetTwoTasks | 372.2635 ns | 3.6436 ns | 19.9568 ns | 2,686,269.24 |
   ParseLiveAspNetInline | 172.7343 ns | 3.5178 ns | 19.2678 ns | 5,789,239.57 |
```