### PR TITLE
Switching to the new toolset compiler.

### DIFF
--- a/samples/System.IO.Pipelines.Samples/HttpClient/LibuvHttpClientHandler.cs
+++ b/samples/System.IO.Pipelines.Samples/HttpClient/LibuvHttpClientHandler.cs
@@ -152,8 +152,7 @@ namespace System.IO.Pipelines.Samples
                             break;
                         }
 
-                        var first = responseBuffer.First.Span;
-                        int ch = first[0];
+                        int ch = responseBuffer.First.Span[0];
 
                         if (ch == '\r')
                         {

--- a/samples/System.IO.Pipelines.Samples/HttpServer/HttpConnection.cs
+++ b/samples/System.IO.Pipelines.Samples/HttpServer/HttpConnection.cs
@@ -171,7 +171,7 @@ namespace System.IO.Pipelines.Samples.Http
             _path = null;
         }
 
-        public async Task WriteAsync(Span<byte> data)
+        public Task WriteAsync(Span<byte> data)
         {
             var buffer = _output.Alloc();
 
@@ -192,6 +192,11 @@ namespace System.IO.Pipelines.Samples.Http
                 buffer.Write(data);
             }
 
+            return FlushAsync(buffer);
+        }
+
+        public async Task FlushAsync(WritableBuffer buffer)
+        {
             await buffer.FlushAsync();
         }
 

--- a/tests/Benchmarks/Helpers/Server.cs
+++ b/tests/Benchmarks/Helpers/Server.cs
@@ -35,14 +35,14 @@ namespace System.IO.Pipelines.Samples
                             break;
                         }
 
-                        var requestBytes = input.First.Span;
+                        var requestBuffer = input.First;
 
-                        if (requestBytes.Length != 492)
+                        if (requestBuffer.Length != 492)
                         {
                             continue;
                         }
                         // Parse the input http request
-                        HttpRequestSingleSegment parsedRequest = HttpRequestSingleSegment.Parse(requestBytes);
+                        HttpRequestSingleSegment parsedRequest = HttpRequestSingleSegment.Parse(requestBuffer.Span);
 
                         // Writing directly to pooled buffers
                         var output = connection.Output.Alloc();

--- a/tests/System.Buffers.Primitives.Tests/EqualityTests.cs
+++ b/tests/System.Buffers.Primitives.Tests/EqualityTests.cs
@@ -41,8 +41,8 @@ namespace System.Buffers.Tests
             var pointingToSameMemory = new Span<byte>(bytes, start, length);
             var structCopy = span;
 
-            SpansReferencingSameMemoryAreEqualInEveryAspect(ref span, ref pointingToSameMemory);
-            SpansReferencingSameMemoryAreEqualInEveryAspect(ref span, ref structCopy);
+            SpansReferencingSameMemoryAreEqualInEveryAspect(span, pointingToSameMemory);
+            SpansReferencingSameMemoryAreEqualInEveryAspect(span, structCopy);
         }
 
         [Theory]
@@ -158,9 +158,7 @@ namespace System.Buffers.Tests
             Assert.False(readOnlySpan != impReadOnlySpan);
         }
 
-        // ref is used just for the structCopy scenario, otherwise it would always be copy
-
-        private static void SpansReferencingSameMemoryAreEqualInEveryAspect(ref Span<byte> span, ref Span<byte> pointingToSameMemory)
+        private static void SpansReferencingSameMemoryAreEqualInEveryAspect(Span<byte> span, Span<byte> pointingToSameMemory)
         {
             Assert.True(span == pointingToSameMemory);
             Assert.True(pointingToSameMemory == span);

--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <CoreFxVersion>4.3.0</CoreFxVersion>
-    <RoslynVersion>2.3.0-rdonly-ref-61530-07</RoslynVersion>
+    <RoslynVersion>2.3.0-rdonly-ref-61607-04</RoslynVersion>
     <SystemMemoryVersion>4.4.0-preview1-25205-01</SystemMemoryVersion>
     <SystemCompilerServicesUnsafeVersion>4.4.0-preview1-25205-01</SystemCompilerServicesUnsafeVersion>
     <LibuvVersion>1.9.1</LibuvVersion>


### PR DESCRIPTION
The new version is
https://dotnet.myget.org/feed/roslyn/package/nuget/Microsoft.Net.Compilers/2.3.0-rdonly-ref-61607-04

The new version enforces the following rules:
- `Span<T>` and `ReadonlySpan<T>` are stack-only types. (no boxing, invalid use in async, etc...)
- `Span<T>` and `ReadonlySpan<T>` cannot be passed via a writeable parameter.

There were several violations that I fixed.

NOTE: we are not yet validating the usage of span-containing structs. There could be more indrect violations of stack safety through that.