### PR TITLE
Fixing use of Span/Utf8String in tests

### DIFF
--- a/src/System.Text.Formatting/System/Text/Formatting/CompositeFormat.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/CompositeFormat.cs
@@ -213,11 +213,6 @@ namespace System.Text.Formatting {
                 formatter.Append(str);
                 return;
             }
-            var utf8 = value as Utf8String?;
-            if (utf8 != null) {
-                formatter.Append(utf8.Value);
-                return;
-            }
             var dt = value as DateTime?;
             if (dt != null)
             {

--- a/src/System.Text.Http/System/Text/Http/HttpRequest.cs
+++ b/src/System.Text.Http/System/Text/Http/HttpRequest.cs
@@ -171,7 +171,7 @@ namespace System.Text.Http
                 ReadOnlyBuffer<byte> segment;
                 while (bytes.TryGet(ref position, out segment, true))
                 {
-                    sb.Append(new Utf8String(segment.Span));
+                    sb.Append(new Utf8String(segment.Span).ToString());
                 }
             }
             else

--- a/src/System.Text.Http/System/Text/Http/IFormatterHttpExtensions.cs
+++ b/src/System.Text.Http/System/Text/Http/IFormatterHttpExtensions.cs
@@ -9,18 +9,18 @@ namespace System.Text.Http
     public static class IFormatterHttpExtensions
     {
         //TODO: Issue #387: In the Http extensions of IFormatter, we need to ensure that all the characters follow the basic rules of rfc2616
-        private static readonly Utf8String Http10 = new Utf8String("HTTP/1.0");
-        private static readonly Utf8String Http11 = new Utf8String("HTTP/1.1");
-        private static readonly Utf8String Http20 = new Utf8String("HTTP/2.0");
+        private static readonly string Http10 = "HTTP/1.0";
+        private static readonly string Http11 = "HTTP/1.1";
+        private static readonly string Http20 = "HTTP/2.0";
 
         private const int ULongMaxValueNumberOfCharacters = 20;
 
         public static void AppendHttpStatusLine<TFormatter>(this TFormatter formatter, HttpVersion version, int statusCode, Utf8String reasonCode) where TFormatter : ITextOutput
         {
             switch (version) {
-                case HttpVersion.V1_0: formatter.Append(Http10); break;
-                case HttpVersion.V1_1: formatter.Append(Http11); break;
-                case HttpVersion.V2_0: formatter.Append(Http20); break;
+                case HttpVersion.V1_0: formatter.Append(new Utf8String(Http10)); break;
+                case HttpVersion.V1_1: formatter.Append(new Utf8String(Http11)); break;
+                case HttpVersion.V2_0: formatter.Append(new Utf8String(Http20)); break;
                 default: throw new ArgumentException(nameof(version));
             }
 

--- a/src/System.Text.Json/System/Text/Json/JsonParser.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonParser.cs
@@ -138,9 +138,9 @@ namespace System.Text.Json
             Value = 6
         };
 
-        private static ReadOnlySpan<byte> s_false = new Utf8String("false").Bytes;
-        private static ReadOnlySpan<byte> s_true = new Utf8String("true").Bytes;
-        private static ReadOnlySpan<byte> s_null = new Utf8String("null").Bytes;
+        private static readonly byte[] s_false = new Utf8String("false").Bytes.ToArray();
+        private static readonly byte[] s_true = new Utf8String("true").Bytes.ToArray();
+        private static readonly byte[] s_null = new Utf8String("null").Bytes.ToArray();
 
         public JsonObject Parse(ReadOnlySpan<byte> utf8Json, BufferPool pool = null)
         {

--- a/tests/Benchmarks/E2EPipelineNoIO.cs
+++ b/tests/Benchmarks/E2EPipelineNoIO.cs
@@ -50,7 +50,7 @@ public partial class E2EPipelineTests
         }
     }
 
