### PR TITLE
Added more OwnedBuffer reference tests

### DIFF
--- a/src/System.Buffers.Primitives/System/Buffers/OwnedArray.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/OwnedArray.cs
@@ -65,7 +65,7 @@ namespace System.Buffers
 
         public override void Retain()
         {
-            if (IsDisposed) throw new InvalidOperationException();
+            if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(OwnedArray<T>));
             Interlocked.Increment(ref _referenceCount);
         }
 

--- a/src/System.Buffers.Primitives/System/Buffers/ReferenceCountedBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReferenceCountedBuffer.cs
@@ -15,7 +15,7 @@ namespace System.Buffers
 
         public override void Retain()
         {
-            if (IsDisposed) BufferPrimitivesThrowHelper.ThrowInvalidOperationException();
+            if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(ReferenceCountedBuffer<T>));
             Interlocked.Increment(ref _referenceCount);
         }
 

--- a/tests/System.Buffers.Primitives.Tests/BufferReferenceTests.cs
+++ b/tests/System.Buffers.Primitives.Tests/BufferReferenceTests.cs
@@ -37,5 +37,13 @@ namespace System.Buffers.Tests
                 return new CustomBuffer();
             });
         }
+
+        [Fact]
+        public void PooledBufferReferenceTests()
+        {
+            BufferReferenceTests.Run(() => {
+                return BufferPool.Default.Rent(1000);
+            });
+        }
     }
 }

--- a/tests/System.Buffers.Primitives.Tests/MemoryTests.cs
+++ b/tests/System.Buffers.Primitives.Tests/MemoryTests.cs
@@ -136,6 +136,7 @@ namespace System.Buffers.Tests
 
         protected override void Dispose(bool disposing)
         {
+            _array = null;
             base.Dispose(disposing);
         }
 


### PR DESCRIPTION
Added more tests to the reference suite.
Found a couple of bugs and fixed them.

The most interesting observation is that after an ownedbuffer is disposed, the implementations are free to throw any exception type from various operations. I was trying to make the implementation to always throw ObjectDisposedException, but this would result in additional, often duplicative, checks.

@mjp41,  @davidfowl, @ahsonkhan, @shiftylogic,  @joshfree 