### PR TITLE
Make flush public on the pipe

### DIFF
--- a/src/System.IO.Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/Pipe.cs
@@ -322,7 +322,7 @@ namespace System.IO.Pipelines
             } // and if zero, just do nothing; don't need to validate tail etc
         }
 
-        internal WritableBufferAwaitable FlushAsync()
+        public WritableBufferAwaitable FlushAsync()
         {
             Action awaitable;
             lock (_sync)

--- a/tests/System.IO.Pipelines.Tests/ReadableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/ReadableBufferFacts.cs
@@ -229,7 +229,7 @@ namespace System.IO.Pipelines.Tests
             var found = readBuffer.TrySliceTo(huntValue, out slice, out cursor);
             Assert.False(found);
 
-            // correctness test all values 
+            // correctness test all values
             for (int i = 0; i < readBuffer.Length; i++)
             {
                 *addresses[i] = huntValue;
@@ -354,74 +354,50 @@ namespace System.IO.Pipelines.Tests
             }
         }
 
-        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a class instance field.")]
-        public async Task ReadTWorksAgainstSimpleBuffers()
+        [Fact]
+        public void ReadTWorksAgainstSimpleBuffers()
         {
-            byte[] chunk = { 0, 1, 2, 3, 4, 5, 6, 7 };
-            var span = new Span<byte>(chunk);
-
-            using (var factory = new PipeFactory())
-            {
-                var readerWriter = factory.Create();
-                var output = readerWriter.Writer.Alloc();
-                output.Write(span);
-                var readable = output.AsReadableBuffer();
-                Assert.True(readable.IsSingleSpan);
-                Assert.Equal(span.Read<byte>(), readable.ReadLittleEndian<byte>());
-                Assert.Equal(span.Read<sbyte>(), readable.ReadLittleEndian<sbyte>());
-                Assert.Equal(span.Read<short>(), readable.ReadLittleEndian<short>());
-                Assert.Equal(span.Read<ushort>(), readable.ReadLittleEndian<ushort>());
-                Assert.Equal(span.Read<int>(), readable.ReadLittleEndian<int>());
-                Assert.Equal(span.Read<uint>(), readable.ReadLittleEndian<uint>());
-                Assert.Equal(span.Read<long>(), readable.ReadLittleEndian<long>());
-                Assert.Equal(span.Read<ulong>(), readable.ReadLittleEndian<ulong>());
-                Assert.Equal(span.Read<float>(), readable.ReadLittleEndian<float>());
-                Assert.Equal(span.Read<double>(), readable.ReadLittleEndian<double>());
-                await output.FlushAsync();
-            }
+            var readable = BufferUtilities.CreateBuffer(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 });
+            var span = readable.First.Span;
+            Assert.True(readable.IsSingleSpan);
+            Assert.Equal(span.Read<byte>(), readable.ReadLittleEndian<byte>());
+            Assert.Equal(span.Read<sbyte>(), readable.ReadLittleEndian<sbyte>());
+            Assert.Equal(span.Read<short>(), readable.ReadLittleEndian<short>());
+            Assert.Equal(span.Read<ushort>(), readable.ReadLittleEndian<ushort>());
+            Assert.Equal(span.Read<int>(), readable.ReadLittleEndian<int>());
+            Assert.Equal(span.Read<uint>(), readable.ReadLittleEndian<uint>());
+            Assert.Equal(span.Read<long>(), readable.ReadLittleEndian<long>());
+            Assert.Equal(span.Read<ulong>(), readable.ReadLittleEndian<ulong>());
+            Assert.Equal(span.Read<float>(), readable.ReadLittleEndian<float>());
+            Assert.Equal(span.Read<double>(), readable.ReadLittleEndian<double>());
         }
 
