### PR TITLE
Added ability to parse headers represented  by ReadOnlyBytes

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/BytesReader.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BytesReader.cs
@@ -50,6 +50,21 @@ namespace System.Buffers
 
         public byte Peek() => _currentSegment.Span[_currentSegmentIndex];
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public byte Read()
+        {
+            var result = _currentSegment.Span[_currentSegmentIndex];
+            _index++;
+            var unreadLength = _currentSegment.Length - _currentSegmentIndex;
+            if (1 < unreadLength) {
+                _currentSegmentIndex++;
+            }
+            else {
+                AdvanceNextSegment(1, advancedInCurrent: unreadLength);
+            }
+            return result;
+        }
+
         public ReadOnlySpan<byte> Unread => _currentSegment.Span.Slice(_currentSegmentIndex);
 
         public TextEncoder Encoder => _encoder;

--- a/src/System.Buffers.Experimental/System/Buffers/BytesReader.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BytesReader.cs
@@ -50,21 +50,6 @@ namespace System.Buffers
 
         public byte Peek() => _currentSegment.Span[_currentSegmentIndex];
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public byte Read()
-        {
-            var result = _currentSegment.Span[_currentSegmentIndex];
-            _index++;
-            var unreadLength = _currentSegment.Length - _currentSegmentIndex;
-            if (1 < unreadLength) {
-                _currentSegmentIndex++;
-            }
-            else {
-                AdvanceNextSegment(1, advancedInCurrent: unreadLength);
-            }
-            return result;
-        }
-
         public ReadOnlySpan<byte> Unread => _currentSegment.Span.Slice(_currentSegmentIndex);
 
         public TextEncoder Encoder => _encoder;

--- a/src/System.Text.Http.Parser/HttpParser.cs
+++ b/src/System.Text.Http.Parser/HttpParser.cs
@@ -354,13 +354,14 @@ namespace System.Text.Http.Parser
                 while (true) {
                     index++;
                     // get next byte 
-                    while (index == length) {
+                    while (length <= index) {
                         if (rest == null) {
                             RejectRequest(RequestRejectionReason.InvalidRequestHeadersNoCRLF);
                         }
                         span = rest.First.Span;
+                        length = span.Length;
                         rest = rest.Rest;
-                        index = -1;
+                        index = 0;
                         straddling = true;
                         throw new NotImplementedException("call to OnHeader below needs to account for straddling spans");
                     }

--- a/src/System.Text.Http.Parser/HttpParser.cs
+++ b/src/System.Text.Http.Parser/HttpParser.cs
@@ -88,7 +88,7 @@ namespace System.Text.Http.Parser
         private unsafe void ParseRequestLine<T>(T handler, byte* data, int length) where T : IHttpRequestLineHandler
         {
             int offset;
-            Span<byte> customMethod;
+            ReadOnlySpan<byte> customMethod;
             // Get Method and set the offset
             var method = HttpUtilities.GetKnownMethod(data, length, out offset);
             if (method == Http.Method.Custom)
@@ -148,7 +148,7 @@ namespace System.Text.Http.Parser
                 RejectRequestLine(data, length);
             }
 
-            var pathBuffer = new Span<byte>(data + pathStart, offset - pathStart);
+            var pathBuffer = new ReadOnlySpan<byte>(data + pathStart, offset - pathStart);
 
             // Query string
             var queryStart = offset;
@@ -171,8 +171,8 @@ namespace System.Text.Http.Parser
                 RejectRequestLine(data, length);
             }
 
-            var targetBuffer = new Span<byte>(data + pathStart, offset - pathStart);
-            var query = new Span<byte>(data + queryStart, offset - queryStart);
+            var targetBuffer = new ReadOnlySpan<byte>(data + pathStart, offset - pathStart);
+            var query = new ReadOnlySpan<byte>(data + queryStart, offset - queryStart);
 
             // Consume space
             offset++;
@@ -199,7 +199,7 @@ namespace System.Text.Http.Parser
                 RejectRequestLine(data, length);
             }
 
