### PR TITLE
Simplified BufferHandle and Pinning

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Net.Http
             return true;
         }
 
-        protected override unsafe bool TryGetPointerInternal(out void* pointer)
+        protected override unsafe bool TryGetPointerAt(int index, out void* pointer)
         {
             pointer = null;
             return false;

--- a/src/System.Buffers.Experimental/System/Buffers/BufferManager.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferManager.cs
@@ -41,10 +41,10 @@ namespace System.Buffers.Pools
                 return false;
             }
 
-            protected override unsafe bool TryGetPointerInternal(out void* pointer)
+            protected override unsafe bool TryGetPointerAt(int index, out void* pointer)
             {
                 if (IsDisposed) BuffersExperimentalThrowHelper.ThrowObjectDisposedException(nameof(BufferManager));
-                pointer = _pointer.ToPointer();
+                pointer = Add(_pointer.ToPointer(), index);
                 return true;
             }
 

--- a/src/System.Buffers.Experimental/System/Buffers/OwnedNativeBuffer.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/OwnedNativeBuffer.cs
@@ -42,10 +42,10 @@ namespace System.Buffers
             return false;
         }
 
-        protected override unsafe bool TryGetPointerInternal(out void* pointer)
+        protected override unsafe bool TryGetPointerAt(int index, out void* pointer)
         {
             if (IsDisposed) BuffersExperimentalThrowHelper.ThrowObjectDisposedException(nameof(OwnedNativeBuffer));
-            pointer = _pointer.ToPointer();
+            pointer = Add(_pointer.ToPointer(), index);
             return true;
         }
 

--- a/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
@@ -71,17 +71,11 @@ namespace System.Buffers
 
         public unsafe bool TryGetPointer(out void* pointer)
         {
-            if (!_owner.TryGetPointerInternal(out pointer))
+            if (!_owner.TryGetPointerAt(_index, out pointer))
             {
                 return false;
             }
-            pointer = Add(pointer, _index);
             return true;
-        }
-
-        internal static unsafe void* Add(void* pointer, int offset)
-        {
-            return (byte*)pointer + ((ulong)Unsafe.SizeOf<T>() * (ulong)offset);
         }
 
         public T[] ToArray() => Span.ToArray();
@@ -132,30 +126,6 @@ namespace System.Buffers
         public override int GetHashCode()
         {
             return HashingHelper.CombineHashCodes(_owner.GetHashCode(), _index.GetHashCode(), _length.GetHashCode());
-        }
-
-        // TODO: this is taken from SpanHelpers. If we move this type to System.Memory, we should remove this helper
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static IntPtr Add(IntPtr start, int index)
-        {
-            Debug.Assert(start.ToInt64() >= 0);
-            Debug.Assert(index >= 0);
-
-            unsafe
-            {
-                if (sizeof(IntPtr) == sizeof(int))
-                {
-                    // 32-bit path.
-                    uint byteLength = (uint)index * (uint)Unsafe.SizeOf<T>();
-                    return (IntPtr)(((byte*)start) + byteLength);
-                }
-                else
-                {
-                    // 64-bit path.
-                    ulong byteLength = (ulong)index * (ulong)Unsafe.SizeOf<T>();
-                    return (IntPtr)(((byte*)start) + byteLength);
-                }
-            }
         }
     }
 }

--- a/src/System.Buffers.Primitives/System/Buffers/DisposableReservation.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/DisposableReservation.cs
@@ -13,7 +13,7 @@ namespace System.Buffers
         internal DisposableReservation(OwnedBuffer<T> owner)
         {
             _owner = owner;
-            _owner.AddReference();
+            _owner.Retain();
         }
 
         public Span<T> Span => _owner.Span;

--- a/src/System.Buffers.Primitives/System/Buffers/IRetainable.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/IRetainable.cs
@@ -3,9 +3,10 @@
 
 namespace System.Buffers
 {
-    internal interface IKnown
+    public interface IRetainable
     {
-        void AddReference();
+        void Retain();
         void Release();
+        bool IsRetained { get; }
     }
 }

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -59,10 +59,9 @@ namespace System.Buffers
    
         public unsafe bool TryGetPointer(out void* pointer)
         {
-            if (!_owner.TryGetPointerInternal(out pointer)) {
+            if (!_owner.TryGetPointerAt(_index, out pointer)) {
                 return false;
             }
-            pointer = Buffer<T>.Add(pointer, _index);
             return true;
         }
 

--- a/src/System.Buffers.Primitives/System/Buffers/ReferenceCountedBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReferenceCountedBuffer.cs
@@ -11,7 +11,7 @@ namespace System.Buffers
         int _referenceCount;
         bool _disposed;
 
-        public override void AddReference()
+        public override void Retain()
         {
             Interlocked.Increment(ref _referenceCount);
         }
@@ -23,7 +23,7 @@ namespace System.Buffers
             }
         }
 
