### PR TITLE
Patching build scripts for new blob storage URLs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# adding dotnet to the path. it is needed to run toolset csc. 
+# adding dotnet to the path. it is needed to run toolset csc.
 parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 dotnet_path=$parent_path/dotnet
 export PATH=$PATH:$dotnet_path
@@ -32,10 +32,10 @@ echo "BuildVersion=$BuildVersion."
 
 if [ ! -d "dotnet" ]; then
   echo "dotnet.exe not installed, downloading and installing."
-  if [ "$Version" = "<default>" ]; then 
+  if [ "$Version" = "<default>" ]; then
     Version=$(head -n 1 "DotnetCLIVersion.txt")
   fi
-  ./scripts/install-dotnet.sh -Version "$Version" -InstallDir "dotnet"
+  ./scripts/install-dotnet.sh -Channel master -Version "$Version" -InstallDir "dotnet"
   ret=$?
   if [ $ret -ne 0 ]; then
     echo "Failed to install latest dotnet.exe, exit code $ret, aborting build."

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -15,7 +15,7 @@ if (!(Test-Path "dotnet\dotnet.exe")) {
     if ($Version -eq "<default>") {
         $Version = (Get-Content "$PSScriptRoot\..\DotnetCLIVersion.txt" -Raw).Trim()
     }
-    Invoke-Expression -Command "$PSScriptRoot\install-dotnet.ps1 -Version $Version -InstallDir $PSScriptRoot\..\dotnet"
+    Invoke-Expression -Command "$PSScriptRoot\install-dotnet.ps1 -Channel master -Version $Version -InstallDir $PSScriptRoot\..\dotnet"
     if ($lastexitcode -ne $null -and $lastexitcode -ne 0) {
         Write-Error "Failed to install latest dotnet.exe, exit code [$lastexitcode], aborting build."
         exit -1

--- a/scripts/install-dotnet.ps1
+++ b/scripts/install-dotnet.ps1
@@ -10,18 +10,14 @@
     Installs dotnet cli. If dotnet installation already exists in the given directory
     it will update it only if the requested version differs from the one already installed.
 .PARAMETER Channel
-    Default: preview
-    Channel is the way of reasoning about stability and quality of dotnet. This parameter takes one of the values:
-    - future - Possibly unstable, frequently changing, may contain new finished and unfinished features
-    - preview - Pre-release stable with known issues and feature gaps
-    - production - Most stable releases
+    Default: release/1.0.0
+    Download from the Channel specified
 .PARAMETER Version
     Default: latest
     Represents a build version on specific channel. Possible values:
-    - 4-part version in a format A.B.C.D - represents specific version of build
     - latest - most latest build on specific channel
-    - lkg - last known good version on specific channel
-    Note: LKG work is in progress. Once the work is finished, this will become new default
+    - 3-part version in a format A.B.C - represents specific version of build
+      examples: 2.0.0-preview2-006120; 1.1.0
 .PARAMETER InstallDir
     Default: %LocalAppData%\Microsoft\dotnet
     Path to where to install dotnet. Note that binaries will be placed directly in a given directory.
@@ -46,13 +42,20 @@
     Displays diagnostics information.
 .PARAMETER AzureFeed
     Default: https://dotnetcli.azureedge.net/dotnet
-    This parameter should not be usually changed by user. It allows to change URL for the Azure feed used by this installer.
+    This parameter typically is not changed by the user.
+    It allows to change URL for the Azure feed used by this installer.
+.PARAMETER UncachedFeed
+    This parameter typically is not changed by the user.
+    It allows to change URL for the Uncached feed used by this installer.
 .PARAMETER ProxyAddress
     If set, the installer will use the proxy when making web requests
+.PARAMETER ProxyUseDefaultCredentials
+    Default: false
+    Use default credentials, when using proxy address.
 #>
 [cmdletbinding()]
 param(
-   [string]$Channel="rel-1.0.0",
+   [string]$Channel="release/1.0.0",
    [string]$Version="Latest",
    [string]$InstallDir="<auto>",
    [string]$Architecture="<auto>",
@@ -62,7 +65,8 @@ param(
    [switch]$NoPath,
    [string]$AzureFeed="https://dotnetcli.azureedge.net/dotnet",
    [string]$UncachedFeed="https://dotnetcli.blob.core.windows.net/dotnet",
-   [string]$ProxyAddress
+   [string]$ProxyAddress,
+   [switch]$ProxyUseDefaultCredentials
 )
 
 Set-StrictMode -Version Latest
@@ -76,7 +80,7 @@ $VersionRegEx="/\d+\.\d+[^/]+/"
 $OverrideNonVersionedFiles=$true
 
 function Say($str) {
-    Write-Host "dotnet-install: $str"
+    Write-Output "dotnet-install: $str"
 }
 
 function Say-Verbose($str) {
@@ -87,6 +91,25 @@ function Say-Invocation($Invocation) {
     $command = $Invocation.MyCommand;
     $args = (($Invocation.BoundParameters.Keys | foreach { "-$_ `"$($Invocation.BoundParameters[$_])`"" }) -join " ")
     Say-Verbose "$command $args"
+}
+
+function Invoke-With-Retry([ScriptBlock]$ScriptBlock, [int]$MaxAttempts = 3, [int]$SecondsBetweenAttempts = 1) {
+    $Attempts = 0
+
+    while ($true) {
+        try {
+            return $ScriptBlock.Invoke()
+        }
+        catch {
+            $Attempts++
+            if ($Attempts -lt $MaxAttempts) {
+                Start-Sleep $SecondsBetweenAttempts
+            }
+            else {
+                throw
+            }
+        }
+    }
 }
 
 function Get-Machine-Architecture() {
@@ -131,61 +154,77 @@ function Load-Assembly([string] $Assembly) {
 
 function GetHTTPResponse([Uri] $Uri)
 {
-    $HttpClient = $null
+    Invoke-With-Retry(
+    {
 
-    try {
-        # HttpClient is used vs Invoke-WebRequest in order to support Nano Server which doesn't support the Invoke-WebRequest cmdlet.
-        Load-Assembly -Assembly System.Net.Http
-        if($ProxyAddress){
-            $HttpClientHandler = New-Object System.Net.Http.HttpClientHandler
-            $HttpClientHandler.Proxy =  New-Object System.Net.WebProxy -Property @{Address=$ProxyAddress}
-            $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
-        } 
-        else {
-            $HttpClient = New-Object System.Net.Http.HttpClient
-        }
-        # Default timeout for HttpClient is 100s.  For a 50 MB download this assumes 500 KB/s average, any less will time out
-        # 5 minutes allows it to work over much slower connections.
-        $HttpClient.Timeout = New-TimeSpan -Minutes 5 
-        $Response = $HttpClient.GetAsync($Uri).Result
-        if (($Response -eq $null) -or (-not ($Response.IsSuccessStatusCode)))
-        {
-            $ErrorMsg = "Failed to download $Uri."
-            if ($Response -ne $null)
+        $HttpClient = $null
+
+        try {
+            # HttpClient is used vs Invoke-WebRequest in order to support Nano Server which doesn't support the Invoke-WebRequest cmdlet.
+            Load-Assembly -Assembly System.Net.Http
+
+            if(-not $ProxyAddress)
             {
-                $ErrorMsg += "  $Response"
+                # Despite no proxy being explicitly specified, we may still be behind a default proxy
+                $DefaultProxy = [System.Net.WebRequest]::DefaultWebProxy;
+                if($DefaultProxy -and (-not $DefaultProxy.IsBypassed($Uri))){
+                    $ProxyAddress =  $DefaultProxy.GetProxy($Uri).OriginalString
+                    $ProxyUseDefaultCredentials = $true
+                }
             }
 
-            throw $ErrorMsg
-        }
+            if($ProxyAddress){
+                $HttpClientHandler = New-Object System.Net.Http.HttpClientHandler
+                $HttpClientHandler.Proxy =  New-Object System.Net.WebProxy -Property @{Address=$ProxyAddress;UseDefaultCredentials=$ProxyUseDefaultCredentials}
+                $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
+            }
+            else {
+                $HttpClient = New-Object System.Net.Http.HttpClient
+            }
+            # Default timeout for HttpClient is 100s.  For a 50 MB download this assumes 500 KB/s average, any less will time out
+            # 10 minutes allows it to work over much slower connections.
+            $HttpClient.Timeout = New-TimeSpan -Minutes 10
+            $Response = $HttpClient.GetAsync($Uri).Result
+            if (($Response -eq $null) -or (-not ($Response.IsSuccessStatusCode)))
+            {
+                $ErrorMsg = "Failed to download $Uri."
+                if ($Response -ne $null)
+                {
+                    $ErrorMsg += "  $Response"
+                }
 
-        return $Response
-    }
-    finally {
-        if ($HttpClient -ne $null) {
-            $HttpClient.Dispose()
+                throw $ErrorMsg
+            }
+
+             return $Response
         }
-    }
+        finally {
+             if ($HttpClient -ne $null) {
+                $HttpClient.Dispose()
+            }
+        }
+    })
 }
 
 
-function Get-Latest-Version-Info([string]$AzureFeed, [string]$AzureChannel, [string]$CLIArchitecture) {
+function Get-Latest-Version-Info([string]$AzureFeed, [string]$Channel) {
     Say-Invocation $MyInvocation
 
     $VersionFileUrl = $null
     if ($SharedRuntime) {
-        $VersionFileUrl = "$UncachedFeed/$AzureChannel/dnvm/latest.sharedfx.win.$CLIArchitecture.version"
+        $VersionFileUrl = "$UncachedFeed/Runtime/$Channel/latest.version"
     }
     else {
-        $VersionFileUrl = "$UncachedFeed/Sdk/$AzureChannel/latest.version"
+        $VersionFileUrl = "$UncachedFeed/Sdk/$Channel/latest.version"
     }
-    
+
     $Response = GetHTTPResponse -Uri $VersionFileUrl
     $StringContent = $Response.Content.ReadAsStringAsync().Result
 
     switch ($Response.Content.Headers.ContentType) {
         { ($_ -eq "application/octet-stream") } { $VersionText = [Text.Encoding]::UTF8.GetString($StringContent) }
         { ($_ -eq "text/plain") } { $VersionText = $StringContent }
+        { ($_ -eq "text/plain; charset=UTF-8") } { $VersionText = $StringContent }
         default { throw "``$Response.Content.Headers.ContentType`` is an unknown .version file content type." }
     }
 
@@ -194,47 +233,47 @@ function Get-Latest-Version-Info([string]$AzureFeed, [string]$AzureChannel, [str
     return $VersionInfo
 }
 
-# TODO: AzureChannel and Channel should be unified
-function Get-Azure-Channel-From-Channel([string]$Channel) {
-    Say-Invocation $MyInvocation
 
-    # For compatibility with build scripts accept also directly Azure channels names
-    switch ($Channel.ToLower()) {
-        { ($_ -eq "future") -or ($_ -eq "dev") } { return "dev" }
-        { $_ -eq "production" } { throw "Production channel does not exist yet" }
-        default { return $_ }
-    }
-}
-
-function Get-Specific-Version-From-Version([string]$AzureFeed, [string]$AzureChannel, [string]$CLIArchitecture, [string]$Version) {
+function Get-Specific-Version-From-Version([string]$AzureFeed, [string]$Channel, [string]$Version) {
     Say-Invocation $MyInvocation
 
     switch ($Version.ToLower()) {
         { $_ -eq "latest" } {
-            $LatestVersionInfo = Get-Latest-Version-Info -AzureFeed $AzureFeed -AzureChannel $AzureChannel -CLIArchitecture $CLIArchitecture
+            $LatestVersionInfo = Get-Latest-Version-Info -AzureFeed $AzureFeed -Channel $Channel
             return $LatestVersionInfo.Version
         }
-        { $_ -eq "lkg" } { throw "``-Version LKG`` not supported yet." }
         default { return $Version }
     }
 }
 
-function Get-Download-Links([string]$AzureFeed, [string]$AzureChannel, [string]$SpecificVersion, [string]$CLIArchitecture) {
+function Get-Download-Link([string]$AzureFeed, [string]$Channel, [string]$SpecificVersion, [string]$CLIArchitecture) {
     Say-Invocation $MyInvocation
-    
-    $ret = @()
-    
+
     if ($SharedRuntime) {
-        $PayloadURL = "$AzureFeed/$AzureChannel/Binaries/$SpecificVersion/dotnet-win-$CLIArchitecture.$SpecificVersion.zip"
+        $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/dotnet-runtime-$SpecificVersion-win-$CLIArchitecture.zip"
+    }
+    else {
+        $PayloadURL = "$AzureFeed/Sdk/$SpecificVersion/dotnet-dev-$SpecificVersion-win-$CLIArchitecture.zip"
+    }
+
+    Say-Verbose "Constructed primary payload URL: $PayloadURL"
+
+    return $PayloadURL
+}
+
+function Get-AltDownload-Link([string]$AzureFeed, [string]$Channel, [string]$SpecificVersion, [string]$CLIArchitecture) {
+    Say-Invocation $MyInvocation
+
+    if ($SharedRuntime) {
+        $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/dotnet-win-$CLIArchitecture.$SpecificVersion.zip"
     }
     else {
         $PayloadURL = "$AzureFeed/Sdk/$SpecificVersion/dotnet-dev-win-$CLIArchitecture.$SpecificVersion.zip"
     }
 
-    Say-Verbose "Constructed payload URL: $PayloadURL"
-    $ret += $PayloadURL
+    Say-Verbose "Constructed alternate payload URL: $PayloadURL"
 
-    return $ret
+    return $PayloadURL
 }
 
 function Get-User-Share-Path() {
@@ -261,7 +300,7 @@ function Get-Version-Info-From-Version-File([string]$InstallRoot, [string]$Relat
 
     $VersionFile = Join-Path -Path $InstallRoot -ChildPath $RelativePathToVersionFile
     Say-Verbose "Local version file: $VersionFile"
-    
+
     if (Test-Path $VersionFile) {
         $VersionText = cat $VersionFile
         Say-Verbose "Local version file text: $VersionText"
@@ -275,7 +314,7 @@ function Get-Version-Info-From-Version-File([string]$InstallRoot, [string]$Relat
 
 function Is-Dotnet-Package-Installed([string]$InstallRoot, [string]$RelativePathToPackage, [string]$SpecificVersion) {
     Say-Invocation $MyInvocation
-    
+
     $DotnetPackagePath = Join-Path -Path $InstallRoot -ChildPath $RelativePathToPackage | Join-Path -ChildPath $SpecificVersion
     Say-Verbose "Is-Dotnet-Package-Installed: Path to a package: $DotnetPackagePath"
     return Test-Path $DotnetPackagePath -PathType Container
@@ -293,13 +332,13 @@ function Get-Path-Prefix-With-Version($path) {
     if ($match.Success) {
         return $entry.FullName.Substring(0, $match.Index + $match.Length)
     }
-    
+
     return $null
 }
 
 function Get-List-Of-Directories-And-Versions-To-Unpack-From-Dotnet-Package([System.IO.Compression.ZipArchive]$Zip, [string]$OutPath) {
     Say-Invocation $MyInvocation
-    
+
     $ret = @()
     foreach ($entry in $Zip.Entries) {
         $dir = Get-Path-Prefix-With-Version $entry.FullName
@@ -310,12 +349,12 @@ function Get-List-Of-Directories-And-Versions-To-Unpack-From-Dotnet-Package([Sys
             }
         }
     }
-    
+
     $ret = $ret | Sort-Object | Get-Unique
-    
+
     $values = ($ret | foreach { "$_" }) -join ";"
     Say-Verbose "Directories to unpack: $values"
-    
+
     return $ret
 }
 
@@ -339,9 +378,9 @@ function Extract-Dotnet-Package([string]$ZipPath, [string]$OutPath) {
     Set-Variable -Name Zip
     try {
         $Zip = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
-        
+
         $DirectoriesToUnpack = Get-List-Of-Directories-And-Versions-To-Unpack-From-Dotnet-Package -Zip $Zip -OutPath $OutPath
-        
+
         foreach ($entry in $Zip.Entries) {
             $PathWithVersion = Get-Path-Prefix-With-Version $entry.FullName
             if (($PathWithVersion -eq $null) -Or ($DirectoriesToUnpack -contains $PathWithVersion)) {
@@ -390,16 +429,15 @@ function Prepend-Sdk-InstallRoot-To-Path([string]$InstallRoot, [string]$BinFolde
     }
 }
 
-$AzureChannel = Get-Azure-Channel-From-Channel -Channel $Channel
 $CLIArchitecture = Get-CLIArchitecture-From-Architecture $Architecture
-$SpecificVersion = Get-Specific-Version-From-Version -AzureFeed $AzureFeed -AzureChannel $AzureChannel -CLIArchitecture $CLIArchitecture -Version $Version
-$DownloadLinks = Get-Download-Links -AzureFeed $AzureFeed -AzureChannel $AzureChannel -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
+$SpecificVersion = Get-Specific-Version-From-Version -AzureFeed $AzureFeed -Channel $Channel -Version $Version
+$DownloadLink = Get-Download-Link -AzureFeed $AzureFeed -Channel $Channel -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
+$AltDownloadLink = Get-AltDownload-Link -AzureFeed $AzureFeed -Channel $Channel -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
 
 if ($DryRun) {
     Say "Payload URLs:"
-    foreach ($DownloadLink in $DownloadLinks) {
-        Say "- $DownloadLink"
-    }
+    Say "Primary - $DownloadLink"
+    Say "Alternate - $AltDownloadLink"
     Say "Repeatable invocation: .\$($MyInvocation.MyCommand) -Version $SpecificVersion -Channel $Channel -Architecture $CLIArchitecture -InstallDir $InstallDir"
     exit 0
 }
@@ -417,22 +455,30 @@ if ($IsSdkInstalled) {
 
 New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
 
-$free = Get-CimInstance -Class win32_logicaldisk | where Deviceid -eq "$((Get-Item $InstallRoot).PSDrive.Name):"
-if ($free.Freespace / 1MB -le 250 ) {
-    Say "there is not enough disk space on drive c:"
+$installDrive = $((Get-Item $InstallRoot).PSDrive.Name);
+Write-Output "${installDrive}:";
+$free = Get-CimInstance -Class win32_logicaldisk | where Deviceid -eq "${installDrive}:"
+if ($free.Freespace / 1MB -le 100 ) {
+    Say "There is not enough disk space on drive ${installDrive}:"
     exit 0
 }
 
-foreach ($DownloadLink in $DownloadLinks) {
+$ZipPath = [System.IO.Path]::GetTempFileName()
+Say "Downloading $DownloadLink"
+try {
+    DownloadFile -Uri $DownloadLink -OutPath $ZipPath
+}
+catch {
+    $DownloadLink = $AltDownloadLink
     $ZipPath = [System.IO.Path]::GetTempFileName()
     Say "Downloading $DownloadLink"
     DownloadFile -Uri $DownloadLink -OutPath $ZipPath
-
-    Say "Extracting zip from $DownloadLink"
-    Extract-Dotnet-Package -ZipPath $ZipPath -OutPath $InstallRoot
-
-    Remove-Item $ZipPath
 }
+
+Say "Extracting zip from $DownloadLink"
+Extract-Dotnet-Package -ZipPath $ZipPath -OutPath $InstallRoot
+
+Remove-Item $ZipPath
 
 Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot -BinFolderRelativePath $BinFolderRelativePath
 

--- a/scripts/install-dotnet.sh
+++ b/scripts/install-dotnet.sh
@@ -115,6 +115,24 @@ get_current_os_name() {
     if [ "$uname" = "Darwin" ]; then
         echo "osx"
         return 0
+    else
+        if [ "$uname" = "Linux" ]; then
+            echo "linux"
+            return 0
+        fi
+    fi
+
+    say_err "OS name could not be detected: $ID.$VERSION_ID"
+    return 1
+}
+
+get_distro_specific_os_name() {
+    eval $invocation
+
+    local uname=$(uname)
+    if [ "$uname" = "Darwin" ]; then
+        echo "osx"
+        return 0
     elif [ -n "$runtime_id" ]; then
         echo $(get_os_download_name_from_platform "${runtime_id%-*}" || echo "${runtime_id%-*}")
         return 0
@@ -128,7 +146,7 @@ get_current_os_name() {
             fi
         fi
     fi
-    
+
     say_err "OS name could not be detected: $ID.$VERSION_ID"
     return 1
 }
@@ -140,18 +158,25 @@ machine_has() {
     return $?
 }
 
+
 check_min_reqs() {
-    if ! machine_has "curl"; then
-        say_err "curl is required to download dotnet. Install curl to proceed."
+    local hasMinimum=false
+    if machine_has "curl"; then
+        hasMinimum=true
+    elif machine_has "wget"; then
+        hasMinimum=true
+    fi
+
+    if [ "$hasMinimum" = "false" ]; then
+        say_err "curl (recommended) or wget are required to download dotnet. Install missing prerequisite to proceed."
         return 1
     fi
-    
     return 0
 }
 
 check_pre_reqs() {
     eval $invocation
-    
+
     local failing=false;
 
     if [ "${DOTNET_INSTALL_SKIP_PREREQS:-}" = "1" ]; then
@@ -168,14 +193,13 @@ check_pre_reqs() {
 
         [ -z "$($LDCONFIG_COMMAND -p | grep libunwind)" ] && say_err "Unable to locate libunwind. Install libunwind to continue" && failing=true
         [ -z "$($LDCONFIG_COMMAND -p | grep libssl)" ] && say_err "Unable to locate libssl. Install libssl to continue" && failing=true
-        [ -z "$($LDCONFIG_COMMAND -p | grep libcurl)" ] && say_err "Unable to locate libcurl. Install libcurl to continue" && failing=true
         [ -z "$($LDCONFIG_COMMAND -p | grep libicu)" ] && say_err "Unable to locate libicu. Install libicu to continue" && failing=true
     fi
 
     if [ "$failing" = true ]; then
        return 1
     fi
-    
+
     return 0
 }
 
@@ -183,7 +207,7 @@ check_pre_reqs() {
 # input - $1
 to_lowercase() {
     #eval $invocation
-    
+
     echo "$1" | tr '[:upper:]' '[:lower:]'
     return 0
 }
@@ -192,7 +216,7 @@ to_lowercase() {
 # input - $1
 remove_trailing_slash() {
     #eval $invocation
-    
+
     local input=${1:-}
     echo "${input%/}"
     return 0
@@ -202,7 +226,7 @@ remove_trailing_slash() {
 # input - $1
 remove_beginning_slash() {
     #eval $invocation
-    
+
     local input=${1:-}
     echo "${input#/}"
     return 0
@@ -213,13 +237,13 @@ remove_beginning_slash() {
 # child_path - $2 - this parameter can be empty
 combine_paths() {
     eval $invocation
-    
+
     # TODO: Consider making it work with any number of paths. For now:
     if [ ! -z "${3:-}" ]; then
         say_err "combine_paths: Function takes two parameters."
         return 1
     fi
-    
+
     local root_path=$(remove_trailing_slash $1)
     local child_path=$(remove_beginning_slash ${2:-})
     say_verbose "combine_paths: root_path=$root_path"
@@ -230,7 +254,7 @@ combine_paths() {
 
 get_machine_architecture() {
     eval $invocation
-    
+
     # Currently the only one supported
     echo "x64"
     return 0
@@ -240,7 +264,7 @@ get_machine_architecture() {
 # architecture - $1
 get_normalized_architecture_from_architecture() {
     eval $invocation
-    
+
     local architecture=$(to_lowercase $1)
     case $architecture in
         \<auto\>)
@@ -252,12 +276,12 @@ get_normalized_architecture_from_architecture() {
             return 0
             ;;
         x86)
-            say_err "Architecture ``x86`` currently not supported"
+            say_err "Architecture \`x86\` currently not supported"
             return 1
             ;;
     esac
-   
-    say_err "Architecture ``$architecture`` not supported. If you think this is a bug, please report it at https://github.com/dotnet/cli/issues"
+
+    say_err "Architecture \`$architecture\` not supported. If you think this is a bug, please report it at https://github.com/dotnet/cli/issues"
     return 1
 }
 
@@ -270,7 +294,7 @@ get_normalized_architecture_from_architecture() {
 # version_text - stdin
 get_version_from_version_info() {
     eval $invocation
-    
+
     cat | tail -n 1
     return 0
 }
@@ -279,7 +303,7 @@ get_version_from_version_info() {
 # version_text - stdin
 get_commit_hash_from_version_info() {
     eval $invocation
-    
+
     cat | head -n 1
     return 0
 }
@@ -290,14 +314,14 @@ get_commit_hash_from_version_info() {
 # specific_version - $3
 is_dotnet_package_installed() {
     eval $invocation
-    
+
     local install_root=$1
     local relative_path_to_package=$2
     local specific_version=${3//[$'\t\r\n']}
-    
+
     local dotnet_package_path=$(combine_paths $(combine_paths $install_root $relative_path_to_package) $specific_version)
     say_verbose "is_dotnet_package_installed: dotnet_package_path=$dotnet_package_path"
-    
+
     if [ -d "$dotnet_package_path" ]; then
         return 0
     else
@@ -307,74 +331,47 @@ is_dotnet_package_installed() {
 
 # args:
 # azure_feed - $1
-# azure_channel - $2
+# channel - $2
 # normalized_architecture - $3
 get_latest_version_info() {
     eval $invocation
-    
+
     local azure_feed=$1
-    local azure_channel=$2
+    local channel=$2
     local normalized_architecture=$3
-    
-    local osname
-    osname=$(get_current_os_name) || return 1
 
     local version_file_url=null
     if [ "$shared_runtime" = true ]; then
-        version_file_url="$uncached_feed/$azure_channel/dnvm/latest.sharedfx.$osname.$normalized_architecture.version"
+        version_file_url="$uncached_feed/Runtime/$channel/latest.version"
     else
-        version_file_url="$uncached_feed/Sdk/$azure_channel/latest.version"
+        version_file_url="$uncached_feed/Sdk/$channel/latest.version"
     fi
     say_verbose "get_latest_version_info: latest url: $version_file_url"
-    
+
     download $version_file_url
     return $?
 }
 
 # args:
-# channel - $1
-get_azure_channel_from_channel() {
-    eval $invocation
-    
-    local channel=$(to_lowercase $1)
-    case $channel in
-        future|dev)
-            echo "dev"
-            return 0
-            ;;
-        production)
-            say_err "Production channel does not exist yet"
-            return 1
-    esac
-    
-	echo $channel
-    return 0
-}
-
-# args:
 # azure_feed - $1
-# azure_channel - $2
+# channel - $2
 # normalized_architecture - $3
 # version - $4
 get_specific_version_from_version() {
     eval $invocation
-    
+
     local azure_feed=$1
-    local azure_channel=$2
+    local channel=$2
     local normalized_architecture=$3
     local version=$(to_lowercase $4)
 
     case $version in
         latest)
             local version_info
-	    version_info="$(get_latest_version_info $azure_feed $azure_channel $normalized_architecture)" || return 1
+            version_info="$(get_latest_version_info $azure_feed $channel $normalized_architecture)" || return 1
             say_verbose "get_specific_version_from_version: version_info=$version_info"
             echo "$version_info" | get_version_from_version_info
             return 0
-            ;;
-        lkg)
-            say_err "``--version LKG`` not supported yet."
-            return 1
             ;;
         *)
             echo $version
@@ -385,34 +382,61 @@ get_specific_version_from_version() {
 
 # args:
 # azure_feed - $1
-# azure_channel - $2
+# channel - $2
 # normalized_architecture - $3
 # specific_version - $4
 construct_download_link() {
     eval $invocation
-    
+
     local azure_feed=$1
-    local azure_channel=$2
+    local channel=$2
     local normalized_architecture=$3
     local specific_version=${4//[$'\t\r\n']}
-    
+
     local osname
     osname=$(get_current_os_name) || return 1
-    
+
     local download_link=null
     if [ "$shared_runtime" = true ]; then
-        download_link="$azure_feed/$azure_channel/Binaries/$specific_version/dotnet-$osname-$normalized_architecture.$specific_version.tar.gz"
+        download_link="$azure_feed/Runtime/$specific_version/dotnet-runtime-$specific_version-$osname-$normalized_architecture.tar.gz"
     else
-        download_link="$azure_feed/Sdk/$specific_version/dotnet-dev-$osname-$normalized_architecture.$specific_version.tar.gz"
+        download_link="$azure_feed/Sdk/$specific_version/dotnet-dev-$specific_version-$osname-$normalized_architecture.tar.gz"
     fi
-    
+
     echo "$download_link"
+    return 0
+}
+
+# args:
+# azure_feed - $1
+# channel - $2
+# normalized_architecture - $3
+# specific_version - $4
+construct_alt_download_link() {
+    eval $invocation
+
+    local azure_feed=$1
+    local channel=$2
+    local normalized_architecture=$3
+    local specific_version=${4//[$'\t\r\n']}
+
+    local distro_specific_osname
+    distro_specific_osname=$(get_distro_specific_os_name) || return 1
+
+    local alt_download_link=null
+    if [ "$shared_runtime" = true ]; then
+        alt_download_link="$azure_feed/Runtime/$specific_version/dotnet-$distro_specific_osname-$normalized_architecture.$specific_version.tar.gz"
+    else
+        alt_download_link="$azure_feed/Sdk/$specific_version/dotnet-dev-$distro_specific_osname-$normalized_architecture.$specific_version.tar.gz"
+    fi
+
+    echo "$alt_download_link"
     return 0
 }
 
 get_user_install_path() {
     eval $invocation
-    
+
     if [ ! -z "${DOTNET_INSTALL_DIR:-}" ]; then
         echo $DOTNET_INSTALL_DIR
     else
@@ -425,7 +449,7 @@ get_user_install_path() {
 # install_dir - $1
 resolve_installation_path() {
     eval $invocation
-    
+
     local install_dir=$1
     if [ "$install_dir" = "<auto>" ]; then
         local user_install_path=$(get_user_install_path)
@@ -433,7 +457,7 @@ resolve_installation_path() {
         echo "$user_install_path"
         return 0
     fi
-    
+
     echo "$install_dir"
     return 0
 }
@@ -442,7 +466,7 @@ resolve_installation_path() {
 # install_root - $1
 get_installed_version_info() {
     eval $invocation
-    
+
     local install_root=$1
     local version_file=$(combine_paths "$install_root" "$local_version_file_relative_path")
     say_verbose "Local version file: $version_file"
@@ -451,7 +475,7 @@ get_installed_version_info() {
         echo "$version_info"
         return 0
     fi
-    
+
     say_verbose "Local version file not found."
     return 0
 }
@@ -460,7 +484,7 @@ get_installed_version_info() {
 # relative_or_absolute_path - $1
 get_absolute_path() {
     eval $invocation
-    
+
     local relative_or_absolute_path=$1
     echo $(cd $(dirname "$1") && pwd -P)/$(basename "$1")
     return 0
@@ -478,7 +502,7 @@ copy_files_or_dirs_from_list() {
     local out_path=$(remove_trailing_slash $2)
     local override=$3
     local override_switch=$(if [ "$override" = false ]; then printf -- "-n"; fi)
-    
+
     cat | uniq | while read -r file_path; do
         local path=$(remove_beginning_slash ${file_path#$root_path})
         local target=$out_path/$path
@@ -494,21 +518,21 @@ copy_files_or_dirs_from_list() {
 # out_path - $2
 extract_dotnet_package() {
     eval $invocation
-    
+
     local zip_path=$1
     local out_path=$2
-    
+
     local temp_out_path=$(mktemp -d $temporary_file_template)
-    
+
     local failed=false
     tar -xzf "$zip_path" -C "$temp_out_path" > /dev/null || failed=true
-    
+
     local folders_with_version_regex='^.*/[0-9]+\.[0-9]+[^/]+/'
     find $temp_out_path -type f | grep -Eo $folders_with_version_regex | copy_files_or_dirs_from_list $temp_out_path $out_path false
     find $temp_out_path -type f | grep -Ev $folders_with_version_regex | copy_files_or_dirs_from_list $temp_out_path $out_path true
-    
+
     rm -rf $temp_out_path
-    
+
     if [ "$failed" = true ]; then
         say_err "Extraction failed"
         return 1
@@ -520,65 +544,112 @@ extract_dotnet_package() {
 # [out_path] - $2 - stdout if not provided
 download() {
     eval $invocation
-    
+
+    local remote_path=$1
+    local out_path=${2:-}
+
+    local failed=false
+    if machine_has "curl"; then
+        downloadcurl $remote_path $out_path || failed=true
+    elif machine_has "wget"; then
+        downloadwget $remote_path $out_path || failed=true
+    else
+        failed=true
+    fi
+    if [ "$failed" = true ]; then
+        say_verbose "Download failed: $remote_path"
+        return 1
+    fi
+    return 0
+}
+
+downloadcurl() {
+    eval $invocation
     local remote_path=$1
     local out_path=${2:-}
 
     local failed=false
     if [ -z "$out_path" ]; then
-        curl --fail -s $remote_path || failed=true
+        curl --retry 10 -sSL -f --create-dirs $remote_path || failed=true
     else
-        curl --fail -s -o $out_path $remote_path || failed=true
+        curl --retry 10 -sSL -f --create-dirs -o $out_path $remote_path || failed=true
     fi
-    
     if [ "$failed" = true ]; then
-        say_err "Download failed"
+        say_verbose "Curl download failed"
         return 1
     fi
+    return 0
+}
+
+downloadwget() {
+    eval $invocation
+    local remote_path=$1
+    local out_path=${2:-}
+
+    local failed=false
+    if [ -z "$out_path" ]; then
+        wget -q --tries 10 $remote_path || failed=true
+    else
+        wget -v --tries 10 -O $out_path $remote_path || failed=true
+    fi
+    if [ "$failed" = true ]; then
+        say_verbose "Wget download failed"
+        return 1
+    fi
+    return 0
 }
 
 calculate_vars() {
     eval $invocation
-    
-    azure_channel=$(get_azure_channel_from_channel "$channel")
-    say_verbose "azure_channel=$azure_channel"
-    
+
     normalized_architecture=$(get_normalized_architecture_from_architecture "$architecture")
     say_verbose "normalized_architecture=$normalized_architecture"
-    
-    specific_version=$(get_specific_version_from_version $azure_feed $azure_channel $normalized_architecture $version)
+
+    specific_version=$(get_specific_version_from_version $azure_feed $channel $normalized_architecture $version)
     say_verbose "specific_version=$specific_version"
     if [ -z "$specific_version" ]; then
         say_err "Could not get version information."
         return 1
     fi
-    
-    download_link=$(construct_download_link $azure_feed $azure_channel $normalized_architecture $specific_version)
+
+    download_link=$(construct_download_link $azure_feed $channel $normalized_architecture $specific_version)
     say_verbose "download_link=$download_link"
-    
+
+    alt_download_link=$(construct_alt_download_link $azure_feed $channel $normalized_architecture $specific_version)
+    say_verbose "alt_download_link=$alt_download_link"
+
     install_root=$(resolve_installation_path $install_dir)
     say_verbose "install_root=$install_root"
 }
 
 install_dotnet() {
     eval $invocation
-    
+    local download_failed=false
+
     if is_dotnet_package_installed $install_root "sdk" $specific_version; then
         say ".NET SDK version $specific_version is already installed."
         return 0
     fi
-    
+
     mkdir -p $install_root
     zip_path=$(mktemp $temporary_file_template)
     say_verbose "Zip path: $zip_path"
-    
-    say "Downloading $download_link"
-    download "$download_link" $zip_path
-    say_verbose "Downloaded file exists and readable? $(if [ -r $zip_path ]; then echo "yes"; else echo "no"; fi)"
-    
+
+    say "Downloading link: $download_link"
+    download "$download_link" $zip_path || download_failed=true
+
+    #  if the download fails, download the alt_download_link
+    if [ "$download_failed" = true ]; then
+        say "Cannot download: $download_link"
+        zip_path=$(mktemp $temporary_file_template)
+        say_verbose "Alternate zip path: $zip_path"
+        say "Downloading alternate link: $alt_download_link"
+        download "$alt_download_link" $zip_path
+    fi
+
     say "Extracting zip"
     extract_dotnet_package $zip_path $install_root
-    
+
     return 0
 }
 
@@ -586,7 +657,7 @@ local_version_file_relative_path="/.version"
 bin_folder_relative_path=""
 temporary_file_template="${TMPDIR:-/tmp}/dotnet.XXXXXXXXX"
 
-channel="rel-1.0.0"
+channel="release/1.0.0"
 version="Latest"
 install_dir="<auto>"
 architecture="<auto>"
@@ -638,6 +709,10 @@ do
             shift
             azure_feed="$1"
             ;;
+        --uncached-feed|-[Uu]ncached[Ff]eed)
+            shift
+            uncached_feed="$1"
+            ;;
         --runtime-id|-[Rr]untime[Ii]d)
             shift
             runtime_id="$1"
@@ -653,7 +728,7 @@ do
             echo "Options:"
             echo "  -c,--channel <CHANNEL>         Download from the CHANNEL specified (default: $channel)."
             echo "      -Channel"
-            echo "  -v,--version <VERSION>         Use specific version, ``latest`` or ``lkg``. Defaults to ``latest``."
+            echo "  -v,--version <VERSION>         Use specific version, or \`latest\`. Defaults to \`latest\`."
             echo "      -Version"
             echo "  -i,--install-dir <DIR>         Install under specified location (see Install Location below)"
             echo "      -InstallDir"
@@ -665,7 +740,8 @@ do
             echo "  --dry-run,-DryRun              Do not perform installation. Display download link."
             echo "  --no-path, -NoPath             Do not set PATH for the current process."
             echo "  --verbose,-Verbose             Display diagnostics information."
-            echo "  --azure-feed,-AzureFeed        Azure feed location. Defaults to $azure_feed"
+            echo "  --azure-feed,-AzureFeed        Azure feed location. Defaults to $azure_feed, This parameter typically is not changed by the user."
+            echo "  --uncached-feed,-UncachedFeed  Uncached feed location. This parameter typically is not changed by the user."
             echo "  --runtime-id                   Installs the .NET Tools for the given platform (use linux-x64 for portable linux)."
             echo "      -RuntimeId"
             echo "  -?,--?,-h,--help,-Help         Shows this help message"
@@ -690,6 +766,7 @@ check_min_reqs
 calculate_vars
 if [ "$dry_run" = true ]; then
     say "Payload URL: $download_link"
+    say "Alternate payload URL: $alt_download_link"
     say "Repeatable invocation: ./$(basename $0) --version $specific_version --channel $channel --install-dir $install_dir"
     exit 0
 fi
@@ -699,7 +776,7 @@ install_dotnet
 
 bin_path=$(get_absolute_path $(combine_paths $install_root $bin_folder_relative_path))
 if [ "$no_path" = false ]; then
-    say "Adding to current process PATH: ``$bin_path``. Note: This change will be visible only when sourcing script."
+    say "Adding to current process PATH: \`$bin_path\`. Note: This change will be visible only when sourcing script."
     export PATH=$bin_path:$PATH
 else
     say "Binaries of dotnet can be found in $bin_path"


### PR DESCRIPTION
The URLs for pulling down .NET Core installs changed for 2.1. This is PR is preparation for that.

NOTE: This is not strictly necessary right now, but will become necessary to get PR #1554 to pass CI once the CLI issues are fixed.