### PR TITLE
Renaming charactersWritten/Consumed to codePointsWritten/Consumed.

### DIFF
--- a/src/System.Text.Primitives/System/Text/Encoding/Utf16/Utf16LittleEndianEncoder.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf16/Utf16LittleEndianEncoder.cs
@@ -101,23 +101,23 @@ namespace System.Text.Utf16
         /// 
         /// This method will consume as many of the input characters as possible.
         ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="charactersConsumed"/> will be
+        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="codePointsConsumed"/> will be
         /// equal to the length of the <paramref name="utf32"/> and <paramref name="charactersWritten"/> will equal the total number of bytes written to
         /// the <paramref name="utf16"/>.
         /// 
         /// On unsuccessful exit, the following conditions can exist.
-        ///  1) If the output buffer has been filled and no more input characters can be encoded, another call to this method with the input sliced to
-        ///     exclude the already encoded characters (using <paramref name="charactersConsumed"/>) and a new output buffer will continue the encoding.
+        ///  1) If the output buffer has been filled and no more input code points can be encoded, another call to this method with the input sliced to
+        ///     exclude the already encoded code points (using <paramref name="codePointsConsumed"/>) and a new output buffer will continue the encoding.
         ///  2) Encoding may have also stopped because the input buffer contains an invalid sequence.
         /// </summary>
         /// <param name="utf32">A span containing a sequence of UTF-32 characters.</param>
         /// <param name="utf16">A span to write the UTF-16 encoded data into.</param>
-        /// <param name="charactersConsumed">On exit, contains the number of code points that were consumed from the UTF-32 character span.</param>
+        /// <param name="codePointsConsumed">On exit, contains the number of code points that were consumed from the UTF-32 character span.</param>
         /// <param name="charactersWritten">An output parameter to store the number of bytes written to <paramref name="utf8"/></param>
         /// <returns>True if the input buffer was fully encoded into the output buffer, otherwise false.</returns>
-        public static bool TryEncode(ReadOnlySpan<uint> utf32, Span<char> utf16, out int charactersConsumed, out int charactersWritten)
+        public static bool TryEncode(ReadOnlySpan<uint> utf32, Span<char> utf16, out int codePointsConsumed, out int charactersWritten)
         {
-            charactersConsumed = 0;
+            codePointsConsumed = 0;
             charactersWritten = 0;
 
             for (int i = 0; i < utf32.Length; i++)
@@ -126,7 +126,7 @@ namespace System.Text.Utf16
                 if (!TryEncode(utf32[i], utf16, charactersWritten, out written))
                     return false;
 
-                charactersConsumed++;
+                codePointsConsumed++;
                 charactersWritten += written;
             }
 

--- a/src/System.Text.Primitives/System/Text/Encoding/Utf16/Utf16LittleEndianEncoder.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf16/Utf16LittleEndianEncoder.cs
@@ -40,7 +40,7 @@ namespace System.Text.Utf16
         /// This method will consume as many of the input characters as possible.
         ///
         /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="charactersConsumed"/> will be
-        /// equal to the length of the <paramref name="utf16"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+        /// equal to the length of the <paramref name="utf16"/> and <paramref name="codeUnitsWritten"/> will equal the total number of code units written to
         /// the <paramref name="utf32"/>.
         /// 
         /// On unsuccessful exit, the following conditions can exist.
@@ -51,16 +51,16 @@ namespace System.Text.Utf16
         /// <param name="utf16">A span containing a sequence of UTF-16 characters.</param>
         /// <param name="utf32">A span to write the UTF-32 data into.</param>
         /// <param name="charactersConsumed">On exit, contains the number of code points that were consumed from the UTF-16 character span.</param>
-        /// <param name="bytesWritten">An output parameter to store the number of bytes written to <paramref name="utf32"/></param>
+        /// <param name="codeUnitsWritten">An output parameter to store the number of code units written to <paramref name="utf32"/></param>
         /// <returns>True if the input buffer was fully encoded into the output buffer, otherwise false.</returns>
