### PR TITLE
Adding Buffer<T> constructors that takes an array

### DIFF
--- a/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
@@ -26,36 +26,17 @@ namespace System.Buffers
             _length = length;
         }
 
-        public Buffer(T[] array)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Buffer(T[] array) : this (array, 0, array.Length)
         {
-            if (array == null)
-                BufferPrimitivesThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-            if (default(T) == null && array.GetType() != typeof(T[]))
-                BufferPrimitivesThrowHelper.ThrowArrayTypeMismatchException(typeof(T));
-
-            _array = array;
-            _owner = null;
-            _index = 0;
-            _length = array.Length;
         }
 
-        public Buffer(T[] array, int start)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Buffer(T[] array, int start) : this(array, start, array.Length - start)
         {
-            if (array == null)
-                BufferPrimitivesThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-            if (default(T) == null && array.GetType() != typeof(T[]))
-                BufferPrimitivesThrowHelper.ThrowArrayTypeMismatchException(typeof(T));
-
-            int arrayLength = array.Length;
-            if ((uint)start > (uint)arrayLength)
-                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-
-            _array = array;
-            _owner = null;
-            _index = start;
-            _length = arrayLength - start;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Buffer(T[] array, int start, int length)
         {
             if (array == null)

--- a/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
@@ -26,11 +26,48 @@ namespace System.Buffers
             _length = length;
         }
 
-        internal Buffer(T[] array, int index, int length)
+        public Buffer(T[] array)
         {
+            if (array == null)
+                BufferPrimitivesThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            if (default(T) == null && array.GetType() != typeof(T[]))
+                BufferPrimitivesThrowHelper.ThrowArrayTypeMismatchException(typeof(T));
+
             _array = array;
             _owner = null;
-            _index = index;
+            _index = 0;
+            _length = array.Length;
+        }
+
+        public Buffer(T[] array, int start)
+        {
+            if (array == null)
+                BufferPrimitivesThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            if (default(T) == null && array.GetType() != typeof(T[]))
+                BufferPrimitivesThrowHelper.ThrowArrayTypeMismatchException(typeof(T));
+
+            int arrayLength = array.Length;
+            if ((uint)start > (uint)arrayLength)
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            _array = array;
+            _owner = null;
+            _index = start;
+            _length = arrayLength - start;
+        }
+
+        public Buffer(T[] array, int start, int length)
+        {
+            if (array == null)
+                BufferPrimitivesThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            if (default(T) == null && array.GetType() != typeof(T[]))
+                BufferPrimitivesThrowHelper.ThrowArrayTypeMismatchException(typeof(T));
+            if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            _array = array;
+            _owner = null;
+            _index = start;
             _length = length;
         }
 

--- a/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
@@ -101,15 +101,21 @@ namespace System.Buffers
         public bool IsEmpty => Length == 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Buffer<T> Slice(int index)
+        public Buffer<T> Slice(int start)
         {
-            return new Buffer<T>(_owner, _array, _index + index, _length - index);
+            if ((uint)start > (uint)_length)
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            return new Buffer<T>(_owner, _array, _index + start, _length - start);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Buffer<T> Slice(int index, int length)
+        public Buffer<T> Slice(int start, int length)
         {
-            return new Buffer<T>(_owner, _array, _index + index, length);
+            if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            return new Buffer<T>(_owner, _array, _index + start, length);
         }
 
         public Span<T> Span

--- a/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
@@ -27,13 +27,35 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Buffer(T[] array) : this (array, 0, array.Length)
+        public Buffer(T[] array)
         {
+            if (array == null)
+                BufferPrimitivesThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            if (default(T) == null && array.GetType() != typeof(T[]))
+                BufferPrimitivesThrowHelper.ThrowArrayTypeMismatchException(typeof(T));
+
+            _array = array;
+            _owner = null;
+            _index = 0;
+            _length = array.Length;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Buffer(T[] array, int start) : this(array, start, array.Length - start)
+        public Buffer(T[] array, int start)
         {
+            if (array == null)
+                BufferPrimitivesThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            if (default(T) == null && array.GetType() != typeof(T[]))
+                BufferPrimitivesThrowHelper.ThrowArrayTypeMismatchException(typeof(T));
+
+            int arrayLength = array.Length;
+            if ((uint)start > (uint)arrayLength)
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            _array = array;
+            _owner = null;
+            _index = start;
+            _length = arrayLength - start;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -63,7 +85,7 @@ namespace System.Buffers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator ReadOnlyBuffer<T>(Buffer<T> buffer)
         {
-            return new ReadOnlyBuffer<T>(buffer._owner, buffer._index, buffer._length);
+            return new ReadOnlyBuffer<T>(buffer._owner, buffer._array, buffer._index, buffer._length);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -26,11 +26,42 @@ namespace System.Buffers
             _length = length;
         }
 
-        internal ReadOnlyBuffer(T[] array, int index, int length)
+        public ReadOnlyBuffer(T[] array)
         {
+            if (array == null)
+                BufferPrimitivesThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+
             _array = array;
             _owner = null;
-            _index = index;
+            _index = 0;
+            _length = array.Length;
+        }
+
+        public ReadOnlyBuffer(T[] array, int start)
+        {
+            if (array == null)
+                BufferPrimitivesThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+
+            int arrayLength = array.Length;
+            if ((uint)start > (uint)arrayLength)
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            _array = array;
+            _owner = null;
+            _index = start;
+            _length = arrayLength - start;
+        }
+
+        public ReadOnlyBuffer(T[] array, int start, int length)
+        {
+            if (array == null)
+                BufferPrimitivesThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            _array = array;
+            _owner = null;
+            _index = start;
             _length = length;
         }
 

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -26,32 +26,17 @@ namespace System.Buffers
             _length = length;
         }
 
-        public ReadOnlyBuffer(T[] array)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ReadOnlyBuffer(T[] array) : this(array, 0, array.Length)
         {
-            if (array == null)
-                BufferPrimitivesThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-
-            _array = array;
-            _owner = null;
-            _index = 0;
-            _length = array.Length;
         }
 
-        public ReadOnlyBuffer(T[] array, int start)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ReadOnlyBuffer(T[] array, int start) : this(array, start, array.Length - start)
         {
-            if (array == null)
-                BufferPrimitivesThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
-
-            int arrayLength = array.Length;
-            if ((uint)start > (uint)arrayLength)
-                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-
-            _array = array;
-            _owner = null;
-            _index = start;
-            _length = arrayLength - start;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlyBuffer(T[] array, int start, int length)
         {
             if (array == null)

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -89,15 +89,21 @@ namespace System.Buffers
         public bool IsEmpty => Length == 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ReadOnlyBuffer<T> Slice(int index)
+        public ReadOnlyBuffer<T> Slice(int start)
         {
-            return new ReadOnlyBuffer<T>(_owner, _array, _index + index, _length - index);
+            if ((uint)start > (uint)_length)
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            return new ReadOnlyBuffer<T>(_owner, _array, _index + start, _length - start);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ReadOnlyBuffer<T> Slice(int index, int length)
+        public ReadOnlyBuffer<T> Slice(int start, int length)
         {
-            return new ReadOnlyBuffer<T>(_owner, _array, _index + index, length);
+            if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            return new ReadOnlyBuffer<T>(_owner, _array, _index + start, length);
         }
 
         public ReadOnlySpan<T> Span

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -27,13 +27,31 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ReadOnlyBuffer(T[] array) : this(array, 0, array.Length)
+        public ReadOnlyBuffer(T[] array)
         {
+            if (array == null)
+                BufferPrimitivesThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+
+            _array = array;
+            _owner = null;
+            _index = 0;
+            _length = array.Length;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ReadOnlyBuffer(T[] array, int start) : this(array, start, array.Length - start)
+        public ReadOnlyBuffer(T[] array, int start)
         {
+            if (array == null)
+                BufferPrimitivesThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+
+            int arrayLength = array.Length;
+            if ((uint)start > (uint)arrayLength)
+                BufferPrimitivesThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
+
+            _array = array;
+            _owner = null;
+            _index = start;
+            _length = arrayLength - start;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -50,7 +68,7 @@ namespace System.Buffers
             _length = length;
         }
 
-        private ReadOnlyBuffer(OwnedBuffer<T> owner, T[] array, int index, int length)
+        internal ReadOnlyBuffer(OwnedBuffer<T> owner, T[] array, int index, int length)
         {
             _array = array;
             _owner = owner;

--- a/src/System.Buffers.Primitives/System/Runtime/BufferPrimitivesThrowHelper.cs
+++ b/src/System.Buffers.Primitives/System/Runtime/BufferPrimitivesThrowHelper.cs
@@ -54,6 +54,11 @@ namespace System.Runtime
             throw GetObjectDisposedException(objectName);
         }
 
+        public static void ThrowArrayTypeMismatchException(Type type)
+        {
+            throw CreateArrayTypeMismatchException(type);
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static ArgumentNullException GetArgumentNullException(ExceptionArgument argument)
         {
@@ -102,6 +107,12 @@ namespace System.Runtime
             return new ObjectDisposedException(objectName);
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArrayTypeMismatchException CreateArrayTypeMismatchException(Type type)
+        {
+            return new ArrayTypeMismatchException(type.ToString());
+        }
+
         private static string GetArgumentName(ExceptionArgument argument)
         {
             Debug.Assert(Enum.IsDefined(typeof(ExceptionArgument), argument),
@@ -114,6 +125,7 @@ namespace System.Runtime
     internal enum ExceptionArgument
     {
         pointer,
-        array
+        array,
+        start
     }
 }

--- a/tests/System.Buffers.Primitives.Tests/BasicUnitTests.cs
+++ b/tests/System.Buffers.Primitives.Tests/BasicUnitTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace System.Buffers.Tests
 {
-    public class SlicesTests
+    public class BasicUnitTests
     {
         [Fact]
         public void ByteSpanEmptyCreateArrayTest()

--- a/tests/System.Buffers.Primitives.Tests/CtorArray.cs
+++ b/tests/System.Buffers.Primitives.Tests/CtorArray.cs
@@ -1,0 +1,216 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Xunit;
+
+namespace System.Buffers.Tests
+{
+    public class CtorArray
+    {
+        [Fact]
+        public static void CtorArray1()
+        {
+            int[] a = { 91, 92, -93, 94 };
+            Buffer<int> buffer;
+
+            buffer = new Buffer<int>(a);
+            TestHelpers.Validate(buffer, 91, 92, -93, 94);
+
+            buffer = new Buffer<int>(a, 0);
+            TestHelpers.Validate(buffer, 91, 92, -93, 94);
+
+            buffer = new Buffer<int>(a, 0, a.Length);
+            TestHelpers.Validate(buffer, 91, 92, -93, 94);
+        }
+
+        [Fact]
+        public static void CtorArray2()
+        {
+            long[] a = { 91, -92, 93, 94, -95 };
+            Buffer<long> buffer;
+
+            buffer = new Buffer<long>(a);
+            TestHelpers.Validate(buffer, 91, -92, 93, 94, -95);
+
+            buffer = new Buffer<long>(a, 0);
+            TestHelpers.Validate(buffer, 91, -92, 93, 94, -95);
+
+            buffer = new Buffer<long>(a, 0, a.Length);
+            TestHelpers.Validate(buffer, 91, -92, 93, 94, -95);
+        }
+
+        [Fact]
+        public static void CtorArray3()
+        {
+            object o1 = new object();
+            object o2 = new object();
+            object[] a = { o1, o2 };
+            Buffer<object> buffer;
+
+            buffer = new Buffer<object>(a);
+            TestHelpers.Validate(buffer, o1, o2);
+
+            buffer = new Buffer<object>(a, 0);
+            TestHelpers.Validate(buffer, o1, o2);
+
+            buffer = new Buffer<object>(a, 0, a.Length);
+            TestHelpers.Validate(buffer, o1, o2);
+        }
+
+        [Fact]
+        public static void CtorArrayZeroLength()
+        {
+            int[] empty = Array.Empty<int>();
+            Buffer<int> buffer;
+
+            buffer = new Buffer<int>(empty);
+            TestHelpers.Validate(buffer);
+
+            buffer = new Buffer<int>(empty, 0);
+            TestHelpers.Validate(buffer);
+
+            buffer = new Buffer<int>(empty, 0, empty.Length);
+            TestHelpers.Validate(buffer);
+        }
+
+        [Fact]
+        public static void CtorArrayNullArray()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Buffer<int>(null));
+            Assert.Throws<ArgumentNullException>(() => new Buffer<int>(null, 0));
+            Assert.Throws<ArgumentNullException>(() => new Buffer<int>(null, 0, 0));
+        }
+
+        [Fact]
+        public static void CtorArrayWrongArrayType()
+        {
+            // Cannot pass variant array, if array type is not a valuetype.
+            string[] a = { "Hello" };
+            Assert.Throws<ArrayTypeMismatchException>(() => new Buffer<object>(a));
+            Assert.Throws<ArrayTypeMismatchException>(() => new Buffer<object>(a, 0));
+            Assert.Throws<ArrayTypeMismatchException>(() => new Buffer<object>(a, 0, a.Length));
+        }
+
+        [Fact]
+        public static void CtorArrayWrongValueType()
+        {
+            // Can pass variant array, if array type is a valuetype.
+
+            uint[] a = { 42u, 0xffffffffu };
+            int[] aAsIntArray = (int[])(object)a;
+            Buffer<int> buffer;
+
+            buffer = new Buffer<int>(aAsIntArray);
+            TestHelpers.Validate(buffer, 42, -1);
+
+            buffer = new Buffer<int>(aAsIntArray, 0);
+            TestHelpers.Validate(buffer, 42, -1);
+
+            buffer = new Buffer<int>(aAsIntArray, 0, aAsIntArray.Length);
+            TestHelpers.Validate(buffer, 42, -1);
+        }
+
+        [Fact]
+        public static void CtorArrayInt1()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
+            var buffer = new Buffer<int>(a, 3);
+            TestHelpers.Validate(buffer, 93, 94, 95, 96, 97, 98);
+        }
+
+        [Fact]
+        public static void CtorArrayInt2()
+        {
+            long[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
+            var buffer = new Buffer<long>(a, 3);
+            TestHelpers.Validate(buffer, 93, 94, 95, 96, 97, 98);
+        }
+
+        [Fact]
+        public static void CtorArrayIntNegativeStart()
+        {
+            int[] a = new int[3];
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, -1));
+        }
+
+        [Fact]
+        public static void CtorArrayIntStartTooLarge()
+        {
+            int[] a = new int[3];
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, 4));
+        }
+
+        [Fact]
+        public static void CtorArrayIntStartEqualsLength()
+        {
+            // Valid for start to equal the array length. This returns an empty buffer that starts "just past the array."
+            int[] a = { 91, 92, 93 };
+            var buffer = new Buffer<int>(a, 3);
+            TestHelpers.Validate(buffer);
+        }
+
+        [Fact]
+        public static void CtorArrayIntInt1()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
+            var buffer = new Buffer<int>(a, 3, 2);
+            TestHelpers.Validate(buffer, 93, 94);
+        }
+
+        [Fact]
+        public static void CtorArrayIntInt2()
+        {
+            long[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
+            var buffer = new Buffer<long>(a, 4, 3);
+            TestHelpers.Validate(buffer, 94, 95, 96);
+        }
+
+        [Fact]
+        public static void CtorArrayIntIntRangeExtendsToEndOfArray()
+        {
+            long[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
+            var buffer = new Buffer<long>(a, 4, 5);
+            TestHelpers.Validate(buffer, 94, 95, 96, 97, 98);
+        }
+
+        [Fact]
+        public static void CtorArrayIntIntNegativeStart()
+        {
+            int[] a = new int[3];
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, -1, 0));
+        }
+
+        [Fact]
+        public static void CtorArrayIntIntStartTooLarge()
+        {
+            int[] a = new int[3];
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, 4, 0));
+        }
+
+        [Fact]
+        public static void CtorArrayIntIntNegativeLength()
+        {
+            int[] a = new int[3];
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, 0, -1));
+        }
+
+        [Fact]
+        public static void CtorArrayIntIntStartAndLengthTooLarge()
+        {
+            int[] a = new int[3];
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, 3, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, 2, 2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, 1, 3));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, 0, 4));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, int.MaxValue, int.MaxValue));
+        }
+
+        [Fact]
+        public static void CtorArrayIntIntStartEqualsLength()
+        {
+            // Valid for start to equal the array length. This returns an empty buffer that starts "just past the array."
+            int[] a = { 91, 92, 93 };
+            var buffer = new Buffer<int>(a, 3, 0);
+            TestHelpers.Validate(buffer);
+        }
+    }
+}

