### PR TITLE
Added OwnedBuffer reference tests

### DIFF
--- a/src/System.Buffers.Primitives/System/Buffers/OwnedArray.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/OwnedArray.cs
@@ -34,6 +34,12 @@ namespace System.Buffers
             return new Span<T>(_array, index, length);
         }
 
+        public override Span<T> AsSpan()
+        {
+            if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(OwnedArray<T>));
+            return new Span<T>(_array, 0, _array.Length);
+        }
+
         public override BufferHandle Pin(int index = 0)
         {
             unsafe
@@ -68,11 +74,11 @@ namespace System.Buffers
             Debug.Assert(!IsDisposed);
             if (Interlocked.Decrement(ref _referenceCount) == 0)
             {
-                OnZeroReferences();
+                OnNoReferences();
             }
         }
 
-        protected virtual void OnZeroReferences()
+        protected virtual void OnNoReferences()
         {
         }
 

--- a/src/System.Buffers.Primitives/System/Buffers/OwnedBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/OwnedBuffer.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime;
 using System.Runtime.CompilerServices;
 
 namespace System.Buffers
@@ -14,7 +15,11 @@ namespace System.Buffers
 
         public abstract Span<T> AsSpan(int index, int length);
 
-        public virtual Span<T> AsSpan() => AsSpan(0, Length);
+        public virtual Span<T> AsSpan()
+        {
+            if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(OwnedBuffer<T>));
+            return AsSpan(0, Length);
+        }
 
         public Buffer<T> Buffer => new Buffer<T>(this, 0, Length);
 

--- a/src/System.Buffers.Primitives/System/Buffers/ReferenceCountedBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReferenceCountedBuffer.cs
@@ -22,14 +22,14 @@ namespace System.Buffers
         public override void Release()
         {
             Debug.Assert(!IsDisposed);
-            if (Interlocked.Decrement(ref _referenceCount) == 0) {
-                OnZeroReferences();
+            if (Interlocked.Decrement(ref _referenceCount) <= 0) {
+                OnNoReferences();
             }
         }
 
         public override bool IsRetained => _referenceCount > 0;
 
-        protected virtual void OnZeroReferences()
+        protected virtual void OnNoReferences()
         {
         }
 

--- a/tests/System.Buffers.Primitives.Tests/BufferReferenceTesting.cs
+++ b/tests/System.Buffers.Primitives.Tests/BufferReferenceTesting.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Xunit;
+
+namespace System.Buffers.Tests
+{
+    public class BufferReferenceTests
+    {
+        public static void Run(Func<OwnedBuffer<byte>> create)
+        {
+            BufferLifetimeBasics(create());
+            ThrowOnAccessAfterDispose(create());
+            PinAddReferenceRelease(create());
+            MemoryHandleDoubleFree(create());
+        }
+
+        static void MemoryAccessBasics(OwnedBuffer<byte> buffer)
+        {
+            var span = buffer.AsSpan();
+            span[10] = 10;
+
+            Assert.Equal(buffer.Length, span.Length);
+            Assert.Equal(10, span[10]);
+            
+            var memory = buffer.Buffer;
+            Assert.Equal(buffer.Length, memory.Length);
+            Assert.Equal(10, memory.Span[10]);
+
+            var array = memory.ToArray();
+            Assert.Equal(buffer.Length, array.Length);
+            Assert.Equal(10, array[10]);
+
+            Span<byte> copy = new byte[20];
+            memory.Slice(10, 20).CopyTo(copy);
+            Assert.Equal(10, copy[0]);
+        }
+
+        static void BufferLifetimeBasics(OwnedBuffer<byte> buffer)
+        {
+            Buffer<byte> copyStoredForLater;
+            try
+            {
+                Buffer<byte> memory = buffer.Buffer;
+                Buffer<byte> slice = memory.Slice(10);
+                copyStoredForLater = slice;
+                var handle = slice.Retain();
+                try
+                {
+                    Assert.Throws<InvalidOperationException>(() =>
+                    { // memory is reserved; premature dispose check fires
+                        buffer.Dispose();
+                    });
+                }
+                finally
+                {
+                    handle.Dispose(); // release reservation
+                }
+            }
+            finally
+            {
+                buffer.Dispose(); // can finish dispose with no exception
+            }
+            Assert.Throws<ObjectDisposedException>(() =>
+            {
+                // memory is disposed; cannot use copy stored for later
+                var span = copyStoredForLater.Span;
+            });
+        }
+
+        static void ThrowOnAccessAfterDispose(OwnedBuffer<byte> buffer)
+        {
+            var length = buffer.Length;
+            var span = buffer.AsSpan();
+            Assert.Equal(length, span.Length);
+            buffer.Release();
+            buffer.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => {
+                var spanDisposed = buffer.AsSpan();
+            });
+
+            Assert.Throws<ObjectDisposedException>(() => {
+                var spanDisposed = buffer.AsSpan(0, length);
+            });
+        }
+
+        static void PinAddReferenceRelease(OwnedBuffer<byte> buffer)
+        {
+            var memory = buffer.Buffer;
+            Assert.False(buffer.IsRetained);
+            var h = memory.Pin();
+            Assert.True(buffer.IsRetained);
+            h.Dispose();
+            Assert.False(buffer.IsRetained);
+        }
+
+        static void MemoryHandleDoubleFree(OwnedBuffer<byte> buffer)
+        {
+            var memory = buffer.Buffer;
+            var h = memory.Pin();
+            Assert.True(buffer.IsRetained);
+            buffer.Retain();
+            Assert.True(buffer.IsRetained);
+            h.Dispose();
+            Assert.True(buffer.IsRetained);
+            h.Dispose();
+            Assert.True(buffer.IsRetained);
+            buffer.Release();
+            Assert.False(buffer.IsRetained);
+        }
+    }
+}

