### PR TITLE
Made BufferPool buffers 'auto-dispose'

### DIFF
--- a/src/System.Buffers.Primitives/System/Internal/ManagedBufferPool.cs
+++ b/src/System.Buffers.Primitives/System/Internal/ManagedBufferPool.cs
@@ -22,7 +22,8 @@ namespace System.Buffers.Internal
 
         public override OwnedBuffer<byte> Rent(int minimumBufferSize)
         {
-            return new ArrayPoolBuffer(minimumBufferSize);
+            var buffer = new ArrayPoolBuffer(minimumBufferSize);
+            return buffer;
         }
 
         protected override void Dispose(bool disposing)
@@ -89,7 +90,10 @@ namespace System.Buffers.Internal
             public override void Release()
             {
                 if (!IsRetained) BufferPrimitivesThrowHelper.ThrowInvalidOperationException();
-                Interlocked.Decrement(ref _referenceCount);
+                if(Interlocked.Decrement(ref _referenceCount) <= 0)
+                {
+                    Dispose();
+                }
             }
         }
     }

--- a/src/System.Buffers.Primitives/System/Internal/ManagedBufferPool.cs
+++ b/src/System.Buffers.Primitives/System/Internal/ManagedBufferPool.cs
@@ -55,11 +55,10 @@ namespace System.Buffers.Internal
 
             protected override void Dispose(bool disposing)
             {
-                _disposed = true;
-                if (_array != null)
-                {
-                    ArrayPool<byte>.Shared.Return(_array);
-                    _array = null;
+                var array = Interlocked.Exchange(ref _array, null);
+                if (array != null)  {
+                    _disposed = true;
+                    ArrayPool<byte>.Shared.Return(array);
                 }
             }
 
@@ -89,10 +88,13 @@ namespace System.Buffers.Internal
 
             public override void Release()
             {
-                if (!IsRetained) BufferPrimitivesThrowHelper.ThrowInvalidOperationException();
-                if(Interlocked.Decrement(ref _referenceCount) <= 0)
-                {
+                var newRefCount = Interlocked.Decrement(ref _referenceCount);
+                if (newRefCount == 0) {
                     Dispose();
+                    return;
+                }
+                if(newRefCount < 0) {
+                    throw new InvalidOperationException();
                 }
             }
         }

--- a/tests/System.Buffers.Primitives.Tests/BufferReferenceTesting.cs
+++ b/tests/System.Buffers.Primitives.Tests/BufferReferenceTesting.cs
@@ -176,6 +176,8 @@ namespace System.Buffers.Tests
                 // memory is disposed; cannot use copy stored for later
                 var span = copyStoredForLater.Span;
             });
+
+            Assert.True(buffer.IsDisposed);
         }
 
         static void MemoryHandleDoubleFree(OwnedBuffer<byte> buffer)


### PR DESCRIPTION
I changed BufferPool's OwnedBuffer to auto-dispose after refcount drops to zero.

When a buffer is renter, its ref count is zero, but unless somebody increments it and then decrements it, the buffer won't be disposed. And so the proper usage is:

```c#
var owned = _pool.Rent();
using(var handle = owned.Buffer.Retain()){
    PassToConsumer(owned.Buffer);
} 
...
void PassToConsumer(Buffer<byte> buffer){
    _handle = buffer.Retain(); // this needs to be disposed when PassToConsumer is done with the buffer
   ...
}
```

@davidfowl, @ahsonkhan, @shiftylogic, @joshfree 