--- a/tests/System.Buffers.Primitives.Tests/CtorArray.cs
+++ b/tests/System.Buffers.Primitives.Tests/CtorArray.cs
@@ -7,39 +7,39 @@ namespace System.Buffers.Tests
     public class CtorArray
     {
         [Fact]
-        public static void CtorArray1()
+        public static void CtorArrayInt()
         {
             int[] a = { 91, 92, -93, 94 };
             Buffer<int> buffer;
 
             buffer = new Buffer<int>(a);
-            TestHelpers.Validate(buffer, 91, 92, -93, 94);
+            TestHelpers.SequenceEqualValueType(buffer, 91, 92, -93, 94);
 
             buffer = new Buffer<int>(a, 0);
-            TestHelpers.Validate(buffer, 91, 92, -93, 94);
+            TestHelpers.SequenceEqualValueType(buffer, 91, 92, -93, 94);
 
             buffer = new Buffer<int>(a, 0, a.Length);
-            TestHelpers.Validate(buffer, 91, 92, -93, 94);
+            TestHelpers.SequenceEqualValueType(buffer, 91, 92, -93, 94);
         }
 
         [Fact]
-        public static void CtorArray2()
+        public static void CtorArrayLong()
         {
             long[] a = { 91, -92, 93, 94, -95 };
             Buffer<long> buffer;
 
             buffer = new Buffer<long>(a);
-            TestHelpers.Validate(buffer, 91, -92, 93, 94, -95);
+            TestHelpers.SequenceEqualValueType<long>(buffer, 91, -92, 93, 94, -95);
 
             buffer = new Buffer<long>(a, 0);
-            TestHelpers.Validate(buffer, 91, -92, 93, 94, -95);
+            TestHelpers.SequenceEqualValueType<long>(buffer, 91, -92, 93, 94, -95);
 
             buffer = new Buffer<long>(a, 0, a.Length);
-            TestHelpers.Validate(buffer, 91, -92, 93, 94, -95);
+            TestHelpers.SequenceEqualValueType<long>(buffer, 91, -92, 93, 94, -95);
         }
 
         [Fact]
-        public static void CtorArray3()
+        public static void CtorArrayObject()
         {
             object o1 = new object();
             object o2 = new object();
@@ -47,13 +47,13 @@ namespace System.Buffers.Tests
             Buffer<object> buffer;
 
             buffer = new Buffer<object>(a);
-            TestHelpers.Validate(buffer, o1, o2);
+            TestHelpers.SequenceEqual(buffer, o1, o2);
 
             buffer = new Buffer<object>(a, 0);
-            TestHelpers.Validate(buffer, o1, o2);
+            TestHelpers.SequenceEqual(buffer, o1, o2);
 
             buffer = new Buffer<object>(a, 0, a.Length);
-            TestHelpers.Validate(buffer, o1, o2);
+            TestHelpers.SequenceEqual(buffer, o1, o2);
         }
 
         [Fact]
@@ -63,13 +63,13 @@ namespace System.Buffers.Tests
             Buffer<int> buffer;
 
             buffer = new Buffer<int>(empty);
-            TestHelpers.Validate(buffer);
+            TestHelpers.SequenceEqualValueType<int>(buffer);
 
             buffer = new Buffer<int>(empty, 0);
-            TestHelpers.Validate(buffer);
+            TestHelpers.SequenceEqualValueType<int>(buffer);
 
             buffer = new Buffer<int>(empty, 0, empty.Length);
-            TestHelpers.Validate(buffer);
+            TestHelpers.SequenceEqualValueType<int>(buffer);
         }
 
         [Fact]
