### PR TITLE
Add ComputeDecodedLength and handle invalid input to Decode

### DIFF
--- a/src/System.Binary.Base64/System/Binary/Base64.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64.cs
@@ -134,7 +134,7 @@ namespace System.Binary.Base64
             while (sourceIndex < srcLength - 2)
             {
                 result = Encode(ref Unsafe.Add(ref srcBytes, sourceIndex));
-                if (destIndex + 4 > destLength) goto False;
+                if (destIndex > destLength - 4) goto FalseExit;
                 Unsafe.WriteUnaligned(ref Unsafe.Add(ref destBytes, destIndex), result);
                 destIndex += 4;
                 sourceIndex += 3;
@@ -143,7 +143,7 @@ namespace System.Binary.Base64
             if (sourceIndex == srcLength - 1)
             {
                 result = EncodePadByTwo(ref Unsafe.Add(ref srcBytes, sourceIndex));
-                if (destIndex + 4 > destLength) goto False;
+                if (destIndex > destLength - 4) goto FalseExit;
                 Unsafe.WriteUnaligned(ref Unsafe.Add(ref destBytes, destIndex), result);
                 destIndex += 4;
                 sourceIndex += 1;
@@ -151,7 +151,7 @@ namespace System.Binary.Base64
             else if (sourceIndex == srcLength - 2)
             {
                 result = EncodePadByOne(ref Unsafe.Add(ref srcBytes, sourceIndex));
-                if (destIndex + 4 > destLength) goto False;
+                if (destIndex > destLength - 4) goto FalseExit;
                 Unsafe.WriteUnaligned(ref Unsafe.Add(ref destBytes, destIndex), result);
                 destIndex += 4;
                 sourceIndex += 2;
@@ -161,7 +161,7 @@ namespace System.Binary.Base64
             bytesWritten = destIndex;
             return true;
 
-            False:
+            FalseExit:
             bytesConsumed = sourceIndex;
             bytesWritten = destIndex;
             return false;
@@ -233,21 +233,21 @@ namespace System.Binary.Base64
         private static bool Decode(byte b0, byte b1, byte b2, byte b3, out byte r0, out byte r1, out byte r2)
         {
             if (b0 > 122 || b1 > 122 || b2 > 122 || b3 > 122 
-                || b0 == s_encodingPad || b1 == s_encodingPad) goto False;
+                || b0 == s_encodingPad || b1 == s_encodingPad) goto ErrorExit;
 
             byte i0 = s_decodingMap[b0];
             byte i1 = s_decodingMap[b1];
             byte i2 = s_decodingMap[b2];
             byte i3 = s_decodingMap[b3];
             
-            if (i0 == s_invalidByte || i1 == s_invalidByte || i2 == s_invalidByte || i3 == s_invalidByte) goto False;
+            if (i0 == s_invalidByte || i1 == s_invalidByte || i2 == s_invalidByte || i3 == s_invalidByte) goto ErrorExit;
 
             r0 = (byte)(i0 << 2 | i1 >> 4);
             r1 = (byte)(i1 << 4 | i2 >> 2);
             r2 = (byte)(i2 << 6 | i3);
             return true;
 
-            False:
+            ErrorExit:
             r0 = r1 = r2 = 0;
             return false;
         }
@@ -256,21 +256,21 @@ namespace System.Binary.Base64
         private static bool DecodeNoPad(byte b0, byte b1, byte b2, byte b3, out byte r0, out byte r1, out byte r2)
         {
             if (b0 > 122 || b1 > 122 || b2 > 122 || b3 > 122 
-                || b0 == s_encodingPad || b1 == s_encodingPad || b2 == s_encodingPad || b3 == s_encodingPad) goto False;
+                || b0 == s_encodingPad || b1 == s_encodingPad || b2 == s_encodingPad || b3 == s_encodingPad) goto ErrorExit;
 
             byte i0 = s_decodingMap[b0];
             byte i1 = s_decodingMap[b1];
             byte i2 = s_decodingMap[b2];
             byte i3 = s_decodingMap[b3];
 
-            if (i0 == s_invalidByte || i1 == s_invalidByte || i2 == s_invalidByte || i3 == s_invalidByte) goto False;
+            if (i0 == s_invalidByte || i1 == s_invalidByte || i2 == s_invalidByte || i3 == s_invalidByte) goto ErrorExit;
 
             r0 = (byte)(i0 << 2 | i1 >> 4);
             r1 = (byte)(i1 << 4 | i2 >> 2);
             r2 = (byte)(i2 << 6 | i3);
             return true;
 
-            False:
+            ErrorExit:
             r0 = r1 = r2 = 0;
             return false;
         }
@@ -293,19 +293,19 @@ namespace System.Binary.Base64
         private static bool Decode(byte b0, byte b1, byte b2, out byte r0, out byte r1)
         {
             if (b0 > 122 || b1 > 122 || b2 > 122 
-                || b0 == s_encodingPad || b1 == s_encodingPad) goto False;
+                || b0 == s_encodingPad || b1 == s_encodingPad) goto ErrorExit;
 
             byte i0 = s_decodingMap[b0];
             byte i1 = s_decodingMap[b1];
             byte i2 = s_decodingMap[b2];
 
-            if (i0 == s_invalidByte || i1 == s_invalidByte || i2 == s_invalidByte) goto False;
+            if (i0 == s_invalidByte || i1 == s_invalidByte || i2 == s_invalidByte) goto ErrorExit;
 
             r0 = (byte)(i0 << 2 | i1 >> 4);
             r1 = (byte)(i1 << 4 | i2 >> 2);
             return true;
 
-            False:
+            ErrorExit:
             r0 = r1 = 0;
             return false;
         }
