### PR TITLE
Add ReadableBuffer.Create(OwnedBuffer<byte>, offset, length)

### DIFF
--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -255,6 +255,32 @@ namespace System.IO.Pipelines
             return new ReadableBuffer(new ReadCursor(segment, offset), new ReadCursor(segment, offset + length));
         }
 
+        /// <summary>
+        /// Create a <see cref="ReadableBuffer"/> over an OwnedBuffer.
+        /// </summary>
+        public static ReadableBuffer Create(OwnedBuffer<byte> data, int offset, int length)
+        {
+            if (data == null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.data);
+            }
+
+            if (offset < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.offset);
+            }
+
+            if (length < 0 || length > data.Length - offset)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+            }
+
+            var segment = new BufferSegment(data);
+            segment.Start = offset;
+            segment.End = offset + length;
+            return new ReadableBuffer(new ReadCursor(segment, offset), new ReadCursor(segment, offset + length));
+        }
+
         bool ISequence<ReadOnlyBuffer<byte>>.TryGet(ref Position position, out ReadOnlyBuffer<byte> item, bool advance)
         {
             if (position == Position.First)

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -222,10 +222,11 @@ namespace System.IO.Pipelines
         {
             if (data == null)
             {
-                throw new ArgumentNullException(nameof(data));
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.data);
             }
 
-            return Create(data, 0, data.Length);
+            OwnedBuffer<byte> buffer = data;
+            return CreateInternal(buffer, 0, data.Length);
         }
 
         /// <summary>
@@ -262,6 +263,11 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
             }
 
+            return CreateInternal(data, offset, length);
+        }
+
+        private static ReadableBuffer CreateInternal(OwnedBuffer<byte> data, int offset, int length)
+        {
             var segment = new BufferSegment(data);
             segment.Start = offset;
             segment.End = offset + length;

--- a/src/System.IO.Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/ReadableBuffer.cs
@@ -238,21 +238,8 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.data);
             }
 
-            if (offset < 0)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.offset);
-            }
-
-            if (length < 0 || length > data.Length - offset)
-            {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
-            }
-
             OwnedBuffer<byte> buffer = data;
-            var segment = new BufferSegment(buffer);
-            segment.Start = offset;
-            segment.End = offset + length;
-            return new ReadableBuffer(new ReadCursor(segment, offset), new ReadCursor(segment, offset + length));
+            return Create(buffer, offset, length);
         }
 
         /// <summary>


### PR DESCRIPTION
This API is useful for receiving data from the network to be added to a Pipe. Network APIs accept buffers and fill those buffers to some extent. This API allows the user to allocate a number of buffers, pass them to a receive API and then Append the filled ranges to a Pipe via WritableBuffer.Append(ReadableBuffer).

https://github.com/dotnet/corefxlab/issues/1233

@davidfowl @benaadams 