@@ -100,101 +100,101 @@ namespace System.Buffers.Tests
             Buffer<int> buffer;
 
             buffer = new Buffer<int>(aAsIntArray);
-            TestHelpers.Validate(buffer, 42, -1);
+            TestHelpers.SequenceEqualValueType(buffer, 42, -1);
 
             buffer = new Buffer<int>(aAsIntArray, 0);
-            TestHelpers.Validate(buffer, 42, -1);
+            TestHelpers.SequenceEqualValueType(buffer, 42, -1);
 
             buffer = new Buffer<int>(aAsIntArray, 0, aAsIntArray.Length);
-            TestHelpers.Validate(buffer, 42, -1);
+            TestHelpers.SequenceEqualValueType(buffer, 42, -1);
         }
 
         [Fact]
-        public static void CtorArrayInt1()
+        public static void CtorArrayWithStartInt()
         {
             int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
             var buffer = new Buffer<int>(a, 3);
-            TestHelpers.Validate(buffer, 93, 94, 95, 96, 97, 98);
+            TestHelpers.SequenceEqualValueType(buffer, 93, 94, 95, 96, 97, 98);
         }
 
         [Fact]
-        public static void CtorArrayInt2()
+        public static void CtorArrayWithStartLong()
         {
             long[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
             var buffer = new Buffer<long>(a, 3);
-            TestHelpers.Validate(buffer, 93, 94, 95, 96, 97, 98);
+            TestHelpers.SequenceEqualValueType<long>(buffer, 93, 94, 95, 96, 97, 98);
         }
 
         [Fact]
-        public static void CtorArrayIntNegativeStart()
+        public static void CtorArrayWithNegativeStart()
         {
             int[] a = new int[3];
             Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, -1));
         }
 
         [Fact]
