### PR TITLE
Added support for ReadOnlyBytes to HttpParser

### DIFF
--- a/src/System.Text.Http.Parser/System.Text.Http.Parser.csproj
+++ b/src/System.Text.Http.Parser/System.Text.Http.Parser.csproj
@@ -8,6 +8,7 @@
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\System.Buffers.Experimental\System.Buffers.Experimental.csproj" />
     <ProjectReference Include="..\System.Buffers.Primitives\System.Buffers.Primitives.csproj" />
     <ProjectReference Include="..\System.Text.Primitives\System.Text.Primitives.csproj" />
     <ProjectReference Include="..\System.IO.Pipelines\System.IO.Pipelines.csproj" />

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -30,6 +30,7 @@
     <ProjectReference Include="..\..\src\System.IO.Pipelines.Text.Primitives\System.IO.Pipelines.Text.Primitives.csproj" />
     <ProjectReference Include="..\..\src\System.IO.Pipelines\System.IO.Pipelines.csproj" />
     <ProjectReference Include="..\..\src\System.Text.Formatting\System.Text.Formatting.csproj" />
+    <ProjectReference Include="..\..\src\System.Text.Http.Parser\System.Text.Http.Parser.csproj" />
     <ProjectReference Include="..\..\src\System.Text.Primitives\System.Text.Primitives.csproj" />
     <ProjectReference Include="..\..\src\System.Text.Http\System.Text.Http.csproj" />
     <ProjectReference Include="..\..\src\System.Text.Json\System.Text.Json.csproj" />

--- a/tests/Benchmarks/HttpParserBench.cs
+++ b/tests/Benchmarks/HttpParserBench.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Xunit.Performance;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Text;
+using System.Text.Http;
+using System.Text.Http.Parser;
+
+public class HttpParserBench
+{
+    private static readonly byte[] s_plaintextTechEmpowerRequestBytes = Encoding.UTF8.GetBytes(_plaintextTechEmpowerRequest);
+
+    private const string _plaintextTechEmpowerRequest =
+        "GET /plaintext HTTP/1.1\r\n" +
+        "Host: localhost\r\n" +
+        "Accept: text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7\r\n" +
+        "Connection: keep-alive\r\n" +
+        "\r\n";
+
+    const int Itterations = 1000;
+
+    [Benchmark(InnerIterationCount = Itterations)]
+    static ulong HttpParserRob()
+    {
+        ReadableBuffer buffer = ReadableBuffer.Create(s_plaintextTechEmpowerRequestBytes);
+        var parser = new HttpParser();
+        var request = new Request();
+
+        ulong acumulator = 0;
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement())
+            {
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    parser.ParseRequestLine(request, buffer, out var consumed, out var read);
+                    acumulator += (ulong)request.Method;
+                }
+            }
+        }
+
+        return acumulator;
+    }
+
+    [Benchmark(InnerIterationCount = Itterations)]
+    static ulong HttpParserReadableBytes()
+    {
+        var buffer = new ReadOnlyBytes(s_plaintextTechEmpowerRequestBytes);
+        var parser = new HttpParser();
+        var request = new Request();
+
+        ulong acumulator = 0;
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement())
+            {
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    parser.ParseRequestLine(request, buffer, out var consumed);
+                    acumulator += (ulong)consumed;
+                }
+            }
+        }
+
+        return acumulator;
+    }
+
+    [Benchmark(InnerIterationCount = Itterations)]
+    static ulong HttpRequestParser()
+    {
+        var buffer = new ReadOnlyBytes(s_plaintextTechEmpowerRequestBytes);
+
+        ulong acumulator = 0;
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement())
+            {
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    var request = HttpRequest.Parse(buffer);
+                    acumulator += (ulong)request.BodyIndex;
+                }
+            }
+        }
+
+        return acumulator;
+    }
+}
+
+class Request : IHttpHeadersHandler, IHttpRequestLineHandler
+{
+    public Http.Method Method;
+    public Http.Version Version;
+    public string Path;
+    public string Query;
+    public string Target;
+
+    public Dictionary<string, string> Headers = new Dictionary<string, string>();
+
+    public void OnHeader(Span<byte> name, Span<byte> value)
+    {
+        //var nameString = PrimitiveEncoder.DecodeAscii(name);
+        //var valueString = PrimitiveEncoder.DecodeAscii(value);
+        //Headers.Add(nameString, valueString);
+    }
+
+    public void OnStartLine(Http.Method method, Http.Version version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
+    {
+        //Method = method;
+        //Version = version;
+        //Path = PrimitiveEncoder.DecodeAscii(path);
+        //Query = PrimitiveEncoder.DecodeAscii(query);
+        //Target = PrimitiveEncoder.DecodeAscii(target);
+    }
+}
+


### PR DESCRIPTION
After I added inner itterations, the results are more realistic:

     Test Name                               | Metric                | Iterations |    AVERAGE |    STDEV.S |        MIN |        MAX
    :--------------------------------------- |:--------------------- |:----------:| ----------:| ----------:| ----------:| ----------:
     HttpParserBench.HttpParserReadableBytes | Duration              |    101     |      0.159 |      0.743 |      0.081 |      7.555
     HttpParserBench.HttpParserReadableBytes | Instructions Retired  |    101     | 1.009E+006 | 3.768E+006 | 6.000E+005 | 3.850E+007
     HttpParserBench.HttpParserReadableBytes | Branch Mispredictions |    101     |   4542.099 |  35810.853 |      0.000 | 3.604E+005
     HttpParserBench.HttpParserReadableBytes | Cache Misses          |    101     |   1581.624 |  15895.122 |      0.000 | 1.597E+005
     HttpParserBench.HttpParserRob           | Duration              |    101     |      0.106 |      0.187 |      0.081 |      1.967
     HttpParserBench.HttpParserRob           | Instructions Retired  |    101     | 8.069E+005 | 8.850E+005 | 7.000E+005 | 9.600E+006
     HttpParserBench.HttpParserRob           | Branch Mispredictions |    101     |   1824.950 |  10641.330 |      0.000 | 1.065E+005
     HttpParserBench.HttpParserRob           | Cache Misses          |    101     |    324.436 |   2877.898 |      0.000 |  28672.000
     HttpParserBench.HttpRequestParser       | Duration              |    101     |      0.398 |      1.654 |      0.229 |     16.854
     HttpParserBench.HttpRequestParser       | Instructions Retired  |    101     | 2.563E+006 | 7.863E+006 | 1.700E+006 | 8.080E+007
     HttpParserBench.HttpRequestParser       | Branch Mispredictions |    101     |   9286.970 |  92100.618 |      0.000 | 9.257E+005
     HttpParserBench.HttpRequestParser       | Cache Misses          |    101     |   2838.812 |  27303.720 |      0.000 | 2.744E+005



HttpParserReadableBytes : uses ReadableBuffer
HttpParserRob : uses ReadOnlyBytes
HttpRequestParser : toy parser in System.Text.Http implements purely in safe code (i.e. no pointers)