### PR TITLE
Optimize Base64 encode and decode methods

### DIFF
--- a/src/System.Binary.Base64/System.Binary.Base64.csproj
+++ b/src/System.Binary.Base64/System.Binary.Base64.csproj
@@ -7,6 +7,7 @@
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\System.Text.Primitives\System.Text.Primitives.csproj" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemCompilerServicesUnsafeVersion)" />
   </ItemGroup>
 </Project>

--- a/src/System.Binary.Base64/System.Binary.Base64.csproj
+++ b/src/System.Binary.Base64/System.Binary.Base64.csproj
@@ -7,7 +7,6 @@
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\System.Binary\System.Binary.csproj" />
     <ProjectReference Include="..\System.Text.Primitives\System.Text.Primitives.csproj" />
   </ItemGroup>
 </Project>

--- a/src/System.Binary.Base64/System/Binary/Base64.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64.cs
@@ -118,7 +118,10 @@ namespace System.Binary.Base64
         /// <returns>Number of bytes written to the destination.</returns>
         public static int Encode(ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            Diagnostics.Debug.Assert(destination.Length >= ComputeEncodedLength(source.Length));
+            if (destination.Length < ComputeEncodedLength(source.Length))
+            {
+                return -1;
+            }
 
             ref byte srcBytes = ref source.DangerousGetPinnableReference();
             ref byte destBytes = ref destination.DangerousGetPinnableReference();
@@ -267,7 +270,10 @@ namespace System.Binary.Base64
         /// <returns>Number of bytes written to the destination.</returns>
         public static int Decode(ReadOnlySpan<byte> source, Span<byte> destination)
         {
-            //Diagnostics.Debug.Assert(destination.Length >= ComputeDecodedLength(source.Length));
+            /*if (destination.Length < ComputeDecodedLength(source.Length))
+            {
+                return -1;
+            }*/
 
             ref byte srcBytes = ref source.DangerousGetPinnableReference();
             ref byte destBytes = ref destination.DangerousGetPinnableReference();

--- a/src/System.Binary.Base64/System/Binary/Base64.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64.cs
@@ -7,28 +7,32 @@ namespace System.Binary.Base64
 {
     public static class Base64
     {
-        static string s_characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-        static readonly byte[] s_encodingMap = GetEncodingMap(s_characters);
-        static readonly byte[] s_decodingMap = GetDecodingMap(s_characters);
-        static readonly byte s_encodingPad = s_encodingMap[64];
+        // Pre-computing this table using a custom string(s_characters) and GenerateEncodingMapAndVerify (found in tests)
+        static readonly byte[] s_encodingMap = {
+            65, 66, 67, 68, 69, 70, 71, 72,         //A..H
+            73, 74, 75, 76, 77, 78, 79, 80,         //I..P
+            81, 82, 83, 84, 85, 86, 87, 88,         //Q..X
+            89, 90, 97, 98, 99, 100, 101, 102,      //Y..Z, a..f
+            103, 104, 105, 106, 107, 108, 109, 110, //g..n
+            111, 112, 113, 114, 115, 116, 117, 118, //o..v
+            119, 120, 121, 122, 48, 49, 50, 51,     //w..z, 0..3
+            52, 53, 54, 55, 56, 57, 43, 47,         //4..9, +, /
+            61                                      // =
+        };
 
+        // Pre-computing this table using a custom string(s_characters) and GenerateDecodingMapAndVerify (found in tests)
+        static readonly byte[] s_decodingMap = {
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 0, 0, 0, 63,           //62 is placed at index 43 (for +), 63 at index 47 (for /)
+            52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 0, 0, 0, 64, 0, 0,  //52-61 are placed at index 48-57 (for 0-9), 64 at index 61 (for =)
+            0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,        
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 0, 0, 0, 0, 0,  //0-25 are placed at index 65-90 (for A-Z)
+            0, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,  
+            41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51                  //26-51 are placed at index 97-122 (for a-z)
+        };
 
-        private static byte[] GetEncodingMap(string str)
-        {
-            var data = new byte[str.Length];
-            Text.TextEncoder.Utf8.TryEncode(str, data, out int written);
-            return data;
-        }
-
-        private static byte[] GetDecodingMap(string str)
-        {
-            var data = new byte[123]; // 'z' = 123
-            for (int i = 0; i < str.Length; i++)
-            {
-                data[str[i]] = (byte)i;
-            }
-            return data;
-        }
+        static readonly byte s_encodingPad = s_encodingMap[64];     // s_encodingMap[64] is '=', for padding
 
         public static int ComputeEncodedLength(int inputLength)
         {

--- a/src/System.Binary.Base64/System/Binary/Base64.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64.cs
@@ -1,26 +1,36 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text.Utf8;
 using System.Runtime.CompilerServices;
 
-namespace System.Binary
+namespace System.Binary.Base64
 {
     public static class Base64
     {
         static string s_characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-        static byte[] s_encodingMap = new Utf8String(s_characters).CopyBytes();
-        static byte[] s_decodingMap = new byte[123];
-
-        static Base64()
-        {
-            for(int i=0; i< s_characters.Length; i++) {
-                var nextChar = s_characters[i];
-                var indexOfChar = s_characters.IndexOf(nextChar);
-                s_decodingMap[nextChar] = (byte)indexOfChar;
-            }
-        }
+        static byte[] s_encodingMap = GetEncodingMap(s_characters);
+        static byte[] s_decodingMap = GetDecodingMap(s_characters);
         
+        private static byte[] GetEncodingMap(string str)
+        {
+            var data = new byte[str.Length];
+            var buffer = new Span<byte>(data);
+            if (!Text.TextEncoder.Utf8.TryEncode(str, buffer, out int written))
+                // This shouldn't happen...
+                return null;
+            return data;
+        }
+
+        private static byte[] GetDecodingMap(string str)
+        {
+            var data = new byte[123];
+            for (int i = 0; i < str.Length; i++)
+            {
+                data[str[i]] = (byte)i;
+            }
+            return data;
+        }
+
         public static int ComputeEncodedLength(int inputLength)
         {
             var third = inputLength / 3;

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 using System.Collections.Generic;
 using System.Text.Utf8;
 
-namespace System.Binary.Tests
+namespace System.Binary.Base64.Tests
 {
     public class Base64Tests
     {

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -2,29 +2,57 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using Xunit;
 using System.Collections.Generic;
-using System.Text.Utf8;
 
 namespace System.Binary.Base64.Tests
 {
     public class Base64Tests
     {
+        static string s_characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+        static readonly byte[] s_encodingMap = {
+            65, 66, 67, 68, 69, 70, 71, 72,
+            73, 74, 75, 76, 77, 78, 79, 80,
+            81, 82, 83, 84, 85, 86, 87, 88,
+            89, 90, 97, 98, 99, 100, 101, 102,
+            103, 104, 105, 106, 107, 108, 109, 110,
+            111, 112, 113, 114, 115, 116, 117, 118,
+            119, 120, 121, 122, 48, 49, 50, 51,
+            52, 53, 54, 55, 56, 57, 43, 47,
+            61
+        };
+
+        static readonly byte[] s_decodingMap = {
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 0, 0, 0, 63,
+            52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 0, 0, 0, 64, 0, 0,
+            0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 0, 0, 0, 0, 0,
+            0, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+            41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51
+        };
+
+        static readonly byte s_encodingPad = 61;    // s_encodingMap[64] is '=', for padding
+
         [Fact]
         public void BasicEncodingDecoding()
         {
             var list = new List<byte>();
-            for(int value=0; value < 256; value++) {
+            for (int value = 0; value < 256; value++)
+            {
                 list.Add((byte)value);
             }
             var testBytes = list.ToArray();
 
-            for (int value = 0; value < 256; value++) {
+            for (int value = 0; value < 256; value++)
+            {
 
                 var sourceBytes = testBytes.AsSpan().Slice(0, value + 1);
                 var encodedBytes = new byte[Base64.ComputeEncodedLength(sourceBytes.Length)].AsSpan();
                 var encodedBytesCount = Base64.Encode(sourceBytes, encodedBytes);
                 Assert.Equal(encodedBytes.Length, encodedBytesCount);
 
-                var encodedText = new Utf8String(encodedBytes).ToString();
+                var encodedText = Text.Encoding.ASCII.GetString(encodedBytes.ToArray());
                 var expectedText = Convert.ToBase64String(testBytes, 0, value + 1);
                 Assert.Equal(expectedText, encodedText);
 
@@ -32,36 +60,40 @@ namespace System.Binary.Base64.Tests
                 var decodedByteCount = Base64.Decode(encodedBytes, decodedBytes.AsSpan());
                 Assert.Equal(sourceBytes.Length, decodedByteCount);
 
-                for (int i=0; i<decodedBytes.Length; i++) {
+                for (int i = 0; i < decodedBytes.Length; i++)
+                {
                     Assert.Equal(sourceBytes[i], decodedBytes[i]);
                 }
-            } 
+            }
         }
 
         [Fact]
         public void DecodeInPlace()
         {
             var list = new List<byte>();
-            for (int value = 0; value < 256; value++) {
+            for (int value = 0; value < 256; value++)
+            {
                 list.Add((byte)value);
             }
             var testBytes = list.ToArray();
 
-            for (int value = 0; value < 256; value++) {
+            for (int value = 0; value < 256; value++)
+            {
                 var sourceBytes = testBytes.AsSpan().Slice(0, value + 1);
                 var buffer = new byte[Base64.ComputeEncodedLength(sourceBytes.Length)];
                 var bufferSlice = buffer.AsSpan();
 
                 Base64.Encode(sourceBytes, bufferSlice);
 
-                var encodedText = new Utf8String(bufferSlice).ToString();
+                var encodedText = Text.Encoding.ASCII.GetString(bufferSlice.ToArray());
                 var expectedText = Convert.ToBase64String(testBytes, 0, value + 1);
                 Assert.Equal(expectedText, encodedText);
 
                 var decodedByteCount = Base64.DecodeInPlace(bufferSlice);
                 Assert.Equal(sourceBytes.Length, decodedByteCount);
 
-                for (int i = 0; i < decodedByteCount; i++) {
+                for (int i = 0; i < decodedByteCount; i++)
+                {
                     Assert.Equal(sourceBytes[i], buffer[i]);
                 }
             }
@@ -73,25 +105,51 @@ namespace System.Binary.Base64.Tests
             const int numberOfBytes = 15;
 
             var list = new List<byte>();
-            for (int value = 0; value < numberOfBytes; value++) {
+            for (int value = 0; value < numberOfBytes; value++)
+            {
                 list.Add((byte)value);
             }
             // padding
-            for (int i = 0; i < (numberOfBytes / 3) + 2; i++) {
+            for (int i = 0; i < (numberOfBytes / 3) + 2; i++)
+            {
                 list.Add(0);
             }
 
             var testBytes = list.ToArray();
 
-            for (int numberOfBytesToTest = 1; numberOfBytesToTest <= numberOfBytes; numberOfBytesToTest++) {
-                var copy = testBytes.Clone();               
+            for (int numberOfBytesToTest = 1; numberOfBytesToTest <= numberOfBytes; numberOfBytesToTest++)
+            {
+                var copy = testBytes.Clone();
                 var expectedText = Convert.ToBase64String(testBytes, 0, numberOfBytesToTest);
 
                 var encoded = Base64.EncodeInPlace(testBytes, numberOfBytesToTest);
-                var encodedText = new Utf8String(testBytes, 0, encoded).ToString();
+                var encodedText = Text.Encoding.ASCII.GetString(testBytes, 0, encoded);
 
                 Assert.Equal(expectedText, encodedText);
             }
+        }
+
+        [Fact]
+        public void GenerateEncodingMapAndVerify()
+        {
+            var data = new byte[65]; // Base64 + pad character
+            for (int i = 0; i < s_characters.Length; i++)
+            {
+                data[i] = (byte)s_characters[i];
+            }
+            Assert.True(s_encodingMap.AsSpan().SequenceEqual(data));
+            Assert.Equal(s_encodingPad, s_encodingMap[64]);
+        }
+
+        [Fact]
+        public void GenerateDecodingMapAndVerify()
+        {
+            var data = new byte[123]; // 'z' = 123
+            for (int i = 0; i < s_characters.Length; i++)
+            {
+                data[s_characters[i]] = (byte)i;
+            }
+            Assert.True(s_decodingMap.AsSpan().SequenceEqual(data));
         }
     }
 }

--- a/tests/System.Binary.Base64.Tests/PerformanceTests.cs
+++ b/tests/System.Binary.Base64.Tests/PerformanceTests.cs
@@ -9,37 +9,37 @@ namespace System.Binary.Base64.Tests
 {
     public class Base64PerformanceTests
     {
-        private static int LOAD_ITERATIONS = 1;
+        private const int InnerCount = 10;
 
         static void InitalizeBytes(Span<byte> bytes, int seed = 100)
         {
-            var r = new Random(seed);
-            for(int i=0; i<bytes.Length; i++) {
-                bytes[i] = (byte)r.Next();
+            var rnd = new Random(seed);
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                bytes[i] = (byte)rnd.Next(0, byte.MaxValue + 1);
             }
         }
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = InnerCount)]
         [InlineData(100)]
         [InlineData(1000)]
         [InlineData(1000 * 1000)]
         [InlineData(1000 * 1000 * 50)]
         private static void Base64Encode(int numberOfBytes)
         {
-            var source = new byte[numberOfBytes].AsSpan();
+            Span<byte> source = new byte[numberOfBytes].AsSpan();
             InitalizeBytes(source);
-            var destination = new byte[Base64.ComputeEncodedLength(numberOfBytes)].AsSpan();
+            Span<byte> destination = new byte[Base64.ComputeEncodedLength(numberOfBytes)].AsSpan();
 
             foreach (var iteration in Benchmark.Iterations) {
                 using (iteration.StartMeasurement()) {
-                    for (int i = 0; i < LOAD_ITERATIONS; i++) {
-                        var encodedBytesCount = Base64.Encode(source, destination);
-                    }
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        Base64.Encode(source, destination);
                 }
             }
         }
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = InnerCount)]
         [InlineData(100)]
         [InlineData(1000)]
         [InlineData(1000 * 1000)]
@@ -52,35 +52,33 @@ namespace System.Binary.Base64.Tests
 
             foreach (var iteration in Benchmark.Iterations) {
                 using (iteration.StartMeasurement()) {
-                    for (int i = 0; i < LOAD_ITERATIONS; i++) {
-                        var count = Convert.ToBase64CharArray(source, 0, source.Length, destination, 0);
-                    }
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        Convert.ToBase64CharArray(source, 0, source.Length, destination, 0);
                 }
             }
         }
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = InnerCount)]
         [InlineData(100)]
         [InlineData(1000)]
         [InlineData(1000 * 1000)]
         [InlineData(1000 * 1000 * 50)]
         private static void Base64Decode(int numberOfBytes)
         {
-            var source = new byte[numberOfBytes].AsSpan();
+            Span<byte> source = new byte[numberOfBytes].AsSpan();
             InitalizeBytes(source);
-            var encoded = new byte[Base64.ComputeEncodedLength(numberOfBytes)].AsSpan();
+            Span<byte> encoded = new byte[Base64.ComputeEncodedLength(numberOfBytes)].AsSpan();
             var encodedBytesCount = Base64.Encode(source, encoded);
 
             foreach (var iteration in Benchmark.Iterations) {
                 using (iteration.StartMeasurement()) {
-                    for (int i = 0; i < LOAD_ITERATIONS; i++) {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                         Base64.Decode(encoded, source);
-                    }
                 }
             }
         }
 
-        [Benchmark]
+        [Benchmark(InnerIterationCount = InnerCount)]
         [InlineData(100)]
         [InlineData(1000)]
         [InlineData(1000 * 1000)]
@@ -89,13 +87,12 @@ namespace System.Binary.Base64.Tests
         {
             var source = new byte[numberOfBytes];
             InitalizeBytes(source.AsSpan());
-            var encoded = Convert.ToBase64String(source).ToCharArray();
+            char[] encoded = Convert.ToBase64String(source).ToCharArray();
 
             foreach (var iteration in Benchmark.Iterations) {
                 using (iteration.StartMeasurement()) {
-                    for (int i = 0; i < LOAD_ITERATIONS; i++) {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                         Convert.FromBase64CharArray(encoded, 0, encoded.Length);
-                    }
                 }
             }
         }

--- a/tests/System.Binary.Base64.Tests/PerformanceTests.cs
+++ b/tests/System.Binary.Base64.Tests/PerformanceTests.cs
@@ -27,9 +27,9 @@ namespace System.Binary.Base64.Tests
         [InlineData(1000 * 1000 * 50)]
         private static void Base64Encode(int numberOfBytes)
         {
-            Span<byte> source = new byte[numberOfBytes].AsSpan();
+            Span<byte> source = new byte[numberOfBytes];
             InitalizeBytes(source);
-            Span<byte> destination = new byte[Base64.ComputeEncodedLength(numberOfBytes)].AsSpan();
+            Span<byte> destination = new byte[Base64.ComputeEncodedLength(numberOfBytes)];
 
             foreach (var iteration in Benchmark.Iterations) {
                 using (iteration.StartMeasurement()) {
@@ -65,9 +65,9 @@ namespace System.Binary.Base64.Tests
         [InlineData(1000 * 1000 * 50)]
         private static void Base64Decode(int numberOfBytes)
         {
-            Span<byte> source = new byte[numberOfBytes].AsSpan();
+            Span<byte> source = new byte[numberOfBytes];
             InitalizeBytes(source);
-            Span<byte> encoded = new byte[Base64.ComputeEncodedLength(numberOfBytes)].AsSpan();
+            Span<byte> encoded = new byte[Base64.ComputeEncodedLength(numberOfBytes)];
             var encodedBytesCount = Base64.Encode(source, encoded);
 
             foreach (var iteration in Benchmark.Iterations) {

--- a/tests/System.Binary.Base64.Tests/PerformanceTests.cs
+++ b/tests/System.Binary.Base64.Tests/PerformanceTests.cs
@@ -5,7 +5,7 @@
 using Xunit;
 using Microsoft.Xunit.Performance;
 
-namespace System.Binary.Tests
+namespace System.Binary.Base64.Tests
 {
     public class Base64PerformanceTests
     {


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/6527137/26186115/0939ecf4-3b44-11e7-965e-bbbaa5c171d3.png)

![image](https://cloud.githubusercontent.com/assets/6527137/26186116/0dfb0fe8-3b44-11e7-84d5-4f2d8740a60e.png)
**Note:** For Decode, the baseline allocates (hence the large performance difference) since we don't have a non-allocating FromBase64CharArray API to compare against.

cc @KrzysztofCwalina, @shiftylogic 


**To do:**
- Add public static int ComputeDecodedLength(int inputLength)
- Optimize EncodeInPlace
- Optimize DecodeInPlace
- Add more performance & functional tests.
