### PR TITLE
Changing Base64 to the public static class model

### DIFF
--- a/src/System.Binary.Base64/System/Binary/Base64.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Buffers;
 
 namespace System.Binary.Base64
 {
-    public sealed class Base64
+    public static partial class Base64
     {
-        public static readonly Base64Encoder Encoder = Base64Encoder.Instance;
-        public static readonly Base64Decoder Decoder = Base64Decoder.Instance;
+        public static readonly ITransformation Encoder = new ToBase64();
+        public static readonly ITransformation Decoder = new FromBase64();
     }
 }

--- a/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
@@ -6,20 +6,8 @@ using System.Runtime.CompilerServices;
 
 namespace System.Binary.Base64
 {
-    public sealed class Base64Decoder : ITransformation
+    public static partial class Base64
     {
-        private static readonly Base64Decoder s_instance = new Base64Decoder();
-
-        public static Base64Decoder Instance
-        {
-            get
-            {
-                return s_instance;
-            }
-        }
-
-        private Base64Decoder() { }
-
         // Pre-computing this table using a custom string(s_characters) and GenerateDecodingMapAndVerify (found in tests)
         static readonly sbyte[] s_decodingMap = {
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
@@ -39,8 +27,6 @@ namespace System.Binary.Base64
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         };
-
-        const byte s_encodingPad = (byte)'=';              // '=', for padding
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int ComputeDecodedLength(ReadOnlySpan<byte> source)
@@ -98,7 +84,7 @@ namespace System.Binary.Base64
             Unsafe.Add(ref destBytes, 2) = (byte)i0;
         }
 
-        public TransformationStatus Transform(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+        public static TransformationStatus Decode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
         {
             ref byte srcBytes = ref source.DangerousGetPinnableReference();
             ref byte destBytes = ref destination.DangerousGetPinnableReference();
@@ -277,9 +263,15 @@ namespace System.Binary.Base64
             }
 
             return destIndex;
-            
+
             InvalidExit:
             return -1;
+        }
+
+        class FromBase64 : ITransformation
+        {
+            public TransformationStatus Transform(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+                => Decode(source, destination, out bytesConsumed, out bytesWritten);
         }
     }
 }

--- a/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
@@ -157,10 +157,10 @@ namespace System.Binary.Base64
         /// <param name="buffer">Buffer containing source bytes and empty space for the encoded bytes</param>
         /// <param name="sourceLength">Number of bytes to encode.</param>
         /// <returns>Number of bytes written to the buffer.</returns>
-        public static int EncodeInPlace(Span<byte> buffer, int sourceLength)
+        public static bool EncodeInPlace(Span<byte> buffer, int sourceLength, out int bytesWritten)
         {
             var encodedLength = ComputeEncodedLength(sourceLength);
-            if (buffer.Length < encodedLength) throw new ArgumentException("buffer too small.");
+            if (buffer.Length < encodedLength) goto FalseExit;
 
             var leftover = sourceLength - sourceLength / 3 * 3; // how many bytes after packs of 3
 
@@ -183,8 +183,13 @@ namespace System.Binary.Base64
                 destinationIndex -= 4;
                 Encode(sourceSlice, desitnationSlice, out int consumed, out int written);
             }
+            
+            bytesWritten = encodedLength;
+            return true;
 