-            var line = new Span<byte>(data, length);
+            var line = new ReadOnlySpan<byte>(data, length);
 
             handler.OnStartLine(method, httpVersion, targetBuffer, pathBuffer, query, customMethod, pathEncoded);
         }
@@ -282,7 +282,7 @@ namespace System.Text.Http.Parser
                                 index = reader.Index;
                             }
 
-                            var endIndex = new Span<byte>(pBuffer + index, remaining).IndexOf(ByteLF);
+                            var endIndex = new ReadOnlySpan<byte>(pBuffer + index, remaining).IndexOf(ByteLF);
                             var length = 0;
 
                             if (endIndex != -1)
@@ -336,6 +336,94 @@ namespace System.Text.Http.Parser
                 if (done)
                 {
                     examined = consumed;
+                }
+            }
+        }
+
+        public unsafe bool ParseHeaders<T>(T handler, ReadOnlyBytes buffer, out int consumedBytes) where T : IHttpHeadersHandler
+        {
+            var span = buffer.First.Span;
+            var rest = buffer.Rest;
+            var length = span.Length;
+            int index = -1;
+            State state = State.ParsingName;
+            int nameStart = 0, nameEnd = 0, valueStart = 0, valueEnd = 0;
+            bool sawCRLF = false;
+            bool straddling = false;
+            fixed (byte* pBuffer = &span.DangerousGetPinnableReference()) {
+                while (true) {
+                    index++;
+                    // get next byte 
+                    while (index == length) {
+                        if (rest == null) {
+                            RejectRequest(RequestRejectionReason.InvalidRequestHeadersNoCRLF);
+                        }
+                        span = rest.First.Span;
+                        rest = rest.Rest;
+                        index = -1;
+                        straddling = true;
+                        throw new NotImplementedException("call to OnHeader below needs to account for straddling spans");
+                    }
+                    var next = pBuffer[index];
+
+                    if (state == State.ParsingValue) {
+                        if (next == ByteCR) {
+                            valueEnd = index;
+                            state = State.ArferCR;
+                        }
+                        // TODO: should value characters be validated?
+                        // TODO: should whitespace after all values (i.e. right before CRLF) be removed here?
+                        // else just keep advancing chracters in name
+                    }
+                    else if (state == State.ParsingName) {
+                        if (next == ByteColon) {
+                            state = State.BeforValue;
+                            nameEnd = index;
+                        }
+                        if (next == ByteCR) state = State.ArferCR;
+                        // TODO: should name characters be validated?
+                        // else just keep advancing chracters in name
+                    }
+                    else if (state == State.BeforValue) {
+                        if (next != ByteSpace && next != ByteTab) {
+                            state = State.ParsingValue;
+                            valueStart = index;
+                        }
+                        else if (next == ByteCR) RejectRequest(RequestRejectionReason.InvalidCharactersInHeaderName);
+                        // else skip whitespace
+                    }
+                    else if (state == State.ArferCR) {
+                        if (next == ByteLF) {
+                            sawCRLF = true;
+                            if (nameEnd != 0) {
+                                if (!straddling) {
+                                    ReadOnlySpan<byte> nameBuffer = new ReadOnlySpan<byte>(pBuffer + nameStart, nameEnd - nameStart);
+                                    ReadOnlySpan<byte> valueBuffer = new ReadOnlySpan<byte>(pBuffer + valueStart, valueEnd - valueStart);
+                                    handler.OnHeader(nameBuffer, valueBuffer);
+                                    nameEnd = 0;
+                                    state = State.ParsingName;
+                                    nameStart = index + 1;
+                                    straddling = false;
+                                }
+                                else {
+                                    throw new NotImplementedException("header is straddling spans");
+                                }
+                            }
+                            else {
+                                if (sawCRLF) {
+                                    consumedBytes = index + 1;
+                                    return true;
+                                }
+                                RejectRequest(RequestRejectionReason.InvalidRequestHeadersNoCRLF);
+                            }
+                        }
+                        else {
+                            RejectRequest(RequestRejectionReason.InvalidRequestHeadersNoCRLF);
+                        }
+                    }                    
+                    else { 
+                        throw new Exception("bug in parser: unknown state");
+                    }
                 }
             }
         }
