### PR TITLE
referencing C# compiler from a myget feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -19,5 +19,6 @@
     <add key="coreclr-xunit" value="https://www.myget.org/F/coreclr-xunit/api/v2" />
     <add key="AspNetCIDev" value="https://www.myget.org/F/aspnetcidev/api/v3/index.json" />
     <add key="nugetbuild" value="https://www.myget.org/F/nugetbuild/api/v3/index.json" />
+    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/" />
   </packageSources>
 </configuration>

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -38,7 +38,7 @@ if ($Restore -eq "true") {
 $errorsEncountered = 0
 
 Write-Host "Building solution $file..."
-Invoke-Expression "$dotnetExePath build $file -c $Configuration /p:VersionSuffix=$BuildVersion"
+Invoke-Expression "$dotnetExePath msbuild $file /p:cofiguration=$Configuration /p:VersionSuffix=$BuildVersion"
 if ($lastexitcode -ne 0) {
     Write-Error "Failed to build solution $file"
     $errorsEncountered++
@@ -48,7 +48,7 @@ $projectsFailed = New-Object System.Collections.Generic.List[String]
 
 foreach ($testFile in [System.IO.Directory]::EnumerateFiles("$PSScriptRoot\..\tests", "*.csproj", "AllDirectories")) {
     Write-Host "Building and running tests for project $testFile..."
-    Invoke-Expression "$dotnetExePath test $testFile -c $Configuration -- -notrait category=performance -notrait category=outerloop"
+    Invoke-Expression "$dotnetExePath test $testFile -c $Configuration --no-build -- -notrait category=performance -notrait category=outerloop"
 
     if ($lastexitcode -ne 0) {
         Write-Error "Some tests failed in project $testFile"

--- a/tools/common.props
+++ b/tools/common.props
@@ -14,4 +14,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Net.Compilers" Version="$(RoslynVersion)" />
+  </ItemGroup>
 </Project>

--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <CoreFxVersion>4.3.0</CoreFxVersion>
+    <RoslynVersion>2.3.0-rdonly-ref-61530-07</RoslynVersion>
     <SystemMemoryVersion>4.4.0-preview1-25205-01</SystemMemoryVersion>
     <SystemCompilerServicesUnsafeVersion>4.4.0-preview1-25205-01</SystemCompilerServicesUnsafeVersion>
     <LibuvVersion>1.9.1</LibuvVersion>


### PR DESCRIPTION
As a first step we are using 2.3.0-rdonly-ref-61530-07 here.

NOTE: This compiler version does not implement any checks for Span<T>. That will come in the next change.