### PR TITLE
Cleaning up text encoder tests code redundancy.

### DIFF
--- a/scripts/PerfHarness/README.md
+++ b/scripts/PerfHarness/README.md
@@ -22,7 +22,9 @@ results.
    
 3c. To run specific tests found in a specific assembly only, pass in the assembly name and type names to the harness:
    
-   (`..\..\dotnet\dotnet.exe run -c Release -- --assembly Benchmarks --perf:typenames name1 [name2] [...]`)
+   (`..\..\dotnet\dotnet.exe run -c Release -- --assembly <name> --perf:typenames name1 [name2] [...]`)
+   
+   Example: `..\..\dotnet\dotnet.exe run -c Release -- --assembly System.Text.Primitives.Tests --perf:typenames System.Text.Primitives.Tests.EncodingPerfComparisonTests`
 
 ## Add a New Performance Test
 

--- a/tests/System.Text.Primitives.Tests/Encoding/EncodeIntoUtf8Tests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/EncodeIntoUtf8Tests.cs
@@ -39,8 +39,8 @@ namespace System.Text.Primitives.Tests.Encoding
             switch (from)
             {
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf8:
-                    byte[] temp = testEncoder.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoder, testEncoder, temp);
+                    byte[] inputStringUtf8 = testEncoder.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoder, testEncoder, inputStringUtf8);
                     encodedBytes = Span<byte>.Empty;    // Output buffer is size 0
                     Assert.True(utf8.TryEncode(ReadOnlySpan<byte>.Empty, encodedBytes, out int charactersConsumed, out bytesWritten));
                     Assert.Equal(0, charactersConsumed);
@@ -50,8 +50,8 @@ namespace System.Text.Primitives.Tests.Encoding
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf16:
-                    temp = testEncoderUnicode.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp);
+                    byte[] inputStringUtf16 = testEncoderUnicode.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputStringUtf16);
                     encodedBytes = Span<byte>.Empty;
                     Assert.True(utf8.TryEncode(ReadOnlySpan<char>.Empty, encodedBytes, out charactersConsumed, out bytesWritten));
                     Assert.Equal(0, charactersConsumed);
@@ -61,8 +61,8 @@ namespace System.Text.Primitives.Tests.Encoding
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromString:
-                    temp = testEncoderUnicode.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp);
+                    inputStringUtf16 = testEncoderUnicode.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputStringUtf16);
                     encodedBytes = Span<byte>.Empty;
                     Assert.True(utf8.TryEncode("", encodedBytes, out bytesWritten));
                     encodedBytes = new Span<byte>(new byte[1]);
@@ -71,8 +71,8 @@ namespace System.Text.Primitives.Tests.Encoding
 
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf32:
                 default:
-                    temp = testEncoderUtf32.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUtf32, testEncoder, temp);
+                    byte[] inputStringUtf32 = testEncoderUtf32.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUtf32, testEncoder, inputStringUtf32);
                     encodedBytes = Span<byte>.Empty;
                     Assert.True(utf8.TryEncode(ReadOnlySpan<uint>.Empty, encodedBytes, out charactersConsumed, out bytesWritten));
                     Assert.Equal(0, charactersConsumed);
@@ -105,22 +105,22 @@ namespace System.Text.Primitives.Tests.Encoding
             switch (from)
             {
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf8:
-                    byte[] temp = testEncoder.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoder, testEncoder, temp);
-                    ReadOnlySpan<byte> inputUtf8 = temp;
+                    byte[] inputStringUtf8 = testEncoder.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoder, testEncoder, inputStringUtf8);
+                    ReadOnlySpan<byte> inputUtf8 = inputStringUtf8;
                     Assert.False(utf8.TryEncode(inputUtf8, encodedBytes, out charactersConsumed, out bytesWritten));
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf16:
-                    temp = testEncoderUnicode.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp);
-                    ReadOnlySpan<char> inputUtf16 = temp.AsSpan().NonPortableCast<byte, char>();
+                    byte[] inputStringUtf16 = testEncoderUnicode.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputStringUtf16);
+                    ReadOnlySpan<char> inputUtf16 = inputStringUtf16.AsSpan().NonPortableCast<byte, char>();
                     Assert.False(utf8.TryEncode(inputUtf16, encodedBytes, out charactersConsumed, out bytesWritten));
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromString:
-                    temp = testEncoderUnicode.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp);
+                    inputStringUtf16 = testEncoderUnicode.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputStringUtf16);
                     string inputStr = inputString;
                     Assert.False(utf8.TryEncode(inputStr, encodedBytes, out bytesWritten));
                     charactersConsumed = 0;
