### PR TITLE
CI should indicate error when test projects fail on linux and mac

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -77,7 +77,7 @@ declare -a projectsFailed
 
 while read testFile;
 do
-  if grep -q "System.IO.Compression.Tests" "$testFile"; then
+  if [[ $testFile == *"System.IO.Compression.Tests"* ]]; then
     echo "Skipping tests in $testFile. Cannot build the brotli dll yet."
     continue
   fi

--- a/build.sh
+++ b/build.sh
@@ -77,6 +77,11 @@ declare -a projectsFailed
 
 while read testFile;
 do
+  if [[ "$testFile" == *"System.IO.Compression.Tests"*]]
+  if grep -q "System.IO.Compression.Tests" "$testFile"; then
+    echo "Skipping tests in $testFile. Cannot build the brotli dll yet."
+    continue
+  fi
   echo "Building and running tests for project $testFile..."
   ./$dotnetExePath test $testFile -c $Configuration --no-build -- -notrait category=performance -notrait category=outerloop
   ret=$?

--- a/build.sh
+++ b/build.sh
@@ -100,3 +100,5 @@ if [ $errorsEncountered -ne 0 ]; then
 else
   echo -e "${GREEN}** Build succeeded. **${NC}"
 fi
+
+exit $errorsEncountered

--- a/build.sh
+++ b/build.sh
@@ -77,7 +77,6 @@ declare -a projectsFailed
 
 while read testFile;
 do
-  if [[ "$testFile" == *"System.IO.Compression.Tests"*]]
   if grep -q "System.IO.Compression.Tests" "$testFile"; then
     echo "Skipping tests in $testFile. Cannot build the brotli dll yet."
     continue

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -32,7 +32,7 @@ namespace System.Binary.Base64.Tests
                 {
                     Span<byte> decodedBytes = new byte[Base64Decoder.ComputeDecodedLength(encodedBytes)];
                     Assert.Equal(TransformationStatus.Done, Base64.Decoder.Transform(encodedBytes, decodedBytes, out consumed, out int decodedByteCount));
-                    Assert.Equal(sourceBytes.Length + 1, decodedByteCount);
+                    Assert.Equal(sourceBytes.Length, decodedByteCount);
                     Assert.True(sourceBytes.SequenceEqual(decodedBytes));
                 }
             }

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -32,7 +32,7 @@ namespace System.Binary.Base64.Tests
                 {
                     Span<byte> decodedBytes = new byte[Base64Decoder.ComputeDecodedLength(encodedBytes)];
                     Assert.Equal(TransformationStatus.Done, Base64.Decoder.Transform(encodedBytes, decodedBytes, out consumed, out int decodedByteCount));
-                    Assert.Equal(sourceBytes.Length, decodedByteCount);
+                    Assert.Equal(sourceBytes.Length + 1, decodedByteCount);
                     Assert.True(sourceBytes.SequenceEqual(decodedBytes));
                 }
             }


### PR DESCRIPTION
Right now the build script exits with 0 (success) even if there are test failures for Linux and OSX.
This change makes sure that the script exits with the right error code (non-zero if test projects failed).

See https://ci.dot.net/job/dotnet_corefxlab/job/master/job/ubuntu16.04_debug_prtest/161/ from https://github.com/dotnet/corefxlab/pull/1554

18:15:51 Test execution time: 7.1188 Seconds
18:15:51 [0;31m** Build failed. 10 projects failed to build or test. **[0m
18:15:51 [0;31m    tests/System.Text.Json.Tests/System.Text.Json.Tests.csproj[0m
18:15:51 [0;31m    tests/System.Text.Http.Parser.Tests/System.Text.Http.Parser.Tests.csproj[0m
18:15:51 [0;31m    tests/System.IO.Pipelines.Tests/System.IO.Pipelines.Tests.csproj[0m
18:15:51 [0;31m    tests/System.Buffers.Primitives.Tests/System.Buffers.Primitives.Tests.csproj[0m
18:15:51 [0;31m    tests/System.IO.Compression.Tests/System.IO.Compression.Tests.csproj[0m
18:15:51 [0;31m    tests/System.Text.Formatting.Globalization.Tests/System.Text.Formatting.Globalization.Tests.csproj[0m
18:15:51 [0;31m    tests/System.Text.Http.Tests/System.Text.Http.Tests.csproj[0m
18:15:51 [0;31m    tests/System.Binary.Base64.Tests/System.Binary.Base64.Tests.csproj[0m
18:15:51 [0;31m    tests/System.Text.Primitives.Tests/System.Text.Primitives.Tests.csproj[0m
18:15:51 [0;31m    tests/System.Buffers.Experimental.Tests/System.Buffers.Experimental.Tests.csproj[0m
18:15:52 Notifying endpoint with id 'HTTP:helix-int-notification-url'
18:15:52 Notifying endpoint with id 'HTTP:helix-prod-notification-url'
18:15:52 Notifying endpoint with id 'HTTP:legacy-notification-url'
18:15:53 Setting status of 8ed9a65b58ee7da637fed1aae1153c7d32eed668 to SUCCESS with url https://ci.dot.net/job/dotnet_corefxlab/job/master/job/ubuntu16.04_debug_prtest/161/ and message: 'Build finished. '
18:15:53 Using context: Innerloop Ubuntu16.04 Debug Build and Test
18:15:53 [WS-CLEANUP] Deleting project workspace...[WS-CLEANUP] done
**18:15:53 Finished: SUCCESS**