-        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a class instance field.")]
-        public async Task ReadTWorksAgainstMultipleBuffers()
+        [Fact]
+        public void ReadTWorksAgainstMultipleBuffers()
         {
-            using (var factory = new PipeFactory())
+            var readable = BufferUtilities.CreateBuffer(new byte[] { 0, 1, 2 }, new byte[] { 3, 4, 5 }, new byte[] { 6, 7, 9 });
+            Assert.Equal(9, readable.Length);
+
+            int spanCount = 0;
+            foreach (var _ in readable)
             {
-                var readerWriter = factory.Create();
-                var output = readerWriter.Writer.Alloc();
-
-                // we're going to try to force 3 buffers for 8 bytes
-                output.Write(new byte[] { 0, 1, 2 });
-                output.Ensure(4031);
-                output.Write(new byte[] { 3, 4, 5 });
-                output.Ensure(4031);
-                output.Write(new byte[] { 6, 7, 9 });
-
-                var readable = output.AsReadableBuffer();
-                Assert.Equal(9, readable.Length);
-
-                int spanCount = 0;
-                foreach (var _ in readable)
-                {
-                    spanCount++;
-                }
-                Assert.Equal(3, spanCount);
-
-                byte[] local = new byte[9];
-                readable.CopyTo(local);
-                var span = new Span<byte>(local);
-
-                Assert.Equal(span.Read<byte>(), readable.ReadLittleEndian<byte>());
-                Assert.Equal(span.Read<sbyte>(), readable.ReadLittleEndian<sbyte>());
-                Assert.Equal(span.Read<short>(), readable.ReadLittleEndian<short>());
-                Assert.Equal(span.Read<ushort>(), readable.ReadLittleEndian<ushort>());
-                Assert.Equal(span.Read<int>(), readable.ReadLittleEndian<int>());
-                Assert.Equal(span.Read<uint>(), readable.ReadLittleEndian<uint>());
-                Assert.Equal(span.Read<long>(), readable.ReadLittleEndian<long>());
-                Assert.Equal(span.Read<ulong>(), readable.ReadLittleEndian<ulong>());
-                Assert.Equal(span.Read<float>(), readable.ReadLittleEndian<float>());
-                Assert.Equal(span.Read<double>(), readable.ReadLittleEndian<double>());
-                await output.FlushAsync();
+                spanCount++;
             }
+            Assert.Equal(3, spanCount);
+
+            Assert.False(readable.IsSingleSpan);
+            Span<byte> span = readable.ToArray();
+
+            Assert.Equal(span.Read<byte>(), readable.ReadLittleEndian<byte>());
+            Assert.Equal(span.Read<sbyte>(), readable.ReadLittleEndian<sbyte>());
+            Assert.Equal(span.Read<short>(), readable.ReadLittleEndian<short>());
+            Assert.Equal(span.Read<ushort>(), readable.ReadLittleEndian<ushort>());
+            Assert.Equal(span.Read<int>(), readable.ReadLittleEndian<int>());
+            Assert.Equal(span.Read<uint>(), readable.ReadLittleEndian<uint>());
+            Assert.Equal(span.Read<long>(), readable.ReadLittleEndian<long>());
+            Assert.Equal(span.Read<ulong>(), readable.ReadLittleEndian<ulong>());
+            Assert.Equal(span.Read<float>(), readable.ReadLittleEndian<float>());
+            Assert.Equal(span.Read<double>(), readable.ReadLittleEndian<double>());
         }
 
         [Fact]

--- a/tests/System.IO.Pipelines.Tests/SocketsFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/SocketsFacts.cs
@@ -109,7 +109,7 @@ namespace System.IO.Pipelines.Tests
             Assert.Equal(MessageToSend, reply);
         }
 
-        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a class instance field.")]
+        [Fact]
         public async Task RunStressPingPongTest_Libuv()
         {
             var endpoint = new IPEndPoint(IPAddress.Loopback, 5040);
@@ -142,7 +142,7 @@ namespace System.IO.Pipelines.Tests
         }
 
 
-        [Fact(Skip = "System.TypeLoadException : A value type containing a by-ref instance field, such as Span<T>, cannot be used as the type for a class instance field.")]
+        [Fact]
         public async Task RunStressPingPongTest_Socket()
         {
             var endpoint = new IPEndPoint(IPAddress.Loopback, 5050);


### PR DESCRIPTION
The problem I have is a sync method that has a loop

```
var hasResult = pipe.Reader.TryRead(out ReadResult result);
if(!hasResult) return;
var buffer = result.Buffer;
while(GetFrame(ref buffer, out frame) != incomplete)
{
        var frameType = getframetype(frame);
        switch(frameType)
               case someFrameType:
                       //Do stuff that writes to another pipe, don't want to flushasync
                       //because there might be more frames so can't pass it out, but also
                       //don't want to make the method async because it is a pretty light
                       //and fully sync method other than flush so want to call commit
               case someOtherFrameType:
                      //same deal
}
```

The problem now comes that when calling this inside of an async method I need to know that writing took place and if it did I would then need to do
var writer = transportPipe.Writer.Alloc(0);
await writer.FlushAsync();

Just to flush. Instead I should be able to call
if(deframingloop() == true)
{
   await transportPipe.Writer.FlushAsync();
}