@@ -128,9 +128,9 @@ namespace System.Text.Primitives.Tests.Encoding
 
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf32:
                 default:
-                    temp = testEncoderUtf32.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUtf32, testEncoder, temp);
-                    ReadOnlySpan<uint> input = temp.AsSpan().NonPortableCast<byte, uint>();
+                    byte[] inputStringUtf32 = testEncoderUtf32.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUtf32, testEncoder, inputStringUtf32);
+                    ReadOnlySpan<uint> input = inputStringUtf32.AsSpan().NonPortableCast<byte, uint>();
                     Assert.False(utf8.TryEncode(input, encodedBytes, out charactersConsumed, out bytesWritten));
                     break;
             }
@@ -162,11 +162,11 @@ namespace System.Text.Primitives.Tests.Encoding
             switch (from)
             {
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf8:
-                    byte[] temp = testEncoder.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoder, testEncoder, temp);
+                    byte[] inputStringUtf8 = testEncoder.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoder, testEncoder, inputStringUtf8);
                     expectedBytesWritten = expectedBytes.Length;
                     encodedBytes1 = new Span<byte>(new byte[expectedBytesWritten / 2]);
-                    ReadOnlySpan<byte> inputUtf8 = temp;
+                    ReadOnlySpan<byte> inputUtf8 = inputStringUtf8;
                     Assert.False(utf8.TryEncode(inputUtf8, encodedBytes1, out int charactersConsumed1, out bytesWritten1));
                     encodedBytes2 = new Span<byte>(new byte[expectedBytesWritten - bytesWritten1]);
                     Assert.True(utf8.TryEncode(inputUtf8.Slice(charactersConsumed1), encodedBytes2, out int charactersConsumed2, out bytesWritten2));
@@ -174,11 +174,11 @@ namespace System.Text.Primitives.Tests.Encoding
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf16:
-                    temp = testEncoderUnicode.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp);
+                    byte[] inputStringUtf16 = testEncoderUnicode.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputStringUtf16);
                     expectedBytesWritten = expectedBytes.Length;
                     encodedBytes1 = new Span<byte>(new byte[expectedBytesWritten / 2]);
-                    ReadOnlySpan<char> inputUtf16 = temp.AsSpan().NonPortableCast<byte, char>();
+                    ReadOnlySpan<char> inputUtf16 = inputStringUtf16.AsSpan().NonPortableCast<byte, char>();
                     Assert.False(utf8.TryEncode(inputUtf16, encodedBytes1, out charactersConsumed1, out bytesWritten1));
                     encodedBytes2 = new Span<byte>(new byte[expectedBytesWritten - bytesWritten1]);
                     Assert.True(utf8.TryEncode(inputUtf16.Slice(charactersConsumed1), encodedBytes2, out charactersConsumed2, out bytesWritten2));
