### PR TITLE
Made ReadResult much smaller

### DIFF
--- a/src/System.IO.Pipelines.Extensions/UnownedBufferReader.cs
+++ b/src/System.IO.Pipelines.Extensions/UnownedBufferReader.cs
@@ -346,7 +346,7 @@ namespace System.IO.Pipelines
                 Reading.GetAwaiter().GetResult();
             }
 
-            return new ReadResult(this, readingIsCancelled, readingIsCompleted);
+            return new ReadResult(null, readingIsCancelled, readingIsCompleted);
         }
 
         private void Dispose()

--- a/src/System.IO.Pipelines/IReadableBufferContainer.cs
+++ b/src/System.IO.Pipelines/IReadableBufferContainer.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.IO.Pipelines
+{
+    public interface IReadableBufferContainer
+    {
+        ReadableBuffer Buffer { get; }
+    }
+}

--- a/src/System.IO.Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/Pipe.cs
@@ -10,7 +10,7 @@ namespace System.IO.Pipelines
     /// <summary>
     /// Default <see cref="IPipeWriter"/> and <see cref="IPipeReader"/> implementation.
     /// </summary>
-    internal class Pipe : IPipe, IPipeReader, IPipeWriter, IReadableBufferAwaiter, IWritableBufferAwaiter
+    internal class Pipe : IPipe, IPipeReader, IPipeWriter, IReadableBufferAwaiter, IWritableBufferAwaiter, IReadableBufferContainer
     {
         // This sync objects protects the following state:
         // 1. _commitHead & _commitHeadIndex
@@ -36,6 +36,8 @@ namespace System.IO.Pipelines
 
         // The read head which is the extent of the IPipelineReader's consumed bytes
         private BufferSegment _readHead;
+        private BufferSegment _readTail;
+        private int _readTailIndex;
 
         // The commit head which is the extent of the bytes available to the IPipelineReader to consume
         private BufferSegment _commitHead;
@@ -424,6 +426,10 @@ namespace System.IO.Pipelines
                     _readerAwaitable.Reset();
                 }
 
+                // Reset the read tail
+                _readTail = null;
+                _readTailIndex = 0;
+
                 _readingState.End(ExceptionResource.NoReadToComplete);
             }
 
@@ -567,18 +573,11 @@ namespace System.IO.Pipelines
                     result.ResultFlags |= ResultFlags.Cancelled;
                 }
 
-                // No need to read end if there is no head
-                var head = _readHead;
-                if (head != null)
-                {
-                    // Reading commit head shared with writer
-                    result.ResultBuffer.BufferEnd.Segment = _commitHead;
-                    result.ResultBuffer.BufferEnd.Index = _commitHeadIndex;
-                    result.ResultBuffer.BufferLength = ReadCursor.GetLength(head, head.Start, _commitHead, _commitHeadIndex);
+                result.BufferContainer = this;
 
-                    result.ResultBuffer.BufferStart.Segment = head;
-                    result.ResultBuffer.BufferStart.Index = head.Start;
-                }
+                // Store the read tail since the commit head and commit index are shared with the writer
+                _readTail = _commitHead;
+                _readTailIndex = _commitHeadIndex;
 
                 _readingState.Begin(ExceptionResource.AlreadyReading);
 
@@ -625,5 +624,24 @@ namespace System.IO.Pipelines
 
         public IPipeReader Reader => this;
         public IPipeWriter Writer => this;
+
+        ReadableBuffer IReadableBufferContainer.Buffer
+        {
+            get
+            {
+                var buffer = new ReadableBuffer();
+                var head = _readHead;
+                if (head != null)
+                {
+                    // Reading commit head shared with writer
+                    buffer.BufferEnd.Segment = _readTail;
+                    buffer.BufferEnd.Index = _readTailIndex;
+                    buffer.BufferLength = ReadCursor.GetLength(head, head.Start, _readTail, _readTailIndex);
+                    buffer.BufferStart.Segment = head;
+                    buffer.BufferStart.Index = head.Start;
+                }
+                return buffer;
+            }
+        }
     }
 }

--- a/src/System.IO.Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/Pipe.cs
@@ -91,7 +91,7 @@ namespace System.IO.Pipelines
             _writerAwaitable = new PipeAwaitable(completed: true);
         }
 