@@ -327,17 +327,17 @@ namespace System.Binary.Base64
         private static bool Decode(byte b0, byte b1, out byte r0)
         {
             if (b0 > 122 || b1 > 122 
-                || b0 == s_encodingPad || b1 == s_encodingPad) goto False;
+                || b0 == s_encodingPad || b1 == s_encodingPad) goto ErrorExit;
 
             byte i0 = s_decodingMap[b0];
             byte i1 = s_decodingMap[b1];
 
-            if (i0 == s_invalidByte || i1 == s_invalidByte) goto False;
+            if (i0 == s_invalidByte || i1 == s_invalidByte) goto ErrorExit;
 
             r0 = (byte)(i0 << 2 | i1 >> 4);
             return true;
 
-            False:
+            ErrorExit:
             r0 = 0;
             return false;
         }
@@ -377,7 +377,7 @@ namespace System.Binary.Base64
             {
                 result = Decode(ref Unsafe.Add(ref srcBytes, sourceIndex));
                 if (result == -1) throw new FormatException();  // invalid bytes
-                if (destIndex + 3 > destLength) goto False;
+                if (destIndex > destLength - 3) goto FalseExit;
                 Unsafe.WriteUnaligned(ref Unsafe.Add(ref destBytes, destIndex), result);
                 destIndex += 3;
                 sourceIndex += 4;
@@ -394,7 +394,7 @@ namespace System.Binary.Base64
             {
                 result = DecodePadByOne(ref Unsafe.Add(ref srcBytes, sourceIndex));
                 if (result == -1) throw new FormatException();  // invalid bytes
-                if (destIndex + 2 > destLength) goto False;
+                if (destIndex > destLength - 2) goto FalseExit;
                 Unsafe.WriteUnaligned(ref Unsafe.Add(ref destBytes, destIndex), result);
                 destIndex += 2;
                 sourceIndex += 4;
@@ -403,7 +403,7 @@ namespace System.Binary.Base64
             {
                 result = DecodePadByTwo(ref Unsafe.Add(ref srcBytes, sourceIndex));
                 if (result == -1) throw new FormatException();  // invalid bytes
-                if (destIndex + 1 > destLength) goto False;
+                if (destIndex > destLength - 1) goto FalseExit;
                 Unsafe.WriteUnaligned(ref Unsafe.Add(ref destBytes, destIndex), result);
                 destIndex += 1;
                 sourceIndex += 4;
@@ -412,7 +412,7 @@ namespace System.Binary.Base64
             {
                 result = Decode(ref Unsafe.Add(ref srcBytes, sourceIndex));
                 if (result == -1) throw new FormatException();  // invalid bytes
-                if (destIndex + 3 > destLength) goto False;
+                if (destIndex > destLength - 3) goto FalseExit;
                 Unsafe.WriteUnaligned(ref Unsafe.Add(ref destBytes, destIndex), result);
                 destIndex += 3;
                 sourceIndex += 4;
@@ -422,7 +422,7 @@ namespace System.Binary.Base64
             bytesWritten = destIndex;
             return true;
 
-            False:
+            FalseExit:
             bytesConsumed = sourceIndex;
             bytesWritten = destIndex;
             return false;

--- a/src/System.Binary.Base64/System/Binary/Base64.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64.cs
@@ -21,7 +21,7 @@ namespace System.Binary.Base64
         };
         
         // Pre-computing this table using a custom string(s_characters) and GenerateDecodingMapAndVerify (found in tests)
-        static readonly byte[] s_decodingMap = {
+        /*static readonly byte[] s_decodingMap = {
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
             255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 62, 255, 255, 255, 63,   //62 is placed at index 43 (for +), 63 at index 47 (for /)
@@ -30,6 +30,26 @@ namespace System.Binary.Base64
             15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 255, 255, 255, 255, 255,            //0-25 are placed at index 65-90 (for A-Z)
             255, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
             41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51                                      //26-51 are placed at index 97-122 (for a-z)
+        };*/
+
+        // Pre-computing this table using a custom string(s_characters) and GenerateDecodingMapAndVerify (found in tests)
+        static readonly byte[] s_decodingMap = {
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 62, 255, 255, 255, 63,   //62 is placed at index 43 (for +), 63 at index 47 (for /)
+            52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 255, 255, 255, 64, 255, 255,            //52-61 are placed at index 48-57 (for 0-9), 64 at index 61 (for =)
+            255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 255, 255, 255, 255, 255,            //0-25 are placed at index 65-90 (for A-Z)
+            255, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+            41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 255, 255, 255, 255, 255,            //26-51 are placed at index 97-122 (for a-z)
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, // Bytes over 122 ('z') are invalid and cannot be decoded
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, // Hence, padding the map with 255, which indicates invalid input
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         };
 
         static readonly byte s_encodingPad = s_encodingMap[64];     // s_encodingMap[64] is '=', for padding
@@ -232,8 +252,7 @@ namespace System.Binary.Base64
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool Decode(byte b0, byte b1, byte b2, byte b3, out byte r0, out byte r1, out byte r2)
         {
-            if (b0 > 122 || b1 > 122 || b2 > 122 || b3 > 122 
-                || b0 == s_encodingPad || b1 == s_encodingPad) goto ErrorExit;
+            if (b0 == s_encodingPad || b1 == s_encodingPad) goto ErrorExit;
 
             byte i0 = s_decodingMap[b0];
             byte i1 = s_decodingMap[b1];
@@ -255,8 +274,7 @@ namespace System.Binary.Base64
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool DecodeNoPad(byte b0, byte b1, byte b2, byte b3, out byte r0, out byte r1, out byte r2)
         {
-            if (b0 > 122 || b1 > 122 || b2 > 122 || b3 > 122 
-                || b0 == s_encodingPad || b1 == s_encodingPad || b2 == s_encodingPad || b3 == s_encodingPad) goto ErrorExit;
+            if (b0 == s_encodingPad || b1 == s_encodingPad || b2 == s_encodingPad || b3 == s_encodingPad) goto ErrorExit;
 
             byte i0 = s_decodingMap[b0];
             byte i1 = s_decodingMap[b1];
@@ -292,8 +310,7 @@ namespace System.Binary.Base64
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool Decode(byte b0, byte b1, byte b2, out byte r0, out byte r1)
         {
-            if (b0 > 122 || b1 > 122 || b2 > 122 
-                || b0 == s_encodingPad || b1 == s_encodingPad) goto ErrorExit;
+            if (b0 == s_encodingPad || b1 == s_encodingPad) goto ErrorExit;
 
             byte i0 = s_decodingMap[b0];
             byte i1 = s_decodingMap[b1];
@@ -326,8 +343,7 @@ namespace System.Binary.Base64
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool Decode(byte b0, byte b1, out byte r0)
         {
-            if (b0 > 122 || b1 > 122 
-                || b0 == s_encodingPad || b1 == s_encodingPad) goto ErrorExit;
+            if (b0 == s_encodingPad || b1 == s_encodingPad) goto ErrorExit;
 
             byte i0 = s_decodingMap[b0];
             byte i1 = s_decodingMap[b1];

--- a/src/System.Binary.Base64/System/Binary/Base64.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64.cs
@@ -19,18 +19,6 @@ namespace System.Binary.Base64
             52, 53, 54, 55, 56, 57, 43, 47,         //4..9, +, /
             61                                      // =
         };
-        
-        // Pre-computing this table using a custom string(s_characters) and GenerateDecodingMapAndVerify (found in tests)
-        /*static readonly byte[] s_decodingMap = {
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 62, 255, 255, 255, 63,   //62 is placed at index 43 (for +), 63 at index 47 (for /)
-            52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 255, 255, 255, 64, 255, 255,            //52-61 are placed at index 48-57 (for 0-9), 64 at index 61 (for =)
-            255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
-            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 255, 255, 255, 255, 255,            //0-25 are placed at index 65-90 (for A-Z)
-            255, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-            41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51                                      //26-51 are placed at index 97-122 (for a-z)
-        };*/
 
         // Pre-computing this table using a custom string(s_characters) and GenerateDecodingMapAndVerify (found in tests)
         static readonly byte[] s_decodingMap = {

--- a/src/System.Binary.Base64/System/Binary/Base64.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64.cs
@@ -369,7 +369,7 @@ namespace System.Binary.Base64
             ref byte srcBytes = ref source.DangerousGetPinnableReference();
             ref byte destBytes = ref destination.DangerousGetPinnableReference();
 
-            int srcLength = source.Length;
+            int srcLength = source.Length / 4 * 4;  // only decode input up to the closest multiple of 4.
             int destLength = destination.Length;
 
             int sourceIndex = 0;
@@ -386,6 +386,8 @@ namespace System.Binary.Base64
                 destIndex += 3;
                 sourceIndex += 4;
             }
+
+            if (sourceIndex >= srcLength) goto FalseExit;
 
             int padding = 0;
 
@@ -421,6 +423,8 @@ namespace System.Binary.Base64
                 destIndex += 3;
                 sourceIndex += 4;
             }
+
+            if (srcLength != source.Length) goto FalseExit;
 
             bytesConsumed = sourceIndex;
             bytesWritten = destIndex;

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/StringFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/StringFormatter.cs
@@ -55,7 +55,7 @@ namespace System.Text.Formatting
 
         public override string ToString()
         {
-            var text = Text.Encoding.Unicode.GetString(_buffer.Items, 0, _buffer.Count);
+            var text = Encoding.Unicode.GetString(_buffer.Items, 0, _buffer.Count);
             return text;
         }
 

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -308,7 +308,7 @@ namespace System.Binary.Base64.Tests
         [Fact]
         public void GenerateDecodingMapAndVerify()
         {
-            var data = new byte[123]; // 'z' = 123
+            var data = new byte[123]; // 'z' = 122
             for(int i = 0; i < data.Length; i++)
             {
                 data[i] = s_invalidByte;

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -68,6 +68,60 @@ namespace System.Binary.Base64.Tests
         }
 
         [Fact]
+        public void ComputeEncodedLength()
+        {
+            // (int.MaxValue - 4)/(4/3) => 1610612733, otherwise integer overflow
+            int[] input = { int.MinValue, -50, -1, 0, 1, 2, 3, 4, 5, 6, 1610612728, 1610612729, 1610612730, 1610612731, 1610612732, 1610612733 };
+            int[] expected = { 0, 0, 0, 0, 4, 4, 4, 8, 8, 8, 2147483640, 2147483640, 2147483640, 2147483644, 2147483644, 2147483644 };
+            for (int i = 0; i < input.Length; i++)
+            {
+                Assert.Equal(expected[i], Base64.ComputeEncodedLength(input[i]));
+            }
+
+            Assert.True(Base64.ComputeEncodedLength(1610612734) < 0);   // integer overflow
+        }
+
+        [Fact]
+        public void ComputeDecodedLength()
+        {
+            Span<byte> sourceEmpty = Span<byte>.Empty;
+            Assert.Equal(0, Base64.ComputeDecodedLength(sourceEmpty));
+
+            // int.MaxValue - (int.MaxValue % 4) => 2147483644, largest multiple of 4 less than int.MaxValue
+            // CLR default limit of 2 gigabytes (GB).
+            int[] input = { 4, 8, 12, 16, 20, 2000000000 };
+            int[] expected = { 3, 6, 9, 12, 15, 1500000000 };
+            
+            for (int i = 0; i < input.Length; i++)
+            {
+                int sourceLength = input[i];
+                Span<byte> source = new byte[sourceLength];
+                Assert.Equal(expected[i], Base64.ComputeDecodedLength(source));
+                source[sourceLength - 1] = s_encodingPad;                          // single character padding
+                Assert.Equal(expected[i] - 1, Base64.ComputeDecodedLength(source));
+                source[sourceLength - 2] = s_encodingPad;                          // two characters padding
+                Assert.Equal(expected[i] - 2, Base64.ComputeDecodedLength(source));
+            }
+
+            // Lengths that are not a multiple of 4.
+            int[] invalidInput = { 1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15, 1001, 1002, 1003};
+
+            for (int i = 0; i < invalidInput.Length; i++)
+            {
+                int sourceLength = invalidInput[i];
+                Span<byte> source = new byte[sourceLength];
+                Assert.Equal(0, Base64.ComputeDecodedLength(source));
+                source[sourceLength - 1] = s_encodingPad;
+                Assert.Equal(0, Base64.ComputeDecodedLength(source));
+                if (sourceLength > 1)
+                {
+                    source[sourceLength - 2] = s_encodingPad;
+                    Assert.Equal(0, Base64.ComputeDecodedLength(source));
+                }
+            }
+        }
+
+        [Fact]
         public void DecodeInPlace()
         {
             var list = new List<byte>();

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -31,7 +31,15 @@ namespace System.Binary.Base64.Tests
             255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
             15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 255, 255, 255, 255, 255,            //0-25 are placed at index 65-90 (for A-Z)
             255, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-            41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51                                      //26-51 are placed at index 97-122 (for a-z)
+            41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 255, 255, 255, 255, 255,            //26-51 are placed at index 97-122 (for a-z)
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, // Bytes over 122 ('z') are invalid and cannot be decoded
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, // Hence, padding the map with 255, which indicates invalid input
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+            255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
         };
 
         static readonly byte s_encodingPad = 61;                    // s_encodingMap[64] is '=', for padding
@@ -308,8 +316,8 @@ namespace System.Binary.Base64.Tests
         [Fact]
         public void GenerateDecodingMapAndVerify()
         {
-            var data = new byte[123]; // 'z' = 122
-            for(int i = 0; i < data.Length; i++)
+            var data = new byte[256]; // 0 to byte.MaxValue (255)
+            for (int i = 0; i < data.Length; i++)
             {
                 data[i] = s_invalidByte;
             }

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -135,8 +135,8 @@ namespace System.Binary.Base64.Tests
         public void ComputeEncodedLength()
         {
             // (int.MaxValue - 4)/(4/3) => 1610612733, otherwise integer overflow
-            int[] input = { int.MinValue, -50, -1, 0, 1, 2, 3, 4, 5, 6, 1610612728, 1610612729, 1610612730, 1610612731, 1610612732, 1610612733 };
-            int[] expected = { -1, -1, -1, 0, 4, 4, 4, 8, 8, 8, 2147483640, 2147483640, 2147483640, 2147483644, 2147483644, 2147483644 };
+            int[] input = { 0, 1, 2, 3, 4, 5, 6, 1610612728, 1610612729, 1610612730, 1610612731, 1610612732, 1610612733 };
+            int[] expected = { 0, 4, 4, 4, 8, 8, 8, 2147483640, 2147483640, 2147483640, 2147483644, 2147483644, 2147483644 };
             for (int i = 0; i < input.Length; i++)
             {
                 Assert.Equal(expected[i], Base64Encoder.ComputeEncodedLength(input[i]));
@@ -169,7 +169,7 @@ namespace System.Binary.Base64.Tests
 
             // Lengths that are not a multiple of 4.
             int[] lengthsNotMultipleOfFour = { 1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15, 1001, 1002, 1003};
-            int[] expectedOutput = { 0, 3, 6, 9, 750 };
+            int[] expectedOutput = { 0, 0, 0, 3, 3, 3, 6, 6, 6, 9, 9, 9, 750, 750, 750 };
             for (int i = 0; i < lengthsNotMultipleOfFour.Length; i++)
             {
                 int sourceLength = lengthsNotMultipleOfFour[i];

--- a/tests/System.Binary.Base64.Tests/PerformanceTests.cs
+++ b/tests/System.Binary.Base64.Tests/PerformanceTests.cs
@@ -29,12 +29,12 @@ namespace System.Binary.Base64.Tests
         {
             Span<byte> source = new byte[numberOfBytes];
             InitalizeBytes(source);
-            Span<byte> destination = new byte[Base64.ComputeEncodedLength(numberOfBytes)];
+            Span<byte> destination = new byte[Base64Encoder.ComputeEncodedLength(numberOfBytes)];
 
             foreach (var iteration in Benchmark.Iterations) {
                 using (iteration.StartMeasurement()) {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                        Base64.Encode(source, destination);
+                        Base64Encoder.TryEncode(source, destination, out int consumed, out int written);
                 }
             }
         }
@@ -48,7 +48,7 @@ namespace System.Binary.Base64.Tests
         {
             var source = new byte[numberOfBytes];
             InitalizeBytes(source.AsSpan());
-            var destination = new char[Base64.ComputeEncodedLength(numberOfBytes)];
+            var destination = new char[Base64Encoder.ComputeEncodedLength(numberOfBytes)];
 
             foreach (var iteration in Benchmark.Iterations) {
                 using (iteration.StartMeasurement()) {
@@ -67,13 +67,13 @@ namespace System.Binary.Base64.Tests
         {
             Span<byte> source = new byte[numberOfBytes];
             InitalizeBytes(source);
-            Span<byte> encoded = new byte[Base64.ComputeEncodedLength(numberOfBytes)];
-            var encodedBytesCount = Base64.Encode(source, encoded);
+            Span<byte> encoded = new byte[Base64Encoder.ComputeEncodedLength(numberOfBytes)];
+            Base64Encoder.TryEncode(source, encoded, out int consumed, out int written);
 
             foreach (var iteration in Benchmark.Iterations) {
                 using (iteration.StartMeasurement()) {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                        Base64.Decode(encoded, source);
+                        Base64Encoder.TryDecode(encoded, source, out int bytesConsumed, out int bytesWritten);
                 }
             }
         }


### PR DESCRIPTION
cc @KrzysztofCwalina, @shiftylogic 

~Partially fixes https://github.com/dotnet/corefxlab/issues/1238 (To do - `Consider changing the APIs to Try`)~

Fixes #1238

Adding error checks so that we can properly handle invalid input came at a perf cost (which is expected). Relative to the baseline, we are still significantly faster (mainly because we don't allocate).

![image](https://cloud.githubusercontent.com/assets/6527137/26232553/ea4620d8-3c0b-11e7-9374-25e47c76c241.png)

