### PR TITLE
Removing unused culture info for Guid::ToString

### DIFF
--- a/tests/System.Text.Primitives.Tests/Formatting/GuidTests.cs
+++ b/tests/System.Text.Primitives.Tests/Formatting/GuidTests.cs
@@ -56,7 +56,7 @@ namespace System.Text.Primitives.Tests
 
         static void TestGuidFormat(Guid guid, char format, TextEncoder encoder)
         {
-            var expected = guid.ToString(format.ToString(), CultureInfo.InvariantCulture);
+            var expected = guid.ToString(format.ToString());
 
             var span = new Span<byte>(new byte[128]);
             Assert.True(PrimitiveFormatter.TryFormat(guid, span, out int written, format, encoder));


### PR DESCRIPTION
Necessary for getting CoreFxLab working in VS again.