@@ -186,8 +186,8 @@ namespace System.Text.Primitives.Tests.Encoding
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromString:    // Open issue: https://github.com/dotnet/corefxlab/issues/1515
-                    /*temp = testEncoderUnicode.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp);
+                    /*inputStringUtf16 = testEncoderUnicode.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputStringUtf16);
                     expectedBytesWritten = expectedBytes.Length;
                     encodedBytes1 = new Span<byte>(new byte[expectedBytesWritten / 2]);
                     string inputStr = inputString;
@@ -198,11 +198,11 @@ namespace System.Text.Primitives.Tests.Encoding
 
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf32:
                 default:
-                    temp = testEncoderUtf32.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUtf32, testEncoder, temp);
+                    byte[] inputStringUtf32 = testEncoderUtf32.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUtf32, testEncoder, inputStringUtf32);
                     expectedBytesWritten = expectedBytes.Length;
                     encodedBytes1 = new Span<byte>(new byte[expectedBytesWritten / 2]);
-                    ReadOnlySpan<uint> input = temp.AsSpan().NonPortableCast<byte, uint>();
+                    ReadOnlySpan<uint> input = inputStringUtf32.AsSpan().NonPortableCast<byte, uint>();
                     Assert.False(utf8.TryEncode(input, encodedBytes1, out charactersConsumed1, out bytesWritten1));
                     encodedBytes2 = new Span<byte>(new byte[expectedBytesWritten - bytesWritten1]);
                     Assert.True(utf8.TryEncode(input.Slice(charactersConsumed1), encodedBytes2, out charactersConsumed2, out bytesWritten2));
@@ -237,14 +237,14 @@ namespace System.Text.Primitives.Tests.Encoding
             switch (from)
             {
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf8:
-                    byte[] temp1 = testEncoder.GetBytes(inputString1);
-                    byte[] temp2 = testEncoder.GetBytes(inputString2);
-                    expectedBytes1 = Text.Encoding.Convert(testEncoder, testEncoder, temp1);
-                    expectedBytes2 = Text.Encoding.Convert(testEncoder, testEncoder, temp2);
+                    byte[] inputString1Utf8 = testEncoder.GetBytes(inputString1);
+                    byte[] inputString2Utf8 = testEncoder.GetBytes(inputString2);
+                    expectedBytes1 = Text.Encoding.Convert(testEncoder, testEncoder, inputString1Utf8);
+                    expectedBytes2 = Text.Encoding.Convert(testEncoder, testEncoder, inputString2Utf8);
                     expectedBytesWritten = expectedBytes1.Length + expectedBytes2.Length;
                     encodedBytes = new Span<byte>(new byte[expectedBytesWritten]);
-                    ReadOnlySpan<byte> firstUtf8 = temp1;
-                    ReadOnlySpan<byte> secondUtf8 = temp2;
+                    ReadOnlySpan<byte> firstUtf8 = inputString1Utf8;
+                    ReadOnlySpan<byte> secondUtf8 = inputString2Utf8;
 
                     Assert.True(utf8.TryEncode(firstUtf8, encodedBytes, out int charactersConsumed, out bytesWritten));
                     Assert.Equal(firstUtf8.Length, charactersConsumed);
@@ -256,10 +256,10 @@ namespace System.Text.Primitives.Tests.Encoding
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf16:
-                    temp1 = testEncoderUnicode.GetBytes(inputString1);
-                    temp2 = testEncoderUnicode.GetBytes(inputString2);
-                    expectedBytes1 = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp1);
-                    expectedBytes2 = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp2);
+                    byte[] inputString1Utf16 = testEncoderUnicode.GetBytes(inputString1);
+                    byte[] inputString2Utf16 = testEncoderUnicode.GetBytes(inputString2);
+                    expectedBytes1 = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputString1Utf16);
+                    expectedBytes2 = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputString2Utf16);
                     expectedBytesWritten = expectedBytes1.Length + expectedBytes2.Length;
                     encodedBytes = new Span<byte>(new byte[expectedBytesWritten]);
                     string firstInputStr = inputString1;
@@ -273,14 +273,14 @@ namespace System.Text.Primitives.Tests.Encoding
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromString:
-                    temp1 = testEncoderUnicode.GetBytes(inputString1);
-                    temp2 = testEncoderUnicode.GetBytes(inputString2);
-                    expectedBytes1 = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp1);
-                    expectedBytes2 = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp2);
+                    inputString1Utf16 = testEncoderUnicode.GetBytes(inputString1);
+                    inputString2Utf16 = testEncoderUnicode.GetBytes(inputString2);
+                    expectedBytes1 = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputString1Utf16);
+                    expectedBytes2 = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputString2Utf16);
                     expectedBytesWritten = expectedBytes1.Length + expectedBytes2.Length;
                     encodedBytes = new Span<byte>(new byte[expectedBytesWritten]);
-                    ReadOnlySpan<char> firstUtf16 = temp1.AsSpan().NonPortableCast<byte, char>();
-                    ReadOnlySpan<char> secondUtf16 = temp2.AsSpan().NonPortableCast<byte, char>();
+                    ReadOnlySpan<char> firstUtf16 = inputString1Utf16.AsSpan().NonPortableCast<byte, char>();
+                    ReadOnlySpan<char> secondUtf16 = inputString2Utf16.AsSpan().NonPortableCast<byte, char>();
 
                     Assert.True(utf8.TryEncode(firstUtf16, encodedBytes, out charactersConsumed, out bytesWritten));
                     Assert.Equal(firstUtf16.Length, charactersConsumed);
@@ -293,14 +293,14 @@ namespace System.Text.Primitives.Tests.Encoding
 
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf32:
                 default:
-                    temp1 = testEncoderUtf32.GetBytes(inputString1);
-                    temp2 = testEncoderUtf32.GetBytes(inputString2);
-                    expectedBytes1 = Text.Encoding.Convert(testEncoderUtf32, testEncoder, temp1);
-                    expectedBytes2 = Text.Encoding.Convert(testEncoderUtf32, testEncoder, temp2);
+                    byte[] inputString1Utf32 = testEncoderUtf32.GetBytes(inputString1);
+                    byte[] inputString2Utf32 = testEncoderUtf32.GetBytes(inputString2);
+                    expectedBytes1 = Text.Encoding.Convert(testEncoderUtf32, testEncoder, inputString1Utf32);
+                    expectedBytes2 = Text.Encoding.Convert(testEncoderUtf32, testEncoder, inputString2Utf32);
                     expectedBytesWritten = expectedBytes1.Length + expectedBytes2.Length;
                     encodedBytes = new Span<byte>(new byte[expectedBytesWritten]);
-                    ReadOnlySpan<uint> firstInput = temp1.AsSpan().NonPortableCast<byte, uint>();
-                    ReadOnlySpan<uint> secondInput = temp2.AsSpan().NonPortableCast<byte, uint>();
+                    ReadOnlySpan<uint> firstInput = inputString1Utf32.AsSpan().NonPortableCast<byte, uint>();
+                    ReadOnlySpan<uint> secondInput = inputString2Utf32.AsSpan().NonPortableCast<byte, uint>();
 
                     Assert.True(utf8.TryEncode(firstInput, encodedBytes, out charactersConsumed, out bytesWritten));
                     Assert.Equal(firstInput.Length, charactersConsumed);
@@ -343,8 +343,8 @@ namespace System.Text.Primitives.Tests.Encoding
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf16:
-                    byte[] temp = testEncoderUnicode.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp);
+                    byte[] inputStringUtf16 = testEncoderUnicode.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputStringUtf16);
                     encodedBytes = new Span<byte>(new byte[expectedBytes.Length]);
                     ReadOnlySpan<char> inputUtf16 = inputString.AsSpan();
                     Assert.False(utf8.TryEncode(inputUtf16, encodedBytes, out charactersConsumed, out bytesWritten));
@@ -352,8 +352,8 @@ namespace System.Text.Primitives.Tests.Encoding
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromString:
-                    temp = testEncoderUnicode.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp);
+                    inputStringUtf16 = testEncoderUnicode.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputStringUtf16);
                     encodedBytes = new Span<byte>(new byte[expectedBytes.Length]);
                     string inputStr = inputString;
                     Assert.False(utf8.TryEncode(inputStr, encodedBytes, out bytesWritten));
@@ -401,8 +401,8 @@ namespace System.Text.Primitives.Tests.Encoding
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf16:
-                    byte[] temp = testEncoderUnicode.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp);
+                    byte[] inputStringUtf16 = testEncoderUnicode.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputStringUtf16);
                     ReadOnlySpan<char> inputUtf16 = inputString.AsSpan();
                     expectedBytesWritten = TextEncoderTestHelper.GetUtf8ByteCount(inputUtf16);
                     encodedBytes = new Span<byte>(new byte[expectedBytesWritten]);
@@ -411,8 +411,8 @@ namespace System.Text.Primitives.Tests.Encoding
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromString:
-                    temp = testEncoderUnicode.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp);
+                    inputStringUtf16 = testEncoderUnicode.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputStringUtf16);
                     string inputStr = inputString;
                     expectedBytesWritten = TextEncoderTestHelper.GetUtf8ByteCount(inputStr);
                     encodedBytes = new Span<byte>(new byte[expectedBytesWritten]);
@@ -483,8 +483,8 @@ namespace System.Text.Primitives.Tests.Encoding
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf16:
-                    byte[] temp = testEncoderUnicode.GetBytes(inputString2);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp);
+                    byte[] inputStringUtf16 = testEncoderUnicode.GetBytes(inputString2);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputStringUtf16);
                     ReadOnlySpan<char> firstUtf16 = inputString1.AsSpan();
                     ReadOnlySpan<char> secondUtf16 = inputString2.AsSpan();
                     encodedBytes = new Span<byte>(new byte[expectedBytes.Length]);
@@ -493,8 +493,8 @@ namespace System.Text.Primitives.Tests.Encoding
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromString:     // Open issue: https://github.com/dotnet/corefxlab/issues/1515
-                    /*temp = testEncoderUnicode.GetBytes(inputString2);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp);
+                    /*inputStringUtf16 = testEncoderUnicode.GetBytes(inputString2);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputStringUtf16);
                     string firstInputStr = inputString1;
                     string secondInputStr = inputString2;
                     encodedBytes = new Span<byte>(new byte[expectedBytes.Length]);
@@ -549,26 +549,26 @@ namespace System.Text.Primitives.Tests.Encoding
             switch (from)
             {
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf8:
-                    byte[] temp = testEncoder.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoder, testEncoder, temp);
+                    byte[] inputStringUtf8 = testEncoder.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoder, testEncoder, inputStringUtf8);
                     encodedBytes = new Span<byte>(new byte[expectedBytes.Length]);
-                    ReadOnlySpan<byte> inputUtf8 = temp;
+                    ReadOnlySpan<byte> inputUtf8 = inputStringUtf8;
                     Assert.True(utf8.TryEncode(inputUtf8, encodedBytes, out int charactersConsumed, out bytesWritten));
                     Assert.Equal(inputUtf8.Length, charactersConsumed);
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf16:
-                    temp = testEncoderUnicode.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp);
+                    byte[] inputStringUtf16 = testEncoderUnicode.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputStringUtf16);
                     encodedBytes = new Span<byte>(new byte[expectedBytes.Length]);
-                    ReadOnlySpan<char> inputUtf16 = temp.AsSpan().NonPortableCast<byte, char>();
+                    ReadOnlySpan<char> inputUtf16 = inputStringUtf16.AsSpan().NonPortableCast<byte, char>();
                     Assert.True(utf8.TryEncode(inputUtf16, encodedBytes, out charactersConsumed, out bytesWritten));
                     Assert.Equal(inputUtf16.Length, charactersConsumed);
                     break;
 
                 case TextEncoderTestHelper.SupportedEncoding.FromString:
-                    temp = testEncoderUnicode.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, temp);
+                    inputStringUtf16 = testEncoderUnicode.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUnicode, testEncoder, inputStringUtf16);
                     encodedBytes = new Span<byte>(new byte[expectedBytes.Length]);
                     string inputStr = inputString;
                     Assert.True(utf8.TryEncode(inputStr, encodedBytes, out bytesWritten));
@@ -576,10 +576,10 @@ namespace System.Text.Primitives.Tests.Encoding
 
                 case TextEncoderTestHelper.SupportedEncoding.FromUtf32:
                 default:
-                    temp = testEncoderUtf32.GetBytes(inputString);
-                    expectedBytes = Text.Encoding.Convert(testEncoderUtf32, testEncoder, temp);
+                    byte[] inputStringUtf32 = testEncoderUtf32.GetBytes(inputString);
+                    expectedBytes = Text.Encoding.Convert(testEncoderUtf32, testEncoder, inputStringUtf32);
                     encodedBytes = new Span<byte>(new byte[expectedBytes.Length]);
-                    ReadOnlySpan<uint> input = temp.AsSpan().NonPortableCast<byte, uint>();
+                    ReadOnlySpan<uint> input = inputStringUtf32.AsSpan().NonPortableCast<byte, uint>();
                     Assert.True(utf8.TryEncode(input, encodedBytes, out charactersConsumed, out bytesWritten));
                     Assert.Equal(input.Length, charactersConsumed);
                     break;

--- a/tests/System.Text.Primitives.Tests/Encoding/TextEncoderTestHelper.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/TextEncoderTestHelper.cs
@@ -145,6 +145,63 @@ namespace System.Text.Primitives.Tests.Encoding
             return plainText.ToString();
         }
 
+        public static string GenerateStringAlternatingASCIIAndNonASCII(int charLength)
+        {
+            Random rand = new Random(TextEncoderConstants.RandomSeed * 5);
+            var plainText = new StringBuilder();
+
+            for (int j = 0; j < charLength / 3; j++)
+            {
+                var ascii = rand.Next(0, TextEncoderConstants.Utf8OneByteLastCodePoint + 1);
+                var highSurrogate = rand.Next(TextEncoderConstants.Utf16HighSurrogateFirstCodePoint, TextEncoderConstants.Utf16HighSurrogateLastCodePoint + 1);
+                var lowSurrogate = rand.Next(TextEncoderConstants.Utf16LowSurrogateFirstCodePoint, TextEncoderConstants.Utf16LowSurrogateLastCodePoint + 1);
+
+                plainText.Append((char)ascii);
+                plainText.Append((char)highSurrogate);
+                plainText.Append((char)lowSurrogate);
+            }
+
+            for (int j = 0; j < charLength % 3; j++)
+            {
+                plainText.Append((char)rand.Next(0, TextEncoderConstants.Utf8OneByteLastCodePoint + 1));
+            }
+
+            return plainText.ToString();
+        }
+
+        public static string GenerateStringWithMostlyASCIIAndSomeNonASCII(int charLength)
+        {
+            Random rand = new Random(TextEncoderConstants.RandomSeed * 6);
+            var plainText = new StringBuilder();
+
+            int j = 0;
+            while (j < charLength - 70)
+            {
+                for (int i = 0; i < rand.Next(20, 51); i++)
+                {
+                    var ascii = rand.Next(0, TextEncoderConstants.Utf8OneByteLastCodePoint + 1);
+                    plainText.Append((char)ascii);
+                    j++;
+                }
+                for (int i = 0; i < rand.Next(5, 11); i++)
+                {
+                    var highSurrogate = rand.Next(TextEncoderConstants.Utf16HighSurrogateFirstCodePoint, TextEncoderConstants.Utf16HighSurrogateLastCodePoint + 1);
+                    var lowSurrogate = rand.Next(TextEncoderConstants.Utf16LowSurrogateFirstCodePoint, TextEncoderConstants.Utf16LowSurrogateLastCodePoint + 1);
+                    j += 2;
+                    plainText.Append((char)highSurrogate);
+                    plainText.Append((char)lowSurrogate);
+                }
+            }
+
+            while (j < charLength)
+            {
+                plainText.Append((char)rand.Next(0, TextEncoderConstants.Utf8OneByteLastCodePoint + 1));
+                j++;
+            }
+
+            return plainText.ToString();
+        }
+
         public static string GenerateAllCharacters()
         {
             var plainText = new StringBuilder();

--- a/tests/System.Text.Primitives.Tests/EncodingPerfTestsUsingTextEncoder.cs
+++ b/tests/System.Text.Primitives.Tests/EncodingPerfTestsUsingTextEncoder.cs
@@ -4,50 +4,36 @@
 using System.Collections.Generic;
 using Xunit;
 using Microsoft.Xunit.Performance;
+using System.Text.Primitives.Tests.Encoding;
 
 namespace System.Text.Primitives.Tests
 {
     public partial class EncodingPerfComparisonTests
     {
-        public const ushort Utf16HighSurrogateFirstCodePoint = 0xD800;
-        public const ushort Utf16HighSurrogateLastCodePoint = 0xDBFF;
-        public const ushort Utf16LowSurrogateFirstCodePoint = 0xDC00;
-        public const ushort Utf16LowSurrogateLastCodePoint = 0xDFFF;
-
-        public const uint LastValidCodePoint = 0x10FFFF;
-
-        public const byte Utf8OneByteLastCodePoint = 0x7F;
-        public const ushort Utf8TwoBytesLastCodePoint = 0x7FF;
-        public const ushort Utf8ThreeBytesLastCodePoint = 0xFFFF;
-
-        public const int DataLength = 999;
-
-        public const int RandomSeed = 42;
-
         private const int InnerCount = 1000;
 
         private static IEnumerable<object[]> GetEncodingPerformanceTestData()
         {
             var data = new List<object[]>();
-            data.Add(new object[] { 99, 0x0, Utf8OneByteLastCodePoint });
-            data.Add(new object[] { 99, Utf8OneByteLastCodePoint + 1, Utf8TwoBytesLastCodePoint });
-            data.Add(new object[] { 99, Utf8TwoBytesLastCodePoint + 1, Utf8ThreeBytesLastCodePoint });
-            data.Add(new object[] { 99, Utf16HighSurrogateFirstCodePoint, Utf16LowSurrogateLastCodePoint });
-            data.Add(new object[] { 99, 0x0, Utf8ThreeBytesLastCodePoint });
+            data.Add(new object[] { 99, 0x0, TextEncoderConstants.Utf8OneByteLastCodePoint });
+            data.Add(new object[] { 99, TextEncoderConstants.Utf8OneByteLastCodePoint + 1, TextEncoderConstants.Utf8TwoBytesLastCodePoint });
+            data.Add(new object[] { 99, TextEncoderConstants.Utf8TwoBytesLastCodePoint + 1, TextEncoderConstants.Utf8ThreeBytesLastCodePoint });
+            data.Add(new object[] { 99, TextEncoderConstants.Utf16HighSurrogateFirstCodePoint, TextEncoderConstants.Utf16LowSurrogateLastCodePoint });
+            data.Add(new object[] { 99, 0x0, TextEncoderConstants.Utf8ThreeBytesLastCodePoint });
             data.Add(new object[] { 99, 0, 0, SpecialTestCases.AlternatingASCIIAndNonASCII });
             data.Add(new object[] { 99, 0, 0, SpecialTestCases.MostlyASCIIAndSomeNonASCII });
-            data.Add(new object[] { 999, 0x0, Utf8OneByteLastCodePoint });
-            data.Add(new object[] { 999, Utf8OneByteLastCodePoint + 1, Utf8TwoBytesLastCodePoint });
-            data.Add(new object[] { 999, Utf8TwoBytesLastCodePoint + 1, Utf8ThreeBytesLastCodePoint });
-            data.Add(new object[] { 999, Utf16HighSurrogateFirstCodePoint, Utf16LowSurrogateLastCodePoint });
-            data.Add(new object[] { 999, 0x0, Utf8ThreeBytesLastCodePoint });
+            data.Add(new object[] { 999, 0x0, TextEncoderConstants.Utf8OneByteLastCodePoint });
+            data.Add(new object[] { 999, TextEncoderConstants.Utf8OneByteLastCodePoint + 1, TextEncoderConstants.Utf8TwoBytesLastCodePoint });
+            data.Add(new object[] { 999, TextEncoderConstants.Utf8TwoBytesLastCodePoint + 1, TextEncoderConstants.Utf8ThreeBytesLastCodePoint });
+            data.Add(new object[] { 999, TextEncoderConstants.Utf16HighSurrogateFirstCodePoint, TextEncoderConstants.Utf16LowSurrogateLastCodePoint });
+            data.Add(new object[] { 999, 0x0, TextEncoderConstants.Utf8ThreeBytesLastCodePoint });
             data.Add(new object[] { 999, 0, 0, SpecialTestCases.AlternatingASCIIAndNonASCII });
             data.Add(new object[] { 999, 0, 0, SpecialTestCases.MostlyASCIIAndSomeNonASCII });
-            data.Add(new object[] { 9999, 0x0, Utf8OneByteLastCodePoint });
-            data.Add(new object[] { 9999, Utf8OneByteLastCodePoint + 1, Utf8TwoBytesLastCodePoint });
-            data.Add(new object[] { 9999, Utf8TwoBytesLastCodePoint + 1, Utf8ThreeBytesLastCodePoint });
-            data.Add(new object[] { 9999, Utf16HighSurrogateFirstCodePoint, Utf16LowSurrogateLastCodePoint });
-            data.Add(new object[] { 9999, 0x0, Utf8ThreeBytesLastCodePoint });
+            data.Add(new object[] { 9999, 0x0, TextEncoderConstants.Utf8OneByteLastCodePoint });
+            data.Add(new object[] { 9999, TextEncoderConstants.Utf8OneByteLastCodePoint + 1, TextEncoderConstants.Utf8TwoBytesLastCodePoint });
+            data.Add(new object[] { 9999, TextEncoderConstants.Utf8TwoBytesLastCodePoint + 1, TextEncoderConstants.Utf8ThreeBytesLastCodePoint });
+            data.Add(new object[] { 9999, TextEncoderConstants.Utf16HighSurrogateFirstCodePoint, TextEncoderConstants.Utf16LowSurrogateLastCodePoint });
+            data.Add(new object[] { 9999, 0x0, TextEncoderConstants.Utf8ThreeBytesLastCodePoint });
             data.Add(new object[] { 9999, 0, 0, SpecialTestCases.AlternatingASCIIAndNonASCII });
             data.Add(new object[] { 9999, 0, 0, SpecialTestCases.MostlyASCIIAndSomeNonASCII });
             return data;
@@ -196,116 +182,14 @@ namespace System.Text.Primitives.Tests
         {
             if (special != SpecialTestCases.None)
             {
-                if (special == SpecialTestCases.AlternatingASCIIAndNonASCII) return GenerateStringAlternatingASCIIAndNonASCII(length);
-                if (special == SpecialTestCases.MostlyASCIIAndSomeNonASCII) return GenerateStringWithMostlyASCIIAndSomeNonASCII(length);
+                if (special == SpecialTestCases.AlternatingASCIIAndNonASCII) return TextEncoderTestHelper.GenerateStringAlternatingASCIIAndNonASCII(length);
+                if (special == SpecialTestCases.MostlyASCIIAndSomeNonASCII) return TextEncoderTestHelper.GenerateStringWithMostlyASCIIAndSomeNonASCII(length);
                 return "";
             }
             else
             {
-                return GenerateValidString(length, minCodePoint, maxCodePoint);
+                return TextEncoderTestHelper.GenerateValidString(length, minCodePoint, maxCodePoint);
             }
-        }
-
-        private static string GenerateValidString(int length, int minCodePoint, int maxCodePoint, bool ignoreSurrogates = false)
-        {
-            Random rand = new Random(RandomSeed);
-            var plainText = new StringBuilder();
-            for (int j = 0; j < length; j++)
-            {
-                var val = rand.Next(minCodePoint, maxCodePoint + 1);
-
-                if (ignoreSurrogates)
-                {
-                    while (val >= Utf16HighSurrogateFirstCodePoint && val <= Utf16LowSurrogateLastCodePoint)
-                    {
-                        val = rand.Next(minCodePoint, maxCodePoint + 1); // skip surrogate characters
-                    }
-                    plainText.Append((char)val);
-                    continue;
-                }
-
-                if (j < length - 1)
-                {
-                    while (val >= Utf16LowSurrogateFirstCodePoint && val <= Utf16LowSurrogateLastCodePoint)
-                    {
-                        val = rand.Next(minCodePoint, maxCodePoint + 1); // skip surrogate characters if they can't be paired
-                    }
-
-                    if (val >= Utf16HighSurrogateFirstCodePoint && val <= Utf16HighSurrogateLastCodePoint)
-                    {
-                        plainText.Append((char)val);    // high surrogate
-                        j++;
-                        val = rand.Next(Utf16LowSurrogateFirstCodePoint, Utf16LowSurrogateLastCodePoint + 1); // low surrogate
-                    }
-                }
-                else
-                {
-                    while (val >= Utf16HighSurrogateFirstCodePoint && val <= Utf16LowSurrogateLastCodePoint)
-                    {
-                        val = rand.Next(0, Utf8ThreeBytesLastCodePoint + 1); // skip surrogate characters if they can't be paired
-                    }
-                }
-                plainText.Append((char)val);
-            }
-            return plainText.ToString();
-        }
-
-
-        private static string GenerateStringAlternatingASCIIAndNonASCII(int charLength)
-        {
-            Random rand = new Random(RandomSeed * 2);
-            var plainText = new StringBuilder();
-
-            for (int j = 0; j < charLength/3; j++)
-            {
-                var ascii = rand.Next(0, Utf8OneByteLastCodePoint + 1);
-                var highSurrogate = rand.Next(Utf16HighSurrogateFirstCodePoint, Utf16HighSurrogateLastCodePoint + 1);
-                var lowSurrogate = rand.Next(Utf16LowSurrogateFirstCodePoint, Utf16LowSurrogateLastCodePoint + 1);
-
-                plainText.Append((char)ascii);
-                plainText.Append((char)highSurrogate);
-                plainText.Append((char)lowSurrogate);
-            }
-
-            for (int j = 0; j < charLength % 3; j++)
-            {
-                plainText.Append((char)rand.Next(0, Utf8OneByteLastCodePoint + 1));
-            }
-
-            return plainText.ToString();
-        }
-
-        private static string GenerateStringWithMostlyASCIIAndSomeNonASCII(int charLength)
-        {
-            Random rand = new Random(RandomSeed * 3);
-            var plainText = new StringBuilder();
-
-            int j = 0;
-            while (j < charLength - 70)
-            {
-                for (int i = 0; i < rand.Next(20, 51); i++)
-                {
-                    var ascii = rand.Next(0, Utf8OneByteLastCodePoint + 1);
-                    plainText.Append((char)ascii);
-                    j++;
-                }
-                for (int i = 0; i < rand.Next(5, 11); i++)
-                {
-                    var highSurrogate = rand.Next(Utf16HighSurrogateFirstCodePoint, Utf16HighSurrogateLastCodePoint + 1);
-                    var lowSurrogate = rand.Next(Utf16LowSurrogateFirstCodePoint, Utf16LowSurrogateLastCodePoint + 1);
-                    j += 2;
-                    plainText.Append((char)highSurrogate);
-                    plainText.Append((char)lowSurrogate);
-                }
-            }
-
-            while (j < charLength)
-            {
-                plainText.Append((char)rand.Next(0, Utf8OneByteLastCodePoint + 1));
-                j++;
-            }
-
-            return plainText.ToString();
         }
 
         public enum SpecialTestCases


### PR DESCRIPTION
cc @shiftylogic 

- Added a concrete example to PerfHarness readme.
- Removing redundant constants definition and using TextEncoderConstants.
- Removing redundant GenerateString methods and using TextEncoderTestHelper.
- Renamed variables named temp.
