### PR TITLE
Work around a JIT bug

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/BytesReader.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BytesReader.cs
@@ -21,7 +21,7 @@ namespace System.Buffers
         public BytesReader(ReadOnlyBytes bytes, TextEncoder encoder)
         {
             _unreadSegments = bytes;
-            _currentSegment = _unreadSegments.First;
+            _currentSegment = bytes.First;
             _encoder = encoder;
             _currentSegmentIndex = 0;
             _index = 0;


### PR DESCRIPTION
- BytesReader reports that it's empty when it isn't because of https://github.com/dotnet/coreclr/issues/10481.
This seems to work around the problem for now.

This is blocking our move to .NET Core 2.0 move in SignalR https://github.com/aspnet/SignalR/pull/338

/cc @anurse 