### PR TITLE
Remove dangling ref from UnownedBufferReader

### DIFF
--- a/src/System.IO.Pipelines.Extensions/UnownedBufferReader.cs
+++ b/src/System.IO.Pipelines.Extensions/UnownedBufferReader.cs
@@ -146,6 +146,11 @@ namespace System.IO.Pipelines
                         // We need to preserve any buffers that haven't been consumed
                         _head = BufferSegment.Clone(new ReadCursor(_head), new ReadCursor(_tail, _tail?.End ?? 0), out _tail);
                     }
+                    else
+                    {
+                        // Drop segement references before Dispose gets called on the segment
+                        _head = _tail = null;
+                    }
                 }
 
                 // Cancel this task if this write is cancelled


### PR DESCRIPTION
Discovered when pooling BufferSegments in https://github.com/dotnet/corefxlab/pull/1360

Isn't a problem currently as they just get GC'd eventually; but is a problem if they get pooled as something else updates the buffer and then its no longer empty.

/cc @davidfowl 