### PR TITLE
Adding span.isempty checks to encoders. Fixes #1524, #1525.

### DIFF
--- a/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs
@@ -644,12 +644,6 @@ namespace System.Text.Utf8
         /// <returns>True if the input buffer was fully encoded into the output buffer, otherwise false.</returns>
         public static unsafe bool TryEncode(ReadOnlySpan<char> utf16, Span<byte> utf8, out int charactersConsumed, out int bytesWritten)
         {
-            if (utf8.IsEmpty)
-            {
-                charactersConsumed = 0;
-                bytesWritten = 0;
-                return utf16.IsEmpty;
-            }
             //
             //
             // KEEP THIS IMPLEMENTATION IN SYNC WITH https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
@@ -842,7 +836,7 @@ namespace System.Text.Utf8
 
                     if (ch <= 0x7F)
                     {
-                        if (pTarget >= pAllocatedBufferEnd)
+                        if (pAllocatedBufferEnd - pTarget <= 0)
                             goto NeedMore;
 
                         *pTarget = (byte)ch;
@@ -853,7 +847,7 @@ namespace System.Text.Utf8
                     int chd;
                     if (ch <= 0x7FF)
                     {
-                        if (pTarget >= pAllocatedBufferEnd - 1)
+                        if (pAllocatedBufferEnd - pTarget <= 1)
                             goto NeedMore;
 
                         // 2 byte encoding
@@ -864,7 +858,7 @@ namespace System.Text.Utf8
                         // if (!IsLowSurrogate(ch) && !IsHighSurrogate(ch))
                         if (!InRange(ch, HIGH_SURROGATE_START, LOW_SURROGATE_END))
                         {
-                            if (pTarget >= pAllocatedBufferEnd - 2)
+                            if (pAllocatedBufferEnd - pTarget <= 2)
                                 goto NeedMore;
 
                             // 3 byte encoding
@@ -872,7 +866,7 @@ namespace System.Text.Utf8
                         }
                         else
                         {
-                            if (pTarget >= pAllocatedBufferEnd - 3)
+                            if (pAllocatedBufferEnd - pTarget <= 3)
                                 goto NeedMore;
 
                             // 4 byte encoding - high surrogate + low surrogate

--- a/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs
@@ -52,19 +52,6 @@ namespace System.Text.Utf8
         /// <returns>True if the input buffer was fully encoded into the output buffer, otherwise false.</returns>
         public static unsafe bool TryDecode(ReadOnlySpan<byte> utf8, Span<char> utf16, out int bytesConsumed, out int charactersWritten)
         {
-            if (utf8.IsEmpty)
-            {
-                bytesConsumed = 0;
-                charactersWritten = 0;
-                return true;
-            }
-            if (utf16.IsEmpty)
-            {
-                bytesConsumed = 0;
-                charactersWritten = 0;
-                return false;
-            }
-
             fixed (byte* pUtf8 = &utf8.DangerousGetPinnableReference())
             fixed (char* pUtf16 = &utf16.DangerousGetPinnableReference())
             {
@@ -657,12 +644,6 @@ namespace System.Text.Utf8
         /// <returns>True if the input buffer was fully encoded into the output buffer, otherwise false.</returns>
         public static unsafe bool TryEncode(ReadOnlySpan<char> utf16, Span<byte> utf8, out int charactersConsumed, out int bytesWritten)
         {
-            if (utf16.IsEmpty)
-            {
-                charactersConsumed = 0;
-                bytesWritten = 0;
-                return true;
-            }
             if (utf8.IsEmpty)
             {
                 charactersConsumed = 0;
@@ -691,7 +672,7 @@ namespace System.Text.Utf8
                 // Thus don't use the fast decoding loop at all if we don't have enough characters. The threashold
                 // was choosen based on performance testing.
                 // Note that if we don't have enough bytes, pStop will prevent us from entering the fast loop.
-                while (pSrc < pEnd - 13)
+                while (pEnd - pSrc > 13)
                 {
                     // we need at least 1 byte per character, but Convert might allow us to convert
                     // only part of the input, so try as much as we can.  Reduce charCount if necessary

--- a/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs
@@ -648,7 +648,7 @@ namespace System.Text.Utf8
             {
                 charactersConsumed = 0;
                 bytesWritten = 0;
-                return false;
+                return utf16.IsEmpty;
             }
             //
             //

--- a/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs
@@ -52,6 +52,19 @@ namespace System.Text.Utf8
         /// <returns>True if the input buffer was fully encoded into the output buffer, otherwise false.</returns>
         public static unsafe bool TryDecode(ReadOnlySpan<byte> utf8, Span<char> utf16, out int bytesConsumed, out int charactersWritten)
         {
+            if (utf8.IsEmpty)
+            {
+                bytesConsumed = 0;
+                charactersWritten = 0;
+                return true;
+            }
+            if (utf16.IsEmpty)
+            {
+                bytesConsumed = 0;
+                charactersWritten = 0;
+                return false;
+            }
+
             fixed (byte* pUtf8 = &utf8.DangerousGetPinnableReference())
             fixed (char* pUtf16 = &utf16.DangerousGetPinnableReference())
             {
@@ -644,6 +657,18 @@ namespace System.Text.Utf8
         /// <returns>True if the input buffer was fully encoded into the output buffer, otherwise false.</returns>
         public static unsafe bool TryEncode(ReadOnlySpan<char> utf16, Span<byte> utf8, out int charactersConsumed, out int bytesWritten)
         {
+            if (utf16.IsEmpty)
+            {
+                charactersConsumed = 0;
+                bytesWritten = 0;
+                return true;
+            }
+            if (utf8.IsEmpty)
+            {
+                charactersConsumed = 0;
+                bytesWritten = 0;
+                return false;
+            }
             //
             //
             // KEEP THIS IMPLEMENTATION IN SYNC WITH https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs

--- a/tests/System.Text.Primitives.Tests/Encoding/EncodeIntoUtf8Tests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/EncodeIntoUtf8Tests.cs
@@ -22,11 +22,7 @@ namespace System.Text.Primitives.Tests.Encoding
         };
 
         [Theory]
-        //[MemberData(nameof(SupportedEncodingTestData))]
-        [InlineData(TextEncoderTestHelper.SupportedEncoding.FromUtf8)]
-        //[InlineData(TextEncoderTestHelper.SupportedEncoding.FromUtf16)]  // Open issue: https://github.com/dotnet/corefxlab/issues/1524
-        [InlineData(TextEncoderTestHelper.SupportedEncoding.FromString)]
-        [InlineData(TextEncoderTestHelper.SupportedEncoding.FromUtf32)]
+        [MemberData(nameof(SupportedEncodingTestData))]
         public void InputBufferEmpty(TextEncoderTestHelper.SupportedEncoding from)
         {
             string inputString = TextEncoderTestHelper.GenerateValidString(0, 0, TextEncoderConstants.Utf8ThreeBytesLastCodePoint);
@@ -87,11 +83,7 @@ namespace System.Text.Primitives.Tests.Encoding
         }
 
         [Theory]
-        //[MemberData(nameof(SupportedEncodingTestData))]
-        [InlineData(TextEncoderTestHelper.SupportedEncoding.FromUtf8)]
-        //[InlineData(TextEncoderTestHelper.SupportedEncoding.FromUtf16)]  // Open issue: https://github.com/dotnet/corefxlab/issues/1525
-        //[InlineData(TextEncoderTestHelper.SupportedEncoding.FromString)]  // Open issue: https://github.com/dotnet/corefxlab/issues/1525
-        [InlineData(TextEncoderTestHelper.SupportedEncoding.FromUtf32)]
+        [MemberData(nameof(SupportedEncodingTestData))]
         public void OutputBufferEmpty(TextEncoderTestHelper.SupportedEncoding from)
         {
             string inputString = TextEncoderTestHelper.GenerateValidString(TextEncoderConstants.DataLength, 0, TextEncoderConstants.Utf8ThreeBytesLastCodePoint);


### PR DESCRIPTION
cc @shiftylogic, @jkotas, @KrzysztofCwalina.

Fixes issue #1524 and #1525.