### PR TITLE
Remove TryGetPointer from RioTcpConnection

### DIFF
--- a/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
@@ -118,6 +118,8 @@ namespace System.IO.Pipelines.Networking.Windows.RIO.Internal
 
         public unsafe RioBufferSegment GetSegmentFromMemory(Buffer<byte> memory)
         {
+            // It's ok to unpin the handle here because the memory is from the pool
+            // we created, which is already pinned.
             var pin = memory.Pin();
             var spanPtr = (IntPtr)pin.PinnedPointer;
             pin.Free();

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO.Pipelines.Networking.Windows.RIO.Internal.Winsock;
 using System.Runtime.InteropServices;
 using System.Threading;
-using System.IO.Pipelines.Networking.Windows.RIO.Internal.Winsock;
-using System.Buffers;
 
 namespace System.IO.Pipelines.Networking.Windows.RIO.Internal
 {

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
@@ -120,10 +120,12 @@ namespace System.IO.Pipelines.Networking.Windows.RIO.Internal
         {
             var pin = memory.Pin();
             var spanPtr = (IntPtr)pin.PinnedPointer;
+            pin.Free();
+
             long startAddress;
             long spanAddress = spanPtr.ToInt64();
             var bufferId = GetBufferId(spanPtr, out startAddress);
-
+            
             checked
             {
                 var offset = (uint)(spanAddress - startAddress);

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/RioTcpConnection.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/RioTcpConnection.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Buffers;
-using System.Threading;
-using System.Threading.Tasks;
 using System.IO.Pipelines.Networking.Windows.RIO.Internal;
 using System.IO.Pipelines.Networking.Windows.RIO.Internal.Winsock;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.IO.Pipelines.Networking.Windows.RIO
 {


### PR DESCRIPTION
Part of #1298

Moves the `GetSegmentFromMemory` method into the `RioThread` and uses `Pin` instead of `TryGetPointer`. I think it's safe to not keep the `MemoryHandle` around because we verify the memory is from a `Slab` in the memory pool using its address, which we know is pinned.

So now it's `RioThread`s responsibility to make sure its buffers are pinned, which is better because it's the one creating the `MemoryPool`.

I'm not sure about error handling, if it turns out the memory isn't from a known slab then the RIO buffer id is `IntPtr.Zero`, but we're not explicitly dealing with this.