--- a/tests/System.Buffers.Primitives.Tests/BufferReferenceTests.cs
+++ b/tests/System.Buffers.Primitives.Tests/BufferReferenceTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Xunit;
+
+namespace System.Buffers.Tests
+{
+    public class BufferReferenceUnitTests
+    {
+        [Fact]
+        public void OwnedArrayReferenceTests()
+        {
+            BufferReferenceTests.Run(() => { 
+                return new OwnedArray<byte>(1024);
+            });
+        }
+
+        [Fact]
+        public void AutoDisposeBufferReferenceTests()
+        {
+            BufferReferenceTests.Run(() => {
+                return new AutoDisposeBuffer<byte>(new byte[1024]);
+            });
+        }
+
+        [Fact]
+        public void AutoPooledBufferReferenceTests()
+        {
+            BufferReferenceTests.Run(() => {
+                return new AutoPooledBuffer(1024);
+            });
+        }
+
+        [Fact]
+        public void CustomBufferReferenceTests()
+        {
+            BufferReferenceTests.Run(() => {
+                return new CustomBuffer();
+            });
+        }
+    }
+}

--- a/tests/System.Buffers.Primitives.Tests/MemoryTests.cs
+++ b/tests/System.Buffers.Primitives.Tests/MemoryTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.Runtime;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -9,145 +10,10 @@ namespace System.Buffers.Tests
     public class MemoryTests
     {
         [Fact]
-        public void SimpleTestS()
-        {
-            {
-                var array = new byte[1024];
-                OwnedArray<byte> owned = array;
-                var span = owned.AsSpan();
-                span[10] = 10;
-                Assert.Equal(10, array[10]);
-
-                var memory = owned.Buffer;
-                var toArrayResult = memory.ToArray();
-                Assert.Equal(owned.Length, array.Length);
-                Assert.Equal(10, toArrayResult[10]);
-
-                Span<byte> copy = new byte[20];
-                memory.Slice(10, 20).CopyTo(copy);
-                Assert.Equal(10, copy[0]);
-            }
-        }
-
-        [Fact]
-        public void ArrayMemoryLifetime()
-        {
-            var array = new byte[1024];
-            OwnedArray<byte> owned = array;
-            TestLifetime(owned);
-        }
-
-        static void TestLifetime(OwnedBuffer<byte> owned)
-        {
-            Buffer<byte> copyStoredForLater;
-            try
-            {
-                Buffer<byte> memory = owned.Buffer;
-                Buffer<byte> memorySlice = memory.Slice(10);
-                copyStoredForLater = memorySlice;
-                var r = memorySlice.Retain();
-                try
-                {
-                    Assert.Throws<InvalidOperationException>(() => { // memory is reserved; premature dispose check fires
-                        owned.Dispose();
-                    });
-                }
-                finally
-                {
-                    r.Dispose(); // release reservation
-                }
-            }
-            finally
-            {
-                owned.Dispose(); // can finish dispose with no exception
-            }
-            Assert.Throws<ObjectDisposedException>(() => {
-                // memory is disposed; cannot use copy stored for later
-                var span = copyStoredForLater.Span;
-            });
-        }
-
-
-        [Fact]
-        public void TestThrowOnAccessAfterDipose()
-        {
-            var array = new byte[1024];
-            AutoDisposeMemory<byte> owned = new AutoDisposeMemory<byte>(array);
-            var span = owned.AsSpan();
-            Assert.Equal(array.Length, span.Length);
-            owned.Release();
-            owned.Dispose();
-
-            Assert.Throws<ObjectDisposedException>(() => {
-                var spanDisposed = owned.AsSpan();
-            });
-        }
-
-        [Fact(Skip = "This needs to be fixed and re-enabled or removed.")]
-        public void RacyAccess()
-        {
-            for(int k = 0; k < 1000; k++) {
-                var owners   = new OwnedArray<byte>[128];
-                var memories = new Buffer<byte>[owners.Length];
-                var reserves = new BufferHandle[owners.Length];
-                var disposeSuccesses = new bool[owners.Length];
-                var reserveSuccesses = new bool[owners.Length];
-
-                for (int i = 0; i < owners.Length; i++) {
-                    var array = new byte[1024];
-                    owners[i] = array;
-                    memories[i] = owners[i].Buffer;
-                }
-
-                var dispose_task = Task.Run(() => {
-                    for (int i = 0; i < owners.Length; i++) {
-                        try {
-                            owners[i].Dispose();
-                            disposeSuccesses[i] = true;
-                        } catch (InvalidOperationException) {
-                            disposeSuccesses[i] = false;
-                        }
-                    }
-                });
-
-                var reserve_task = Task.Run(() => {
-                    for (int i = owners.Length - 1; i >= 0; i--) {
-                        try {
-                            reserves[i] = memories[i].Retain();
-                            reserveSuccesses[i] = true;
-                        } catch (ObjectDisposedException) {
-                            reserveSuccesses[i] = false;
-                        }
-                    }
-                });
-
-                Task.WaitAll(reserve_task, dispose_task);
-
-                for(int i = 0; i < owners.Length; i++) {
-                    Assert.False(disposeSuccesses[i] && reserveSuccesses[i]);
-                }
-            }
-        }
-
-        [Fact]
-        public unsafe void ReferenceCounting()
-        {
-            var owned = new CustomMemory();
-            var memory = owned.Buffer;
-            Assert.Equal(0, owned.OnZeroRefencesCount);
-            Assert.False(owned.IsRetained);
-            using (memory.Retain()) {
-                Assert.Equal(0, owned.OnZeroRefencesCount);
-                Assert.True(owned.IsRetained);
-            }
-            Assert.Equal(1, owned.OnZeroRefencesCount);
-            Assert.False(owned.IsRetained);
-        }
-
-        [Fact]
         public void AutoDispose()
         {
-            OwnedBuffer<byte> owned = new AutoPooledMemory(1000);
+            OwnedBuffer<byte> owned = new AutoPooledBuffer(1000);
+            owned.Retain();
             var memory = owned.Buffer;
             Assert.Equal(false, owned.IsDisposed);
             var reservation = memory.Retain();
@@ -159,19 +25,6 @@ namespace System.Buffers.Tests
         }
 
         [Fact]
-        public void PinAddReferenceReleaseTest()
-        {
-            var array = new byte[1024];
-            OwnedArray<byte> owned = array;
-            var memory = owned.Buffer;
-            Assert.False(owned.IsRetained);
-            var h = memory.Pin();
-            Assert.True(owned.IsRetained);
-            h.Dispose();
-            Assert.False(owned.IsRetained);
-        }
-
-        [Fact]
         public void MemoryHandleFreeUninitialized()
         {
             var h = default(BufferHandle);
@@ -179,90 +32,105 @@ namespace System.Buffers.Tests
         }
 
         [Fact]
-        public void MemoryHandleDoubleFree() 
+        public void OnNoReferencesTest()
         {
-            var array = new byte[1024];
-            OwnedArray<byte> owned = array;
+            var owned = new CustomBuffer();
             var memory = owned.Buffer;
-            var h = memory.Pin();
-            Assert.True(owned.IsRetained);
-            owned.Retain();
-            Assert.True(owned.IsRetained);
-            h.Dispose();
-            Assert.True(owned.IsRetained);
-            h.Dispose();
-            Assert.True(owned.IsRetained);
-            owned.Release();
+            Assert.Equal(0, owned.OnNoRefencesCalledCount);
+            Assert.False(owned.IsRetained);
+            using (memory.Retain())
+            {
+                Assert.Equal(0, owned.OnNoRefencesCalledCount);
+                Assert.True(owned.IsRetained);
+            }
+            Assert.Equal(1, owned.OnNoRefencesCalledCount);
             Assert.False(owned.IsRetained);
         }
 
-
-        WeakReference LeakHandle()
+        [Fact(Skip = "This needs to be fixed and re-enabled or removed.")]
+        public void RacyAccess()
         {
-            // Creates an object that is both Pinned with a MemoryHandle,
-            // and has a weak reference.
-            var array = new byte[1024];
-            OwnedArray<byte> owned = array;
-            var memory = owned.Buffer;
-            memory.Pin();
-            return new WeakReference(array);
-        }
+            for (int k = 0; k < 1000; k++)
+            {
+                var owners = new OwnedArray<byte>[128];
+                var memories = new Buffer<byte>[owners.Length];
+                var reserves = new BufferHandle[owners.Length];
+                var disposeSuccesses = new bool[owners.Length];
+                var reserveSuccesses = new bool[owners.Length];
 
-        void DoGC()
-        {
-            GC.Collect(2);
-            GC.WaitForPendingFinalizers();
-            GC.Collect(2);
-        }
+                for (int i = 0; i < owners.Length; i++)
+                {
+                    var array = new byte[1024];
+                    owners[i] = array;
+                    memories[i] = owners[i].Buffer;
+                }
 
-        [Fact]
-        void PinGCArrayTest()
-        {
-            var w = LeakHandle();
-            // Weak reference should be kept alive.
-            DoGC();
-            Assert.True(w.IsAlive);
+                var dispose_task = Task.Run(() => {
+                    for (int i = 0; i < owners.Length; i++)
+                    {
+                        try
+                        {
+                            owners[i].Dispose();
+                            disposeSuccesses[i] = true;
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            disposeSuccesses[i] = false;
+                        }
+                    }
+                });
+
+                var reserve_task = Task.Run(() => {
+                    for (int i = owners.Length - 1; i >= 0; i--)
+                    {
+                        try
+                        {
+                            reserves[i] = memories[i].Retain();
+                            reserveSuccesses[i] = true;
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            reserveSuccesses[i] = false;
+                        }
+                    }
+                });
+
+                Task.WaitAll(reserve_task, dispose_task);
+
+                for (int i = 0; i < owners.Length; i++)
+                {
+                    Assert.False(disposeSuccesses[i] && reserveSuccesses[i]);
+                }
+            }
         }
     }
 