-        public static bool TryDecode(ReadOnlySpan<char> utf16, Span<uint> utf32, out int charactersConsumed, out int charactersWritten)
+        public static bool TryDecode(ReadOnlySpan<char> utf16, Span<uint> utf32, out int charactersConsumed, out int codeUnitsWritten)
         {
             charactersConsumed = 0;
-            charactersWritten = 0;
+            codeUnitsWritten = 0;
 
             for (int i = 0; i < utf16.Length; i++)
             {
-                if (charactersWritten >= utf32.Length)
+                if (codeUnitsWritten >= utf32.Length)
                     return false;
 
                 uint codePoint = utf16[i];
@@ -85,7 +85,7 @@ namespace System.Text.Utf16
                     charactersConsumed++;
                 }
 
-                utf32[charactersWritten++] = codePoint;
+                utf32[codeUnitsWritten++] = codePoint;
                 charactersConsumed++;
             }
 
@@ -101,23 +101,23 @@ namespace System.Text.Utf16
         /// 
         /// This method will consume as many of the input characters as possible.
         ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="codePointsConsumed"/> will be
+        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="codeUnitsConsumed"/> will be
         /// equal to the length of the <paramref name="utf32"/> and <paramref name="charactersWritten"/> will equal the total number of bytes written to
         /// the <paramref name="utf16"/>.
         /// 
         /// On unsuccessful exit, the following conditions can exist.
-        ///  1) If the output buffer has been filled and no more input code points can be encoded, another call to this method with the input sliced to
-        ///     exclude the already encoded code points (using <paramref name="codePointsConsumed"/>) and a new output buffer will continue the encoding.
+        ///  1) If the output buffer has been filled and no more input code units can be encoded, another call to this method with the input sliced to
+        ///     exclude the already encoded code points (using <paramref name="codeUnitsConsumed"/>) and a new output buffer will continue the encoding.
         ///  2) Encoding may have also stopped because the input buffer contains an invalid sequence.
         /// </summary>
         /// <param name="utf32">A span containing a sequence of UTF-32 characters.</param>
         /// <param name="utf16">A span to write the UTF-16 encoded data into.</param>
-        /// <param name="codePointsConsumed">On exit, contains the number of code points that were consumed from the UTF-32 character span.</param>
+        /// <param name="codeUnitsConsumed">On exit, contains the number of code units that were consumed from the UTF-32 character span.</param>
         /// <param name="charactersWritten">An output parameter to store the number of bytes written to <paramref name="utf8"/></param>
         /// <returns>True if the input buffer was fully encoded into the output buffer, otherwise false.</returns>
-        public static bool TryEncode(ReadOnlySpan<uint> utf32, Span<char> utf16, out int codePointsConsumed, out int charactersWritten)
+        public static bool TryEncode(ReadOnlySpan<uint> utf32, Span<char> utf16, out int codeUnitsConsumed, out int charactersWritten)
         {
-            codePointsConsumed = 0;
+            codeUnitsConsumed = 0;
             charactersWritten = 0;
 
             for (int i = 0; i < utf32.Length; i++)
@@ -126,7 +126,7 @@ namespace System.Text.Utf16
                 if (!TryEncode(utf32[i], utf16, charactersWritten, out written))
                     return false;
 
-                codePointsConsumed++;
+                codeUnitsConsumed++;
                 charactersWritten += written;
             }
 

--- a/src/System.Text.Primitives/System/Text/Encoding/Utf16/Utf16TextEncoderLE.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf16/Utf16TextEncoderLE.cs
@@ -85,11 +85,11 @@ namespace System.Text.Utf16
             return true;
         }
 
-        public override bool TryDecode(ReadOnlySpan<byte> encodedBytes, Span<uint> utf32, out int bytesConsumed, out int codePointsWritten)
+        public override bool TryDecode(ReadOnlySpan<byte> encodedBytes, Span<uint> utf32, out int bytesConsumed, out int codeUnitsWritten)
         {
             int consumed;
             var utf16 = encodedBytes.NonPortableCast<byte, char>();
-            var result = Utf16LittleEndianEncoder.TryDecode(utf16, utf32, out consumed, out codePointsWritten);
+            var result = Utf16LittleEndianEncoder.TryDecode(utf16, utf32, out consumed, out codeUnitsWritten);
 
             bytesConsumed = consumed * sizeof(char);
             return result;
@@ -129,11 +129,11 @@ namespace System.Text.Utf16
             return true;
         }
 
