### PR TITLE
Fixing quotation usage in build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,16 +35,16 @@ if [ ! -d "dotnet" ]; then
   if [ "$Version" = "<default>" ]; then 
     Version=$(head -n 1 "DotnetCLIVersion.txt")
   fi
-  ./scripts/install-dotnet.sh -Version $Version -InstallDir "dotnet"
+  ./scripts/install-dotnet.sh -Version "$Version" -InstallDir "dotnet"
   ret=$?
   if [ $ret -ne 0 ]; then
-    echo "Failed to install latest dotnet.exe, exit code "$ret", aborting build."
+    echo "Failed to install latest dotnet.exe, exit code $ret, aborting build."
     exit -1
   fi
   ./scripts/install-dotnet.sh -Version 1.0.0 -InstallDir "dotnet"
   ret=$?
   if [ $ret -ne 0 ]; then
-    echo "Failed to install framework version 1.0.0, exit code "$ret", aborting build."
+    echo "Failed to install framework version 1.0.0, exit code $ret, aborting build."
     exit -1
   fi
 fi
@@ -55,7 +55,7 @@ myFile="corefxlab.sln"
 
 if [ "$Restore" = "true" ]; then
   echo "Restoring all packages"
-  ./$dotnetExePath restore $myFile /p:VersionSuffix=$BuildVersion
+  ./$dotnetExePath restore $myFile /p:VersionSuffix="$BuildVersion"
   ret=$?
   if [ $ret -ne 0 ]; then
     echo "Failed to restore packages."
@@ -65,7 +65,7 @@ fi
 
 echo "Building solution $myFile..."
 
-./$dotnetExePath build $myFile -c $Configuration /p:VersionSuffix=$BuildVersion
+./$dotnetExePath build $myFile -c "$Configuration" /p:VersionSuffix="$BuildVersion"
 ret=$?
 if [ $ret -ne 0 ]; then
   echo "Failed to build solution $myFile"
@@ -75,14 +75,14 @@ fi
 errorsEncountered=0
 declare -a projectsFailed
 
-while read testFile;
+while read -r testFile;
 do
   if [[ $testFile == *"System.IO.Compression.Tests"* ]]; then
     echo "Skipping tests in $testFile. Cannot build the brotli dll yet."
     continue
   fi
   echo "Building and running tests for project $testFile..."
-  ./$dotnetExePath test $testFile -c $Configuration --no-build -- -notrait category=performance -notrait category=outerloop
+  ./$dotnetExePath test "$testFile" -c "$Configuration" --no-build -- -notrait category=performance -notrait category=outerloop
   ret=$?
   if [ $ret -ne 0 ]; then
     echo "Some tests failed in project $testFile"


### PR DESCRIPTION
Clean up changes:
- Double quote to prevent globbing and word splitting [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086).
- The surrounding quotes actually unquote this. Remove or escape them [SC2027](https://github.com/koalaman/shellcheck/wiki/SC2027).
- read without -r mangle backslashes [SC2162](https://github.com/koalaman/shellcheck/wiki/SC2162).

cc @shiftylogic, @KrzysztofCwalina 