### PR TITLE
Fix race in BufferSegment and MemoryPoolBlock

### DIFF
--- a/src/System.Buffers.Primitives/System/Buffers/OwnedBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/OwnedBuffer.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Runtime;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace System.Buffers
@@ -41,7 +39,7 @@ namespace System.Buffers
         {
             get
             {
-                return _referenceCount > 0
+                return Volatile.Read(ref _referenceCount) > 0
                         || (ReferenceCountingSettings.OwnedMemory == ReferenceCountingMethod.ReferenceCounter
                             && ReferenceCounter.HasReference(this));
             }
@@ -54,13 +52,13 @@ namespace System.Buffers
 
         public void Release()
         {
-            if(Interlocked.Decrement(ref _referenceCount) == 0)
+            if (Interlocked.Decrement(ref _referenceCount) == 0)
                 OnZeroReferences();
         }
 
         protected virtual void OnZeroReferences()
         { }
-        
+
         public virtual BufferHandle Pin(int index = 0)
         {
             return BufferHandle.Create(this, index);

--- a/src/System.IO.Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/BufferSegment.cs
@@ -91,11 +91,6 @@ namespace System.IO.Pipelines
             Debug.Assert(_owned.HasOutstandingReferences);
 
             _owned.Release();
-
-            if (!_owned.HasOutstandingReferences)
-            {
-                _owned.Dispose();
-            }
         }
 
 

--- a/src/System.IO.Pipelines/MemoryPool.cs
+++ b/src/System.IO.Pipelines/MemoryPool.cs
@@ -109,7 +109,6 @@ namespace System.IO.Pipelines
                 block.Leaser = Environment.StackTrace;
                 block.IsLeased = true;
 #endif
-                block.Initialize();
                 return block;
             }
             // no blocks available - grow the pool

--- a/src/System.IO.Pipelines/MemoryPoolBlock.cs
+++ b/src/System.IO.Pipelines/MemoryPoolBlock.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.Text;
+using System.Diagnostics;
 
 namespace System.IO.Pipelines
 {
@@ -81,7 +82,6 @@ namespace System.IO.Pipelines
 
         /// <summary>
         /// ToString overridden for debugger convenience. This displays the "active" byte information in this block as ASCII characters.
-        /// ToString overridden for debugger convenience. This displays the byte information in this block as ASCII characters.
         /// </summary>
         /// <returns></returns>
         public override string ToString()
@@ -91,17 +91,8 @@ namespace System.IO.Pipelines
             return builder.ToString();
         }
 
-        internal void Initialize()
+        protected override void OnZeroReferences()
         {
-            // This is VERY bad, but is required while there is no re-initialization support
-            base.Dispose(false);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            // Dispose before returning to pool to prevent race between Lease and Dispose
-            base.Dispose(disposing);
-
             Pool.Return(this);
         }
 

--- a/src/System.IO.Pipelines/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/System.IO.Pipelines.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>An abstraction for doing efficient asynchronous IO</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>
     <!--<DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);OPERATION_LOCATION_TRACKING;COMPLETION_LOCATION_TRACKING</DefineConstants>-->

--- a/src/System.Text.Http.Parser/System.Text.Http.Parser.csproj
+++ b/src/System.Text.Http.Parser/System.Text.Http.Parser.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>HTTP Parser</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>HTTP Parser</PackageTags>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>

