### PR TITLE
Removing duplicate test cases and fixing typo in Text.Primitives.Tests.

### DIFF
--- a/tests/System.Text.Primitives.Tests/Encoding/RandomTests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/RandomTests.cs
@@ -109,8 +109,6 @@ namespace System.Text.Primitives.Tests
 
         public static object[][] StringEqualsTestCases_EmptyStrings = new object[][] {
             new object[] { true, "", ""},
-            new object[] { true, "", "" },
-            new object[] { true, "", "" },
 
             new object[] { false, "", " "},
             new object[] { false, "", "a"},
@@ -150,6 +148,7 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(expected, s2.Equals(s1));
         }
 
+        [Theory]
         [MemberData("StringEqualsTestCases_EmptyStrings")]
         [MemberData("StringEqualsTestCases_SimpleStrings")]
         public unsafe void StringEqualsConvertedToUtf16String(bool expected, string str1, string str2)
@@ -734,7 +733,6 @@ namespace System.Text.Primitives.Tests
                 "abc",
                 "def",
                 "\uABCD",
-                "\uABC0\uABC1\uABC2",
                 "\uABC0bc",
                 "a\uABC1c",
                 "ab\uABC2",


### PR DESCRIPTION
Resolves this discrepancy between VS test discovery/run and command line:

------ Discover test started ------
[xUnit.net 00:00:00.5287380]   Discovering: System.Text.Primitives.Tests
[xUnit.net 00:00:02.2739751]   Discovered:  System.Text.Primitives.Tests
A test with the same name 'System.Text.Primitives.Tests.Utf8StringTests.StringEqualsWithThreeArgs (7b20df66ebc54d70aa2f6290cb0e75c08e639f33)' already exists. This test is not added to the test window.
A test with the same name 'System.Text.Primitives.Tests.Utf8StringTests.StringEqualsWithThreeArgs (7b20df66ebc54d70aa2f6290cb0e75c08e639f33)' already exists. This test is not added to the test window.
A test with the same name 'System.Text.Primitives.Tests.Utf8StringTests.TryComputeEncodedBytesShouldMatchEncoding_Utf8 (fae5145b9049eaa872e7b3fb901cf7ee166bfa6a)' already exists. This test is not added to the test window.
A test with the same name 'System.Text.Primitives.Tests.Utf8StringTests.TryComputeEncodedBytesShouldMatchEncoding_Utf16 (36396a74f5c5bb934ec1d1dbf0d03865b66434c5)' already exists. This test is not added to the test window.
**========== Discover test finished: 572 found (0:00:02.9093646) ==========**
------ Run test started ------
[xUnit.net 00:00:00.7018542]   Starting:    System.Text.Primitives.Tests
[xUnit.net 00:00:05.7034494]   Finished:    System.Text.Primitives.Tests
**========== Run test finished: 568 run (0:00:07.9177629) ==========**


cc @shiftylogic, @KrzysztofCwalina 