-            return encodedLength;
+            FalseExit:
+            bytesWritten = 0;
+            return false;
         }
 
         class ToBase64 : ITransformation

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -20,7 +20,7 @@ namespace System.Binary.Base64.Tests
             for (int value = 0; value < 256; value++)
             {
                 Span<byte> sourceBytes = bytes.AsSpan().Slice(0, value + 1);
-                Span<byte> encodedBytes = new byte[Base64Encoder.ComputeEncodedLength(sourceBytes.Length)];
+                Span<byte> encodedBytes = new byte[Base64.ComputeEncodedLength(sourceBytes.Length)];
                 Assert.Equal(TransformationStatus.Done, Base64.Encoder.Transform(sourceBytes, encodedBytes, out int consumed, out int encodedBytesCount));
                 Assert.Equal(encodedBytes.Length, encodedBytesCount);
 
@@ -30,7 +30,7 @@ namespace System.Binary.Base64.Tests
 
                 if (encodedBytes.Length % 4 == 0)
                 {
-                    Span<byte> decodedBytes = new byte[Base64Decoder.ComputeDecodedLength(encodedBytes)];
+                    Span<byte> decodedBytes = new byte[Base64.ComputeDecodedLength(encodedBytes)];
                     Assert.Equal(TransformationStatus.Done, Base64.Decoder.Transform(encodedBytes, decodedBytes, out consumed, out int decodedByteCount));
                     Assert.Equal(sourceBytes.Length, decodedByteCount);
                     Assert.True(sourceBytes.SequenceEqual(decodedBytes));
@@ -48,7 +48,7 @@ namespace System.Binary.Base64.Tests
                 Span<byte> source = new byte[numBytes];
                 Base64TestHelper.InitalizeBytes(source, numBytes);
 
-                Span<byte> encodedBytes = new byte[Base64Encoder.ComputeEncodedLength(source.Length)];
+                Span<byte> encodedBytes = new byte[Base64.ComputeEncodedLength(source.Length)];
                 Assert.Equal(TransformationStatus.Done, Base64.Encoder.Transform(source, encodedBytes, out int consumed, out int encodedBytesCount));
                 Assert.Equal(encodedBytes.Length, encodedBytesCount);
 
@@ -65,7 +65,7 @@ namespace System.Binary.Base64.Tests
             Base64TestHelper.InitalizeBytes(source);
 
             int outputSize = 320;
-            int requiredSize = Base64Encoder.ComputeEncodedLength(source.Length);
+            int requiredSize = Base64.ComputeEncodedLength(source.Length);
 
             Span<byte> encodedBytes = new byte[outputSize];
             Assert.Equal(TransformationStatus.DestinationTooSmall,
@@ -97,7 +97,7 @@ namespace System.Binary.Base64.Tests
                 Span<byte> source = new byte[numBytes];
                 Base64TestHelper.InitalizeDecodableBytes(source, numBytes);
 
-                Span<byte> decodedBytes = new byte[Base64Decoder.ComputeDecodedLength(source)];
+                Span<byte> decodedBytes = new byte[Base64.ComputeDecodedLength(source)];
                 Assert.Equal(TransformationStatus.Done, 
                     Base64.Decoder.Transform(source, decodedBytes, out int consumed, out int decodedByteCount));
                 Assert.Equal(decodedBytes.Length, decodedByteCount);
@@ -116,7 +116,7 @@ namespace System.Binary.Base64.Tests
             for (int j = 0; j < 8; j++)
             {
                 Span<byte> source = new byte[] { 50, 50, 50, 50, 80, 80, 80, 80 };
-                Span<byte> decodedBytes = new byte[Base64Decoder.ComputeDecodedLength(source)];
+                Span<byte> decodedBytes = new byte[Base64.ComputeDecodedLength(source)];
 
                 for (int i = 0; i < invalidBytes.Length; i++)
                 {
@@ -138,7 +138,7 @@ namespace System.Binary.Base64.Tests
             for (int j = 0; j < 7; j++)
             {
                 Span<byte> source = new byte[] { 50, 50, 50, 50, 80, 80, 80, 80 };
-                Span<byte> decodedBytes = new byte[Base64Decoder.ComputeDecodedLength(source)];
+                Span<byte> decodedBytes = new byte[Base64.ComputeDecodedLength(source)];
                 source[j] = Base64TestHelper.s_encodingPad;
                 Assert.Equal(TransformationStatus.InvalidData,
                     Base64.Decoder.Transform(source, decodedBytes, out int consumed, out int decodedByteCount));
@@ -146,7 +146,7 @@ namespace System.Binary.Base64.Tests
 
             {
                 Span<byte> source = new byte[] { 50, 50, 50, 50, 80, 80, 80, 80 };
-                Span<byte> decodedBytes = new byte[Base64Decoder.ComputeDecodedLength(source)];
+                Span<byte> decodedBytes = new byte[Base64.ComputeDecodedLength(source)];
                 source[6] = Base64TestHelper.s_encodingPad;
                 source[7] = Base64TestHelper.s_encodingPad;
                 Assert.Equal(TransformationStatus.Done,
@@ -166,7 +166,7 @@ namespace System.Binary.Base64.Tests
             Base64TestHelper.InitalizeDecodableBytes(source);
 
             int outputSize = 240;
-            int requiredSize = Base64Decoder.ComputeDecodedLength(source);
+            int requiredSize = Base64.ComputeDecodedLength(source);
 
             Span<byte> decodedBytes = new byte[outputSize];
             Assert.Equal(TransformationStatus.DestinationTooSmall, 
@@ -192,32 +192,48 @@ namespace System.Binary.Base64.Tests
             int[] expected = { 0, 4, 4, 4, 8, 8, 8, 2147483640, 2147483640, 2147483640, 2147483644, 2147483644, 2147483644 };
             for (int i = 0; i < input.Length; i++)
             {
-                Assert.Equal(expected[i], Base64Encoder.ComputeEncodedLength(input[i]));
+                Assert.Equal(expected[i], Base64.ComputeEncodedLength(input[i]));
             }
 
-            Assert.True(Base64Encoder.ComputeEncodedLength(1610612734) < 0);   // integer overflow
+            Assert.True(Base64.ComputeEncodedLength(1610612734) < 0);   // integer overflow
         }
 
         [Fact]
         public void ComputeDecodedLength()
         {
             Span<byte> sourceEmpty = Span<byte>.Empty;
-            Assert.Equal(0, Base64Decoder.ComputeDecodedLength(sourceEmpty));
+            Assert.Equal(0, Base64.ComputeDecodedLength(sourceEmpty));
 
-            // int.MaxValue - (int.MaxValue % 4) => 2147483644, largest multiple of 4 less than int.MaxValue
-            // CLR default limit of 2 gigabytes (GB).
-            int[] input = { 4, 8, 12, 16, 20, 2000000000 };
-            int[] expected = { 3, 6, 9, 12, 15, 1500000000 };
+            int[] input = { 4, 8, 12, 16, 20 };
+            int[] expected = { 3, 6, 9, 12, 15 };
 
             for (int i = 0; i < input.Length; i++)
             {
                 int sourceLength = input[i];
                 Span<byte> source = new byte[sourceLength];
-                Assert.Equal(expected[i], Base64Decoder.ComputeDecodedLength(source));
+                Assert.Equal(expected[i], Base64.ComputeDecodedLength(source));
                 source[sourceLength - 1] = Base64TestHelper.s_encodingPad;                          // single character padding
-                Assert.Equal(expected[i] - 1, Base64Decoder.ComputeDecodedLength(source));
+                Assert.Equal(expected[i] - 1, Base64.ComputeDecodedLength(source));
                 source[sourceLength - 2] = Base64TestHelper.s_encodingPad;                          // two characters padding
-                Assert.Equal(expected[i] - 2, Base64Decoder.ComputeDecodedLength(source));
+                Assert.Equal(expected[i] - 2, Base64.ComputeDecodedLength(source));
+            }
+
+            // int.MaxValue - (int.MaxValue % 4) => 2147483644, largest multiple of 4 less than int.MaxValue
+            // CLR default limit of 2 gigabytes (GB).
+            try
+            {
+                int sourceLength = 2000000000;
+                int expectedLength = 1500000000;
+                Span<byte> source = new byte[sourceLength];
+                Assert.Equal(expectedLength, Base64.ComputeDecodedLength(source));
+                source[sourceLength - 1] = Base64TestHelper.s_encodingPad;                          // single character padding
+                Assert.Equal(expectedLength - 1, Base64.ComputeDecodedLength(source));
+                source[sourceLength - 2] = Base64TestHelper.s_encodingPad;                          // two characters padding
+                Assert.Equal(expectedLength - 2, Base64.ComputeDecodedLength(source));
+            }
+            catch (OutOfMemoryException)
+            {
+                // do nothing
             }
 
             // Lengths that are not a multiple of 4.
@@ -227,13 +243,13 @@ namespace System.Binary.Base64.Tests
             {
                 int sourceLength = lengthsNotMultipleOfFour[i];
                 Span<byte> source = new byte[sourceLength];
-                Assert.Equal(expectedOutput[i], Base64Decoder.ComputeDecodedLength(source));
+                Assert.Equal(expectedOutput[i], Base64.ComputeDecodedLength(source));
                 source[sourceLength - 1] = Base64TestHelper.s_encodingPad;
-                Assert.Equal(expectedOutput[i], Base64Decoder.ComputeDecodedLength(source));
+                Assert.Equal(expectedOutput[i], Base64.ComputeDecodedLength(source));
                 if (sourceLength > 1)
                 {
                     source[sourceLength - 2] = Base64TestHelper.s_encodingPad;
-                    Assert.Equal(expectedOutput[i], Base64Decoder.ComputeDecodedLength(source));
+                    Assert.Equal(expectedOutput[i], Base64.ComputeDecodedLength(source));
                 }
             }
         }
@@ -251,7 +267,7 @@ namespace System.Binary.Base64.Tests
             for (int value = 0; value < 256; value++)
             {
                 var sourceBytes = testBytes.AsSpan().Slice(0, value + 1);
-                var buffer = new byte[Base64Encoder.ComputeEncodedLength(sourceBytes.Length)];
+                var buffer = new byte[Base64.ComputeEncodedLength(sourceBytes.Length)];
                 var bufferSlice = buffer.AsSpan();
 
                 Base64.Encoder.Transform(sourceBytes, bufferSlice, out int consumed, out int written);
@@ -260,7 +276,7 @@ namespace System.Binary.Base64.Tests
                 var expectedText = Convert.ToBase64String(testBytes, 0, value + 1);
                 Assert.Equal(expectedText, encodedText);
 
-                var decodedByteCount = Base64Decoder.DecodeInPlace(bufferSlice);
+                var decodedByteCount = Base64.DecodeInPlace(bufferSlice);
                 Assert.Equal(sourceBytes.Length, decodedByteCount);
 
                 for (int i = 0; i < decodedByteCount; i++)
@@ -275,7 +291,7 @@ namespace System.Binary.Base64.Tests
         {
             Span<byte> inputSpan = new byte[1000];
             Base64TestHelper.InitalizeDecodableBytes(inputSpan);
-            int requiredLength = Base64Decoder.ComputeDecodedLength(inputSpan);
+            int requiredLength = Base64.ComputeDecodedLength(inputSpan);
             Span<byte> expected = new byte[requiredLength];
             Assert.Equal(TransformationStatus.Done, Base64.Decoder.Transform(inputSpan, expected, out int bytesConsumed, out int bytesWritten));
 
@@ -321,7 +337,7 @@ namespace System.Binary.Base64.Tests
                 var copy = testBytes.Clone();
                 var expectedText = Convert.ToBase64String(testBytes, 0, numberOfBytesToTest);
 
-                var encoded = Base64Encoder.EncodeInPlace(testBytes, numberOfBytesToTest);
+                var encoded = Base64.EncodeInPlace(testBytes, numberOfBytesToTest);
                 var encodedText = Text.Encoding.ASCII.GetString(testBytes, 0, encoded);
 
                 Assert.Equal(expectedText, encodedText);

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -276,12 +276,13 @@ namespace System.Binary.Base64.Tests
                 var expectedText = Convert.ToBase64String(testBytes, 0, value + 1);
                 Assert.Equal(expectedText, encodedText);
 
-                var decodedByteCount = Base64.DecodeInPlace(bufferSlice);
-                Assert.Equal(sourceBytes.Length, decodedByteCount);
+                Assert.Equal(TransformationStatus.Done, Base64.DecodeInPlace(bufferSlice, out int bytesConsumed, out int bytesWritten));
+                Assert.Equal(sourceBytes.Length, bytesWritten);
+                Assert.Equal(bufferSlice.Length, bytesConsumed);
 
-                for (int i = 0; i < decodedByteCount; i++)
+                for (int i = 0; i < bytesWritten; i++)
                 {
-                    Assert.Equal(sourceBytes[i], buffer[i]);
+                    Assert.Equal(sourceBytes[i], bufferSlice[i]);
                 }
             }
         }
@@ -337,8 +338,10 @@ namespace System.Binary.Base64.Tests
                 var copy = testBytes.Clone();
                 var expectedText = Convert.ToBase64String(testBytes, 0, numberOfBytesToTest);
 
-                var encoded = Base64.EncodeInPlace(testBytes, numberOfBytesToTest);
-                var encodedText = Text.Encoding.ASCII.GetString(testBytes, 0, encoded);
+                Assert.True(Base64.EncodeInPlace(testBytes, numberOfBytesToTest, out int bytesWritten));
+                Assert.Equal(Base64.ComputeEncodedLength(numberOfBytesToTest), bytesWritten);
+
+                var encodedText = Text.Encoding.ASCII.GetString(testBytes, 0, bytesWritten);
 
                 Assert.Equal(expectedText, encodedText);
             }

--- a/tests/System.Binary.Base64.Tests/PerformanceTests.cs
+++ b/tests/System.Binary.Base64.Tests/PerformanceTests.cs
@@ -107,7 +107,7 @@ namespace System.Binary.Base64.Tests
                     {
                         Span<byte> encodedSpan = new byte[length];
                         Base64.Encoder.Transform(source, encodedSpan, out int consumed, out int written);
-                        Base64.DecodeInPlace(encodedSpan);
+                        Base64.DecodeInPlace(encodedSpan, out int bytesConsumed, out int bytesWritten);
                     }
                 }
             }

--- a/tests/System.Binary.Base64.Tests/PerformanceTests.cs
+++ b/tests/System.Binary.Base64.Tests/PerformanceTests.cs
@@ -20,7 +20,7 @@ namespace System.Binary.Base64.Tests
         {
             Span<byte> source = new byte[numberOfBytes];
             Base64TestHelper.InitalizeBytes(source);
-            Span<byte> destination = new byte[Base64Encoder.ComputeEncodedLength(numberOfBytes)];
+            Span<byte> destination = new byte[Base64.ComputeEncodedLength(numberOfBytes)];
 
             foreach (var iteration in Benchmark.Iterations) {
                 using (iteration.StartMeasurement()) {
@@ -39,7 +39,7 @@ namespace System.Binary.Base64.Tests
         {
             var source = new byte[numberOfBytes];
             Base64TestHelper.InitalizeBytes(source.AsSpan());
-            var destination = new char[Base64Encoder.ComputeEncodedLength(numberOfBytes)];
+            var destination = new char[Base64.ComputeEncodedLength(numberOfBytes)];
 
             foreach (var iteration in Benchmark.Iterations) {
                 using (iteration.StartMeasurement()) {
@@ -58,7 +58,7 @@ namespace System.Binary.Base64.Tests
         {
             Span<byte> source = new byte[numberOfBytes];
             Base64TestHelper.InitalizeBytes(source);
-            Span<byte> encoded = new byte[Base64Encoder.ComputeEncodedLength(numberOfBytes)];
+            Span<byte> encoded = new byte[Base64.ComputeEncodedLength(numberOfBytes)];
             Base64.Encoder.Transform(source, encoded, out int consumed, out int written);
 
             foreach (var iteration in Benchmark.Iterations) {
@@ -97,7 +97,7 @@ namespace System.Binary.Base64.Tests
         {
             Span<byte> source = new byte[numberOfBytes];
             Base64TestHelper.InitalizeBytes(source);
-            int length = Base64Encoder.ComputeEncodedLength(numberOfBytes);
+            int length = Base64.ComputeEncodedLength(numberOfBytes);
 
             foreach (var iteration in Benchmark.Iterations)
             {
@@ -107,7 +107,7 @@ namespace System.Binary.Base64.Tests
                     {
                         Span<byte> encodedSpan = new byte[length];
                         Base64.Encoder.Transform(source, encodedSpan, out int consumed, out int written);
-                        Base64Decoder.DecodeInPlace(encodedSpan);
+                        Base64.DecodeInPlace(encodedSpan);
                     }
                 }
             }


### PR DESCRIPTION
cc @KrzysztofCwalina. @shiftylogic 

**API shape changed to:**
```C#
namespace System.Binary.Base64 {
    public static class Base64 {
        public static readonly ITransformation Decoder;
        public static readonly ITransformation Encoder;
        public static int ComputeDecodedLength(ReadOnlySpan<byte> source);
        public static int ComputeEncodedLength(int sourceLength);
        public static TransformationStatus Decode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten);
        public static TransformationStatus DecodeInPlace(Span<byte> buffer, out int bytesConsumed, out int bytesWritten);
        public static TransformationStatus Encode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten);
        public static bool EncodeInPlace(Span<byte> buffer, int sourceLength, out int bytesWritten);
    }
}
```

Also changed the shape of the *InPlace APIs.

It previously used the Singleton pattern and the API shape looked like this:
```C#
namespace System.Binary.Base64 {
    public sealed class Base64 {
        public static readonly ITransformation Decoder;
        public static readonly ITransformation Encoder;
        public Base64();
    }
    public sealed class Base64Decoder : ITransformation {
        public static Base64Decoder Instance { get; }
        public static int ComputeDecodedLength(ReadOnlySpan<byte> source);
        public static int DecodeInPlace(Span<byte> buffer);
        public TransformationStatus Transform(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten);
        public static TransformationStatus TransformA(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten);
    }
    public sealed class Base64Encoder : ITransformation {
        public static Base64Encoder Instance { get; }
        public static int ComputeEncodedLength(int sourceLength);
        public static int EncodeInPlace(Span<byte> buffer, int sourceLength);
        public TransformationStatus Transform(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten);
    }
}
```