### PR TITLE
Perf tests must be run as an admin, catch the exception and fail safely

### DIFF
--- a/scripts/PerfHarness/PerfHarness.cs
+++ b/scripts/PerfHarness/PerfHarness.cs
@@ -61,8 +61,7 @@ public class PerfHarness
         return new [] {
             "Benchmarks",
             "System.Binary.Base64.Tests",
-            "System.Text.Primitives.Tests",
-            "System.Buffers.Primitives.Tests"
+            "System.Text.Primitives.Tests"
         };
     }
 }

--- a/scripts/PerfHarness/PerfHarness.cs
+++ b/scripts/PerfHarness/PerfHarness.cs
@@ -9,29 +9,42 @@ using Microsoft.Xunit.Performance.Api;
 
 public class PerfHarness
 {
-    public static void Main(string[] args)
+    public static int Main(string[] args)
     {
-        string[] assemblies = GetTestAssemblies();
-
-        int pos =  Array.IndexOf(args, "--assembly");
-
-        using (XunitPerformanceHarness harness = new XunitPerformanceHarness(args))
+        try
         {
-            if (pos > -1 && args.Length > pos + 1)
+            string[] assemblies = GetTestAssemblies();
+
+            int pos =  Array.IndexOf(args, "--assembly");
+
+            using (XunitPerformanceHarness harness = new XunitPerformanceHarness(args))
             {
-                pos = Array.IndexOf(assemblies, args[pos + 1]);
-                if (pos > -1)
+                if (pos > -1 && args.Length > pos + 1)
                 {
-                    harness.RunBenchmarks(GetTestAssembly(assemblies[pos]));
-                    return;
+                    pos = Array.IndexOf(assemblies, args[pos + 1]);
+                    if (pos > -1)
+                    {
+                        harness.RunBenchmarks(GetTestAssembly(assemblies[pos]));
+                        return 0;
+                    }
+                }
+
+                foreach(var testName in assemblies)
+                {
+                    harness.RunBenchmarks(GetTestAssembly(testName));
                 }
             }
-
-            foreach(var testName in assemblies)
-            {
-                harness.RunBenchmarks(GetTestAssembly(testName));
-            }
         }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex.ToString());
+            if(ex is System.InvalidOperationException)
+            {
+                Console.Error.WriteLine("Please check if you have admin privileges");
+            }
+            return -1;
+        }
+        return 0;
     }
 
     private static string GetTestAssembly(string testName)

--- a/scripts/PerfHarness/PerfHarness.csproj
+++ b/scripts/PerfHarness/PerfHarness.csproj
@@ -13,7 +13,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\tests\Benchmarks\Benchmarks.csproj" />
     <ProjectReference Include="..\..\tests\System.Binary.Base64.Tests\System.Binary.Base64.Tests.csproj" />
-    <ProjectReference Include="..\..\tests\System.Buffers.Primitives.Tests\System.Buffers.Primitives.Tests.csproj" />
     <ProjectReference Include="..\..\tests\System.Text.Primitives.Tests\System.Text.Primitives.Tests.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
From https://github.com/dotnet/corefxlab/pull/1481

cc @mgravell, @shiftylogic 

Also, removing System.Buffers.Primitives.Tests from PerfHarness since it no longer contains any benchmark tests.