-        public override bool HasOutstandingReferences => _referenceCount > 0;
+        public override bool IsRetained => _referenceCount > 0;
 
         protected virtual void OnZeroReferences()
         {

--- a/src/System.Buffers.Primitives/System/Internal/ManagedBufferPool.cs
+++ b/src/System.Buffers.Primitives/System/Internal/ManagedBufferPool.cs
@@ -57,7 +57,7 @@ namespace System.Buffers.Internal
                 return true;
             }
 
-            protected internal override unsafe bool TryGetPointerInternal(out void* pointer)
+            protected internal override unsafe bool TryGetPointerAt(int index, out void* pointer)
             {
                 pointer = null;
                 return false;

--- a/src/System.Buffers.Primitives/System/Internal/OwnedArray.cs
+++ b/src/System.Buffers.Primitives/System/Internal/OwnedArray.cs
@@ -50,7 +50,7 @@ namespace System.Buffers.Internal
             return true;
         }
 
-        protected internal override unsafe bool TryGetPointerInternal(out void* pointer)
+        protected internal override unsafe bool TryGetPointerAt(int index, out void* pointer)
         {
             pointer = null;
             return false;

--- a/src/System.Buffers.Primitives/System/Internal/OwnerEmptyMemory.cs
+++ b/src/System.Buffers.Primitives/System/Internal/OwnerEmptyMemory.cs
@@ -23,15 +23,15 @@ namespace System.Buffers.Internal
             return true;
         }
 
-        protected internal override unsafe bool TryGetPointerInternal(out void* pointer)
+        protected internal override unsafe bool TryGetPointerAt(int index, out void* pointer)
         {
             pointer = null;
             return false;
         }
 
-        public override void AddReference() { }
+        public override void Retain() { }
         public override void Release() { }
-        public override bool HasOutstandingReferences => false;
+        public override bool IsRetained => false;
 
         public override bool IsDisposed => false;
     }

--- a/src/System.IO.Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/BufferSegment.cs
@@ -45,7 +45,7 @@ namespace System.IO.Pipelines
             Start = 0;
             End = 0;
 
-            _owned.AddReference();
+            _owned.Retain();
             _buffer = _owned.Buffer;
         }
 
@@ -64,7 +64,7 @@ namespace System.IO.Pipelines
                 _owned = unowned.MakeCopy(start, end - start, out Start, out End);
             }
 
-            _owned.AddReference();
+            _owned.Retain();
             _buffer = _owned.Buffer;
         }
 
@@ -88,11 +88,11 @@ namespace System.IO.Pipelines
 
         public void Dispose()
         {
-            Debug.Assert(_owned.HasOutstandingReferences);
+            Debug.Assert(_owned.IsRetained);
 
             _owned.Release();
 
-            if (!_owned.HasOutstandingReferences)
+            if (!_owned.IsRetained)
             {
                 _owned.Dispose();
             }

--- a/src/System.IO.Pipelines/MemoryPoolBlock.cs
+++ b/src/System.IO.Pipelines/MemoryPoolBlock.cs
@@ -122,10 +122,10 @@ namespace System.IO.Pipelines
 #if KESTREL_BY_SOURCE
         internal
 #endif
-        protected override unsafe bool TryGetPointerInternal(out void* pointer)
+        protected override unsafe bool TryGetPointerAt(int index, out void* pointer)
         {
             if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(nameof(MemoryPoolBlock));
-            pointer = (Slab.NativePointer + _offset).ToPointer();
+            pointer = (Slab.NativePointer + _offset + index).ToPointer();
             return true;
         }
     }

