### PR TITLE
Add WritableBufferWriter for fast writes

### DIFF
--- a/src/System.IO.Pipelines/WritableBuffer.cs
+++ b/src/System.IO.Pipelines/WritableBuffer.cs
@@ -10,17 +10,17 @@ namespace System.IO.Pipelines
     /// </summary>
     public struct WritableBuffer : IOutput
     {
-        private Pipe _pipe;
+        internal Pipe Pipe;
 
         internal WritableBuffer(Pipe pipe)
         {
-            _pipe = pipe;
+            Pipe = pipe;
         }
 
         /// <summary>
         /// Available memory.
         /// </summary>
-        public Buffer<byte> Buffer => _pipe.Buffer;
+        public Buffer<byte> Buffer => Pipe.Buffer;
 
         /// <summary>
         /// Returns the number of bytes currently written and uncommitted.
@@ -46,7 +46,7 @@ namespace System.IO.Pipelines
         /// </summary>
         public ReadableBuffer AsReadableBuffer()
         {
-            return _pipe.AsReadableBuffer();
+            return Pipe.AsReadableBuffer();
         }
 
         /// <summary>
@@ -55,14 +55,14 @@ namespace System.IO.Pipelines
         /// </summary>
         /// <param name="count">number of bytes</param>
         /// <remarks>
-        /// Used when writing to <see cref="Buffer"/> directly. 
+        /// Used when writing to <see cref="Buffer"/> directly.
         /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">
         /// More requested than underlying <see cref="IBufferPool"/> can allocate in a contiguous block.
         /// </exception>
         public void Ensure(int count = 1)
         {
-            _pipe.Ensure(count);
+            Pipe.Ensure(count);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace System.IO.Pipelines
         /// <param name="buffer">The <see cref="ReadableBuffer"/> to append</param>
         public void Append(ReadableBuffer buffer)
         {
-            _pipe.Append(buffer);
+            Pipe.Append(buffer);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace System.IO.Pipelines
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="bytesWritten"/> is negative.</exception>
         public void Advance(int bytesWritten)
         {
-            _pipe.AdvanceWriter(bytesWritten);
+            Pipe.AdvanceWriter(bytesWritten);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace System.IO.Pipelines
         /// </remarks>
         public void Commit()
         {
-            _pipe.Commit();
+            Pipe.Commit();
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace System.IO.Pipelines
         /// <returns>A task that completes when the data is fully flushed.</returns>
         public WritableBufferAwaitable FlushAsync()
         {
-            return _pipe.FlushAsync();
+            return Pipe.FlushAsync();
         }
     }
 }

--- a/src/System.IO.Pipelines/WritableBuffer.cs
+++ b/src/System.IO.Pipelines/WritableBuffer.cs
@@ -10,17 +10,17 @@ namespace System.IO.Pipelines
     /// </summary>
     public struct WritableBuffer : IOutput
     {
-        internal Pipe Pipe;
+        private Pipe _pipe;
 
         internal WritableBuffer(Pipe pipe)
         {
-            Pipe = pipe;
+            _pipe = pipe;
         }
 
         /// <summary>
         /// Available memory.
         /// </summary>
-        public Buffer<byte> Buffer => Pipe.Buffer;
+        public Buffer<byte> Buffer => _pipe.Buffer;
 
         /// <summary>
         /// Returns the number of bytes currently written and uncommitted.
@@ -46,7 +46,7 @@ namespace System.IO.Pipelines
         /// </summary>
         public ReadableBuffer AsReadableBuffer()
         {
-            return Pipe.AsReadableBuffer();
+            return _pipe.AsReadableBuffer();
         }
 
         /// <summary>
@@ -55,14 +55,14 @@ namespace System.IO.Pipelines
         /// </summary>
         /// <param name="count">number of bytes</param>
         /// <remarks>
-        /// Used when writing to <see cref="Buffer"/> directly.
+        /// Used when writing to <see cref="Buffer"/> directly. 
         /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">
         /// More requested than underlying <see cref="IBufferPool"/> can allocate in a contiguous block.
         /// </exception>
         public void Ensure(int count = 1)
         {
-            Pipe.Ensure(count);
+            _pipe.Ensure(count);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace System.IO.Pipelines
         /// <param name="buffer">The <see cref="ReadableBuffer"/> to append</param>
         public void Append(ReadableBuffer buffer)
         {
-            Pipe.Append(buffer);
+            _pipe.Append(buffer);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace System.IO.Pipelines
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="bytesWritten"/> is negative.</exception>
         public void Advance(int bytesWritten)
         {
-            Pipe.AdvanceWriter(bytesWritten);
+            _pipe.AdvanceWriter(bytesWritten);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace System.IO.Pipelines
         /// </remarks>
         public void Commit()
         {
-            Pipe.Commit();
+            _pipe.Commit();
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace System.IO.Pipelines
         /// <returns>A task that completes when the data is fully flushed.</returns>
         public WritableBufferAwaitable FlushAsync()
         {
-            return Pipe.FlushAsync();
+            return _pipe.FlushAsync();
         }
     }
 }

--- a/src/System.IO.Pipelines/WritableBufferWriter.cs
+++ b/src/System.IO.Pipelines/WritableBufferWriter.cs
@@ -1,0 +1,80 @@
+using System.Runtime.CompilerServices;
+
+namespace System.IO.Pipelines
+{
+    public struct WritableBufferWriter
+    {
+        private WritableBuffer _writableBuffer;
+        private Span<byte> _span;
+
+        public WritableBufferWriter(WritableBuffer writableBuffer)
+        {
+            _writableBuffer = writableBuffer;
+            _span = writableBuffer.Buffer.Span;
+        }
+
+        public Span<byte> Span => _span;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Advance(int count)
+        {
+            _span = _span.Slice(count);
+            _writableBuffer.Advance(count);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Write(byte[] source)
+        {
+            Write(source, 0, source.Length);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Write(byte[] source, int offset, int length)
+        {
+            if (length <= _span.Length && length > 0)
+            {
+                ref byte pSource = ref source[offset];
+                ref byte pDest = ref _span.DangerousGetPinnableReference();
+
+                Unsafe.CopyBlockUnaligned(ref pDest, ref pSource, (uint)length);
+
+                Advance(length);
+                return;
+            }
+
+            WriteMultiBuffer(source, offset, length);
+        }
+
+        private void WriteMultiBuffer(byte[] source, int offset, int length)
+        {
+            var remaining = length;
+
+            while (remaining > 0)
+            {
+                if (_span.Length == 0)
+                {
+                    Ensure();
+                }
+
+                var writable = Math.Min(remaining, _span.Length);
+
+                ref byte pSource = ref source[offset];
+                ref byte pDest = ref _span.DangerousGetPinnableReference();
+
+                Unsafe.CopyBlockUnaligned(ref pDest, ref pSource, (uint)writable);
+
+                Advance(writable);
+
+                remaining -= writable;
+                offset += writable;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Ensure()
+        {
+            _writableBuffer.Ensure();
+            _span = _writableBuffer.Buffer.Span;
+        }
+    }
+}

--- a/src/System.IO.Pipelines/WritableBufferWriter.cs
+++ b/src/System.IO.Pipelines/WritableBufferWriter.cs
@@ -26,13 +26,11 @@ namespace System.IO.Pipelines
             _writableBuffer.Advance(count);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public void Write(byte[] source)
         {
             Write(source, 0, source.Length);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public void Write(byte[] source, int offset, int length)
         {
             if (length <= _span.Length && length > 0)

--- a/src/System.IO.Pipelines/WritableBufferWriter.cs
+++ b/src/System.IO.Pipelines/WritableBufferWriter.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 
 namespace System.IO.Pipelines

--- a/tests/System.IO.Pipelines.Tests/PipeLengthTests.cs
+++ b/tests/System.IO.Pipelines.Tests/PipeLengthTests.cs
@@ -106,7 +106,7 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public void ByteByByteTest()
         {
-            WritableBuffer writableBuffer;
+            WritableBuffer writableBuffer = default(WritableBuffer);
             for (int i = 1; i <= 1024 * 1024; i++)
             {
                 writableBuffer = _pipe.Writer.Alloc(100);
@@ -115,6 +115,7 @@ namespace System.IO.Pipelines.Tests
 
                 Assert.Equal(i, _pipe.Length);
             }
+
             writableBuffer.FlushAsync();
 
             for (int i = 1024 * 1024 - 1; i >= 0; i--)

--- a/tests/System.IO.Pipelines.Tests/PipeLengthTests.cs
+++ b/tests/System.IO.Pipelines.Tests/PipeLengthTests.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.IO.Pipelines.Testing;
-using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace System.IO.Pipelines.Tests

--- a/tests/System.IO.Pipelines.Tests/WritableBufferWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/WritableBufferWriterFacts.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.Pipelines.Tests
 {
-    public class WritableBufferWriterFacts: IDisposable
+    public class WritableBufferWriterFacts : IDisposable
     {
         private PipeFactory _pipeFactory;
         private IPipe _pipe;

--- a/tests/System.IO.Pipelines.Tests/WritableBufferWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/WritableBufferWriterFacts.cs
@@ -47,13 +47,13 @@ namespace System.IO.Pipelines.Tests
         public void SlicesSpanAndAdvancesAfterWrite()
         {
             _buffer = _pipe.Writer.Alloc(1);
-            var initialLenght = _buffer.Buffer.Length;
+            var initialLength = _buffer.Buffer.Length;
 
             var writer = new WritableBufferWriter(_buffer);
 
             writer.Write(new byte[] { 1, 2, 3 });
 
-            Assert.Equal(initialLenght - 3, writer.Span.Length);
+            Assert.Equal(initialLength - 3, writer.Span.Length);
             Assert.Equal(_buffer.Buffer.Length, writer.Span.Length);
             Assert.Equal(new byte[] { 1, 2, 3 }, Read());
         }

--- a/tests/System.IO.Pipelines.Tests/WritableBufferWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/WritableBufferWriterFacts.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Xunit;
+
+namespace System.IO.Pipelines.Tests
+{
+    public class WritableBufferWriterFacts: IDisposable
+    {
+        private PipeFactory _pipeFactory;
+        private IPipe _pipe;
+        private WritableBuffer _buffer;
+
+        public WritableBufferWriterFacts()
+        {
+            _pipeFactory = new PipeFactory();
+            _pipe = _pipeFactory.Create();
+        }
+
+        public void Dispose()
+        {
+            _pipe.Writer.Complete();
+            _pipe.Reader.Complete();
+            _pipeFactory.Dispose();
+        }
+
+        private byte[] Read()
+        {
+             _buffer.FlushAsync().GetAwaiter().GetResult();
+            var readResult = _pipe.Reader.ReadAsync().GetAwaiter().GetResult();
+            var data = readResult.Buffer.ToArray();
+            _pipe.Reader.Advance(readResult.Buffer.End);
+            return data;
+        }
+
+        [Fact]
+        public void ExposesSpan()
+        {
+            _buffer = _pipe.Writer.Alloc(1);
+            var writer = new WritableBufferWriter(_buffer);
+            Assert.Equal(_buffer.Buffer.Length, writer.Span.Length);
+            Assert.Equal(new byte[] { }, Read());
+        }
+
+        [Fact]
+        public void SlicesSpanAndAdvancesAfterWrite()
+        {
+            _buffer = _pipe.Writer.Alloc(1);
+            var initialLenght = _buffer.Buffer.Length;
+
+            var writer = new WritableBufferWriter(_buffer);
+
+            writer.Write(new byte[] { 1, 2, 3 });
+
+            Assert.Equal(initialLenght - 3, writer.Span.Length);
+            Assert.Equal(_buffer.Buffer.Length, writer.Span.Length);
+            Assert.Equal(new byte[] { 1, 2, 3 }, Read());
+        }
+
+        [Fact]
+        public void CanWriteIntoHeadlessBuffer()
+        {
+            _buffer = _pipe.Writer.Alloc();
+            var writer = new WritableBufferWriter(_buffer);
+
+            writer.Write(new byte[] { 1, 2, 3 });
+            Assert.Equal(new byte[] { 1, 2, 3 }, Read());
+        }
+
+        [Fact]
+        public void CanWriteMultipleTimes()
+        {
+            _buffer = _pipe.Writer.Alloc();
+            var writer = new WritableBufferWriter(_buffer);
+
+            writer.Write(new byte[] { 1 });
+            writer.Write(new byte[] { 2 });
+            writer.Write(new byte[] { 3 });
+
+            Assert.Equal(new byte[] { 1, 2, 3 }, Read());
+        }
+
+        [Fact]
+        public void CanWriteEmpty()
+        {
+            _buffer = _pipe.Writer.Alloc();
+            var writer = new WritableBufferWriter(_buffer);
+
+            writer.Write(new byte[] { });
+
+            Assert.Equal(new byte[] { }, Read());
+        }
+
+        [Fact]
+        public void CanWriteOverTheBlockLength()
+        {
+            _buffer = _pipe.Writer.Alloc(1);
+            var writer = new WritableBufferWriter(_buffer);
+
+            var source = Enumerable.Range(0, _buffer.Buffer.Length).Select(i => (byte)i);
+            var expectedBytes = source.Concat(source).Concat(source).ToArray();
+
+            writer.Write(expectedBytes);
+
+            Assert.Equal(expectedBytes, Read());
+        }
+    }
+}


### PR DESCRIPTION
Comparison with writefast that kestrel uses:

```
                                          Method |        Mean |    StdErr |     StdDev |          RPS |
------------------------------------------------ |------------ |---------- |----------- |------------- |
                      WriteFastPlaintextResponse | 519.8520 ns | 6.5837 ns | 36.0603 ns | 1,923,624.52 |
 WriteableBufferWriterWriteFastPlaintextResponse | 374.1911 ns | 6.0379 ns | 33.0709 ns | 2,672,431.50 |
```
/cc @benaadams