### PR TITLE
Made FlushAsync public

### DIFF
--- a/src/System.IO.Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/Pipe.cs
@@ -322,7 +322,7 @@ namespace System.IO.Pipelines
             } // and if zero, just do nothing; don't need to validate tail etc
         }
 
-        internal WritableBufferAwaitable FlushAsync()
+        public WritableBufferAwaitable FlushAsync()
         {
             Action awaitable;
             lock (_sync)


### PR DESCRIPTION
The problem I have is a sync method that has a loop

```
var hasResult = pipe.Reader.TryRead(out ReadResult result);
if(!hasResult) return;
var buffer = result.Buffer;
while(GetFrame(ref buffer, out frame) != incomplete)
{
        var frameType = getframetype(frame);
        switch(frameType)
               case someFrameType:
                       //Do stuff that writes to another pipe, don't want to flushasync
                       //because there might be more frames so can't pass it out, but also
                       //don't want to make the method async because it is a pretty light
                       //and fully sync method other than flush so want to call commit
               case someOtherFrameType:
                      //same deal
}
```
The problem now comes that when calling this inside of an async method I need to know that writing took place and if it did I would then need to do
```
var writer = transportPipe.Writer.Alloc(0);
await writer.FlushAsync();
```

Just to flush. Instead I should be able to call
```
if(deframingloop() == true)
{
await transportPipe.Writer.FlushAsync();
}
```