--- a/tests/System.IO.Pipelines.Tests/PipeCompletionCallbacksTests.cs
+++ b/tests/System.IO.Pipelines.Tests/PipeCompletionCallbacksTests.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace System.IO.Pipelines.Tests
 {
-    public class PipeCompletionCallbacksTests
+    public class PipeCompletionCallbacksTests : IDisposable
     {
         private readonly PipeFactory _pipeFactory;
 
@@ -415,8 +415,8 @@ namespace System.IO.Pipelines.Tests
 
             pipe.Writer.OnReaderCompleted((exception, state) =>
             {
-                callbackRan = true;
                 Assert.False(continuationRan);
+                callbackRan = true;
             }, null);
 
             var buffer = pipe.Writer.Alloc(10);
@@ -431,6 +431,7 @@ namespace System.IO.Pipelines.Tests
             pipe.Reader.Complete();
 
             Assert.True(callbackRan);
+            pipe.Writer.Complete();
         }
 
         [Fact]

--- a/tests/System.IO.Pipelines.Tests/PipeResetTests.cs
+++ b/tests/System.IO.Pipelines.Tests/PipeResetTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.IO.Pipelines.Tests
 {
-    public class PipeResetTests
+    public class PipeResetTests : IDisposable
     {
         private PipeFactory _pipeFactory;
 

--- a/tests/System.IO.Pipelines.Tests/PipeTest.cs
+++ b/tests/System.IO.Pipelines.Tests/PipeTest.cs
@@ -3,7 +3,7 @@
 
 namespace System.IO.Pipelines.Tests
 {
-    public class PipeTest: IDisposable
+    public abstract class PipeTest : IDisposable
     {
         protected const int MaximumSizeHigh = 65;
 

--- a/tests/System.IO.Pipelines.Tests/UnownedBufferReaderFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/UnownedBufferReaderFacts.cs
@@ -288,7 +288,7 @@ namespace System.IO.Pipelines.Tests
             EnsureSpanDisposed(data);
         }
 
-        [Fact]
+        [Fact(Skip = "OwnedArray<T>.OnZeroReferences() does not dispose itself.")]
         public async Task PreservingUnownedBufferCopies()
         {
             var stream = new CallbackStream(async (s, token) =>
@@ -315,7 +315,7 @@ namespace System.IO.Pipelines.Tests
 
                 preserved = buffer.Preserve();
 
-                // Make sure we can acccess the span
+                // Make sure we can access the span
                 EnsureSpanValid(buffer.First);
 
                 reader.Advance(buffer.End);

--- a/tests/System.IO.Pipelines.Tests/UnownedBufferReaderFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/UnownedBufferReaderFacts.cs
@@ -288,7 +288,7 @@ namespace System.IO.Pipelines.Tests
             EnsureSpanDisposed(data);
         }
 
-        [Fact(Skip = "OwnedArray<T>.OnZeroReferences() does not dispose itself.")]
+        [Fact]
         public async Task PreservingUnownedBufferCopies()
         {
             var stream = new CallbackStream(async (s, token) =>
@@ -299,34 +299,28 @@ namespace System.IO.Pipelines.Tests
             });
 
             var reader = stream.AsPipelineReader();
+            var result = await reader.ReadAsync();
+            var buffer = result.Buffer;
+            var preserved = buffer.Preserve();
 
-            var preserved = default(PreservedBuffer);
+            // Make sure we can access the span
+            EnsureSpanValid(buffer.First);
+            Assert.True(buffer.First.Length > 0);
+            buffer.First.Span[0] = (byte)'J';
+            Assert.Equal("Jello ", Encoding.UTF8.GetString(buffer.ToArray()));
 
-            while (true)
-            {
-                var result = await reader.ReadAsync();
-                var buffer = result.Buffer;
+            reader.Advance(buffer.End);
 
-                if (buffer.IsEmpty && result.IsCompleted)
-                {
-                    // Done
-                    break;
-                }
-
-                preserved = buffer.Preserve();
-
-                // Make sure we can access the span
-                EnsureSpanValid(buffer.First);
-
-                reader.Advance(buffer.End);
-            }
+            result = await reader.ReadAsync();
+            Assert.True(result.IsCompleted);
 
             using (preserved)
             {
+                // Preserved was copied, so it still contains "Hello " instead of "Jello ".
                 Assert.Equal("Hello ", Encoding.UTF8.GetString(preserved.Buffer.ToArray()));
             }
 
-            EnsureSpanDisposed(preserved.Buffer.First);
+            // There is currently no way to verify that OwnedArray<byte> is fully released.
         }
 
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]


### PR DESCRIPTION
- Assert MemoryPoolBlocks don't get finalized in all debug builds

I found this issue when enabling BLOCK_LEASE_TRACKING and running Kestrel's functional test project.