-        internal Buffer<byte> Buffer => _writingHead?.Buffer.Slice(_writingHead.End, _writingHead.WritableBytes) ?? Buffer<byte>.Empty;
+        internal Buffer<byte> Data => _writingHead?.Buffer.Slice(_writingHead.End, _writingHead.WritableBytes) ?? Buffer<byte>.Empty;
 
         /// <summary>
         /// Allocates memory from the pipeline to write into.
@@ -625,7 +625,7 @@ namespace System.IO.Pipelines
         public IPipeReader Reader => this;
         public IPipeWriter Writer => this;
 
-        ReadableBuffer IReadableBufferContainer.Buffer
+        public ReadableBuffer Buffer
         {
             get
             {

--- a/src/System.IO.Pipelines/ReadResult.cs
+++ b/src/System.IO.Pipelines/ReadResult.cs
@@ -8,10 +8,10 @@ namespace System.IO.Pipelines
     /// </summary>
     public struct ReadResult
     {
-        internal IReadableBufferContainer BufferContainer;
+        internal Pipe BufferContainer;
         internal ResultFlags ResultFlags;
 
-        public ReadResult(IReadableBufferContainer bufferContainer, bool isCancelled, bool isCompleted)
+        internal ReadResult(Pipe bufferContainer, bool isCancelled, bool isCompleted)
         {
             BufferContainer = bufferContainer;
             ResultFlags = ResultFlags.None;
@@ -29,7 +29,7 @@ namespace System.IO.Pipelines
         /// <summary>
         /// The <see cref="ReadableBuffer"/> that was read
         /// </summary>
-        public ReadableBuffer Buffer => ((Pipe)BufferContainer).Buffer;
+        public ReadableBuffer Buffer => BufferContainer.Buffer;
 
         /// <summary>
         /// True if the currrent read was cancelled

--- a/src/System.IO.Pipelines/ReadResult.cs
+++ b/src/System.IO.Pipelines/ReadResult.cs
@@ -29,7 +29,7 @@ namespace System.IO.Pipelines
         /// <summary>
         /// The <see cref="ReadableBuffer"/> that was read
         /// </summary>
-        public ReadableBuffer Buffer => BufferContainer.Buffer;
+        public ReadableBuffer Buffer => ((Pipe)BufferContainer).Buffer;
 
         /// <summary>
         /// True if the currrent read was cancelled

--- a/src/System.IO.Pipelines/ReadResult.cs
+++ b/src/System.IO.Pipelines/ReadResult.cs
@@ -8,12 +8,12 @@ namespace System.IO.Pipelines
     /// </summary>
     public struct ReadResult
     {
-        internal ReadableBuffer ResultBuffer;
+        internal IReadableBufferContainer BufferContainer;
         internal ResultFlags ResultFlags;
 
-        public ReadResult(ReadableBuffer buffer, bool isCancelled, bool isCompleted)
+        public ReadResult(IReadableBufferContainer bufferContainer, bool isCancelled, bool isCompleted)
         {
-            ResultBuffer = buffer;
+            BufferContainer = bufferContainer;
             ResultFlags = ResultFlags.None;
 
             if (isCompleted)
@@ -29,7 +29,7 @@ namespace System.IO.Pipelines
         /// <summary>
         /// The <see cref="ReadableBuffer"/> that was read
         /// </summary>
-        public ReadableBuffer Buffer => ResultBuffer;
+        public ReadableBuffer Buffer => BufferContainer.Buffer;
 
         /// <summary>
         /// True if the currrent read was cancelled

--- a/src/System.IO.Pipelines/WritableBuffer.cs
+++ b/src/System.IO.Pipelines/WritableBuffer.cs
@@ -20,7 +20,7 @@ namespace System.IO.Pipelines
         /// <summary>
         /// Available memory.
         /// </summary>
-        public Buffer<byte> Buffer => _pipe.Buffer;
+        public Buffer<byte> Buffer => _pipe.Data;
 
         /// <summary>
         /// Returns the number of bytes currently written and uncommitted.


### PR DESCRIPTION
- Removed ReadableBuffer from ReadResult
- Introduced IReadableBufferContainer to abstract
where the buffer comes from (since we have 2 implementations of
IPipeReader).

/cc @benaadams 

Looks worse:

## master

```
                                          Method |          Mean |     StdDev |          RPS |
------------------------------------------------ |-------------- |----------- |------------- |
                         ParseLiveAspNetTwoTasks |   330.7742 ns | 17.7211 ns | 3,023,210.53 |
                           ParseLiveAspNetInline |   227.6225 ns |  9.5324 ns | 4,393,239.30 |
                          WritePlaintextResponse | 1,166.4743 ns | 27.5751 ns |   857,284.22 |
                      WriteFastPlaintextResponse |   636.8326 ns | 25.4006 ns | 1,570,271.38 |
 WriteableBufferWriterWriteFastPlaintextResponse |   373.7927 ns |  8.2061 ns | 2,675,279.69 |
 ```

## PR

```
                                          Method |          Mean |     StdDev |          RPS |
------------------------------------------------ |-------------- |----------- |------------- |
                         ParseLiveAspNetTwoTasks |   345.7023 ns |  8.8914 ns | 2,892,661.99 |
                           ParseLiveAspNetInline |   256.5148 ns |  5.4145 ns | 3,898,411.00 |
                          WritePlaintextResponse | 1,201.2230 ns | 25.0501 ns |   832,484.88 |
                      WriteFastPlaintextResponse |   659.7527 ns | 11.3433 ns | 1,515,719.34 |
 WriteableBufferWriterWriteFastPlaintextResponse |   404.2825 ns | 12.3326 ns | 2,473,517.64 |
 ```

Looking into it. 

**EDIT: The tests were accessing .Buffer multiple times per read loop. I've made a change**

https://github.com/dotnet/corefxlab/commit/acf97df67fce1a2cb40f0843067186efd400ce3b

Will re-run. 

Slightly worse still. I'll play with advance to see if there's any benefit there.

## master

 ```
                                           Method |          Mean |     StdDev |          RPS |
------------------------------------------------ |-------------- |----------- |------------- |
                         ParseLiveAspNetTwoTasks |   329.8636 ns | 15.9275 ns | 3,031,556.33 |
                           ParseLiveAspNetInline |   221.4754 ns |  5.8819 ns | 4,515,173.33 |
                          WritePlaintextResponse | 1,179.9437 ns | 32.2254 ns |   847,498.04 |
                      WriteFastPlaintextResponse |   637.2167 ns | 14.9200 ns | 1,569,324.73 |
 WriteableBufferWriterWriteFastPlaintextResponse |   383.3450 ns | 10.4070 ns | 2,608,615.94 |
 ```

 ## PR


```
                                           Method |          Mean |    StdErr |     StdDev |          RPS |
------------------------------------------------ |-------------- |---------- |----------- |------------- |
                         ParseLiveAspNetTwoTasks |   352.4723 ns | 5.6477 ns | 30.9337 ns | 2,837,102.20 |
                           ParseLiveAspNetInline |   235.4571 ns | 1.4218 ns |  7.7877 ns | 4,247,058.13 |
                          WritePlaintextResponse | 1,161.5754 ns | 4.3150 ns | 23.6341 ns |   860,899.76 |
                      WriteFastPlaintextResponse |   631.0954 ns | 2.9704 ns | 16.2695 ns | 1,584,546.42 |
 WriteableBufferWriterWriteFastPlaintextResponse |   381.2534 ns | 1.8657 ns | 10.2189 ns | 2,622,927.18 |
 ```

Looks like a wash, I need to look at the asm

```
                                           Method |          Mean |     StdDev |          RPS |
------------------------------------------------ |-------------- |----------- |------------- |
                         ParseLiveAspNetTwoTasks |   316.3155 ns | 16.6208 ns | 3,161,400.68 |
                           ParseLiveAspNetInline |   236.6768 ns |  6.0560 ns | 4,225,170.38 |
                          WritePlaintextResponse | 1,182.1459 ns | 37.0573 ns |   845,919.28 |
                      WriteFastPlaintextResponse |   626.2426 ns |  9.9867 ns | 1,596,825.23 |
 WriteableBufferWriterWriteFastPlaintextResponse |   387.2140 ns | 11.2070 ns | 2,582,551.45 |
 ```