### PR TITLE
Fixing typo from PR #1569, adding throw keyword.

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Net.Http
 
         public override Span<byte> AsSpan(int index, int length)
         {
-            if (IsDisposed) new ObjectDisposedException(nameof(OwnedBuffer));
+            if (IsDisposed) throw new ObjectDisposedException(nameof(OwnedBuffer));
             return _array.AsSpan().Slice(index, length);
         }
 
@@ -126,7 +126,7 @@ namespace Microsoft.Net.Http
 
         protected override bool TryGetArray(out ArraySegment<byte> buffer)
         {
-            if (IsDisposed) new ObjectDisposedException(nameof(OwnedBuffer));
+            if (IsDisposed) throw new ObjectDisposedException(nameof(OwnedBuffer));
             buffer = new ArraySegment<byte>(_array);
             return true;
         }


### PR DESCRIPTION
From PR #1569: https://github.com/dotnet/corefxlab/pull/1569/files

cc @KrzysztofCwalina 