-    class CustomMemory : OwnedArray<byte>
+    class CustomBuffer : OwnedArray<byte>
     {
-        public CustomMemory() : base(new byte[255]) { }
+        int _noReferencesCalledCount;
 
-        public int OnZeroRefencesCount => _onZeroRefencesCount;
+        public CustomBuffer() : base(new byte[255]) { }
 
-        protected override void OnZeroReferences()
-        {
-            _onZeroRefencesCount++;
-        }
+        public int OnNoRefencesCalledCount => _noReferencesCalledCount;
 
-        public override void Retain()
+        protected override void OnNoReferences()
         {
-            _count++;
+            _noReferencesCalledCount++;
         }
-        public override void Release()
-        {
-            _count--;
-            if (_count == 0) OnZeroReferences();
-        }
-        public override bool IsRetained => _count > 0;
-        int _onZeroRefencesCount;
-        int _count;
     }
 
-    class AutoDisposeMemory<T> : ReferenceCountedBuffer<T>
+    class AutoDisposeBuffer<T> : ReferenceCountedBuffer<T>
     {
-        public AutoDisposeMemory(T[] array)
+        public AutoDisposeBuffer(T[] array)
         {
             _array = array;
-            Retain();
         }
 
         public override int Length => _array.Length;
 
         public override Span<T> AsSpan(int index, int length)
         {
-            if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(CustomMemory));
+            if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(CustomBuffer));
             return new Span<T>(_array, index, length);
         }
 