-        public static void CtorArrayIntStartTooLarge()
+        public static void CtorArrayWithStartTooLarge()
         {
             int[] a = new int[3];
             Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, 4));
         }
 
         [Fact]
-        public static void CtorArrayIntStartEqualsLength()
+        public static void CtorArrayWithStartEqualsLength()
         {
             // Valid for start to equal the array length. This returns an empty buffer that starts "just past the array."
             int[] a = { 91, 92, 93 };
             var buffer = new Buffer<int>(a, 3);
-            TestHelpers.Validate(buffer);
+            TestHelpers.SequenceEqualValueType<int>(buffer);
         }
 
         [Fact]
-        public static void CtorArrayIntInt1()
+        public static void CtorArrayWithStartAndLengthInt()
         {
             int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
             var buffer = new Buffer<int>(a, 3, 2);
-            TestHelpers.Validate(buffer, 93, 94);
+            TestHelpers.SequenceEqualValueType(buffer, 93, 94);
         }
 
         [Fact]
-        public static void CtorArrayIntInt2()
+        public static void CtorArrayWithStartAndLengthLong()
         {
             long[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
             var buffer = new Buffer<long>(a, 4, 3);
-            TestHelpers.Validate(buffer, 94, 95, 96);
+            TestHelpers.SequenceEqualValueType<long>(buffer, 94, 95, 96);
         }
 
         [Fact]
-        public static void CtorArrayIntIntRangeExtendsToEndOfArray()
+        public static void CtorArrayWithStartAndLengthRangeExtendsToEndOfArray()
         {
             long[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
             var buffer = new Buffer<long>(a, 4, 5);
-            TestHelpers.Validate(buffer, 94, 95, 96, 97, 98);
+            TestHelpers.SequenceEqualValueType<long>(buffer, 94, 95, 96, 97, 98);
         }
 
         [Fact]
-        public static void CtorArrayIntIntNegativeStart()
+        public static void CtorArrayWithNegativeStartAndLength()
         {
             int[] a = new int[3];
             Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, -1, 0));
         }
 
         [Fact]
-        public static void CtorArrayIntIntStartTooLarge()
+        public static void CtorArrayWithStartTooLargeAndLength()
         {
             int[] a = new int[3];
             Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, 4, 0));
         }
 
         [Fact]
-        public static void CtorArrayIntIntNegativeLength()
+        public static void CtorArrayWithStartAndNegativeLength()
         {
             int[] a = new int[3];
             Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, 0, -1));
         }
 
         [Fact]
-        public static void CtorArrayIntIntStartAndLengthTooLarge()
+        public static void CtorArrayWithStartAndLengthTooLarge()
         {
             int[] a = new int[3];
             Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a, 3, 1));
@@ -205,12 +205,12 @@ namespace System.Buffers.Tests
         }
 
         [Fact]
-        public static void CtorArrayIntIntStartEqualsLength()
+        public static void CtorArrayWithStartAndLengthBothEqual()
         {
             // Valid for start to equal the array length. This returns an empty buffer that starts "just past the array."
             int[] a = { 91, 92, 93 };
             var buffer = new Buffer<int>(a, 3, 0);
-            TestHelpers.Validate(buffer);
+            TestHelpers.SequenceEqualValueType<int>(buffer);
         }
     }
 }

