### PR TITLE
Adding encoder test to increase coverage.

### DIFF
--- a/tests/System.Text.Primitives.Tests/Encoding/EncodeIntoUtf8Tests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/EncodeIntoUtf8Tests.cs
@@ -161,14 +161,14 @@ namespace System.Text.Primitives.Tests.Encoding
                             retVal = utf8.TryEncode(inputUtf8, encodedBytes, out int charactersConsumed, out bytesWritten);
                             if (expectedBytesWritten > j)   // output buffer is too small
                             {
-                                Assert.Equal(false, retVal);
+                                Assert.False(retVal);
                                 Assert.True(charactersConsumed < inputUtf8.Length);
                                 Assert.True(expectedBytesWritten > bytesWritten);
                                 Assert.True(expectedBytes.AsSpan().Slice(0, bytesWritten).SequenceEqual(encodedBytes.Slice(0, bytesWritten)));
                             }
                             else
                             {
-                                Assert.Equal(true, retVal);
+                                Assert.True(retVal);
                                 Assert.Equal(charactersConsumed, inputUtf8.Length);
                                 Assert.Equal(expectedBytesWritten, bytesWritten);
                                 Assert.True(expectedBytes.AsSpan().SequenceEqual(encodedBytes.Slice(0, bytesWritten)));
@@ -191,14 +191,14 @@ namespace System.Text.Primitives.Tests.Encoding
                             retVal = utf8.TryEncode(inputUtf16, encodedBytes, out int charactersConsumed, out bytesWritten);
                             if (expectedBytesWritten > j)   // output buffer is too small
                             {
-                                Assert.Equal(false, retVal);
+                                Assert.False(retVal);
                                 Assert.True(charactersConsumed < inputUtf16.Length);
                                 Assert.True(expectedBytesWritten > bytesWritten);
                                 Assert.True(expectedBytes.AsSpan().Slice(0, bytesWritten).SequenceEqual(encodedBytes.Slice(0, bytesWritten)));
                             }
                             else
                             {
-                                Assert.Equal(true, retVal);
+                                Assert.True(retVal);
                                 Assert.Equal(charactersConsumed, inputUtf16.Length);
                                 Assert.Equal(expectedBytesWritten, bytesWritten);
                                 Assert.True(expectedBytes.AsSpan().SequenceEqual(encodedBytes.Slice(0, bytesWritten)));
@@ -221,13 +221,13 @@ namespace System.Text.Primitives.Tests.Encoding
                             retVal = utf8.TryEncode(inputStr, encodedBytes, out bytesWritten);
                             if (expectedBytesWritten > j)   // output buffer is too small
                             {
-                                Assert.Equal(false, retVal);
+                                Assert.False(retVal);
                                 Assert.True(expectedBytesWritten > bytesWritten);
                                 Assert.True(expectedBytes.AsSpan().Slice(0, bytesWritten).SequenceEqual(encodedBytes.Slice(0, bytesWritten)));
                             }
                             else
                             {
-                                Assert.Equal(true, retVal);
+                                Assert.True(retVal);
                                 Assert.Equal(expectedBytesWritten, bytesWritten);
                                 Assert.True(expectedBytes.AsSpan().SequenceEqual(encodedBytes.Slice(0, bytesWritten)));
                             }
@@ -250,14 +250,14 @@ namespace System.Text.Primitives.Tests.Encoding
                             retVal = utf8.TryEncode(input, encodedBytes, out int charactersConsumed, out bytesWritten);
                             if (expectedBytesWritten > j)   // output buffer is too small
                             {
-                                Assert.Equal(false, retVal);
+                                Assert.False(retVal);
                                 Assert.True(charactersConsumed < input.Length);
                                 Assert.True(expectedBytesWritten > bytesWritten);
                                 Assert.True(expectedBytes.AsSpan().Slice(0, bytesWritten).SequenceEqual(encodedBytes.Slice(0, bytesWritten)));
                             }
                             else
                             {
-                                Assert.Equal(true, retVal);
+                                Assert.True(retVal);
                                 Assert.Equal(charactersConsumed, input.Length);
                                 Assert.Equal(expectedBytesWritten, bytesWritten);
                                 Assert.True(expectedBytes.AsSpan().SequenceEqual(encodedBytes.Slice(0, bytesWritten)));

--- a/tests/System.Text.Primitives.Tests/Encoding/ITextEncoderTest.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/ITextEncoderTest.cs
@@ -8,6 +8,7 @@ namespace System.Text.Primitives.Tests.Encoding
     {
         void InputBufferEmpty(TextEncoderTestHelper.SupportedEncoding from);
         void OutputBufferEmpty(TextEncoderTestHelper.SupportedEncoding from);
+        void InputOutputBufferSizeCombinations(TextEncoderTestHelper.SupportedEncoding from);
         void InputBufferLargerThanOutputBuffer(TextEncoderTestHelper.SupportedEncoding from);
         void OutputBufferLargerThanInputBuffer(TextEncoderTestHelper.SupportedEncoding from);
         void InputBufferContainsOnlyInvalidData(TextEncoderTestHelper.SupportedEncoding from);

--- a/tests/System.Text.Primitives.Tests/Encoding/TextEncoderTestHelper.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/TextEncoderTestHelper.cs
@@ -229,13 +229,15 @@ namespace System.Text.Primitives.Tests.Encoding
             return plainText.ToString();    // Length should be 0x10FFFF characters (1114112 in decimal)
         }
 
-        public static string GenerateOnlyInvalidString(int length)
+        public static string GenerateOnlyInvalidString(int length, bool highSurrogateOnly = false)
         {
             Random rand = new Random(TextEncoderConstants.RandomSeed * 2);
             var plainText = new StringBuilder();
             for (int j = 0; j < length; j++)
             {
-                var val = rand.Next(TextEncoderConstants.Utf16LowSurrogateFirstCodePoint, TextEncoderConstants.Utf16LowSurrogateLastCodePoint + 1);
+                var val = highSurrogateOnly ?
+                    rand.Next(TextEncoderConstants.Utf16HighSurrogateFirstCodePoint, TextEncoderConstants.Utf16HighSurrogateLastCodePoint + 1) : 
+                    rand.Next(TextEncoderConstants.Utf16LowSurrogateFirstCodePoint, TextEncoderConstants.Utf16LowSurrogateLastCodePoint + 1);
                 plainText.Append((char)val);
             }
             return plainText.ToString();
@@ -251,6 +253,20 @@ namespace System.Text.Primitives.Tests.Encoding
                 utf8Byte[j] = (byte)val;
             }
             return utf8Byte;
+        }
+
+        public static string GenerateInvalidStringEndsWithLow(int length)
+        {
+            Random rand = new Random(TextEncoderConstants.RandomSeed * 3);
+            var plainText = new StringBuilder();
+            for (int j = 0; j < length - 1; j++)
+            {
+                var val = rand.Next(0, TextEncoderConstants.Utf8TwoBytesLastCodePoint + 1);
+                plainText.Append((char)val);
+            }
+            // last char should be low surrogate (no high surrogate before, invalid)
+            plainText.Append((char)rand.Next(TextEncoderConstants.Utf16LowSurrogateFirstCodePoint, TextEncoderConstants.Utf16LowSurrogateLastCodePoint + 1));
+            return plainText.ToString();
         }
 
         public static string GenerateStringWithInvalidChars(int length)


### PR DESCRIPTION
Testing combinations of input (0 to 30) and output (0 to 4x input) span sizes for encoding to increase code coverage.

For example, adds coverage for: https://github.com/dotnet/corefxlab/blob/master/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs#L837-L855
```C#
 if (pAllocatedBufferEnd - pTarget <= 0)
    goto NeedMore;
```
And:
https://github.com/dotnet/corefxlab/blob/master/src/System.Text.Primitives/System/Text/Encoding/Utf8/Utf8Encoder.cs#L874-L878
```C#
if (ch > HIGH_SURROGATE_END)
{
    // low without high -> bad
    goto NeedMore;
}                    
```

cc @shiftylogic, @KrzysztofCwalina 