@@ -271,34 +139,43 @@ namespace System.Buffers.Tests
             base.Dispose(disposing);
         }
 
-        protected override void OnZeroReferences()
+        protected override void OnNoReferences()
         {
             Dispose();
         }
 
         protected override bool TryGetArray(out ArraySegment<T> buffer)
         {
-            if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(AutoDisposeMemory<T>));
+            if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(AutoDisposeBuffer<T>));
             buffer = new ArraySegment<T>(_array);
             return true;
         }
 
         public override BufferHandle Pin(int index = 0)
         {
-            throw new NotImplementedException();
+            unsafe
+            {
+                Retain();
+                var handle = GCHandle.Alloc(_array, GCHandleType.Pinned);
+                var pointer = Add((void*)handle.AddrOfPinnedObject(), index);
+                return new BufferHandle(this, pointer, handle);
+            }
         }
 
         protected T[] _array;
     }
 
-    class AutoPooledMemory : AutoDisposeMemory<byte>
+    class AutoPooledBuffer : AutoDisposeBuffer<byte>
     {
-        public AutoPooledMemory(int length) : base(ArrayPool<byte>.Shared.Rent(length)) {
+        public AutoPooledBuffer(int length) : base(ArrayPool<byte>.Shared.Rent(length)) {
         }
 
         protected override void Dispose(bool disposing)
         {
-            ArrayPool<byte>.Shared.Return(_array);
+            var array = _array;
+            if (array != null) {
+                ArrayPool<byte>.Shared.Return(array);
+            }
             _array = null;
             base.Dispose(disposing);
         }


### PR DESCRIPTION
OwnedBuffer semantics are quite complicated. This PR creates a set of reusable tests that can be run on subclasses of OwnedBuffer to ensure that the subclasses implement OwnedBuffer correctly.

For now:
1. The reference tests are run on OwnedBuffer implementations in System.Text.Primitives and its test project. We should try to run them on implementations in System.IO.Pipelines
2. I just refactored existing tests, but we can add more new tests to the suite.

While developing this change, I discovered two bugs (non-conforming implementations):
1. AsSpan was throwing NullReferenceException, instead of ObjectDisposedException
2. AutoDisposeBuffers was inconsistent in how it implements retain/release

The first issues was trivial to fix.

I fixed the second one by removing Retain from AutoDisposeBuffer ctor and changing OnZeroReferences to OnNoReferences. We should talk about the implications of this change, i.e. we need to decide what the exact semantics of auto-disposable buffers should be. Normal buffers start their lifetime with reference count == 0. This makes total sense for buffers that don't auto dispose when reference count drops to zero. The same behavior is problematic for auto dispose buffers. 

@davidfowl, @ahsonkhan, @mjp41, @shiftylogic, @joshfree 