--- a/tests/System.Buffers.Primitives.Tests/CtorArrayReadOnlyBuffer.cs
+++ b/tests/System.Buffers.Primitives.Tests/CtorArrayReadOnlyBuffer.cs
@@ -7,39 +7,39 @@ namespace System.Buffers.Tests
     public class CtorArrayReadOnlyBuffer
     {
         [Fact]
-        public static void CtorArray1()
+        public static void CtorArrayInt()
         {
             int[] a = { 91, 92, -93, 94 };
             ReadOnlyBuffer<int> buffer;
 
             buffer = new ReadOnlyBuffer<int>(a);
-            TestHelpers.Validate(buffer, 91, 92, -93, 94);
+            TestHelpers.SequenceEqualValueType(buffer, 91, 92, -93, 94);
 
             buffer = new ReadOnlyBuffer<int>(a, 0);
-            TestHelpers.Validate(buffer, 91, 92, -93, 94);
+            TestHelpers.SequenceEqualValueType(buffer, 91, 92, -93, 94);
 
             buffer = new ReadOnlyBuffer<int>(a, 0, a.Length);
-            TestHelpers.Validate(buffer, 91, 92, -93, 94);
+            TestHelpers.SequenceEqualValueType(buffer, 91, 92, -93, 94);
         }
 
         [Fact]
-        public static void CtorArray2()
+        public static void CtorArrayLong()
         {
             long[] a = { 91, -92, 93, 94, -95 };
             ReadOnlyBuffer<long> buffer;
 
             buffer = new ReadOnlyBuffer<long>(a);
-            TestHelpers.Validate(buffer, 91, -92, 93, 94, -95);
+            TestHelpers.SequenceEqualValueType(buffer, 91, -92, 93, 94, -95);
 
             buffer = new ReadOnlyBuffer<long>(a, 0);
-            TestHelpers.Validate(buffer, 91, -92, 93, 94, -95);
+            TestHelpers.SequenceEqualValueType(buffer, 91, -92, 93, 94, -95);
 
             buffer = new ReadOnlyBuffer<long>(a, 0, a.Length);
-            TestHelpers.Validate(buffer, 91, -92, 93, 94, -95);
+            TestHelpers.SequenceEqualValueType(buffer, 91, -92, 93, 94, -95);
         }
 
         [Fact]
-        public static void CtorArray3()
+        public static void CtorArrayObject()
         {
             object o1 = new object();
             object o2 = new object();
@@ -47,13 +47,13 @@ namespace System.Buffers.Tests
             ReadOnlyBuffer<object> buffer;
 
             buffer = new ReadOnlyBuffer<object>(a);
-            TestHelpers.Validate(buffer, o1, o2);
+            TestHelpers.SequenceEqual(buffer, o1, o2);
 
             buffer = new ReadOnlyBuffer<object>(a, 0);
-            TestHelpers.Validate(buffer, o1, o2);
+            TestHelpers.SequenceEqual(buffer, o1, o2);
 
             buffer = new ReadOnlyBuffer<object>(a, 0, a.Length);
-            TestHelpers.Validate(buffer, o1, o2);
+            TestHelpers.SequenceEqual(buffer, o1, o2);
         }
 
         [Fact]
@@ -63,13 +63,13 @@ namespace System.Buffers.Tests
             ReadOnlyBuffer<int> buffer;
 
             buffer = new ReadOnlyBuffer<int>(empty);
-            TestHelpers.Validate(buffer);
+            TestHelpers.SequenceEqualValueType(buffer);
 
             buffer = new ReadOnlyBuffer<int>(empty, 0);
-            TestHelpers.Validate(buffer);
+            TestHelpers.SequenceEqualValueType(buffer);
 
             buffer = new ReadOnlyBuffer<int>(empty, 0, empty.Length);
-            TestHelpers.Validate(buffer);
+            TestHelpers.SequenceEqualValueType(buffer);
         }
 
         [Fact]
@@ -90,13 +90,13 @@ namespace System.Buffers.Tests
             ReadOnlyBuffer<int> buffer;
 
             buffer = new ReadOnlyBuffer<int>(aAsIntArray);
-            TestHelpers.Validate(buffer, 42, -1);
+            TestHelpers.SequenceEqualValueType(buffer, 42, -1);
 
             buffer = new ReadOnlyBuffer<int>(aAsIntArray, 0);
-            TestHelpers.Validate(buffer, 42, -1);
+            TestHelpers.SequenceEqualValueType(buffer, 42, -1);
 
             buffer = new ReadOnlyBuffer<int>(aAsIntArray, 0, aAsIntArray.Length);
-            TestHelpers.Validate(buffer, 42, -1);
+            TestHelpers.SequenceEqualValueType(buffer, 42, -1);
         }
 
         [Fact]
@@ -109,109 +109,109 @@ namespace System.Buffers.Tests
 
             string[] strArray = { "Hello" };
             buffer = new ReadOnlyBuffer<object>(strArray);
-            TestHelpers.Validate(buffer, "Hello");
+            TestHelpers.SequenceEqual(buffer, "Hello");
             buffer = new ReadOnlyBuffer<object>(strArray, 0);
-            TestHelpers.Validate(buffer, "Hello");
+            TestHelpers.SequenceEqual(buffer, "Hello");
             buffer = new ReadOnlyBuffer<object>(strArray, 0, strArray.Length);
-            TestHelpers.Validate(buffer, "Hello");
+            TestHelpers.SequenceEqual(buffer, "Hello");
 
             TestHelpers.TestClass c1 = new TestHelpers.TestClass();
             TestHelpers.TestClass c2 = new TestHelpers.TestClass();
             TestHelpers.TestClass[] clsArray = { c1, c2 };
             buffer = new ReadOnlyBuffer<object>(clsArray);
-            TestHelpers.Validate(buffer, c1, c2);
+            TestHelpers.SequenceEqual(buffer, c1, c2);
             buffer = new ReadOnlyBuffer<object>(clsArray, 0);
-            TestHelpers.Validate(buffer, c1, c2);
+            TestHelpers.SequenceEqual(buffer, c1, c2);
             buffer = new ReadOnlyBuffer<object>(clsArray, 0, clsArray.Length);
-            TestHelpers.Validate(buffer, c1, c2);
+            TestHelpers.SequenceEqual(buffer, c1, c2);
         }
 
         [Fact]
-        public static void CtorArrayInt1()
+        public static void CtorArrayWithStartInt()
         {
             int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
             var buffer = new ReadOnlyBuffer<int>(a, 3);
-            TestHelpers.Validate(buffer, 93, 94, 95, 96, 97, 98);
+            TestHelpers.SequenceEqualValueType(buffer, 93, 94, 95, 96, 97, 98);
         }
 
         [Fact]
-        public static void CtorArrayInt2()
+        public static void CtorArrayWithStartLong()
         {
             long[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
             var buffer = new ReadOnlyBuffer<long>(a, 3);
-            TestHelpers.Validate(buffer, 93, 94, 95, 96, 97, 98);
+            TestHelpers.SequenceEqualValueType(buffer, 93, 94, 95, 96, 97, 98);
         }
 
         [Fact]
-        public static void CtorArrayIntNegativeStart()
+        public static void CtorArrayWithNegativeStart()
         {
             int[] a = new int[3];
             Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, -1));
         }
 
         [Fact]
-        public static void CtorArrayIntStartTooLarge()
+        public static void CtorArrayWithStartTooLarge()
         {
             int[] a = new int[3];
             Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, 4));
         }
 
         [Fact]
-        public static void CtorArrayIntStartEqualsLength()
+        public static void CtorArrayWithStartEqualsLength()
         {
             // Valid for start to equal the array length. This returns an empty buffer that starts "just past the array."
             int[] a = { 91, 92, 93 };
             var buffer = new ReadOnlyBuffer<int>(a, 3);
-            TestHelpers.Validate(buffer);
+            TestHelpers.SequenceEqualValueType(buffer);
         }
 
         [Fact]
