### PR TITLE
Fixing DecodeInPlace and optimizing it.

### DIFF
--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -238,7 +238,7 @@ namespace System.Binary.Base64.Tests
             }
         }
 
-        [Fact(Skip ="Implementation of DecodeInPlace needs to be fixed.")]
+        [Fact]
         public void DecodeInPlace()
         {
             var list = new List<byte>();

--- a/tests/System.Binary.Base64.Tests/PerformanceTests.cs
+++ b/tests/System.Binary.Base64.Tests/PerformanceTests.cs
@@ -16,7 +16,6 @@ namespace System.Binary.Base64.Tests
         [InlineData(100)]
         [InlineData(1000)]
         [InlineData(1000 * 1000)]
-        [InlineData(1000 * 1000 * 50)]
         private static void Base64Encode(int numberOfBytes)
         {
             Span<byte> source = new byte[numberOfBytes];
@@ -36,7 +35,6 @@ namespace System.Binary.Base64.Tests
         [InlineData(100)]
         [InlineData(1000)]
         [InlineData(1000 * 1000)]
-        [InlineData(1000 * 1000 * 50)]
         private static void Base64EncodeBaseline(int numberOfBytes)
         {
             var source = new byte[numberOfBytes];
@@ -56,7 +54,6 @@ namespace System.Binary.Base64.Tests
         [InlineData(100)]
         [InlineData(1000)]
         [InlineData(1000 * 1000)]
-        [InlineData(1000 * 1000 * 50)]
         private static void Base64Decode(int numberOfBytes)
         {
             Span<byte> source = new byte[numberOfBytes];
@@ -77,7 +74,6 @@ namespace System.Binary.Base64.Tests
         [InlineData(100)]
         [InlineData(1000)]
         [InlineData(1000 * 1000)]
-        [InlineData(1000 * 1000 * 50)]
         private static void Base64DecodeBaseline(int numberOfBytes)
         {
             var source = new byte[numberOfBytes];
@@ -88,6 +84,31 @@ namespace System.Binary.Base64.Tests
                 using (iteration.StartMeasurement()) {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                         Convert.FromBase64CharArray(encoded, 0, encoded.Length);
+                }
+            }
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(1000 * 1000)]
+        private static void Base64DecodeInPlace(int numberOfBytes)
+        {
+            Span<byte> source = new byte[numberOfBytes];
+            Base64TestHelper.InitalizeBytes(source);
+            int length = Base64Encoder.ComputeEncodedLength(numberOfBytes);
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        Span<byte> encodedSpan = new byte[length];
+                        Base64.Encoder.Transform(source, encodedSpan, out int consumed, out int written);
+                        Base64Decoder.DecodeInPlace(encodedSpan);
+                    }
                 }
             }
         }


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/6527137/26750088/e76568dc-47ce-11e7-816a-9a813457f4e7.png)

The performance gain mainly comes from the optimizations that were done for the Decoder **(see https://github.com/dotnet/corefxlab/pull/1586#issue-232772292, and https://github.com/dotnet/corefxlab/pull/1555#issue-229548969)**.
- indexing into the span by ref instead of the indexer (for read and write)
- saving operations on the redundant padding calc/branch
- using an optimized Decode helper function that does fewer bit shift operations
- this change is actually even faster than the previous (relatively speaking) since the previous one wouldn't check for invalid input bytes but this one does

**Open question:**
Should we change the signature of DecodeInPlace to follow Transform?
i.e.
```C#
public TransformationStatus DecodeInPlace(Span<byte> buffer, out int bytesConsumed, out int bytesWritten)
```
The way it is defined atm, it returns an int (for the number of bytes written to the buffer), but we don't know error/state information for invalid bytes, etc. We also do not currently know how much was consumed which could be useful to the caller.

cc @KrzysztofCwalina, @jkotas 

As an aside:
I removed the case `[InlineData(1000 * 1000 * 50)]` from the perf tests. Testing the Encode/Decode APIs for such a large span (while inner iteration count is 1k) takes too long and doesn't provide much value/insight.