### PR TITLE
Expose OwnedBuffer.TryGetPointer

### DIFF
--- a/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
@@ -65,11 +65,7 @@ namespace System.Buffers
 
         public unsafe bool TryGetPointer(out void* pointer)
         {
-            if (!_owner.TryGetPointerInternal(out pointer)) {
-                return false;
-            }
-            pointer = Add(pointer, _index);
-            return true;
+            return _owner.TryGetPointerInternal(_index, out pointer);
         }
 
         public bool TryGetArray(out ArraySegment<T> buffer)
@@ -79,11 +75,6 @@ namespace System.Buffers
             }
             buffer = new ArraySegment<T>(buffer.Array, buffer.Offset + _index, _length);
             return true;
-        }
-
-        internal static unsafe void* Add(void* pointer, int offset)
-        {
-            return (byte*)pointer + ((ulong)Unsafe.SizeOf<T>() * (ulong)offset);
         }
 
         public T[] ToArray() => Span.ToArray();

--- a/src/System.Buffers.Primitives/System/Buffers/BufferHandle.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/BufferHandle.cs
@@ -16,17 +16,15 @@ namespace System.Buffers
         {
             void* pointer;
             GCHandle handle;
-            if (owner.TryGetPointerInternal(out pointer))
-            {
-                pointer = Buffer<T>.Add(pointer, index);
-            }
+            if (owner.TryGetPointerInternal(index, out pointer))
+            {}
             else
             {
                 ArraySegment<T> buffer;
                 if (owner.TryGetArrayInternal(out buffer))
                 {
                     handle = GCHandle.Alloc(buffer.Array, GCHandleType.Pinned);
-                    pointer = Buffer<T>.Add((void*)handle.AddrOfPinnedObject(), buffer.Offset + index);
+                    pointer = OwnedBuffer<T>.Add((void*)handle.AddrOfPinnedObject(), buffer.Offset + index);
                 }
                 else
                 {

--- a/src/System.Buffers.Primitives/System/Buffers/OwnedBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/OwnedBuffer.cs
@@ -78,7 +78,7 @@ namespace System.Buffers
             return true;
         }
 
-        protected unsafe bool TryGetPointerCore(out void* pointer)
+        public unsafe bool TryGetPointer(out void* pointer)
         {
             if (Pointer == IntPtr.Zero) {
                 pointer = null;
@@ -150,9 +150,18 @@ namespace System.Buffers
             Release();
         }
 
-        internal unsafe bool TryGetPointerInternal(out void* pointer)
+        internal unsafe bool TryGetPointerInternal(int offset, out void* pointer)
         {
-            return TryGetPointerCore(out pointer);
+            if (!TryGetPointer(out pointer)) {
+                return false;
+            }
+            pointer = Add(pointer, offset);
+            return true;
+        }
+
+        internal static unsafe void* Add(void* pointer, int offset)
+        {
+            return (byte*)pointer + ((ulong)Unsafe.SizeOf<T>() * (ulong)offset);
         }
 
         internal bool TryGetArrayInternal(out ArraySegment<T> buffer)

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -62,11 +62,7 @@ namespace System.Buffers
    
         public unsafe bool TryGetPointer(out void* pointer)
         {
-            if (!_owner.TryGetPointerInternal(out pointer)) {
-                return false;
-            }
-            pointer = Buffer<T>.Add(pointer, _index);
-            return true;
+            return _owner.TryGetPointerInternal(_index, out pointer);
         }
 
         public unsafe bool TryGetArray(out ArraySegment<T> buffer)


### PR DESCRIPTION
There is no way to get the pointer of an OwnedBuffer which is needed to support https://github.com/dotnet/corefxlab/issues/1233.

@davidfowl @benaadams