-        public static void CtorArrayIntInt1()
+        public static void CtorArrayWithStartAndLengthInt()
         {
             int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
             var buffer = new ReadOnlyBuffer<int>(a, 3, 2);
-            TestHelpers.Validate(buffer, 93, 94);
+            TestHelpers.SequenceEqualValueType(buffer, 93, 94);
         }
 
         [Fact]
-        public static void CtorArrayIntInt2()
+        public static void CtorArrayWithStartAndLengthLong()
         {
             long[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
             var buffer = new ReadOnlyBuffer<long>(a, 4, 3);
-            TestHelpers.Validate(buffer, 94, 95, 96);
+            TestHelpers.SequenceEqualValueType(buffer, 94, 95, 96);
         }
 
         [Fact]
-        public static void CtorArrayIntIntRangeExtendsToEndOfArray()
+        public static void CtorArrayWithStartAndLengthRangeExtendsToEndOfArray()
         {
             long[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
             var buffer = new ReadOnlyBuffer<long>(a, 4, 5);
-            TestHelpers.Validate(buffer, 94, 95, 96, 97, 98);
+            TestHelpers.SequenceEqualValueType(buffer, 94, 95, 96, 97, 98);
         }
 
         [Fact]
-        public static void CtorArrayIntIntNegativeStart()
+        public static void CtorArrayWithNegativeStartAndLength()
         {
             int[] a = new int[3];
             Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, -1, 0));
         }
 
         [Fact]
-        public static void CtorArrayIntIntStartTooLarge()
+        public static void CtorArrayWithStartTooLargeAndLength()
         {
             int[] a = new int[3];
             Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, 4, 0));
         }
 
         [Fact]
-        public static void CtorArrayIntIntNegativeLength()
+        public static void CtorArrayWithStartAndNegativeLength()
         {
             int[] a = new int[3];
             Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, 0, -1));
         }
 
         [Fact]
-        public static void CtorArrayIntIntStartAndLengthTooLarge()
+        public static void CtorArrayWithStartAndLengthTooLarge()
         {
             int[] a = new int[3];
             Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, 3, 1));
@@ -222,12 +222,12 @@ namespace System.Buffers.Tests
         }
 
         [Fact]
-        public static void CtorArrayIntIntStartEqualsLength()
+        public static void CtorArrayWithStartAndLengthBothEqual()
         {
             // Valid for start to equal the array length. This returns an empty buffer that starts "just past the array."
             int[] a = { 91, 92, 93 };
             var buffer = new ReadOnlyBuffer<int>(a, 3, 0);
-            TestHelpers.Validate(buffer);
+            TestHelpers.SequenceEqualValueType(buffer);
         }
     }
 }

