### PR TITLE
Prevent commit head from being disposed and not reset

### DIFF
--- a/src/System.IO.Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/Pipe.cs
@@ -457,12 +457,14 @@ namespace System.IO.Pipelines
                     if (consumed.Index == returnEnd.End &&
                         !(_commitHead == returnEnd && _writingState.IsActive))
                     {
-                        returnEnd = returnEnd.Next;
-                        if (_commitHead == _readHead)
+                        var nextBlock = returnEnd.Next;
+                        if (_commitHead == returnEnd)
                         {
-                            _commitHead = returnEnd;
+                            _commitHead = nextBlock;
                         }
-                        _readHead = returnEnd;
+
+                        _readHead = nextBlock;
+                        returnEnd = nextBlock;
                     }
                     else
                     {


### PR DESCRIPTION
`_commitHead` is last block so when returning multiple blocks comparison with `_readHead` would fail and `_commitHead`  would not be reset.