### PR TITLE
ReadableBufferReader Skip split

### DIFF
--- a/src/System.IO.Pipelines/ReadableBufferReader.cs
+++ b/src/System.IO.Pipelines/ReadableBufferReader.cs
@@ -37,18 +37,13 @@ namespace System.IO.Pipelines
             get
             {
                 var part = _enumerator.Current;
+                var index = !_end ? _index : _currentSpan.Length;
 
-                ReadCursor cursor;
-                if (!_end)
+                return new ReadCursor()
                 {
-                    cursor = new ReadCursor(part.Segment, part.Start + _index);
-                }
-                else
-                {
-                    cursor = new ReadCursor(part.Segment, part.Start + _currentSpan.Length);
-                }
-
-                return cursor;
+                    Segment = part.Segment,
+                    Index = part.Start + index
+                };
             }
         }
 

--- a/src/System.IO.Pipelines/ReadableBufferReader.cs
+++ b/src/System.IO.Pipelines/ReadableBufferReader.cs
@@ -130,7 +130,7 @@ namespace System.IO.Pipelines
 
                 length -= remaining;
                 AdvanceSegmentNoInline();
-            } while (length > 0 && !_end );
+            } while (length > 0 && !_end);
 
             if (length > 0)
             {


### PR DESCRIPTION
Inlined same span for Skip
Non-inlined for skip span

Inlined enumerator next (`AdvanceSegment`) for .ctor and start of SkipMulti as always called
Non-inlined for Take and SkipMulti loop

SkipMulti to do while

Reversed if tests (cold branch prediction doesn't predict jump forward; loops jump backwards and Exceptions throws are moved to end of method to make them a jump forward)