### PR TITLE
Removing array CopyTo span as it is being added to SpanExtensions

### DIFF
--- a/src/System.Buffers.Primitives/System/SpanExtensions_array.cs
+++ b/src/System.Buffers.Primitives/System/SpanExtensions_array.cs
@@ -12,11 +12,6 @@ namespace System
     /// </summary>
     public static partial class SpanExtensionsLabs
     {
-        public static void CopyTo<T>(this T[] array, Span<T> span)
-        {
-            array.AsSpan().CopyTo(span);
-        }
-
         /// <summary>
         /// Creates a new readonly span over the portion of the target string.
         /// </summary>

--- a/tests/System.Buffers.Primitives.Tests/BasicUnitTests.cs
+++ b/tests/System.Buffers.Primitives.Tests/BasicUnitTests.cs
@@ -307,7 +307,7 @@ namespace System.Buffers.Tests
         {
             var destination = new Span<byte>(new byte[100]);
             var source = new byte[] { 1, 2, 3 };
-            source.CopyTo(destination);
+            source.AsSpan().CopyTo(destination);
             for (int i = 0; i < source.Length; i++)
             {
                 Assert.Equal(source[i], destination[i]);

--- a/tests/System.Buffers.Primitives.Tests/UsageScenarioTests.cs
+++ b/tests/System.Buffers.Primitives.Tests/UsageScenarioTests.cs
@@ -314,11 +314,11 @@ namespace System.Slices.Tests
         {
             IntPtr pa = Marshal.AllocHGlobal(a.Length);
             Span<byte> na = new Span<byte>(pa.ToPointer(), a.Length);
-            a.CopyTo(na);
+            a.AsSpan().CopyTo(na);
 
             IntPtr pb = Marshal.AllocHGlobal(b.Length);
             Span<byte> nb = new Span<byte>(pb.ToPointer(), b.Length);
-            b.CopyTo(nb);
+            b.AsSpan().CopyTo(nb);
 
             ReadOnlySpan<byte> spanA = na.Slice(aidx, acount);
             Span<byte> spanB = nb.Slice(bidx, bcount);


### PR DESCRIPTION
As part of: https://github.com/dotnet/corefxlab/issues/1314 / https://github.com/dotnet/corefxlab/issues/1292

Being added in this PR: https://github.com/dotnet/corefx/pull/17783

cc @shiftylogic, @davidfowl 