-        public override bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> encodedBytes, out int codePointsConsumed, out int bytesWritten)
+        public override bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> encodedBytes, out int codeUnitsConsumed, out int bytesWritten)
         {
             int written;
             var utf16 = encodedBytes.NonPortableCast<byte, char>();
-            var result = Utf16LittleEndianEncoder.TryEncode(utf32, utf16, out codePointsConsumed, out written);
+            var result = Utf16LittleEndianEncoder.TryEncode(utf32, utf16, out codeUnitsConsumed, out written);
 
             bytesWritten = written * sizeof(char);
             return result;

--- a/src/System.Text.Primitives/System/Text/Encoding/Utf16/Utf16TextEncoderLE.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf16/Utf16TextEncoderLE.cs
@@ -85,11 +85,11 @@ namespace System.Text.Utf16
             return true;
         }
 
-        public override bool TryDecode(ReadOnlySpan<byte> encodedBytes, Span<uint> utf32, out int bytesConsumed, out int charactersWritten)
+        public override bool TryDecode(ReadOnlySpan<byte> encodedBytes, Span<uint> utf32, out int bytesConsumed, out int codePointsWritten)
         {
             int consumed;
             var utf16 = encodedBytes.NonPortableCast<byte, char>();
-            var result = Utf16LittleEndianEncoder.TryDecode(utf16, utf32, out consumed, out charactersWritten);
+            var result = Utf16LittleEndianEncoder.TryDecode(utf16, utf32, out consumed, out codePointsWritten);
 
             bytesConsumed = consumed * sizeof(char);
             return result;
@@ -129,11 +129,11 @@ namespace System.Text.Utf16
             return true;
         }
 
-        public override bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> encodedBytes, out int charactersConsumed, out int bytesWritten)
+        public override bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> encodedBytes, out int codePointsConsumed, out int bytesWritten)
         {
             int written;
             var utf16 = encodedBytes.NonPortableCast<byte, char>();
-            var result = Utf16LittleEndianEncoder.TryEncode(utf32, utf16, out charactersConsumed, out written);
+            var result = Utf16LittleEndianEncoder.TryEncode(utf32, utf16, out codePointsConsumed, out written);
 
             bytesWritten = written * sizeof(char);
             return result;

--- a/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs
@@ -927,23 +927,23 @@ namespace System.Text.Utf8
         ///
         /// This method will consume as many of the input characters as possible.
         ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="charactersConsumed"/> will be
+        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="codePointsConsumed"/> will be
         /// equal to the length of the <paramref name="utf32"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
         /// the <paramref name="utf8"/>.
         ///
         /// On unsuccessful exit, the following conditions can exist.
-        ///  1) If the output buffer has been filled and no more input characters can be encoded, another call to this method with the input sliced to
-        ///     exclude the already encoded characters (using <paramref name="charactersConsumed"/>) and a new output buffer will continue the encoding.
+        ///  1) If the output buffer has been filled and no more input code points can be encoded, another call to this method with the input sliced to
+        ///     exclude the already encoded code points (using <paramref name="codePointsConsumed"/>) and a new output buffer will continue the encoding.
         ///  2) Encoding may have also stopped because the input buffer contains an invalid sequence.
         /// </summary>
         /// <param name="utf32">A span containing a sequence of UTF-32 characters.</param>
         /// <param name="utf8">A span to write the UTF-8 encoded data into.</param>
-        /// <param name="charactersConsumed">On exit, contains the number of code points that were consumed from the UTF-32 character span.</param>
+        /// <param name="codePointsConsumed">On exit, contains the number of code points that were consumed from the UTF-32 character span.</param>
         /// <param name="bytesWritten">An output parameter to store the number of bytes written to <paramref name="utf8"/></param>
         /// <returns>True if the input buffer was fully encoded into the output buffer, otherwise false.</returns>
-        public static bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> utf8, out int charactersConsumed, out int bytesWritten)
+        public static bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> utf8, out int codePointsConsumed, out int bytesWritten)
         {
-            charactersConsumed = 0;
+            codePointsConsumed = 0;
             bytesWritten = 0;
 
             for (int i = 0; i < utf32.Length; i++)
@@ -952,7 +952,7 @@ namespace System.Text.Utf8
                 if (!TryEncodeCodePoint(utf32[i], utf8, bytesWritten, out written))
                     return false;
 
-                charactersConsumed++;
+                codePointsConsumed++;
                 bytesWritten += written;
             }
 

