### PR TITLE
[WIP] Fix RIO Thread

### DIFF
--- a/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
@@ -280,7 +280,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO.Internal
 
         private static void Notify(RioTcpConnection[] connectionsToSignal, uint count)
         {
-            for (var i = 0; i<connectionsToSignal.Length; i++)
+            for (var i = 0; i < connectionsToSignal.Length; i++)
             {
                 if (i >= count)
                 {

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
@@ -441,7 +441,9 @@ namespace System.IO.Pipelines.Networking.Windows.RIO.Internal
                         }
 
                         Complete(results, count, connectionsToSignal);
-                        
+
+                        Notify(connectionsToSignal, count);
+
                         if (!activatedNotify)
                         {
                             activatedNotify = true;

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
@@ -291,7 +291,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO.Internal
 
                 if (connection != null)
                 {
-                    // REVIEW: Would it be better to call connection.ReceiveComplete() here?
+                    connection.ReceiveEndComplete();
                     connectionsToSignal[i] = null;
                 }
             }
@@ -395,7 +395,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO.Internal
                 {
                     if (result.RequestCorrelation >= 0)
                     {
-                        connection.ReceiveComplete(result.BytesTransferred);
+                        connection.ReceiveBeginComplete(result.BytesTransferred);
                         connectionsToSignal[i] = connection;
                     }
                     else

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
@@ -349,9 +349,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO.Internal
                         var connectionsToSignal = batch.ConnectionsToSignal;
 
                         Complete(results, count, connectionsToSignal);
-
-                        Notify(connectionsToSignal, count);
-
+                        
                         lock (_notify)
                         {
                             _notifyBatches.Enqueue(batch);

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/RioThread.cs
@@ -349,7 +349,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO.Internal
                         var connectionsToSignal = batch.ConnectionsToSignal;
 
                         Complete(results, count, connectionsToSignal);
-                        
+
                         lock (_notify)
                         {
                             _notifyBatches.Enqueue(batch);

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/RioTcpConnection.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/RioTcpConnection.cs
@@ -53,6 +53,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
 
             rioThread.AddConnection(connectionId, this);
 
+            _buffer = _input.Writer.Alloc(2048);
             ProcessReceives();
             _sendTask = ProcessSends();
         }
@@ -62,7 +63,6 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
 
         private void ProcessReceives()
         {
-            _buffer = _input.Writer.Alloc(2048);
             var receiveBufferSeg = _rioThread.GetSegmentFromMemory(_buffer.Buffer);
 
             if (!_rio.RioReceive(_requestQueue, ref receiveBufferSeg, 1, RioReceiveFlags.None, 0))
@@ -97,7 +97,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
                         current = next;
                     }
 
-                    await PreviousSendingComplete;
+                    await PreviousSendingComplete();
 
                     _sendingBuffer = buffer.Preserve();
 
@@ -112,7 +112,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
 
         private Task SendAsync(Buffer<byte> memory, bool endOfMessage)
         {
-            if (!IsReadyToSend)
+            if (!IsReadyToSend())
             {
                 return SendAsyncAwaited(memory, endOfMessage);
             }
@@ -131,7 +131,7 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
 
         private async Task SendAsyncAwaited(Buffer<byte> memory, bool endOfMessage)
         {
-            await ReadyToSend;
+            await ReadyToSend();
 
             var flushSends = endOfMessage || MaxOutstandingSendsReached;
 
@@ -139,13 +139,13 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
 
             if (flushSends && !endOfMessage)
             {
-                await ReadyToSend;
+                await ReadyToSend();
             }
         }
 
         private async Task AwaitReadyToSend()
         {
-            await ReadyToSend;
+            await ReadyToSend();
         }
 
         private void Send(RioBufferSegment segment, bool flushSends)
@@ -159,11 +159,11 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
             }
         }
 
-        private Task PreviousSendingComplete => _previousSendsComplete.WaitAsync();
+        private Task PreviousSendingComplete() => _previousSendsComplete.WaitAsync();
 
-        private Task ReadyToSend => _outgoingSends.WaitAsync();
+        private Task ReadyToSend() => _outgoingSends.WaitAsync();
 
-        private bool IsReadyToSend => _outgoingSends.Wait(0);
+        private bool IsReadyToSend() => _outgoingSends.Wait(0);
 
         private bool MaxOutstandingSendsReached => _outgoingSends.CurrentCount == 0;
 
@@ -198,17 +198,25 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
             }
         }
 
-        public void ReceiveComplete(uint bytesTransferred)
+        public void ReceiveBeginComplete(uint bytesTransferred)
         {
-            // REVIEW: Why was there special behaviour for bytesTransferred = 0?
-            if (bytesTransferred > 0)
+            if (bytesTransferred == 0)
             {
+                _input.Writer.Complete();
+            }
+            else
+            {
+                _buffer = _input.Writer.Alloc(2048);
                 _buffer.Advance((int)bytesTransferred);
                 _buffer.Commit();
-                _buffer.FlushAsync();
 
                 ProcessReceives();
             }
+        }
+
+        public void ReceiveEndComplete()
+        {
+            _buffer.FlushAsync();
         }
        
         private static void ThrowError(ErrorType type)

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/RioTcpConnection.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/RioTcpConnection.cs
@@ -198,26 +198,19 @@ namespace System.IO.Pipelines.Networking.Windows.RIO
             }
         }
 