-    [Benchmark(Skip = "The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+    //[Benchmark(Skip = "The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
     [InlineData(1000, 256)]
     [InlineData(1000, 1024)]
     [InlineData(1000, 4096)]

--- a/tests/System.Text.Formatting.Tests/CompositeFormattingTests.cs
+++ b/tests/System.Text.Formatting.Tests/CompositeFormattingTests.cs
@@ -24,7 +24,7 @@ namespace System.Text.Formatting.Tests
             CultureInfo.CurrentUICulture = culture;
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Nullable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        [Fact]
         public void CompositeFormattingBasics()
         {
             var time = new DateTime(2016, 2, 9, 4, 1, 59, DateTimeKind.Utc);
@@ -34,17 +34,7 @@ namespace System.Text.Formatting.Tests
             }
         }
 
-        [Fact(Skip = "System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
-        public void CompositeFormattingUtf8String()
-        {
-            var value = new Utf8String("hello world!");
-            using (var formatter = new StringFormatter()) {
-                formatter.Format("{0}#{1}", value, value);
-                Assert.Equal("hello world!#hello world!", formatter.ToString());
-            }
-        }
-
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Nullable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        [Fact]
         public void CompositeFormattingDateTimeOffset()
         {
             var value = new DateTimeOffset(2016, 9, 23, 10, 53, 1, 1, TimeSpan.FromHours(1));
@@ -54,7 +44,7 @@ namespace System.Text.Formatting.Tests
             }
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Nullable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        [Fact]
         public void CompositeFormattingGuid()
         {
             var value = Guid.NewGuid();
@@ -64,7 +54,7 @@ namespace System.Text.Formatting.Tests
             }
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Nullable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        [Fact]
         public void CompositeFormattingFormatStrings()
         {
             var formatter = new StringFormatter();
@@ -73,7 +63,7 @@ namespace System.Text.Formatting.Tests
             Assert.Equal("HelloaFF3", formatter.ToString());
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Nullable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        [Fact]
         public void CompositeFormattingEscaping()
         {
             var format = "}}a {0} b {0} c {{{0}}} d {{e}} {{";
@@ -90,7 +80,7 @@ namespace System.Text.Formatting.Tests
             Assert.Throws<Exception>(() => formatter.Format("{{0}", 1));
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Nullable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        [Fact]
         public void CompositeFormattingEscapingMissingStartBracket()
         {
             var formatter = new StringFormatter();

--- a/tests/System.Text.Http.Tests/GivenAnHttpHeaders.cs
+++ b/tests/System.Text.Http.Tests/GivenAnHttpHeaders.cs
@@ -4,7 +4,6 @@
 using FluentAssertions;
 using Xunit;
 using System.Text.Utf8;
-using System.Text.Http;
 using System.Text.Http.SingleSegment;
 
 namespace System.Text.Http.Tests
@@ -25,28 +24,28 @@ namespace System.Text.Http.Tests
 
         private const string HeaderWithoutCrlf = "Host: localhost:8080";
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        //[Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void It_counts_the_number_of_headers_correctly()
         {
             var httpHeader = new HttpHeadersSingleSegment(new Span<byte>(new UTF8Encoding().GetBytes(HeadersString)));
             Assert.Equal(httpHeader.Count, 8);
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        //[Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void It_can_get_the_value_of_a_particular_header()
         {
             var httpHeader = new HttpHeadersSingleSegment(new Span<byte>(new UTF8Encoding().GetBytes(HeadersString)));
             Assert.Equal(httpHeader["Host"].ToString(), " localhost:8080");
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        //[Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void It_returns_empty_string_when_header_is_not_present()
         {
             var httpHeader = new HttpHeadersSingleSegment(new Span<byte>(new UTF8Encoding().GetBytes(HeadersString)));
             httpHeader["Content-Length"].Length.Should().Be(0);
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        //[Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void Its_enumerator_Current_returns_the_same_item_until_MoveNext_gets_called()
         {
             var httpHeader = new HttpHeadersSingleSegment(new Span<byte>(new UTF8Encoding().GetBytes(HeadersString)));
@@ -62,7 +61,7 @@ namespace System.Text.Http.Tests
             current.Should().NotBe(enumerator.Current);
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        //[Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void Its_Enumerator_iterates_through_all_headers()
         {
             var httpHeaders = new HttpHeadersSingleSegment(new Span<byte>(new UTF8Encoding().GetBytes(HeadersString)));
@@ -75,7 +74,7 @@ namespace System.Text.Http.Tests
             count.Should().Be(8);
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        //[Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void It_parsers_Utf8String_as_well()
         {
             var httpHeader = new HttpHeadersSingleSegment(new Utf8String(new UTF8Encoding().GetBytes(HeadersString)));
@@ -83,7 +82,7 @@ namespace System.Text.Http.Tests
             httpHeader.Count.Should().Be(8);
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        //[Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void String_without_column_throws_ArgumentException()
         {
             var httpHeader = new HttpHeadersSingleSegment(new Utf8String(new UTF8Encoding().GetBytes(HeaderWithoutColumn)));
@@ -99,7 +98,7 @@ namespace System.Text.Http.Tests
             }
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        //[Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void String_without_carriage_return_and_line_feed_throws_ArgumentException()
         {
             var httpHeader = new HttpHeadersSingleSegment(new Utf8String(new UTF8Encoding().GetBytes(HeaderWithoutCrlf)));
@@ -115,7 +114,7 @@ namespace System.Text.Http.Tests
             }
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        //[Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void CanParseBodylessRequest()
         {
             var request = new Utf8String("GET / HTTP/1.1\r\nConnection: close\r\n\r\n").CopyBytes().AsSpan();

--- a/tests/System.Text.Http.Tests/GivenIFormatterExtensionsForHttp.cs
+++ b/tests/System.Text.Http.Tests/GivenIFormatterExtensionsForHttp.cs
@@ -34,7 +34,7 @@ namespace System.Text.Http.Tests
             _formatter = new ArrayFormatter(124, TextEncoder.Utf8, ArrayPool<byte>.Shared);
         }
 
-        [Fact(Skip= "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a static field.")]
+        [Fact]
         public void It_has_an_extension_method_to_write_status_line()
         {            
             _formatter.AppendHttpStatusLine(HttpVersion.V1_1, 200, new Utf8String("OK"));
@@ -45,7 +45,7 @@ namespace System.Text.Http.Tests
             _formatter.Clear();
         }
 
-        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a static field.")]
+        [Fact]
         public void The_http_extension_methods_can_be_composed_to_generate_the_http_message()
         {
             _formatter.AppendHttpStatusLine(HttpVersion.V1_1, 200, new Utf8String("OK"));

--- a/tests/System.Text.Http.Tests/HttpRequestTests.cs
+++ b/tests/System.Text.Http.Tests/HttpRequestTests.cs
@@ -6,14 +6,13 @@ using System.Collections.Generic;
 using System.Collections.Sequences;
 using System.Text;
 using System.Text.Http;
-using System.Text.Utf8;
 using Xunit;
 
 namespace System.Slices.Tests
 {
     public partial class HttpRequestTests
     {
-        [Fact(Skip = "System.InvalidProgramException : Common Language Runtime detected an invalid program.")]
+        [Fact]
         public void HttpReaderSingleSegment()
         {
             var bytes = new ReadOnlyBytes(s_requestBytes);
@@ -37,7 +36,7 @@ namespace System.Slices.Tests
             }
         }
 
-        [Fact(Skip = "System.InvalidProgramException : Common Language Runtime detected an invalid program.")]
+        [Fact]
         public void HttpReaderMultipleSegments()
         {
             ReadOnlyBytes bytes = s_segmentedRequest;

--- a/tests/System.Text.Json.Tests.Dynamic/JsonDynamicObjectTests.cs
+++ b/tests/System.Text.Json.Tests.Dynamic/JsonDynamicObjectTests.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Dynamic.Tests
 {
     public class JsonDynamicObjectTests
     {
-        [Fact(Skip = "A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a static field.")]
+        [Fact(Skip= "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a class instance field.")]
         public void DynamicArrayLazy()
         {
             using (dynamic json = JsonLazyDynamicObject.Parse(new Utf8String("[true, false]"))) {
@@ -19,7 +19,7 @@ namespace System.Text.Json.Dynamic.Tests
             }
         }
 
-        [Fact(Skip = "A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a static field.")]
+        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a class instance field.")]
         public void NestedEagerReadLazy()
         {
             using(dynamic json = JsonLazyDynamicObject.Parse(new Utf8String("{ \"FirstName\": \"John\", \"LastName\": \"Smith\", \"Address\": { \"Street\": \"21 2nd Street\", \"City\": \"New York\", \"State\": \"NY\", \"Zip\": \"10021-3100\" }, \"IsAlive\": true, \"Age\": 25, \"Spouse\":null }"))){
@@ -37,26 +37,26 @@ namespace System.Text.Json.Dynamic.Tests
             }
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.Action`4' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        [Fact(Skip = "System.TypeLoadException : The generic type 'System.IEquatable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void NestedEagerRead()
         {
             dynamic json = JsonDynamicObject.Parse(new Utf8String("{ \"FirstName\": \"John\", \"LastName\": \"Smith\", \"Address\": { \"Street\": \"21 2nd Street\", \"City\": \"New York\", \"State\": \"NY\", \"Zip\": \"10021-3100\" }, \"IsAlive\": true, \"Age\": 25, \"Spouse\":null }"));
-            Assert.Equal(new Utf8String("John"), json.FirstName);
-            Assert.Equal(new Utf8String("Smith"), json.LastName);
+            Assert.Equal("John", json.FirstName);
+            Assert.Equal("Smith", json.LastName);
             Assert.Equal(true, json.IsAlive);
             Assert.Equal(25, json.Age);
             Assert.Equal(null, json.Spouse);
             Assert.Equal(6, json.Count);
 
             dynamic address = json.Address;
-            Assert.Equal(new Utf8String("21 2nd Street"), address.Street);
-            Assert.Equal(new Utf8String("New York"), address.City);
-            Assert.Equal(new Utf8String("NY"), address.State);
-            Assert.Equal(new Utf8String("10021-3100"), address.Zip);
+            Assert.Equal("21 2nd Street", address.Street);
+            Assert.Equal("New York", address.City);
+            Assert.Equal("NY", address.State);
+            Assert.Equal("10021-3100", address.Zip);
             Assert.Equal(4, address.Count);
         }
 
-        [Fact(Skip = "System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
+        [Fact(Skip = "System.TypeLoadException : The generic type 'System.IEquatable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void NestedEagerWrite()
         {
             var jsonText = new Utf8String("{\"FirstName\":\"John\",\"LastName\":\"Smith\",\"Address\":{\"Street\":\"21 2nd Street\",\"City\":\"New York\",\"State\":\"NY\",\"Zip\":\"10021-3100\"},\"IsAlive\":true,\"Age\":25,\"Spouse\":null}");
@@ -67,10 +67,10 @@ namespace System.Text.Json.Dynamic.Tests
 
             // The follwoing check only works given the current implmentation of Dictionary.
             // If the implementation changes, the properties might round trip to different places in the JSON text.
-            Assert.Equal(jsonText, formattedText); 
+            Assert.Equal(jsonText.ToString(), formattedText.ToString()); 
         }
 
-        [Fact(Skip= "System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
+        [Fact(Skip = "System.TypeLoadException : The generic type 'System.IEquatable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void EagerWrite()
         {
             dynamic json = new JsonDynamicObject();
@@ -78,30 +78,28 @@ namespace System.Text.Json.Dynamic.Tests
 
             var formatter = new ArrayFormatter(1024, TextEncoder.Utf8);
             formatter.Append((JsonDynamicObject)json);
-            var formattedText = new Utf8String(formatter.Formatted);
-            Assert.Equal(new Utf8String("{\"First\":\"John\"}"), formattedText);
+            Assert.Equal("{\"First\":\"John\"}", formatter.Formatted.ToString());
         }
 
-        [Fact(Skip= "A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a static field.")]
+        [Fact(Skip = "System.TypeLoadException : The generic type 'System.IEquatable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void NonAllocatingRead()
         {
-            var jsonText = new Utf8String("{\"First\":\"John\",\"Age\":25}");
-            JsonDynamicObject json = JsonDynamicObject.Parse(jsonText);
+            JsonDynamicObject json = JsonDynamicObject.Parse(new Utf8String("{\"First\":\"John\",\"Age\":25}"));
 
-            Assert.Equal(new Utf8String("John"), json.First());
+            Assert.Equal("John", json.First().ToString());
             Assert.Equal(25U, json.Age());
         }
     }
 
     static class SchemaExtensions
     {
-        static readonly Utf8String s_first = new Utf8String("First");
-        static readonly Utf8String s_age = new Utf8String("Age");
+        static readonly string s_first = "First";
+        static readonly string s_age = "Age";
 
         public static Utf8String First(this JsonDynamicObject json)
         {
             Utf8String value;
-            if(json.TryGetString(s_first, out value)) {
+            if(json.TryGetString(new Utf8String(s_first), out value)) {
                 return value;
             }
             throw new InvalidOperationException();
@@ -110,7 +108,7 @@ namespace System.Text.Json.Dynamic.Tests
         public static uint Age(this JsonDynamicObject json)
         {
             uint value;
-            if (json.TryGetUInt32(s_age, out value)) {
+            if (json.TryGetUInt32(new Utf8String(s_age), out value)) {
                 return value;
             }
             throw new InvalidOperationException();

--- a/tests/System.Text.Json.Tests.Dynamic/JsonDynamicObjectTests.cs
+++ b/tests/System.Text.Json.Tests.Dynamic/JsonDynamicObjectTests.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Dynamic.Tests
 {
     public class JsonDynamicObjectTests
     {
-        [Fact(Skip= "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a class instance field.")]
+        //[Fact(Skip= "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a class instance field.")]
         public void DynamicArrayLazy()
         {
             using (dynamic json = JsonLazyDynamicObject.Parse(new Utf8String("[true, false]"))) {
@@ -19,7 +19,7 @@ namespace System.Text.Json.Dynamic.Tests
             }
         }
 
-        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a class instance field.")]
+        //[Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a class instance field.")]
         public void NestedEagerReadLazy()
         {
             using(dynamic json = JsonLazyDynamicObject.Parse(new Utf8String("{ \"FirstName\": \"John\", \"LastName\": \"Smith\", \"Address\": { \"Street\": \"21 2nd Street\", \"City\": \"New York\", \"State\": \"NY\", \"Zip\": \"10021-3100\" }, \"IsAlive\": true, \"Age\": 25, \"Spouse\":null }"))){
@@ -37,7 +37,7 @@ namespace System.Text.Json.Dynamic.Tests
             }
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.IEquatable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        //[Fact(Skip = "System.TypeLoadException : The generic type 'System.IEquatable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void NestedEagerRead()
         {
             dynamic json = JsonDynamicObject.Parse(new Utf8String("{ \"FirstName\": \"John\", \"LastName\": \"Smith\", \"Address\": { \"Street\": \"21 2nd Street\", \"City\": \"New York\", \"State\": \"NY\", \"Zip\": \"10021-3100\" }, \"IsAlive\": true, \"Age\": 25, \"Spouse\":null }"));
@@ -56,7 +56,7 @@ namespace System.Text.Json.Dynamic.Tests
             Assert.Equal(4, address.Count);
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.IEquatable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        //[Fact(Skip = "System.TypeLoadException : The generic type 'System.IEquatable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void NestedEagerWrite()
         {
             var jsonText = new Utf8String("{\"FirstName\":\"John\",\"LastName\":\"Smith\",\"Address\":{\"Street\":\"21 2nd Street\",\"City\":\"New York\",\"State\":\"NY\",\"Zip\":\"10021-3100\"},\"IsAlive\":true,\"Age\":25,\"Spouse\":null}");
@@ -70,7 +70,7 @@ namespace System.Text.Json.Dynamic.Tests
             Assert.Equal(jsonText.ToString(), formattedText.ToString()); 
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.IEquatable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        //[Fact(Skip = "System.TypeLoadException : The generic type 'System.IEquatable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void EagerWrite()
         {
             dynamic json = new JsonDynamicObject();
@@ -81,7 +81,7 @@ namespace System.Text.Json.Dynamic.Tests
             Assert.Equal("{\"First\":\"John\"}", formatter.Formatted.ToString());
         }
 
-        [Fact(Skip = "System.TypeLoadException : The generic type 'System.IEquatable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
+        //[Fact(Skip = "System.TypeLoadException : The generic type 'System.IEquatable`1' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void NonAllocatingRead()
         {
             JsonDynamicObject json = JsonDynamicObject.Parse(new Utf8String("{\"First\":\"John\",\"Age\":25}"));

--- a/tests/System.Text.Json.Tests/JsonObjectTests.cs
+++ b/tests/System.Text.Json.Tests/JsonObjectTests.cs
@@ -10,17 +10,7 @@ namespace System.Text.Json.Tests
 {
     public class JsonObjectTests
     {
-
-        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a static field.")]
-        public void DynamicArrayLazy()
-        {
-            using (dynamic json = JsonLazyDynamicObject.Parse(new Utf8String("[true, false]"))) {
-                Assert.Equal(true, json[0]);
-                Assert.Equal(false, json[1]);
-            }
-        }
-
-        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a static field.")]
+        [Fact]
         public void ParseArray()
         {
             var buffer = StringToUtf8BufferWithEmptySpace(TestJson.SimpleArrayJson, 60);
@@ -33,7 +23,7 @@ namespace System.Text.Json.Tests
             }
         }
 
-        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a static field.")]
+        [Fact]
         public void ParseSimpleObject()
         {
             var buffer = StringToUtf8BufferWithEmptySpace(TestJson.SimpleObjectJson);
@@ -62,7 +52,7 @@ namespace System.Text.Json.Tests
             }
         }
 
-        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a static field.")]
+        [Fact]
         public void ParseNestedJson()
         {
             var buffer = StringToUtf8BufferWithEmptySpace(TestJson.ParseJson);
@@ -103,7 +93,7 @@ namespace System.Text.Json.Tests
             //var j = (string)person;                   // InvalidCastException
         }
 
-        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a static field.")]
+        [Fact]
         public void ParseBoolean()
         {
             var buffer = StringToUtf8BufferWithEmptySpace("[true,false]", 60);

--- a/tests/System.Text.Primitives.Tests/Encoding/RandomTests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/RandomTests.cs
@@ -83,7 +83,7 @@ namespace System.Text.Utf8.Tests
             new object[] { 4, "a\uABEE\uABCDa"}
         };
 
-        [Theory(Skip = "System.InvalidProgramException : Common Language Runtime detected an invalid program."), MemberData("LengthInCodePointsTestCases")]
+        //[Theory(Skip = "System.InvalidProgramException : Common Language Runtime detected an invalid program."), MemberData("LengthInCodePointsTestCases")]
         public void LengthInCodePoints(int expectedLength, string str)
         {
             Utf8String s = new Utf8String(str);

--- a/tests/System.Text.Primitives.Tests/Encoding/TypeConstraintsTests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/TypeConstraintsTests.cs
@@ -9,42 +9,34 @@ namespace System.Text.Utf8.Tests
 {
     public class TypeConstraintsTests
     {
-        [Fact(Skip = "System.InvalidProgramException : Common Language Runtime detected an invalid program.")]
+        [Fact]
         public void Utf8StringIsAStruct()
         {
-            Utf8String _anyUtf8String = new Utf8String("anyString");
-            Assert.True(_anyUtf8String.GetType().GetTypeInfo().IsValueType);
+            Assert.True(typeof(Utf8String).GetTypeInfo().IsValueType);
         }
 
-        [Fact(Skip = "System.InvalidProgramException : Common Language Runtime detected an invalid program.")]
+        [Fact]
         public void Utf8StringCodeUnitsEnumeratorIsAStruct()
         {
-            Utf8String _anyUtf8String = new Utf8String("anyString");
-            var utf8CodeUnitsEnumerator = _anyUtf8String.GetEnumerator();
-            Assert.True(_anyUtf8String.GetType().GetTypeInfo().IsValueType);
+            Assert.True(typeof(Utf8String.Enumerator).GetTypeInfo().IsValueType);
         }
 
-        [Fact(Skip = "System.InvalidProgramException : Common Language Runtime detected an invalid program.")]
+        [Fact]
         public void Utf8StringCodePointEnumerableIsAStruct()
         {
-            Utf8String _anyUtf8String = new Utf8String("anyString");
-            Assert.True(_anyUtf8String.CodePoints.GetType().GetTypeInfo().IsValueType);
+            Assert.True(typeof(Utf8String.CodePointEnumerable).GetTypeInfo().IsValueType);
         }
 
-        [Fact(Skip = "System.InvalidProgramException : Common Language Runtime detected an invalid program.")]
+        [Fact]
         public void Utf8StringCodePointEnumeratorIsAStruct()
         {
-            Utf8String _anyUtf8String = new Utf8String("anyString");
-            var utf8CodePointEnumerator = _anyUtf8String.CodePoints.GetEnumerator();
-            Assert.True(utf8CodePointEnumerator.GetType().GetTypeInfo().IsValueType);
+            Assert.True(typeof(Utf8String.CodePointEnumerator).GetTypeInfo().IsValueType);
         }
 
-        [Fact(Skip = "System.InvalidProgramException : Common Language Runtime detected an invalid program.")]
+        [Fact]
         public void Utf8StringReverseCodePointEnumeratorIsAStruct()
         {
-            Utf8String _anyUtf8String = new Utf8String("anyString");
-            var utf8CodePointEnumerator = _anyUtf8String.CodePoints.GetReverseEnumerator();
-            Assert.True(utf8CodePointEnumerator.GetType().GetTypeInfo().IsValueType);
+            Assert.True(typeof(Utf8String.CodePointReverseEnumerator).GetTypeInfo().IsValueType);
         }
     }
 }


### PR DESCRIPTION
Re-enabling tests that were disabled during migration to net core 2.0 here: https://github.com/dotnet/corefxlab/pull/1401

- Utf8String cannot be used as a generic in `Nullable<T>`.
- Cannot use Utf8String as a static.
- Cannot box Utf8String by calling GetType on it.
-  Cannot use Span or Utf8String as a static + removing a duplicate test.
-  Cannot cast Utf8String as an object.
- Removing tests (commenting out) around JsonDynamicObject and HttpHeadersSingleSegment.

Opened issues to address change requests to these types since they need to be redesigned.
- JsonDynamicObject / JsonLazyDynamicObject - #1434
- HttpHeadersSingleSegment - #1435
- Utf8String CodePointReverseEnumerator / CodePointEnumerator / CodePointEnumerable - #1235

cc @shiftylogic, @KrzysztofCwalina