--- a/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs
@@ -398,7 +398,7 @@ namespace System.Text.Utf8
         /// This method will consume as many of the input characters as possible.
         ///
         /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
-        /// equal to the length of the <paramref name="utf8"/> and <paramref name="charactersWritten"/> will equal the total number of bytes written to
+        /// equal to the length of the <paramref name="utf8"/> and <paramref name="codeUnitsWritten"/> will equal the total number of code units written to
         /// the <paramref name="utf32"/>.
         ///
         /// On unsuccessful exit, the following conditions can exist.
@@ -409,12 +409,12 @@ namespace System.Text.Utf8
         /// <param name="utf8">A span containing a sequence of UTF-8 bytes.</param>
         /// <param name="utf32">A span to write the UTF-32 data into.</param>
         /// <param name="bytesConsumed">On exit, contains the number of code points that were consumed from the UTF-8 byte span.</param>
-        /// <param name="charactersWritten">An output parameter to store the number of characters written to <paramref name="utf32"/></param>
+        /// <param name="codeUnitsWritten">An output parameter to store the number of code units written to <paramref name="utf32"/></param>
         /// <returns>True if the input buffer was fully encoded into the output buffer, otherwise false.</returns>
-        public static bool TryDecode(ReadOnlySpan<byte> utf8, Span<uint> utf32, out int bytesConsumed, out int charactersWritten)
+        public static bool TryDecode(ReadOnlySpan<byte> utf8, Span<uint> utf32, out int bytesConsumed, out int codeUnitsWritten)
         {
             bytesConsumed = 0;
-            charactersWritten = 0;
+            codeUnitsWritten = 0;
 
             while (bytesConsumed < utf8.Length)
             {
@@ -424,7 +424,7 @@ namespace System.Text.Utf8
                 if (!TryDecodeCodePoint(utf8, bytesConsumed, out codePoint, out consumed))
                     return false;
 
-                utf32[charactersWritten++] = codePoint;
+                utf32[codeUnitsWritten++] = codePoint;
                 bytesConsumed += consumed;
             }
 
@@ -927,23 +927,23 @@ namespace System.Text.Utf8
         ///
         /// This method will consume as many of the input characters as possible.
         ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="codePointsConsumed"/> will be
+        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="codeUnitsConsumed"/> will be
         /// equal to the length of the <paramref name="utf32"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
         /// the <paramref name="utf8"/>.
         ///
         /// On unsuccessful exit, the following conditions can exist.
-        ///  1) If the output buffer has been filled and no more input code points can be encoded, another call to this method with the input sliced to
-        ///     exclude the already encoded code points (using <paramref name="codePointsConsumed"/>) and a new output buffer will continue the encoding.
+        ///  1) If the output buffer has been filled and no more input code units can be encoded, another call to this method with the input sliced to
+        ///     exclude the already encoded code units (using <paramref name="codeUnitsConsumed"/>) and a new output buffer will continue the encoding.
         ///  2) Encoding may have also stopped because the input buffer contains an invalid sequence.
         /// </summary>
         /// <param name="utf32">A span containing a sequence of UTF-32 characters.</param>
         /// <param name="utf8">A span to write the UTF-8 encoded data into.</param>
-        /// <param name="codePointsConsumed">On exit, contains the number of code points that were consumed from the UTF-32 character span.</param>
+        /// <param name="codeUnitsConsumed">On exit, contains the number of code points that were consumed from the UTF-32 character span.</param>
         /// <param name="bytesWritten">An output parameter to store the number of bytes written to <paramref name="utf8"/></param>
         /// <returns>True if the input buffer was fully encoded into the output buffer, otherwise false.</returns>
-        public static bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> utf8, out int codePointsConsumed, out int bytesWritten)
+        public static bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> utf8, out int codeUnitsConsumed, out int bytesWritten)
         {
-            codePointsConsumed = 0;
+            codeUnitsConsumed = 0;
             bytesWritten = 0;
 
             for (int i = 0; i < utf32.Length; i++)
@@ -952,7 +952,7 @@ namespace System.Text.Utf8
                 if (!TryEncodeCodePoint(utf32[i], utf8, bytesWritten, out written))
                     return false;
 
-                codePointsConsumed++;
+                codeUnitsConsumed++;
                 bytesWritten += written;
             }
 

