### PR TITLE
Abstraced OwnedBuffer lifetime management

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
@@ -9,7 +9,7 @@ using System.Runtime;
 
 namespace Microsoft.Net.Http
 {
-    class OwnedBuffer : OwnedBuffer<byte>, IBufferList<byte>, IReadOnlyBufferList<byte>
+    class OwnedBuffer : ReferenceCountedBuffer<byte>, IBufferList<byte>, IReadOnlyBufferList<byte>
     {
         public const int DefaultBufferSize = 1024;
 

--- a/src/System.Buffers.Experimental/System/Buffers/BufferManager.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferManager.cs
@@ -7,7 +7,7 @@ namespace System.Buffers.Pools
 {
     public unsafe sealed partial class NativeBufferPool : BufferPool
     {
-        internal sealed class BufferManager : OwnedBuffer<byte>
+        internal sealed class BufferManager : ReferenceCountedBuffer<byte>
         {
             public BufferManager(NativeBufferPool pool, IntPtr memory, int length)
             {

--- a/src/System.Buffers.Experimental/System/Buffers/OwnedNativeBuffer.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/OwnedNativeBuffer.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 
 namespace System.Buffers
 {
-    public class OwnedNativeBuffer : OwnedBuffer<byte>
+    public class OwnedNativeBuffer : ReferenceCountedBuffer<byte>
     {
         public OwnedNativeBuffer(int length) : this(length, Marshal.AllocHGlobal(length))
         { }

--- a/src/System.Buffers.Experimental/System/Buffers/OwnedPinnedBuffer.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/OwnedPinnedBuffer.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 namespace System.Buffers
 {
     // This is to support secnarios today covered by Buffer<T> in corefxlab
-    public class OwnedPinnedBuffer<T> : OwnedBuffer<T>
+    public class OwnedPinnedBuffer<T> : ReferenceCountedBuffer<T>
     {
         public unsafe OwnedPinnedBuffer(T[] array, void* pointer, GCHandle handle = default(GCHandle))
         {

--- a/src/System.Buffers.Primitives/System/Buffers/DisposableReservation.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/DisposableReservation.cs
@@ -13,34 +13,14 @@ namespace System.Buffers
         internal DisposableReservation(OwnedBuffer<T> owner)
         {
             _owner = owner;
-            switch (ReferenceCountingSettings.OwnedMemory)
-            {
-                case ReferenceCountingMethod.Interlocked:
-                    ((IKnown)_owner).AddReference();
-                    break;
-                case ReferenceCountingMethod.ReferenceCounter:
-                    ReferenceCounter.AddReference(_owner);
-                    break;
-                case ReferenceCountingMethod.None:
-                    break;
-            }
+            _owner.AddReference();
         }
 
         public Span<T> Span => _owner.Span;
 
         public void Dispose()
         {
-            switch (ReferenceCountingSettings.OwnedMemory)
-            {
-                case ReferenceCountingMethod.Interlocked:
-                    ((IKnown)_owner).Release();
-                    break;
-                case ReferenceCountingMethod.ReferenceCounter:
-                    ReferenceCounter.Release(_owner);
-                    break;
-                case ReferenceCountingMethod.None:
-                    break;
-            }
+            _owner.Release();
             _owner = null;
         }
     }

--- a/src/System.Buffers.Primitives/System/Internal/ManagedBufferPool.cs
+++ b/src/System.Buffers.Primitives/System/Internal/ManagedBufferPool.cs
@@ -26,7 +26,7 @@ namespace System.Buffers.Internal
         {
         }
 
-        private class ArrayPoolMemory : OwnedBuffer<byte>
+        private class ArrayPoolMemory : ReferenceCountedBuffer<byte>
         {
             public ArrayPoolMemory(int size)
             {

--- a/src/System.Buffers.Primitives/System/Internal/OwnedArray.cs
+++ b/src/System.Buffers.Primitives/System/Internal/OwnedArray.cs
@@ -2,11 +2,15 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime;
+using System.Threading;
+using System.Buffers;
 
 namespace System.Buffers.Internal
 {
-    internal sealed class OwnedArray<T> : OwnedBuffer<T>
+    internal sealed class OwnedArray<T> : ReferenceCountedBuffer<T>
     {
+        T[] _array;
+
         public OwnedArray(int length)
         {
             _array = new T[length];
@@ -22,20 +26,11 @@ namespace System.Buffers.Internal
             _array = segment.AsSpan().ToArray();
         }
 
-        public static implicit operator T[] (OwnedArray<T> owner)
-        {
-            return owner._array;
-        }
+        public static implicit operator T[] (OwnedArray<T> owner) => owner._array;
 
-        public static implicit operator OwnedArray<T>(T[] array)
-        {
-            return new OwnedArray<T>(array);
-        }
+        public static implicit operator OwnedArray<T>(T[] array) => new OwnedArray<T>(array);
 
-        public static implicit operator OwnedArray<T>(ArraySegment<T> segment)
-        {
-            return new OwnedArray<T>(segment);
-        }
+        public static implicit operator OwnedArray<T>(ArraySegment<T> segment) => new OwnedArray<T>(segment);
 
         public override int Length => _array.Length;
 
@@ -60,7 +55,5 @@ namespace System.Buffers.Internal
             pointer = null;
             return false;
         }
-
-        T[] _array;
     }
 }

--- a/src/System.Buffers.Primitives/System/Internal/OwnerEmptyMemory.cs
+++ b/src/System.Buffers.Primitives/System/Internal/OwnerEmptyMemory.cs
@@ -12,21 +12,13 @@ namespace System.Buffers.Internal
 
         public override int Length => s_empty.Length;
 
-        public override Span<T> Span
-        {
-            get
-            {
-                if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(OwnerEmptyMemory<T>));
-                return s_empty;
-            }
-        }
+        public override Span<T> Span => s_empty;
 
         protected override void Dispose(bool disposing)
         {}
 
         protected internal override bool TryGetArrayInternal(out ArraySegment<T> buffer)
         {
-            if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(OwnerEmptyMemory<T>));
             buffer = new ArraySegment<T>(s_empty);
             return true;
         }
@@ -36,5 +28,9 @@ namespace System.Buffers.Internal
             pointer = null;
             return false;
         }
+
+        public override void AddReference() { }
+        public override void Release() { }
+        public override bool HasOutstandingReferences => false;
     }
 }

--- a/src/System.IO.Pipelines/MemoryPoolBlock.cs
+++ b/src/System.IO.Pipelines/MemoryPoolBlock.cs
@@ -10,7 +10,7 @@ namespace System.IO.Pipelines
     /// Block tracking object used by the byte buffer memory pool. A slab is a large allocation which is divided into smaller blocks. The
     /// individual blocks are then treated as independent array segments.
     /// </summary>
-    public class MemoryPoolBlock : OwnedBuffer<byte>
+    public class MemoryPoolBlock : ReferenceCountedBuffer<byte>
     {
         private readonly int _offset;
         private readonly int _length;

--- a/src/System.IO.Pipelines/UnownedBuffer.cs
+++ b/src/System.IO.Pipelines/UnownedBuffer.cs
@@ -9,7 +9,7 @@ namespace System.IO.Pipelines
     /// <summary>
     /// Represents a buffer that is owned by an external component.
     /// </summary>
-    public class UnownedBuffer : OwnedBuffer<byte>
+    public class UnownedBuffer : ReferenceCountedBuffer<byte>
     {
         public UnownedBuffer(ArraySegment<byte> buffer)
         {

--- a/tests/System.Buffers.Primitives.Tests/MemoryTests.cs
+++ b/tests/System.Buffers.Primitives.Tests/MemoryTests.cs
@@ -316,7 +316,7 @@ namespace System.Buffers.Tests
         }
     }
 
-    class CustomMemory : OwnedBuffer<byte>
+    class CustomMemory : ReferenceCountedBuffer<byte>
     {
         public CustomMemory()
         {
@@ -358,7 +358,7 @@ namespace System.Buffers.Tests
         byte[] _array;
     }
 
-    class AutoDisposeMemory<T> : OwnedBuffer<T>
+    class AutoDisposeMemory<T> : ReferenceCountedBuffer<T>
     {
         public AutoDisposeMemory(T[] array)
         {

--- a/tests/System.IO.Pipelines.Tests/PipelineReaderWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/PipelineReaderWriterFacts.cs
@@ -532,7 +532,7 @@ namespace System.IO.Pipelines.Tests
 
             }
 
-            private class DisposeTrackingOwnedMemory : OwnedBuffer<byte>
+            private class DisposeTrackingOwnedMemory : ReferenceCountedBuffer<byte>
             {
                 public DisposeTrackingOwnedMemory(byte[] array)
                 {


### PR DESCRIPTION
Abstracted lifetime management (reference counting) out of OwnedBuffer\<T\>.
Added a subclass ReferenceCountedBuffer for interlocked-based reference counting.
Other subclasses, can use whatever they want for lifetime management.

After this change, OwnedBuffer has just one field left (_disposed) which can be removed quite easily (at the cost of making it more tedious to implement IDisposable on subclasses.  

cc: @mjp41, @davidfowl, @ahsonkhan, @shiftylogic  