--- a/tests/System.Buffers.Primitives.Tests/CtorArrayReadOnlyBuffer.cs
+++ b/tests/System.Buffers.Primitives.Tests/CtorArrayReadOnlyBuffer.cs
@@ -1,0 +1,233 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Xunit;
+
+namespace System.Buffers.Tests
+{
+    public class CtorArrayReadOnlyBuffer
+    {
+        [Fact]
+        public static void CtorArray1()
+        {
+            int[] a = { 91, 92, -93, 94 };
+            ReadOnlyBuffer<int> buffer;
+
+            buffer = new ReadOnlyBuffer<int>(a);
+            TestHelpers.Validate(buffer, 91, 92, -93, 94);
+
+            buffer = new ReadOnlyBuffer<int>(a, 0);
+            TestHelpers.Validate(buffer, 91, 92, -93, 94);
+
+            buffer = new ReadOnlyBuffer<int>(a, 0, a.Length);
+            TestHelpers.Validate(buffer, 91, 92, -93, 94);
+        }
+
+        [Fact]
+        public static void CtorArray2()
+        {
+            long[] a = { 91, -92, 93, 94, -95 };
+            ReadOnlyBuffer<long> buffer;
+
+            buffer = new ReadOnlyBuffer<long>(a);
+            TestHelpers.Validate(buffer, 91, -92, 93, 94, -95);
+
+            buffer = new ReadOnlyBuffer<long>(a, 0);
+            TestHelpers.Validate(buffer, 91, -92, 93, 94, -95);
+
+            buffer = new ReadOnlyBuffer<long>(a, 0, a.Length);
+            TestHelpers.Validate(buffer, 91, -92, 93, 94, -95);
+        }
+
+        [Fact]
+        public static void CtorArray3()
+        {
+            object o1 = new object();
+            object o2 = new object();
+            object[] a = { o1, o2 };
+            ReadOnlyBuffer<object> buffer;
+
+            buffer = new ReadOnlyBuffer<object>(a);
+            TestHelpers.Validate(buffer, o1, o2);
+
+            buffer = new ReadOnlyBuffer<object>(a, 0);
+            TestHelpers.Validate(buffer, o1, o2);
+
+            buffer = new ReadOnlyBuffer<object>(a, 0, a.Length);
+            TestHelpers.Validate(buffer, o1, o2);
+        }
+
+        [Fact]
+        public static void CtorArrayZeroLength()
+        {
+            int[] empty = Array.Empty<int>();
+            ReadOnlyBuffer<int> buffer;
+
+            buffer = new ReadOnlyBuffer<int>(empty);
+            TestHelpers.Validate(buffer);
+
+            buffer = new ReadOnlyBuffer<int>(empty, 0);
+            TestHelpers.Validate(buffer);
+
+            buffer = new ReadOnlyBuffer<int>(empty, 0, empty.Length);
+            TestHelpers.Validate(buffer);
+        }
+
+        [Fact]
+        public static void CtorArrayNullArray()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ReadOnlyBuffer<int>(null));
+            Assert.Throws<ArgumentNullException>(() => new ReadOnlyBuffer<int>(null, 0));
+            Assert.Throws<ArgumentNullException>(() => new ReadOnlyBuffer<int>(null, 0, 0));
+        }
+
+        [Fact]
+        public static void CtorArrayWrongValueType()
+        {
+            // Can pass variant array, if array type is a valuetype.
+
+            uint[] a = { 42u, 0xffffffffu };
+            int[] aAsIntArray = (int[])(object)a;
+            ReadOnlyBuffer<int> buffer;
+
+            buffer = new ReadOnlyBuffer<int>(aAsIntArray);
+            TestHelpers.Validate(buffer, 42, -1);
+
+            buffer = new ReadOnlyBuffer<int>(aAsIntArray, 0);
+            TestHelpers.Validate(buffer, 42, -1);
+
+            buffer = new ReadOnlyBuffer<int>(aAsIntArray, 0, aAsIntArray.Length);
+            TestHelpers.Validate(buffer, 42, -1);
+        }
+
+        [Fact]
+        public static void CtorVariantArrayType()
+        {
+            // For ReadOnlyBuffer<T>, variant arrays are allowed for string to object
+            // and reference type to object.
+
+            ReadOnlyBuffer<object> buffer;
+
+            string[] strArray = { "Hello" };
+            buffer = new ReadOnlyBuffer<object>(strArray);
+            TestHelpers.Validate(buffer, "Hello");
+            buffer = new ReadOnlyBuffer<object>(strArray, 0);
+            TestHelpers.Validate(buffer, "Hello");
+            buffer = new ReadOnlyBuffer<object>(strArray, 0, strArray.Length);
+            TestHelpers.Validate(buffer, "Hello");
+
+            TestHelpers.TestClass c1 = new TestHelpers.TestClass();
+            TestHelpers.TestClass c2 = new TestHelpers.TestClass();
+            TestHelpers.TestClass[] clsArray = { c1, c2 };
+            buffer = new ReadOnlyBuffer<object>(clsArray);
+            TestHelpers.Validate(buffer, c1, c2);
+            buffer = new ReadOnlyBuffer<object>(clsArray, 0);
+            TestHelpers.Validate(buffer, c1, c2);
+            buffer = new ReadOnlyBuffer<object>(clsArray, 0, clsArray.Length);
+            TestHelpers.Validate(buffer, c1, c2);
+        }
+
+        [Fact]
+        public static void CtorArrayInt1()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
+            var buffer = new ReadOnlyBuffer<int>(a, 3);
+            TestHelpers.Validate(buffer, 93, 94, 95, 96, 97, 98);
+        }
+
+        [Fact]
+        public static void CtorArrayInt2()
+        {
+            long[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
+            var buffer = new ReadOnlyBuffer<long>(a, 3);
+            TestHelpers.Validate(buffer, 93, 94, 95, 96, 97, 98);
+        }
+
+        [Fact]
+        public static void CtorArrayIntNegativeStart()
+        {
+            int[] a = new int[3];
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, -1));
+        }
+
+        [Fact]
+        public static void CtorArrayIntStartTooLarge()
+        {
+            int[] a = new int[3];
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, 4));
+        }
+
+        [Fact]
+        public static void CtorArrayIntStartEqualsLength()
+        {
+            // Valid for start to equal the array length. This returns an empty buffer that starts "just past the array."
+            int[] a = { 91, 92, 93 };
+            var buffer = new ReadOnlyBuffer<int>(a, 3);
+            TestHelpers.Validate(buffer);
+        }
+
+        [Fact]
+        public static void CtorArrayIntInt1()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
+            var buffer = new ReadOnlyBuffer<int>(a, 3, 2);
+            TestHelpers.Validate(buffer, 93, 94);
+        }
+
+        [Fact]
+        public static void CtorArrayIntInt2()
+        {
+            long[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
+            var buffer = new ReadOnlyBuffer<long>(a, 4, 3);
+            TestHelpers.Validate(buffer, 94, 95, 96);
+        }
+
+        [Fact]
+        public static void CtorArrayIntIntRangeExtendsToEndOfArray()
+        {
+            long[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98 };
+            var buffer = new ReadOnlyBuffer<long>(a, 4, 5);
+            TestHelpers.Validate(buffer, 94, 95, 96, 97, 98);
+        }
+
+        [Fact]
+        public static void CtorArrayIntIntNegativeStart()
+        {
+            int[] a = new int[3];
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, -1, 0));
+        }
+
+        [Fact]
+        public static void CtorArrayIntIntStartTooLarge()
+        {
+            int[] a = new int[3];
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, 4, 0));
+        }
+
+        [Fact]
+        public static void CtorArrayIntIntNegativeLength()
+        {
+            int[] a = new int[3];
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, 0, -1));
+        }
+
+        [Fact]
+        public static void CtorArrayIntIntStartAndLengthTooLarge()
+        {
+            int[] a = new int[3];
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, 3, 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, 2, 2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, 1, 3));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, 0, 4));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a, int.MaxValue, int.MaxValue));
+        }
+
+        [Fact]
+        public static void CtorArrayIntIntStartEqualsLength()
+        {
+            // Valid for start to equal the array length. This returns an empty buffer that starts "just past the array."
+            int[] a = { 91, 92, 93 };
+            var buffer = new ReadOnlyBuffer<int>(a, 3, 0);
+            TestHelpers.Validate(buffer);
+        }
+    }
+}

--- a/tests/System.Buffers.Primitives.Tests/SliceReadOnlyBufferTests.cs
+++ b/tests/System.Buffers.Primitives.Tests/SliceReadOnlyBufferTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Xunit;
+using System.Runtime.CompilerServices;
+
+namespace System.Buffers.Tests
+{
+    public class SliceReadOnlyBufferTests
+    {
+        [Fact]
+        public static void SliceWithStart()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 };
+            var buffer = new ReadOnlyBuffer<int>(a).Slice(6);
+            Assert.Equal(4, buffer.Length);
+            Assert.True(Unsafe.AreSame(ref a[6], ref buffer.Span.DangerousGetPinnableReference()));
+        }
+
+        [Fact]
+        public static void SliceWithStartPastEnd()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 };
+            var buffer = new ReadOnlyBuffer<int>(a).Slice(a.Length);
+            Assert.Equal(0, buffer.Length);
+            Assert.True(Unsafe.AreSame(ref a[a.Length - 1], ref Unsafe.Subtract(ref buffer.Span.DangerousGetPinnableReference(), 1)));
+        }
+
+        [Fact]
+        public static void SliceWithStartAndLength()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 };
+            var buffer = new ReadOnlyBuffer<int>(a).Slice(3, 5);
+            Assert.Equal(5, buffer.Length);
+            Assert.True(Unsafe.AreSame(ref a[3], ref buffer.Span.DangerousGetPinnableReference()));
+        }
+
+        [Fact]
+        public static void SliceWithStartAndLengthUpToEnd()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 };
+            var buffer = new ReadOnlyBuffer<int>(a).Slice(4, 6);
+            Assert.Equal(6, buffer.Length);
+            Assert.True(Unsafe.AreSame(ref a[4], ref buffer.Span.DangerousGetPinnableReference()));
+        }
+
+        [Fact]
+        public static void SliceWithStartAndLengthPastEnd()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 };
+            var buffer = new ReadOnlyBuffer<int>(a).Slice(a.Length, 0);
+            Assert.Equal(0, buffer.Length);
+            Assert.True(Unsafe.AreSame(ref a[a.Length - 1], ref Unsafe.Subtract(ref buffer.Span.DangerousGetPinnableReference(), 1)));
+        }
+
+        [Fact]
+        public static void SliceRangeChecks()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 };
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a).Slice(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a).Slice(a.Length + 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a).Slice(-1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a).Slice(0, a.Length + 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a).Slice(2, a.Length + 1 - 2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a).Slice(a.Length + 1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new ReadOnlyBuffer<int>(a).Slice(a.Length, 1));
+        }
+    }
+}