--- a/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8TextEncoder.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8TextEncoder.cs
@@ -99,40 +99,40 @@ namespace System.Text.Utf8
 
         #region Encoding implementation
 
-        public override bool TryEncode(ReadOnlySpan<byte> utf8, Span<byte> data, out int bytesConsumed, out int bytesWritten)
+        public override bool TryEncode(ReadOnlySpan<byte> utf8, Span<byte> encodedBytes, out int bytesConsumed, out int bytesWritten)
         {
             // TODO: Other methods validate that the input stream contains valid sequences as they are consumed.
             //       Currently, this is a copy operation with no validation. What is the right thing here?
 
-            if (utf8.Length > data.Length)
+            if (utf8.Length > encodedBytes.Length)
             {
                 bytesConsumed = 0;
                 bytesWritten = 0;
                 return false;
             }
 
-            utf8.CopyTo(data);
+            utf8.CopyTo(encodedBytes);
             bytesWritten = utf8.Length;
             bytesConsumed = utf8.Length;
             return true;
         }
 
-        public override bool TryEncode(ReadOnlySpan<char> utf16, Span<byte> data, out int charactersConsumed, out int bytesWritten)
+        public override bool TryEncode(ReadOnlySpan<char> utf16, Span<byte> encodedBytes, out int charactersConsumed, out int bytesWritten)
         {
-            return Utf8Encoder.TryEncode(utf16, data, out charactersConsumed, out bytesWritten);
+            return Utf8Encoder.TryEncode(utf16, encodedBytes, out charactersConsumed, out bytesWritten);
         }
 
-        public override bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> data, out int codeUnitsConsumed, out int bytesWritten)
+        public override bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> encodedBytes, out int codeUnitsConsumed, out int bytesWritten)
         {
-            return Utf8Encoder.TryEncode(utf32, data, out codeUnitsConsumed, out bytesWritten);
+            return Utf8Encoder.TryEncode(utf32, encodedBytes, out codeUnitsConsumed, out bytesWritten);
         }
 
-        public override bool TryEncode(string text, Span<byte> data, out int bytesWritten)
+        public override bool TryEncode(string text, Span<byte> encodedBytes, out int bytesWritten)
         {
             int consumed;
             var utf16 = text.AsSpan();
 
-            return Utf8Encoder.TryEncode(utf16, data, out consumed, out bytesWritten);
+            return Utf8Encoder.TryEncode(utf16, encodedBytes, out consumed, out bytesWritten);
         }
 
         public override bool TryComputeEncodedBytes(ReadOnlySpan<byte> utf8, out int bytesNeeded)

--- a/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8TextEncoder.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8TextEncoder.cs
@@ -90,9 +90,9 @@ namespace System.Text.Utf8
             return Utf8Encoder.TryDecode(encodedBytes, utf16, out bytesConsumed, out charactersWritten);
         }
 
-        public override bool TryDecode(ReadOnlySpan<byte> encodedBytes, Span<uint> utf32, out int bytesConsumed, out int codePointsWritten)
+        public override bool TryDecode(ReadOnlySpan<byte> encodedBytes, Span<uint> utf32, out int bytesConsumed, out int codeUnitsWritten)
         {
-            return Utf8Encoder.TryDecode(encodedBytes, utf32, out bytesConsumed, out codePointsWritten);
+            return Utf8Encoder.TryDecode(encodedBytes, utf32, out bytesConsumed, out codeUnitsWritten);
         }
 
         #endregion Decoding implementation
@@ -122,9 +122,9 @@ namespace System.Text.Utf8
             return Utf8Encoder.TryEncode(utf16, data, out charactersConsumed, out bytesWritten);
         }
 
