### PR TITLE
Fixed r/w hole in DisposableReservation

### DIFF
--- a/scripts/PerfHarness/run.bat
+++ b/scripts/PerfHarness/run.bat
@@ -1,1 +1,1 @@
-dotnet run -c Release -- --perf:outputdir results --perf:typenames %1
+..\..\dotnet\dotnet.exe run -c Release -- --perf:outputdir results --perf:typenames %1

--- a/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
@@ -56,7 +56,7 @@ namespace System.Buffers
 
         public Span<T> Span => _owner.Span.Slice(_index, _length);
 
-        public DisposableReservation<T> Reserve() => new DisposableReservation<T>(_owner);
+        public DisposableReservation Retain() => new DisposableReservation(_owner);
 
         public BufferHandle Pin() => _owner.Pin(_index);
 

--- a/src/System.Buffers.Primitives/System/Buffers/DisposableReservation.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/DisposableReservation.cs
@@ -5,17 +5,15 @@
 
 namespace System.Buffers
 {
-    public struct DisposableReservation<T> : IDisposable
+    public struct DisposableReservation : IDisposable
     {
-        OwnedBuffer<T> _owner;
+        IRetainable _owner;
 
-        internal DisposableReservation(OwnedBuffer<T> owner)
+        internal DisposableReservation(IRetainable owner)
         {
             _owner = owner;
             _owner.Retain();
         }
-
-        public Span<T> Span => _owner.Span;
 
         public void Dispose()
         {

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -50,10 +50,7 @@ namespace System.Buffers
 
         public ReadOnlySpan<T> Span => _owner.Span.Slice(_index, _length);
 
-        public DisposableReservation<T> Reserve()
-        {
-            return _owner.Buffer.Reserve();
-        }
+        public DisposableReservation Retain() => new DisposableReservation(_owner);
 
         public BufferHandle Pin() => _owner.Pin(_index);
    

--- a/tests/Benchmarks/E2EPipelineNoIO.cs
+++ b/tests/Benchmarks/E2EPipelineNoIO.cs
@@ -23,9 +23,7 @@ public partial class E2EPipelineTests
         "\r\n";
 
     [Benchmark]
-    [InlineData(1000, 256)]
-    [InlineData(1000, 1024)]
-    [InlineData(1000, 4096)]
+    [InlineData(10000, 256)]
     private static void TechEmpowerHelloWorldNoIO(int numberOfRequests, int concurrentConnections)
     {
         foreach (var iteration in Benchmark.Iterations)
@@ -48,36 +46,8 @@ public partial class E2EPipelineTests
         }
     }
 
-    //[Benchmark(Skip = "The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
-    [InlineData(1000, 256)]
-    [InlineData(1000, 1024)]
-    [InlineData(1000, 4096)]
-    private static void TechEmpowerHelloWorldNoIOSingleSegmentParser(int numberOfRequests, int concurrentConnections)
-    {
-        foreach (var iteration in Benchmark.Iterations)
-        {
-            using (iteration.StartMeasurement())
-            {
-                RawInMemoryHttpServer.RunSingleSegmentParser(numberOfRequests, concurrentConnections, s_genericRequest, (request, response)=> {
-                    var formatter = new OutputFormatter<WritableBuffer>(response, TextEncoder.Utf8);
-                    formatter.Append("HTTP/1.1 200 OK");
-                    formatter.Append("\r\nContent-Length: 13");
-                    formatter.Append("\r\nContent-Type: text/plain");
-                    formatter.Format("\r\nDate: {0:R}", DateTime.UtcNow);
-                    formatter.Append("Server: System.IO.Pipelines");
-                    formatter.Append("\r\n\r\n");
-
-                    // write body
-                    formatter.Append("Hello, World!");
-                });
-            }
-        }
-    }
-
     [Benchmark]
-    [InlineData(1000, 256)]
-    [InlineData(1000, 1024)]
-    [InlineData(1000, 4096)]
+    [InlineData(10000, 256)]
     private static void TechEmpowerJsonNoIO(int numberOfRequests, int concurrentConnections)
     {
         foreach (var iteration in Benchmark.Iterations)

--- a/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
@@ -67,7 +67,7 @@ namespace System.Slices.Tests
                 Buffer<byte> memory = owned.Buffer;
                 Buffer<byte> memorySlice = memory.Slice(10);
                 copyStoredForLater = memorySlice;
-                var r = memorySlice.Reserve();
+                var r = memorySlice.Retain();
                 try {
                     Assert.Throws<InvalidOperationException>(() => { // memory is reserved; premature dispose check fires
                         owned.Dispose();

--- a/tests/System.Buffers.Primitives.Tests/MemoryTests.cs
+++ b/tests/System.Buffers.Primitives.Tests/MemoryTests.cs
@@ -46,7 +46,7 @@ namespace System.Buffers.Tests
                 Buffer<byte> memory = owned.Buffer;
                 Buffer<byte> memorySlice = memory.Slice(10);
                 copyStoredForLater = memorySlice;
-                var r = memorySlice.Reserve();
+                var r = memorySlice.Retain();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => { // memory is reserved; premature dispose check fires
@@ -90,7 +90,7 @@ namespace System.Buffers.Tests
             for(int k = 0; k < 1000; k++) {
                 var owners   = new OwnedBuffer<byte>[128];
                 var memories = new Buffer<byte>[owners.Length];
-                var reserves = new DisposableReservation<byte>[owners.Length];
+                var reserves = new DisposableReservation[owners.Length];
                 var disposeSuccesses = new bool[owners.Length];
                 var reserveSuccesses = new bool[owners.Length];
 
@@ -114,7 +114,7 @@ namespace System.Buffers.Tests
                 var reserve_task = Task.Run(() => {
                     for (int i = owners.Length - 1; i >= 0; i--) {
                         try {
-                            reserves[i] = memories[i].Reserve();
+                            reserves[i] = memories[i].Retain();
                             reserveSuccesses[i] = true;
                         } catch (ObjectDisposedException) {
                             reserveSuccesses[i] = false;
@@ -172,7 +172,7 @@ namespace System.Buffers.Tests
             var memory = owned.Buffer;
             Assert.Equal(0, owned.OnZeroRefencesCount);
             Assert.False(owned.IsRetained);
-            using (memory.Reserve()) {
+            using (memory.Retain()) {
                 Assert.Equal(0, owned.OnZeroRefencesCount);
                 Assert.True(owned.IsRetained);
             }
@@ -186,7 +186,7 @@ namespace System.Buffers.Tests
             OwnedBuffer<byte> owned = new AutoPooledMemory(1000);
             var memory = owned.Buffer;
             Assert.Equal(false, owned.IsDisposed);
-            var reservation = memory.Reserve();
+            var reservation = memory.Retain();
             Assert.Equal(false, owned.IsDisposed);
             owned.Release();
             Assert.Equal(false, owned.IsDisposed);


### PR DESCRIPTION
DisposableReservation returned from ReadOnlyBuffer.Reserve could be used to create r/w Span<T>. 
One way to resolve the issue was to create ReadOnlyDisposableReservation, but this would just add to the complexity of lifetime management.
I opted into removing DisposableReservation.Span. DisposableReservation is now just a way to call retain and release on owned buffers. To get spans, the calling code needs to call Buffer.Span or ReadOnlyBuffer.Span. These properties always give spans with the appropriate r/w access.

I also simplified the benchmarks I use to verify that we don't regress pipelines performance.

cc: @mjp41, @ahsonkhan, @shiftylogic, @davidfowl 