--- a/src/System.IO.Pipelines/UnownedBuffer.cs
+++ b/src/System.IO.Pipelines/UnownedBuffer.cs
@@ -54,7 +54,7 @@ namespace System.IO.Pipelines
 #if KESTREL_BY_SOURCE
         internal
 #endif
-        protected override unsafe bool TryGetPointerInternal(out void* pointer)
+        protected override unsafe bool TryGetPointerAt(int index, out void* pointer)
         {
             pointer = null;
             return false;

--- a/tests/System.Buffers.Primitives.Tests/MemoryTests.cs
+++ b/tests/System.Buffers.Primitives.Tests/MemoryTests.cs
@@ -173,13 +173,13 @@ namespace System.Buffers.Tests
             var owned = new CustomMemory();
             var memory = owned.Buffer;
             Assert.Equal(0, owned.OnZeroRefencesCount);
-            Assert.False(owned.HasOutstandingReferences);
+            Assert.False(owned.IsRetained);
             using (memory.Reserve()) {
                 Assert.Equal(0, owned.OnZeroRefencesCount);
-                Assert.True(owned.HasOutstandingReferences);
+                Assert.True(owned.IsRetained);
             }
             Assert.Equal(1, owned.OnZeroRefencesCount);
-            Assert.False(owned.HasOutstandingReferences);
+            Assert.False(owned.IsRetained);
         }
 
         [Fact]
@@ -202,11 +202,11 @@ namespace System.Buffers.Tests
             var array = new byte[1024];
             OwnedBuffer<byte> owned = array;
             var memory = owned.Buffer;
-            Assert.False(owned.HasOutstandingReferences);
+            Assert.False(owned.IsRetained);
             var h = memory.Pin();
-            Assert.True(owned.HasOutstandingReferences);
+            Assert.True(owned.IsRetained);
             h.Free();
-            Assert.False(owned.HasOutstandingReferences);
+            Assert.False(owned.IsRetained);
         }
 
         [Fact]
@@ -223,15 +223,15 @@ namespace System.Buffers.Tests
             OwnedBuffer<byte> owned = array;
             var memory = owned.Buffer;
             var h = memory.Pin();
-            Assert.True(owned.HasOutstandingReferences);
-            owned.AddReference();
-            Assert.True(owned.HasOutstandingReferences);
+            Assert.True(owned.IsRetained);
+            owned.Retain();
+            Assert.True(owned.IsRetained);
             h.Free();
-            Assert.True(owned.HasOutstandingReferences);
+            Assert.True(owned.IsRetained);
             h.Free();
-            Assert.True(owned.HasOutstandingReferences);
+            Assert.True(owned.IsRetained);
             owned.Release();
-            Assert.False(owned.HasOutstandingReferences);
+            Assert.False(owned.IsRetained);
         }
 
 
@@ -295,7 +295,7 @@ namespace System.Buffers.Tests
             return true;
         }
 
-        protected override unsafe bool TryGetPointerInternal(out void* pointer)
+        protected override unsafe bool TryGetPointerAt(int index, out void* pointer)
         {
             pointer = null;
             return false;
@@ -310,7 +310,7 @@ namespace System.Buffers.Tests
         public AutoDisposeMemory(T[] array)
         {
             _array = array;
-            AddReference();
+            Retain();
         }
 
         public override int Length => _array.Length;
@@ -341,7 +341,7 @@ namespace System.Buffers.Tests
             return true;
         }
 
-        protected override unsafe bool TryGetPointerInternal(out void* pointer)
+        protected override unsafe bool TryGetPointerAt(int index, out void* pointer)
         {
             pointer = null;
             return false;

--- a/tests/System.IO.Pipelines.Tests/PipelineReaderWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/PipelineReaderWriterFacts.cs
@@ -552,7 +552,7 @@ namespace System.IO.Pipelines.Tests
                     return true;
                 }
 
-                protected override unsafe bool TryGetPointerInternal(out void* pointer)
+                protected override unsafe bool TryGetPointerAt(int index, out void* pointer)
                 {
                     pointer = null;
                     return false;


### PR DESCRIPTION
This change allows the called of BufferHandle ctor to decide how GCHandle is constructed. For example, permamently pinned buffers can use default GCHandle and array based buffers can create single GCHandle per OwnedBuffer which gets released when reference count goes to zero.

The main changes are in BufferHandle.Create/ctor

cc: @davidfowl, @shiftylogic 