@@ -415,8 +503,8 @@ namespace System.Text.Http.Parser
                 }
             }
 
-            var nameBuffer = new Span<byte>(headerLine, nameEnd);
-            var valueBuffer = new Span<byte>(headerLine + valueStart, valueEnd - valueStart + 1);
+            var nameBuffer = new ReadOnlySpan<byte>(headerLine, nameEnd);
+            var valueBuffer = new ReadOnlySpan<byte>(headerLine + valueStart, valueEnd - valueStart + 1);
 
             handler.OnHeader(nameBuffer, valueBuffer);
         }
@@ -457,7 +545,6 @@ namespace System.Text.Http.Parser
             return true;
         }
 
-
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static bool TryGetNewLineSpan(ref ReadableBuffer buffer, ref Span<byte> span, out ReadCursor end)
         {
@@ -473,7 +560,7 @@ namespace System.Text.Http.Parser
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private unsafe Span<byte> GetUnknownMethod(byte* data, int length, out int methodLength)
+        private unsafe ReadOnlySpan<byte> GetUnknownMethod(byte* data, int length, out int methodLength)
         {
             methodLength = 0;
             for (var i = 0; i < length; i++)
@@ -496,7 +583,7 @@ namespace System.Text.Http.Parser
                 }
             }
 
-            return new Span<byte>(data, methodLength);
+            return new ReadOnlySpan<byte>(data, methodLength);
         }
 
         // TODO: this could be optimized by using a table
@@ -553,6 +640,14 @@ namespace System.Text.Http.Parser
             // However this does cause it to become an intrinsic (with additional multiply and reg->reg copy)
             // https://github.com/dotnet/coreclr/issues/7459#issuecomment-253965670
             return Vector.AsVectorByte(new Vector<uint>(vectorByte * 0x01010101u));
+        }
+
+        enum State : byte
+        {
+            ParsingName,
+            BeforValue,
+            ParsingValue,
+            ArferCR,
         }
     }
 }

--- a/src/System.Text.Http.Parser/IHttpHeadersHandler.cs
+++ b/src/System.Text.Http.Parser/IHttpHeadersHandler.cs
@@ -7,6 +7,6 @@ namespace System.Text.Http.Parser
 {
     public interface IHttpHeadersHandler
     {
-        void OnHeader(Span<byte> name, Span<byte> value);
+        void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value);
     }
 }

--- a/src/System.Text.Http.Parser/IHttpRequestLineHandler.cs
+++ b/src/System.Text.Http.Parser/IHttpRequestLineHandler.cs
@@ -7,6 +7,6 @@ namespace System.Text.Http.Parser
 {
     public interface IHttpRequestLineHandler
     {
-        void OnStartLine(Http.Method method, Http.Version version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded);
+        void OnStartLine(Http.Method method, Http.Version version, ReadOnlySpan<byte> target, ReadOnlySpan<byte> path, ReadOnlySpan<byte> query, ReadOnlySpan<byte> customMethod, bool pathEncoded);
     }
 }

--- a/tests/Benchmarks/HttpParserBench.cs
+++ b/tests/Benchmarks/HttpParserBench.cs
@@ -22,24 +22,114 @@ public class HttpParserBench
         "Connection: keep-alive\r\n" +
         "\r\n";
 
-    const int Itterations = 1000;
+    private static readonly byte[] s_plaintextTechEmpowerHeadersBytes = Encoding.UTF8.GetBytes(_plaintextTechEmpowerHeaders);
+
+    private const string _plaintextTechEmpowerHeaders =
+    "Host: localhost\r\n" +
+    "Accept: text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7\r\n" +
+    "Connection: keep-alive\r\n" +
+    "\r\n";
+
+    const int Itterations = 10000;
 
     [Benchmark(InnerIterationCount = Itterations)]