-        public override bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> data, out int codePointsConsumed, out int bytesWritten)
+        public override bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> data, out int codeUnitsConsumed, out int bytesWritten)
         {
-            return Utf8Encoder.TryEncode(utf32, data, out codePointsConsumed, out bytesWritten);
+            return Utf8Encoder.TryEncode(utf32, data, out codeUnitsConsumed, out bytesWritten);
         }
 
         public override bool TryEncode(string text, Span<byte> data, out int bytesWritten)

--- a/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8TextEncoder.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8TextEncoder.cs
@@ -90,9 +90,9 @@ namespace System.Text.Utf8
             return Utf8Encoder.TryDecode(encodedBytes, utf16, out bytesConsumed, out charactersWritten);
         }
 
-        public override bool TryDecode(ReadOnlySpan<byte> encodedBytes, Span<uint> utf32, out int bytesConsumed, out int charactersWritten)
+        public override bool TryDecode(ReadOnlySpan<byte> encodedBytes, Span<uint> utf32, out int bytesConsumed, out int codePointsWritten)
         {
-            return Utf8Encoder.TryDecode(encodedBytes, utf32, out bytesConsumed, out charactersWritten);
+            return Utf8Encoder.TryDecode(encodedBytes, utf32, out bytesConsumed, out codePointsWritten);
         }
 
         #endregion Decoding implementation
@@ -122,9 +122,9 @@ namespace System.Text.Utf8
             return Utf8Encoder.TryEncode(utf16, data, out charactersConsumed, out bytesWritten);
         }
 
-        public override bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> data, out int charactersConsumed, out int bytesWritten)
+        public override bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> data, out int codePointsConsumed, out int bytesWritten)
         {
-            return Utf8Encoder.TryEncode(utf32, data, out charactersConsumed, out bytesWritten);
+            return Utf8Encoder.TryEncode(utf32, data, out codePointsConsumed, out bytesWritten);
         }
 
         public override bool TryEncode(string text, Span<byte> data, out int bytesWritten)

--- a/src/System.Text.Primitives/System/Text/TextEncoder.cs
+++ b/src/System.Text.Primitives/System/Text/TextEncoder.cs
@@ -140,7 +140,7 @@ namespace System.Text
         /// <param name="encodedBytes">The data span to consume for decoding. The encoded data should be relative to the concrete instance of the class used.</param>
         /// <param name="utf32">A span buffer to capture the decoded UTF-32 characters.</param>
         /// <param name="bytesConsumed">An output parameter to capture the number of bytes successfully consumed during decoding from <paramref name="encodedBytes"/></param>
-        /// <param name="charactersWritten">A output parameter to capture the number of bytes written to <paramref name="utf32"/></param>
+        /// <param name="codePointsWritten">A output parameter to capture the number of code points written to <paramref name="utf32"/></param>
         /// <returns>
         /// True if successfully able to consume the entire data span in the decoding process.
         /// False if decoding failed. <paramref name="utf32"/> will contain as much of the data as possible to decode with
@@ -149,7 +149,7 @@ namespace System.Text
         /// It is possible to continue decoding from the stop point by slicing off the processed part of <paramref name="encodedBytes"/>, fixing
         /// errors (reading more data, patching encoded bytes, etc.) and calling this method again.
         /// </returns>
-        public abstract bool TryDecode(ReadOnlySpan<byte> encodedBytes, Span<uint> utf32, out int bytesConsumed, out int charactersWritten);
+        public abstract bool TryDecode(ReadOnlySpan<byte> encodedBytes, Span<uint> utf32, out int bytesConsumed, out int codePointsWritten);
 
         #endregion Decode Methods
 
@@ -194,17 +194,17 @@ namespace System.Text
         /// </summary>
         /// <param name="utf32">The data span to consume for encoding.</param>
         /// <param name="encodedBytes">A span buffer to write the encoded bytes.</param>
-        /// <param name="charactersConsumed">An output parameter to capture the number of characters successfully consumed during encoding from <paramref name="utf8"/></param>
+        /// <param name="codePointsConsumed">An output parameter to capture the number of code points successfully consumed during encoding from <paramref name="utf8"/></param>
         /// <param name="bytesWritten">A output parameter to capture the number of bytes written to <paramref name="encodedBytes"/></param>
         /// <returns>
         /// True if successfully able to consume the entire data span in the encoding process.
         /// False if encoding failed. <paramref name="encodedBytes"/> will contain as much of the data as possible to encode with
