### PR TITLE
Cannot use Span as a generic type

### DIFF
--- a/tests/System.Text.Primitives.Tests/PrimitiveParserUInt32PerfTests.cs
+++ b/tests/System.Text.Primitives.Tests/PrimitiveParserUInt32PerfTests.cs
@@ -279,23 +279,28 @@ namespace System.Text.Primitives.Tests
             }
         }
 
-        [Benchmark(Skip = "The generic type 'System.Collections.Generic.List`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
-        private unsafe static void PrimitiveParserByteSpanToUInt32_VariableLength()
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        private unsafe static void PrimitiveParserByteSpanToUInt32_VariableLength(int index)
         {
-            List<ReadOnlySpan<byte>> byteSpanList = new List<ReadOnlySpan<byte>>();
-            foreach (string text in s_UInt32TextArray)
-            {
-                byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-                ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
-                byteSpanList.Add(utf8ByteSpan);
-            }
+            string text = s_UInt32TextArray[index];
+            byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
+            ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
                     for (int i = 0; i < LoadIterations; i++)
                     {
-                        ReadOnlySpan<byte> utf8ByteSpan = byteSpanList[i % 10];
                         uint value;
                         PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteSpan, out value);
                         DoNotIgnore(value, 0);
@@ -327,23 +332,28 @@ namespace System.Text.Primitives.Tests
             }
         }
 
-        [Benchmark(Skip = "The generic type 'System.Collections.Generic.List`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
-        private unsafe static void PrimitiveParserByteSpanToUInt32_BytesConsumed_VariableLength()
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(9)]
+        private unsafe static void PrimitiveParserByteSpanToUInt32_BytesConsumed_VariableLength(int index)
         {
-            List<ReadOnlySpan<byte>> byteSpanList = new List<ReadOnlySpan<byte>>();
-            foreach (string text in s_UInt32TextArray)
-            {
-                byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-                ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
-                byteSpanList.Add(utf8ByteSpan);
-            }
+            string text = s_UInt32TextArray[index];
+            byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
+            ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
                     for (int i = 0; i < LoadIterations; i++)
                     {
-                        ReadOnlySpan<byte> utf8ByteSpan = byteSpanList[i % 10];
                         uint value;
                         int bytesConsumed;
                         PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);
@@ -481,23 +491,26 @@ namespace System.Text.Primitives.Tests
             }
         }
 
-        [Benchmark(Skip = "The generic type 'System.Collections.Generic.List`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
-        private unsafe static void PrimitiveParserByteSpanToUInt32Hex_VariableLength()
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        private unsafe static void PrimitiveParserByteSpanToUInt32Hex_VariableLength(int index)
         {
-            List<ReadOnlySpan<byte>> byteSpanList = new List<ReadOnlySpan<byte>>();
-            foreach (string text in s_UInt32TextArrayHex)
-            {
-                byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-                ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
-                byteSpanList.Add(utf8ByteSpan);
-            }
+            string text = s_UInt32TextArrayHex[index];
+            byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
+            ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
                     for (int i = 0; i < LoadIterations; i++)
                     {
-                        ReadOnlySpan<byte> utf8ByteSpan = byteSpanList[i % 8];
                         uint value;
                         PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(utf8ByteSpan, out value);
                         DoNotIgnore(value, 0);
@@ -529,23 +542,26 @@ namespace System.Text.Primitives.Tests
             }
         }
 
-        [Benchmark(Skip = "The generic type 'System.Collections.Generic.List`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
-        private unsafe static void PrimitiveParserByteSpanToUInt32Hex_BytesConsumed_VariableLength()
+        [Benchmark]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        private unsafe static void PrimitiveParserByteSpanToUInt32Hex_BytesConsumed_VariableLength(int index)
         {
-            List<ReadOnlySpan<byte>> byteSpanList = new List<ReadOnlySpan<byte>>();
-            foreach (string text in s_UInt32TextArrayHex)
-            {
-                byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-                ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
-                byteSpanList.Add(utf8ByteSpan);
-            }
+            string text = s_UInt32TextArrayHex[index];
+            byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
+            ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
                     for (int i = 0; i < LoadIterations; i++)
                     {
-                        ReadOnlySpan<byte> utf8ByteSpan = byteSpanList[i % 8];
                         uint value;
                         int bytesConsumed;
                         PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);

--- a/tests/System.Text.Primitives.Tests/PrimitiveParserUInt32PerfTests.cs
+++ b/tests/System.Text.Primitives.Tests/PrimitiveParserUInt32PerfTests.cs
@@ -264,7 +264,7 @@ namespace System.Text.Primitives.Tests
         private unsafe static void PrimitiveParserByteSpanToUInt32(string text)
         {
             byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-            ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
+            var utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
@@ -294,7 +294,7 @@ namespace System.Text.Primitives.Tests
         {
             string text = s_UInt32TextArray[index];
             byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-            ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
+            var utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
@@ -316,7 +316,7 @@ namespace System.Text.Primitives.Tests
         private unsafe static void PrimitiveParserByteSpanToUInt32_BytesConsumed(string text)
         {
             byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-            ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
+            var utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
@@ -347,7 +347,7 @@ namespace System.Text.Primitives.Tests
         {
             string text = s_UInt32TextArray[index];
             byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-            ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
+            var utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
@@ -476,7 +476,7 @@ namespace System.Text.Primitives.Tests
         private unsafe static void PrimitiveParserByteSpanToUInt32Hex(string text)
         {
             byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-            ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
+            var utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
@@ -504,7 +504,7 @@ namespace System.Text.Primitives.Tests
         {
             string text = s_UInt32TextArrayHex[index];
             byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-            ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
+            var utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
@@ -526,7 +526,7 @@ namespace System.Text.Primitives.Tests
         private unsafe static void PrimitiveParserByteSpanToUInt32Hex_BytesConsumed(string text)
         {
             byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-            ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
+            var utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
@@ -555,7 +555,7 @@ namespace System.Text.Primitives.Tests
         {
             string text = s_UInt32TextArrayHex[index];
             byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-            ReadOnlySpan<byte> utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
+            var utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())

--- a/tests/System.Text.Primitives.Tests/PrimitiveParserUInt32PerfTests.cs
+++ b/tests/System.Text.Primitives.Tests/PrimitiveParserUInt32PerfTests.cs
@@ -336,20 +336,17 @@ namespace System.Text.Primitives.Tests
             {
                 utf8ByteArray[i] = Encoding.UTF8.GetBytes(s_UInt32TextArray[i]);
             }
-            for (int j = 0; j < 10; j++)
+            foreach (var iteration in Benchmark.Iterations)
             {
-                foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
                 {
-                    using (iteration.StartMeasurement())
+                    for (int i = 0; i < LoadIterations; i++)
                     {
-                        for (int i = 0; i < LoadIterations; i++)
-                        {
-                            ReadOnlySpan<byte> utf8ByteSpan = utf8ByteArray[i % textLength];
-                            uint value;
-                            int bytesConsumed;
-                            PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);
-                            DoNotIgnore(value, bytesConsumed);
-                        }
+                        ReadOnlySpan<byte> utf8ByteSpan = utf8ByteArray[i % textLength];
+                        uint value;
+                        int bytesConsumed;
+                        PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);
+                        DoNotIgnore(value, bytesConsumed);
                     }
                 }
             }

--- a/tests/System.Text.Primitives.Tests/PrimitiveParserUInt32PerfTests.cs
+++ b/tests/System.Text.Primitives.Tests/PrimitiveParserUInt32PerfTests.cs
@@ -280,27 +280,22 @@ namespace System.Text.Primitives.Tests
         }
 
         [Benchmark]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(2)]
-        [InlineData(3)]
-        [InlineData(4)]
-        [InlineData(5)]
-        [InlineData(6)]
-        [InlineData(7)]
-        [InlineData(8)]
-        [InlineData(9)]
-        private unsafe static void PrimitiveParserByteSpanToUInt32_VariableLength(int index)
+        private unsafe static void PrimitiveParserByteSpanToUInt32_VariableLength()
         {
-            string text = s_UInt32TextArray[index];
-            byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-            var utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
+            int textLength = s_UInt32TextArray.Length;
+            byte[][] utf8ByteArray = (byte[][])Array.CreateInstance(typeof(byte[]), textLength);
+            for (var i = 0; i < textLength; i++)
+            {
+                utf8ByteArray[i] = Encoding.UTF8.GetBytes(s_UInt32TextArray[i]);
+            }
+
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
                     for (int i = 0; i < LoadIterations; i++)
                     {
+                        ReadOnlySpan<byte> utf8ByteSpan = utf8ByteArray[i % textLength];
                         uint value;
                         PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteSpan, out value);
                         DoNotIgnore(value, 0);
@@ -333,31 +328,28 @@ namespace System.Text.Primitives.Tests
         }
 
         [Benchmark]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(2)]
-        [InlineData(3)]
-        [InlineData(4)]
-        [InlineData(5)]
-        [InlineData(6)]
-        [InlineData(7)]
-        [InlineData(8)]
-        [InlineData(9)]
-        private unsafe static void PrimitiveParserByteSpanToUInt32_BytesConsumed_VariableLength(int index)
+        private unsafe static void PrimitiveParserByteSpanToUInt32_BytesConsumed_VariableLength()
         {
-            string text = s_UInt32TextArray[index];
-            byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-            var utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
-            foreach (var iteration in Benchmark.Iterations)
+            int textLength = s_UInt32TextArray.Length;
+            byte[][] utf8ByteArray = (byte[][])Array.CreateInstance(typeof(byte[]), textLength);
+            for (var i = 0; i < textLength; i++)
             {
-                using (iteration.StartMeasurement())
+                utf8ByteArray[i] = Encoding.UTF8.GetBytes(s_UInt32TextArray[i]);
+            }
+            for (int j = 0; j < 10; j++)
+            {
+                foreach (var iteration in Benchmark.Iterations)
                 {
-                    for (int i = 0; i < LoadIterations; i++)
+                    using (iteration.StartMeasurement())
                     {
-                        uint value;
-                        int bytesConsumed;
-                        PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);
-                        DoNotIgnore(value, bytesConsumed);
+                        for (int i = 0; i < LoadIterations; i++)
+                        {
+                            ReadOnlySpan<byte> utf8ByteSpan = utf8ByteArray[i % textLength];
+                            uint value;
+                            int bytesConsumed;
+                            PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);
+                            DoNotIgnore(value, bytesConsumed);
+                        }
                     }
                 }
             }
@@ -492,25 +484,21 @@ namespace System.Text.Primitives.Tests
         }
 
         [Benchmark]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(2)]
-        [InlineData(3)]
-        [InlineData(4)]
-        [InlineData(5)]
-        [InlineData(6)]
-        [InlineData(7)]
-        private unsafe static void PrimitiveParserByteSpanToUInt32Hex_VariableLength(int index)
+        private unsafe static void PrimitiveParserByteSpanToUInt32Hex_VariableLength()
         {
-            string text = s_UInt32TextArrayHex[index];
-            byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-            var utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
+            int textLength = s_UInt32TextArrayHex.Length;
+            byte[][] utf8ByteArray = (byte[][])Array.CreateInstance(typeof(byte[]), textLength);
+            for (var i = 0; i < textLength; i++)
+            {
+                utf8ByteArray[i] = Encoding.UTF8.GetBytes(s_UInt32TextArrayHex[i]);
+            }
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
                     for (int i = 0; i < LoadIterations; i++)
                     {
+                        ReadOnlySpan<byte> utf8ByteSpan = utf8ByteArray[i % textLength];
                         uint value;
                         PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(utf8ByteSpan, out value);
                         DoNotIgnore(value, 0);
@@ -543,25 +531,21 @@ namespace System.Text.Primitives.Tests
         }
 
         [Benchmark]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(2)]
-        [InlineData(3)]
-        [InlineData(4)]
-        [InlineData(5)]
-        [InlineData(6)]
-        [InlineData(7)]
-        private unsafe static void PrimitiveParserByteSpanToUInt32Hex_BytesConsumed_VariableLength(int index)
+        private unsafe static void PrimitiveParserByteSpanToUInt32Hex_BytesConsumed_VariableLength()
         {
-            string text = s_UInt32TextArrayHex[index];
-            byte[] utf8ByteArray = Encoding.UTF8.GetBytes(text);
-            var utf8ByteSpan = new ReadOnlySpan<byte>(utf8ByteArray);
+            int textLength = s_UInt32TextArrayHex.Length;
+            byte[][] utf8ByteArray = (byte[][])Array.CreateInstance(typeof(byte[]), textLength);
+            for (var i = 0; i < textLength; i++)
+            {
+                utf8ByteArray[i] = Encoding.UTF8.GetBytes(s_UInt32TextArrayHex[i]);
+            }
             foreach (var iteration in Benchmark.Iterations)
             {
                 using (iteration.StartMeasurement())
                 {
                     for (int i = 0; i < LoadIterations; i++)
                     {
+                        ReadOnlySpan<byte> utf8ByteSpan = utf8ByteArray[i % textLength];
                         uint value;
                         int bytesConsumed;
                         PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);


### PR DESCRIPTION
Fixing some tests that were previously skipped because Span was used as a generic type within List<T>.

cc @shiftylogic, @botaberg, @davidfowl 