-        public void ReceiveBeginComplete(uint bytesTransferred)
+        public void ReceiveComplete(uint bytesTransferred)
         {
-            if (bytesTransferred == 0)
-            {
-                _input.Writer.Complete();
-            }
-            else
+            // REVIEW: Why was there special behaviour for bytesTransferred = 0?
+            if (bytesTransferred > 0)
             {
                 _buffer.Advance((int)bytesTransferred);
                 _buffer.Commit();
+                _buffer.FlushAsync();
 
                 ProcessReceives();
             }
         }
-
-        public void ReceiveEndComplete()
-        {
-            _buffer.FlushAsync();
-        }
-
+       
         private static void ThrowError(ErrorType type)
         {
             var errorNo = RioImports.WSAGetLastError();

--- a/tests/System.IO.Pipelines.Tests/SocketsFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/SocketsFacts.cs
@@ -110,7 +110,7 @@ namespace System.IO.Pipelines.Tests
             Assert.Equal(MessageToSend, reply);
         }
 
-        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a class instance field.")]
+        [Fact]
         public async Task RunStressPingPongTest_Libuv()
         {
             var endpoint = new IPEndPoint(IPAddress.Loopback, 5040);
@@ -142,7 +142,7 @@ namespace System.IO.Pipelines.Tests
             }
         }
 
-        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a class instance field.")]
+        [Fact]
         public async Task RunStressPingPongTest_Socket()
         {
             var endpoint = new IPEndPoint(IPAddress.Loopback, 5050);
@@ -173,7 +173,7 @@ namespace System.IO.Pipelines.Tests
             }
         }
 
-        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a class instance field.")]
+        [Fact]
         public async Task RunStressPingPongTest_RioServer_LibuvClient()
         {
             var endpoint = new IPEndPoint(IPAddress.Loopback, 5060);
@@ -218,8 +218,8 @@ namespace System.IO.Pipelines.Tests
 
         static async Task<Tuple<int, int, int>> PingClient(IPipeConnection connection, int messagesToSend)
         {
-            Span<byte> _ping = new Span<byte>(Encoding.ASCII.GetBytes("PING"));
-            Span<byte> _pong = new Span<byte>(Encoding.ASCII.GetBytes("PING"));
+            byte[] _ping = Encoding.ASCII.GetBytes("PING");
+            byte[] _pong = Encoding.ASCII.GetBytes("PING");
 
             int count = 0;
             var watch = Stopwatch.StartNew();
@@ -276,8 +276,8 @@ namespace System.IO.Pipelines.Tests
 
         private static async Task PongServer(IPipeConnection connection)
         {
-            Span<byte> _ping = new Span<byte>(Encoding.ASCII.GetBytes("PING"));
-            Span<byte> _pong = new Span<byte>(Encoding.ASCII.GetBytes("PING"));
+            byte[] _ping = Encoding.ASCII.GetBytes("PING");
+            byte[] _pong = Encoding.ASCII.GetBytes("PING");
 
             while (true)
             {


### PR DESCRIPTION
There's an issue with the RIO code calling `_buffer.FlushAsync()` in `ReceiveEndComplete` after it's been ~~reallocated~~ put back in a writable state by `ReceiveBeginComplete`.

To work around this I've just removed the `ReceiveEndComplete` method and am flushing before updating the shared input buffer.

I haven't removed any of the notify infrastructure in `RioThread`, even though it currently does nothing, because I thought we could work out what to do with it here. Maybe it can just be deleted, or some other work could be shifted onto the notify thread. Not sure.

The test is blocked on by-ref stuff, but this same code change worked fine pre-2.0 so it should work once that's sorted.

CC: @davidfowl @benaadams @aL3891