-    static ulong HttpParserRob()
+    static ulong RequestLineRb()
     {
         ReadableBuffer buffer = ReadableBuffer.Create(s_plaintextTechEmpowerRequestBytes);
         var parser = new HttpParser();
         var request = new Request();
+        ReadCursor consumed = default(ReadCursor);
+        ReadCursor read;
 
-        ulong acumulator = 0;
         foreach (var iteration in Benchmark.Iterations)
         {
             using (iteration.StartMeasurement())
             {
                 for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                 {
-                    parser.ParseRequestLine(request, buffer, out var consumed, out var read);
-                    acumulator += (ulong)request.Method;
+                    parser.ParseRequestLine(request, buffer, out consumed, out read);
+                    parser.ParseRequestLine(request, buffer, out consumed, out read);
+                    parser.ParseRequestLine(request, buffer, out consumed, out read);
+                    parser.ParseRequestLine(request, buffer, out consumed, out read);
+                    parser.ParseRequestLine(request, buffer, out consumed, out read);
+                    parser.ParseRequestLine(request, buffer, out consumed, out read);
+                    parser.ParseRequestLine(request, buffer, out consumed, out read);
+                    parser.ParseRequestLine(request, buffer, out consumed, out read);
+                    parser.ParseRequestLine(request, buffer, out consumed, out read);
+                    parser.ParseRequestLine(request, buffer, out consumed, out read);
+
+                }
+            }
+        }
+
+        return (ulong)buffer.Slice(buffer.Start, consumed).Length;
+    }
+
+    [Benchmark(InnerIterationCount = Itterations)]
+    static int RequestLineRob()
+    {
+        var buffer = new ReadOnlyBytes(s_plaintextTechEmpowerRequestBytes);
+        var parser = new HttpParser();
+        var request = new Request();
+        int consumed = 0;
+
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement())
+            {
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    parser.ParseRequestLine(request, buffer, out consumed);
+                    parser.ParseRequestLine(request, buffer, out consumed);
+                    parser.ParseRequestLine(request, buffer, out consumed);
+                    parser.ParseRequestLine(request, buffer, out consumed);
+                    parser.ParseRequestLine(request, buffer, out consumed);
+                    parser.ParseRequestLine(request, buffer, out consumed);
+                    parser.ParseRequestLine(request, buffer, out consumed);
+                    parser.ParseRequestLine(request, buffer, out consumed);
+                    parser.ParseRequestLine(request, buffer, out consumed);
+                    parser.ParseRequestLine(request, buffer, out consumed);
+                }
+            }
+        }
+
+        return consumed;
+    }
+
+    [Benchmark(InnerIterationCount = Itterations)]
+    static ulong HeadersRb()
+    {
+        ReadableBuffer buffer = ReadableBuffer.Create(s_plaintextTechEmpowerHeadersBytes);
+        var parser = new HttpParser();
+        var request = new Request();
+        ReadCursor consumed;
+        ReadCursor examined;
+        int consumedBytes;
+
+        ulong acumulator = 0;
+        foreach (var iteration in Benchmark.Iterations) {
+            using (iteration.StartMeasurement()) {
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++) {
+                    parser.ParseHeaders(request, buffer, out consumed, out examined, out consumedBytes);
+                    acumulator += (ulong)consumedBytes;
+                    parser.ParseHeaders(request, buffer, out consumed, out examined, out consumedBytes);
+                    acumulator += (ulong)consumedBytes;
+                    parser.ParseHeaders(request, buffer, out consumed, out examined, out consumedBytes);
+                    acumulator += (ulong)consumedBytes;
+                    parser.ParseHeaders(request, buffer, out consumed, out examined, out consumedBytes);
+                    acumulator += (ulong)consumedBytes;
+                    parser.ParseHeaders(request, buffer, out consumed, out examined, out consumedBytes);
+                    acumulator += (ulong)consumedBytes;
+                    parser.ParseHeaders(request, buffer, out consumed, out examined, out consumedBytes);
+                    acumulator += (ulong)consumedBytes;
+                    parser.ParseHeaders(request, buffer, out consumed, out examined, out consumedBytes);
+                    acumulator += (ulong)consumedBytes;
+                    parser.ParseHeaders(request, buffer, out consumed, out examined, out consumedBytes);
+                    acumulator += (ulong)consumedBytes;
+                    parser.ParseHeaders(request, buffer, out consumed, out examined, out consumedBytes);
+                    acumulator += (ulong)consumedBytes;
+                    parser.ParseHeaders(request, buffer, out consumed, out examined, out consumedBytes);
+                    acumulator += (ulong)consumedBytes;
                 }
             }
         }