--- a/tests/System.Buffers.Primitives.Tests/SliceTests.cs
+++ b/tests/System.Buffers.Primitives.Tests/SliceTests.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Xunit;
+using System.Runtime.CompilerServices;
+
+namespace System.Buffers.Tests
+{
+    public class SliceTests
+    {
+        [Fact]
+        public static void SliceWithStart()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 };
+            var buffer = new Buffer<int>(a).Slice(6);
+            Assert.Equal(4, buffer.Length);
+            Assert.True(Unsafe.AreSame(ref a[6], ref buffer.Span.DangerousGetPinnableReference()));
+        }
+
+        [Fact]
+        public static void SliceWithStartPastEnd()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 };
+            var buffer = new Buffer<int>(a).Slice(a.Length);
+            Assert.Equal(0, buffer.Length);
+            Assert.True(Unsafe.AreSame(ref a[a.Length - 1], ref Unsafe.Subtract(ref buffer.Span.DangerousGetPinnableReference(), 1)));
+        }
+
+        [Fact]
+        public static void SliceWithStartAndLength()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 };
+            var buffer = new Buffer<int>(a).Slice(3, 5);
+            Assert.Equal(5, buffer.Length);
+            Assert.True(Unsafe.AreSame(ref a[3], ref buffer.Span.DangerousGetPinnableReference()));
+        }
+
+        [Fact]
+        public static void SliceWithStartAndLengthUpToEnd()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 };
+            var buffer = new Buffer<int>(a).Slice(4, 6);
+            Assert.Equal(6, buffer.Length);
+            Assert.True(Unsafe.AreSame(ref a[4], ref buffer.Span.DangerousGetPinnableReference()));
+        }
+
+        [Fact]
+        public static void SliceWithStartAndLengthPastEnd()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 };
+            var buffer = new Buffer<int>(a).Slice(a.Length, 0);
+            Assert.Equal(0, buffer.Length);
+            Assert.True(Unsafe.AreSame(ref a[a.Length - 1], ref Unsafe.Subtract(ref buffer.Span.DangerousGetPinnableReference(), 1)));
+        }
+
+        [Fact]
+        public static void SliceRangeChecks()
+        {
+            int[] a = { 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 };
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a).Slice(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a).Slice(a.Length + 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a).Slice(-1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a).Slice(0, a.Length + 1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a).Slice(2, a.Length + 1 - 2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a).Slice(a.Length + 1, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new Buffer<int>(a).Slice(a.Length, 1));
+        }
+    }
+}

--- a/tests/System.Buffers.Primitives.Tests/TestHelpers.cs
+++ b/tests/System.Buffers.Primitives.Tests/TestHelpers.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using Xunit;
+
+namespace System.Buffers.Tests
+{
+    internal static class TestHelpers
+    {
+        public static void Validate<T>(Buffer<T> buffer, params T[] expected)
+        {
+            bool isValueType = default(T) != null || Nullable.GetUnderlyingType(typeof(T)) != null;
+            T[] bufferArray = buffer.ToArray();
+            Assert.Equal(buffer.Length, expected.Length);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                T actual = bufferArray[i];
+                if (isValueType)
+                    Assert.Equal(expected[i], actual);
+                else
+                    Assert.Same(expected[i], actual);
+            }
+        }
+
+        public static void Validate<T>(ReadOnlyBuffer<T> buffer, params T[] expected)
+        {
+            bool isValueType = default(T) != null || Nullable.GetUnderlyingType(typeof(T)) != null;
+            T[] bufferArray = buffer.ToArray();
+            Assert.Equal(buffer.Length, expected.Length);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                T actual = bufferArray[i];
+                if (isValueType)
+                    Assert.Equal(expected[i], actual);
+                else
+                    Assert.Same(expected[i], actual);
+            }
+        }
+
+        public sealed class TestClass
+        {
+            private double _d;
+            public char C0;
+            public char C1;
+            public char C2;
+            public char C3;
+            public char C4;
+        }
+    }
+}

--- a/tests/System.Buffers.Primitives.Tests/TestHelpers.cs
+++ b/tests/System.Buffers.Primitives.Tests/TestHelpers.cs
@@ -6,33 +6,19 @@ namespace System.Buffers.Tests
 {
     internal static class TestHelpers
     {
-        public static void Validate<T>(Buffer<T> buffer, params T[] expected)
+        public static void SequenceEqualValueType<T>(ReadOnlyBuffer<T> buffer, params T[] expected) where T: struct, IEquatable<T>
         {
-            bool isValueType = default(T) != null || Nullable.GetUnderlyingType(typeof(T)) != null;
-            T[] bufferArray = buffer.ToArray();
-            Assert.Equal(buffer.Length, expected.Length);
-            for (int i = 0; i < expected.Length; i++)
-            {
-                T actual = bufferArray[i];
-                if (isValueType)
-                    Assert.Equal(expected[i], actual);
-                else
-                    Assert.Same(expected[i], actual);
-            }
+            Assert.True(buffer.Span.SequenceEqual(expected));
         }
 
-        public static void Validate<T>(ReadOnlyBuffer<T> buffer, params T[] expected)
+        public static void SequenceEqual<T>(ReadOnlyBuffer<T> buffer, params T[] expected)
         {
-            bool isValueType = default(T) != null || Nullable.GetUnderlyingType(typeof(T)) != null;
             T[] bufferArray = buffer.ToArray();
             Assert.Equal(buffer.Length, expected.Length);
             for (int i = 0; i < expected.Length; i++)
             {
                 T actual = bufferArray[i];
-                if (isValueType)
-                    Assert.Equal(expected[i], actual);
-                else
-                    Assert.Same(expected[i], actual);
+                Assert.Same(expected[i], actual);
             }
         }
 


### PR DESCRIPTION
- Making `internal Buffer(T[] array, int index, int length)` public
- Adding constructors (similar to Span):
   - public Buffer(T[] array)
   - public Buffer(T[] array, int start)
   - public Buffer(T[] array, int start, int length)
- Adding tests for all scenarios.
- Same with ReadOnlyBuffer\<T\>

cc @KrzysztofCwalina, @shiftylogic 