### PR TITLE
OwnedBuffer should avoid accidentally initializing into sentinel values

### DIFF
--- a/src/System.Buffers.Primitives/System/Buffers/OwnedBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/OwnedBuffer.cs
@@ -97,8 +97,12 @@ namespace System.Buffers
             if (!IsDisposed && Id!=InitializedId) {
                 throw new InvalidOperationException("this instance has to be disposed to initialize");
             }
-
-            _id = (int)Interlocked.Increment(ref _nextId);
+            
+            do
+            {
+                _id = (int)Interlocked.Increment(ref _nextId);
+            } while(_id == InitializedId || _id == FreedId); // if we wrap around and collide with sentinels: pick again
+            
             _array = array;
             _arrayIndex = arrayOffset;
             _length = length;


### PR DESCRIPTION
After many allocations, `OwnedBuffer`'s `_id` will wrap around; we should ensure that it doesn't accidentally select the sentinel values