@@ -48,20 +138,37 @@ public class HttpParserBench
     }
 
     [Benchmark(InnerIterationCount = Itterations)]
-    static ulong HttpParserReadableBytes()
+    static ulong HeadersRob()
     {
-        var buffer = new ReadOnlyBytes(s_plaintextTechEmpowerRequestBytes);
+        var buffer = new ReadOnlyBytes(s_plaintextTechEmpowerHeadersBytes);
         var parser = new HttpParser();
         var request = new Request();
 
+        int consumed;
         ulong acumulator = 0;
-        foreach (var iteration in Benchmark.Iterations)
-        {
-            using (iteration.StartMeasurement())
-            {
-                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                {
-                    parser.ParseRequestLine(request, buffer, out var consumed);
+
+        foreach (var iteration in Benchmark.Iterations) {
+            using (iteration.StartMeasurement()) {
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++) {
+                    parser.ParseHeaders(request, buffer, out consumed);
+                    acumulator += (ulong)consumed;
+                    parser.ParseHeaders(request, buffer, out consumed);
+                    acumulator += (ulong)consumed;
+                    parser.ParseHeaders(request, buffer, out consumed);
+                    acumulator += (ulong)consumed;
+                    parser.ParseHeaders(request, buffer, out consumed);
+                    acumulator += (ulong)consumed;
+                    parser.ParseHeaders(request, buffer, out consumed);
+                    acumulator += (ulong)consumed;
+                    parser.ParseHeaders(request, buffer, out consumed);
+                    acumulator += (ulong)consumed;
+                    parser.ParseHeaders(request, buffer, out consumed);
+                    acumulator += (ulong)consumed;
+                    parser.ParseHeaders(request, buffer, out consumed);
+                    acumulator += (ulong)consumed;
+                    parser.ParseHeaders(request, buffer, out consumed);
+                    acumulator += (ulong)consumed;
+                    parser.ParseHeaders(request, buffer, out consumed);
                     acumulator += (ulong)consumed;
                 }
             }
@@ -71,24 +178,82 @@ public class HttpParserBench
     }
 
     [Benchmark(InnerIterationCount = Itterations)]
-    static ulong HttpRequestParser()
+    static int FullRequestRb()
     {
-        var buffer = new ReadOnlyBytes(s_plaintextTechEmpowerRequestBytes);
+        ReadableBuffer buffer = ReadableBuffer.Create(s_plaintextTechEmpowerRequestBytes);
+        var parser = new HttpParser();
+        var request = new Request();
+        int consumedBytes  = 0;
+        ReadCursor examined;
+        ReadCursor consumed;
 
-        ulong acumulator = 0;
-        foreach (var iteration in Benchmark.Iterations)
-        {
-            using (iteration.StartMeasurement())
-            {
-                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                {
-                    var request = HttpRequest.Parse(buffer);
-                    acumulator += (ulong)request.BodyIndex;
+        foreach (var iteration in Benchmark.Iterations) {
+            using (iteration.StartMeasurement()) {
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++) {
+                    parser.ParseRequestLine(request, buffer, out consumed, out examined);
+                    parser.ParseHeaders(request, buffer.Slice(consumed), out consumed, out examined, out consumedBytes);
+                    parser.ParseRequestLine(request, buffer, out consumed, out examined);
+                    parser.ParseHeaders(request, buffer.Slice(consumed), out consumed, out examined, out consumedBytes);
+                    parser.ParseRequestLine(request, buffer, out consumed, out examined);
+                    parser.ParseHeaders(request, buffer.Slice(consumed), out consumed, out examined, out consumedBytes);
+                    parser.ParseRequestLine(request, buffer, out consumed, out examined);
+                    parser.ParseHeaders(request, buffer.Slice(consumed), out consumed, out examined, out consumedBytes);
+                    parser.ParseRequestLine(request, buffer, out consumed, out examined);
+                    parser.ParseHeaders(request, buffer.Slice(consumed), out consumed, out examined, out consumedBytes);
                 }
             }
         }
 
-        return acumulator;
+        return consumedBytes;
+    }
+
+    [Benchmark(InnerIterationCount = Itterations)]
+    static int FullRequestRob()
+    {
+        var buffer = new ReadOnlyBytes(s_plaintextTechEmpowerRequestBytes);
+        var parser = new HttpParser();
+        var request = new Request();
+        int consumedBytes = 0;
+
+        foreach (var iteration in Benchmark.Iterations) {
+            using (iteration.StartMeasurement()) {
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++) {
+                    parser.ParseRequestLine(request, buffer, out consumedBytes);
+                    parser.ParseHeaders(request, buffer.Slice(consumedBytes), out consumedBytes);
+                    parser.ParseRequestLine(request, buffer, out consumedBytes);
+                    parser.ParseHeaders(request, buffer.Slice(consumedBytes), out consumedBytes);
+                    parser.ParseRequestLine(request, buffer, out consumedBytes);
+                    parser.ParseHeaders(request, buffer.Slice(consumedBytes), out consumedBytes);
+                    parser.ParseRequestLine(request, buffer, out consumedBytes);
+                    parser.ParseHeaders(request, buffer.Slice(consumedBytes), out consumedBytes);
+                    parser.ParseRequestLine(request, buffer, out consumedBytes);
+                    parser.ParseHeaders(request, buffer.Slice(consumedBytes), out consumedBytes);
+                }
+            }
+        }
+
+        return consumedBytes;
+    }
+
+    [Benchmark(InnerIterationCount = Itterations)]
+    static int FullRequestLegacy()
+    {
+        var buffer = new ReadOnlyBytes(s_plaintextTechEmpowerRequestBytes);
+        HttpRequest request = default(HttpRequest);
+
+        foreach (var iteration in Benchmark.Iterations) {
+            using (iteration.StartMeasurement()) {
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++) {
+                    request = HttpRequest.Parse(buffer);
+                    request = HttpRequest.Parse(buffer);
+                    request = HttpRequest.Parse(buffer);
+                    request = HttpRequest.Parse(buffer);
+                    request = HttpRequest.Parse(buffer);
+                }
+            }
+        }
+
+        return request.BodyIndex;
     }
 }
 
@@ -102,14 +267,14 @@ class Request : IHttpHeadersHandler, IHttpRequestLineHandler
 
     public Dictionary<string, string> Headers = new Dictionary<string, string>();
 
-    public void OnHeader(Span<byte> name, Span<byte> value)
+    public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
     {
         //var nameString = PrimitiveEncoder.DecodeAscii(name);
         //var valueString = PrimitiveEncoder.DecodeAscii(value);
         //Headers.Add(nameString, valueString);
     }
 
-    public void OnStartLine(Http.Method method, Http.Version version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
+    public void OnStartLine(Http.Method method, Http.Version version, ReadOnlySpan<byte> target, ReadOnlySpan<byte> path, ReadOnlySpan<byte> query, ReadOnlySpan<byte> customMethod, bool pathEncoded)
     {
         //Method = method;
         //Version = version;

--- a/tests/System.Text.Http.Parser.Tests/HttpParserTests.cs
+++ b/tests/System.Text.Http.Parser.Tests/HttpParserTests.cs
@@ -5,11 +5,66 @@ using Xunit;
 using System.Text.Http.Parser;
 using System.IO.Pipelines;
 using System.Collections.Generic;
+using System.Buffers;
 
 namespace System.Text.Http.Parser.Tests
 {
     public class HttpParserTests
     {
+        byte[] _simpleRequestBytes = Encoding.ASCII.GetBytes("GET /plaintext HTTP/1.1\r\nN: V\r\n\r\n");
+
+        [Fact]
+        public void HttpParserBasicsRobSimple()
+        {
+            var parser = new HttpParser();
+            var request = new Request();
+            ReadOnlyBytes buffer = new ReadOnlyBytes(_simpleRequestBytes);
+
+            Assert.True(parser.ParseRequestLine(request, buffer, out var consumed));
+            Assert.Equal(25, consumed);
+
+            Assert.True(parser.ParseHeaders(request, buffer.Slice(consumed), out consumed));
+            Assert.Equal(8, consumed);
+
+            // request line
+            Assert.Equal(Http.Method.Get, request.Method);
+            Assert.Equal(Http.Version.Http11, request.Version);
+            Assert.Equal("/plaintext", request.Path);
+
+            // headers
+            Assert.Equal(1, request.Headers.Count);
+            Assert.True(request.Headers.ContainsKey("N"));       
+            Assert.Equal("V", request.Headers["N"]);
+        }
+
+        [Fact]
+        public void HttpParserBasicsRob()
+        {
+            var parser = new HttpParser();
+            var request = new Request();
+            ReadOnlyBytes buffer = new ReadOnlyBytes(_plaintextTechEmpowerRequestBytes);
+
+            Assert.True(parser.ParseRequestLine(request, buffer, out var consumed));
+            Assert.Equal(25, consumed);
+
+            Assert.True(parser.ParseHeaders(request, buffer.Slice(consumed), out consumed));
+            Assert.Equal(139, consumed);
+
+            // request line
+            Assert.Equal(Http.Method.Get, request.Method);
+            Assert.Equal(Http.Version.Http11, request.Version);
+            Assert.Equal("/plaintext", request.Path);
+
+            // headers
+            Assert.Equal(3, request.Headers.Count);
+            Assert.True(request.Headers.ContainsKey("Host"));
+            Assert.True(request.Headers.ContainsKey("Accept"));
+            Assert.True(request.Headers.ContainsKey("Connection"));
+            Assert.Equal("localhost", request.Headers["Host"]);
+            Assert.Equal("text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7", request.Headers["Accept"]);
+            Assert.Equal("keep-alive", request.Headers["Connection"]);
+        }
+
         [Fact]
         public void HttpParserBasics()
         {
@@ -19,6 +74,7 @@ namespace System.Text.Http.Parser.Tests
 
             Assert.True(parser.ParseRequestLine(request, buffer, out var consumed, out var read));
             Assert.True(parser.ParseHeaders(request, buffer.Slice(consumed), out consumed, out var examined, out var consumedBytes));
+            Assert.Equal(139, consumedBytes);
 
             // request line
             Assert.Equal(Http.Method.Get, request.Method);
@@ -54,14 +110,14 @@ namespace System.Text.Http.Parser.Tests
 
         public Dictionary<string, string> Headers = new Dictionary<string, string>();
 
-        public void OnHeader(Span<byte> name, Span<byte> value)
+        public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
             var nameString = PrimitiveEncoder.DecodeAscii(name);
             var valueString = PrimitiveEncoder.DecodeAscii(value);
             Headers.Add(nameString, valueString);
         }
 
-        public void OnStartLine(Http.Method method, Http.Version version, Span<byte> target, Span<byte> path, Span<byte> query, Span<byte> customMethod, bool pathEncoded)
+        public void OnStartLine(Http.Method method, Http.Version version, ReadOnlySpan<byte> target, ReadOnlySpan<byte> path, ReadOnlySpan<byte> query, ReadOnlySpan<byte> customMethod, bool pathEncoded)
         {
             Method = method;
             Version = version;


### PR DESCRIPTION
Note that the parser does not yet handle headers straddling spans. It will throw NotImplementedException in such case. I will add this capability later.

The parser is slightly faster than the ReadableBuffer parser, but I need to implement straddling headers and possibly removal of white space trailing header values, so I will refrain form publishing benchmarks for now.

The ReadableBuffer does more than one pass over bytes in some cases. This parser is single pass. But the ReadableBuffer used vectorized operations for searching some delimiters; this parser is sequential only.

Also, I improved performance tests to make results more consistent, but increasing inner iterations and unrolling the inner loop.

Lastly, I changed the handler callbacks to take ReadOnlySpan<byte> instead of taking Span<byte>. This is because ReadOnlyBytes does not give access to r/w data. ReadableBuffer (contrary to its name) givves access to r/w data.