-        /// <paramref name="charactersConsumed"> set to the number of characters used.
+        /// <paramref name="codePointsConsumed"> set to the number of code points used.
         /// 
         /// It is possible to continue encoding from the stop point by slicing off the processed part of <paramref name="utf32"/>, fixing
         /// errors (reading more data, new output buffer, etc.) and calling this method again.
         /// </returns>
-        public abstract bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> encodedBytes, out int charactersConsumed, out int bytesWritten);
+        public abstract bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> encodedBytes, out int codePointsConsumed, out int bytesWritten);
 
         /// <summary>
         /// Encodes a UTF-16 string. The target encoding is relative to the concrete class being executed.

--- a/src/System.Text.Primitives/System/Text/TextEncoder.cs
+++ b/src/System.Text.Primitives/System/Text/TextEncoder.cs
@@ -140,7 +140,7 @@ namespace System.Text
         /// <param name="encodedBytes">The data span to consume for decoding. The encoded data should be relative to the concrete instance of the class used.</param>
         /// <param name="utf32">A span buffer to capture the decoded UTF-32 characters.</param>
         /// <param name="bytesConsumed">An output parameter to capture the number of bytes successfully consumed during decoding from <paramref name="encodedBytes"/></param>
-        /// <param name="codePointsWritten">A output parameter to capture the number of code points written to <paramref name="utf32"/></param>
+        /// <param name="codeUnitsWritten">A output parameter to capture the number of code units written to <paramref name="utf32"/></param>
         /// <returns>
         /// True if successfully able to consume the entire data span in the decoding process.
         /// False if decoding failed. <paramref name="utf32"/> will contain as much of the data as possible to decode with
@@ -149,7 +149,7 @@ namespace System.Text
         /// It is possible to continue decoding from the stop point by slicing off the processed part of <paramref name="encodedBytes"/>, fixing
         /// errors (reading more data, patching encoded bytes, etc.) and calling this method again.
         /// </returns>
-        public abstract bool TryDecode(ReadOnlySpan<byte> encodedBytes, Span<uint> utf32, out int bytesConsumed, out int codePointsWritten);
+        public abstract bool TryDecode(ReadOnlySpan<byte> encodedBytes, Span<uint> utf32, out int bytesConsumed, out int codeUnitsWritten);
 
         #endregion Decode Methods
 
@@ -194,17 +194,17 @@ namespace System.Text
         /// </summary>
         /// <param name="utf32">The data span to consume for encoding.</param>
         /// <param name="encodedBytes">A span buffer to write the encoded bytes.</param>
-        /// <param name="codePointsConsumed">An output parameter to capture the number of code points successfully consumed during encoding from <paramref name="utf8"/></param>
+        /// <param name="codeUnitsConsumed">An output parameter to capture the number of code units successfully consumed during encoding from <paramref name="utf8"/></param>
         /// <param name="bytesWritten">A output parameter to capture the number of bytes written to <paramref name="encodedBytes"/></param>
         /// <returns>
         /// True if successfully able to consume the entire data span in the encoding process.
         /// False if encoding failed. <paramref name="encodedBytes"/> will contain as much of the data as possible to encode with
-        /// <paramref name="codePointsConsumed"> set to the number of code points used.
+        /// <paramref name="codeUnitsConsumed"> set to the number of code units used.
         /// 
         /// It is possible to continue encoding from the stop point by slicing off the processed part of <paramref name="utf32"/>, fixing
         /// errors (reading more data, new output buffer, etc.) and calling this method again.
         /// </returns>
-        public abstract bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> encodedBytes, out int codePointsConsumed, out int bytesWritten);
+        public abstract bool TryEncode(ReadOnlySpan<uint> utf32, Span<byte> encodedBytes, out int codeUnitsConsumed, out int bytesWritten);
 
         /// <summary>
         /// Encodes a UTF-16 string. The target encoding is relative to the concrete class being executed.


### PR DESCRIPTION
Specifically for encoding/decoding `ReadOnlySpan<uint> utf32`