### PR TITLE
Br performance test

### DIFF
--- a/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/BrotliNative.cs
+++ b/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/BrotliNative.cs
@@ -17,10 +17,10 @@ using System.Runtime.InteropServices;
 namespace System.IO.Compression
 {
     ///  /// <summary>
-    /// 0 - Process input. Encoder may postpone producing output, until it has processed enough input.
-    /// 1 - Produce output for all processed input.  Actual flush is performed when input stream is depleted and there is enough space in output stream.
-    /// 2 - Finalize the stream. Adding more input data to finalized stream is impossible.
-    /// 3 - Emit metadata block to stream. Stream is soft-flushed before metadata block is emitted. Metadata bloc MUST be no longer than 16MiB.
+    /// Process - Process input. Encoder may postpone producing output, until it has processed enough input.
+    /// Flush - Produce output for all processed input.  Actual flush is performed when input stream is depleted and there is enough space in output stream.
+    /// Finish - Finalize the stream. Adding more input data to finalized stream is impossible.
+    /// EmitMetadata - Emit metadata block to stream. Stream is soft-flushed before metadata block is emitted. Metadata bloc MUST be no longer than 16MiB.
     /// </summary>
     public enum BrotliEncoderOperation
     {
@@ -31,12 +31,12 @@ namespace System.IO.Compression
     };
 
     /// <summary>
-    /// 0 - BrotliEncoderMode enumerates all available values.
-    /// 1 - The main compression speed-density lever. The higher the quality, the slower the compression.Range is from ::BROTLI_MIN_QUALITY to::BROTLI_MAX_QUALITY.
-    /// 2 - Recommended sliding LZ77 window size  2^value -16 .  Encoder may reduce this value, e.g. if input is much smaller than window size.
-    /// 3 - Recommended input block size. 
-    /// 4-  Flag that affects usage of "literal context modeling" format feature. This flag is a "decoding-speed vs compression ratio" trade-off.
-    /// 5 - Estimated total input size for all ::BrotliEncoderCompressStream calls. The default value is 0, which means that the total input size is unknown.
+    /// Mode - BrotliEncoderMode enumerates all available values.
+    /// Quality - The main compression speed-density lever. The higher the quality, the slower the compression.Range is from ::BROTLI_MIN_QUALITY to::BROTLI_MAX_QUALITY.
+    /// LGWin - Recommended sliding LZ77 window size  2^value -16 .  Encoder may reduce this value, e.g. if input is much smaller than window size.
+    /// LGBlock - Recommended input block size. 
+    /// LCModeling-  Flag that affects usage of "literal context modeling" format feature. This flag is a "decoding-speed vs compression ratio" trade-off.
+    /// SizeHint - Estimated total input size for all ::BrotliEncoderCompressStream calls. The default value is 0, which means that the total input size is unknown.
     /// </summary>
     public enum BrotliEncoderParameter
     {
@@ -49,10 +49,10 @@ namespace System.IO.Compression
     };
 
     /// <summary>
-    /// 0 - Decoding error, e.g. corrupted input or memory allocation problem.
-    /// 1 - Decoding successfully completed
-    /// 2 - Partially done; should be called again with more input
-    /// 3 - Partially done; should be called again with more output
+    /// Error - Decoding error, e.g. corrupted input or memory allocation problem.
+    /// Success - Decoding successfully completed
+    /// NeedMoreInput - Partially done; should be called again with more input
+    /// NeedMOreOutput - Partially done; should be called again with more output
     /// </summary>
     public enum BrotliDecoderResult
     {
@@ -63,9 +63,9 @@ namespace System.IO.Compression
     };
 
     /// <summary>
-    /// 0 - Default (Compressor does not know anything in advance properties of the input)
-    /// 1 - For UTF-8 formatted text input
-    /// 2 - Mode used in WOFF 2.0
+    /// Generic - Default (Compressor does not know anything in advance properties of the input)
+    /// Text - For UTF-8 formatted text input
+    /// Font - Mode used in WOFF 2.0
     /// </summary>
     public enum BrotliEncoderMode
     {

--- a/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/BrotliStream.cs
+++ b/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/BrotliStream.cs
@@ -22,7 +22,6 @@ namespace System.IO.Compression
         private int _bufferSize;
         private Stream _stream;
         private CompressionMode _mode;
-        private nuint _totalOutput;
         private nuint _availableOutput;
         private IntPtr _nextOutput = IntPtr.Zero;
         private nuint _availableInput;

--- a/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/BrotliStream.cs
+++ b/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/BrotliStream.cs
@@ -32,12 +32,12 @@ namespace System.IO.Compression
         private IntPtr _bufferOutput;
         private bool _leaveOpen;
         private int totalWrote;
-        IntPtr Dict;//TODO
+        private IntPtr _dictionary;//TODO
         private int _readOffset = 0;
         Decoder _decoder;
         Encoder _encoder;
 
-        public BrotliStream(Stream baseStream, CompressionMode mode, bool leaveOpen, int BuffSize, uint windowSize, uint quality) : this(baseStream, mode, leaveOpen, BuffSize)
+        public BrotliStream(Stream baseStream, CompressionMode mode, bool leaveOpen, int buffSize, uint windowSize, uint quality) : this(baseStream, mode, leaveOpen, buffSize)
         {
             if (_mode == CompressionMode.Decompress) throw new System.IO.IOException(BrotliEx.QualityAndWinSize);
             else
@@ -47,7 +47,7 @@ namespace System.IO.Compression
             }
         }
 
-        public BrotliStream(Stream baseStream, CompressionMode mode, bool leaveOpen = false, int BuffSize = DefaultBufferSize)
+        public BrotliStream(Stream baseStream, CompressionMode mode, bool leaveOpen = false, int buffSize = DefaultBufferSize)
         {
             if (baseStream == null) throw new ArgumentNullException("baseStream");
             _mode = mode;
@@ -63,12 +63,12 @@ namespace System.IO.Compression
             {
                 _decoder = new Decoder();
             }
-            _bufferSize = BuffSize;
+            _bufferSize = buffSize;
             _bufferInput = Marshal.AllocHGlobal(_bufferSize);
             _bufferOutput = Marshal.AllocHGlobal(_bufferSize);
             _nextInput = _bufferInput;
             _nextOutput = _bufferOutput;
-            _availableOutput = (nuint)BuffSize;
+            _availableOutput = (nuint)buffSize;
         }
 
         public override bool CanRead

--- a/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/BrotliStream.cs
+++ b/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/BrotliStream.cs
@@ -32,12 +32,12 @@ namespace System.IO.Compression
         private IntPtr _bufferOutput;
         private bool _leaveOpen;
         private int totalWrote;
-        private IntPtr _dictionary;//TODO
+        private IntPtr _dictionary;//TODO an opportunity to create, add, save and use compression dictionary
         private int _readOffset = 0;
         Decoder _decoder;
         Encoder _encoder;
 
-        public BrotliStream(Stream baseStream, CompressionMode mode, bool leaveOpen, int buffSize, uint windowSize, uint quality) : this(baseStream, mode, leaveOpen, buffSize)
+        public BrotliStream(Stream baseStream, CompressionMode mode, bool leaveOpen, int bufferSize, uint windowSize, uint quality) : this(baseStream, mode, leaveOpen, bufferSize)
         {
             if (_mode == CompressionMode.Decompress) throw new System.IO.IOException(BrotliEx.QualityAndWinSize);
             else
@@ -47,7 +47,7 @@ namespace System.IO.Compression
             }
         }
 
-        public BrotliStream(Stream baseStream, CompressionMode mode, bool leaveOpen = false, int buffSize = DefaultBufferSize)
+        public BrotliStream(Stream baseStream, CompressionMode mode, bool leaveOpen = false, int bufferSize = DefaultBufferSize)
         {
             if (baseStream == null) throw new ArgumentNullException("baseStream");
             _mode = mode;
@@ -63,12 +63,12 @@ namespace System.IO.Compression
             {
                 _decoder = new Decoder();
             }
-            _bufferSize = buffSize;
+            _bufferSize = bufferSize;
             _bufferInput = Marshal.AllocHGlobal(_bufferSize);
             _bufferOutput = Marshal.AllocHGlobal(_bufferSize);
             _nextInput = _bufferInput;
             _nextOutput = _bufferOutput;
-            _availableOutput = (nuint)buffSize;
+            _availableOutput = (nuint)_bufferSize;
         }
 
         public override bool CanRead
@@ -113,7 +113,7 @@ namespace System.IO.Compression
             set { throw new NotSupportedException(); }
         }
 
-        protected virtual void FlushEncoder(Boolean finished)
+        protected virtual void FlushEncoder(bool finished)
         {
             if (_encoder._state == IntPtr.Zero) return;
             if (BrotliNative.BrotliEncoderIsFinished(_encoder._state)) return;
@@ -214,8 +214,8 @@ namespace System.IO.Compression
 
             int bytesRead = (int)(_decoder._bufferStream.Length - _readOffset);
             nuint totalCount = 0;
-            Boolean endOfStream = false;
-            Boolean errorDetected = false;
+            bool endOfStream = false;
+            bool errorDetected = false;
             Byte[] buf = new Byte[_bufferSize];
             while (bytesRead < count)
             {

--- a/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/BrotliStream.cs
+++ b/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/BrotliStream.cs
@@ -18,7 +18,6 @@ namespace System.IO.Compression
 {
     public partial class BrotliStream : Stream
     {
-
         private const int DefaultBufferSize = 64 * 1024;
         private int _bufferSize;
         private Stream _stream;

--- a/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/Decoder.cs
+++ b/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/Decoder.cs
@@ -10,8 +10,8 @@ namespace System.IO.Compression
 {
     internal sealed class Decoder
     {
-        internal IntPtr _state = IntPtr.Zero;
-        internal BrotliDecoderResult _lastDecoderResult = BrotliDecoderResult.NeedsMoreInput;
+        internal IntPtr State { get; private set; }
+        internal BrotliDecoderResult LastDecoderResult { get; set; }
         internal MemoryStream _bufferStream;
         private bool _isDisposed = false;
 
@@ -23,19 +23,20 @@ namespace System.IO.Compression
 
         private void InitializeDecoder()
         {
-            _state = BrotliNative.BrotliDecoderCreateInstance();
-            if (_state == IntPtr.Zero)
+            State = BrotliNative.BrotliDecoderCreateInstance();
+            if (State == IntPtr.Zero)
             {
-                throw new System.IO.IOException(BrotliEx.DecoderInstanceCreate);//TODO Create exception
+                throw new System.IO.IOException(BrotliEx.DecoderInstanceCreate);
             }
+            LastDecoderResult = BrotliDecoderResult.NeedsMoreInput;
             _bufferStream = new MemoryStream();
         }
 
         internal void Dispose()
         {
-            if (!_isDisposed && _state != IntPtr.Zero)
+            if (!_isDisposed && State != IntPtr.Zero)
             {
-                BrotliNative.BrotliDecoderDestroyInstance(_state);
+                BrotliNative.BrotliDecoderDestroyInstance(State);
                 _bufferStream.Dispose();
             }
             _isDisposed = true;

--- a/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/Decoder.cs
+++ b/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/Decoder.cs
@@ -12,7 +12,7 @@ namespace System.IO.Compression
     {
         internal IntPtr State { get; private set; }
         internal BrotliDecoderResult LastDecoderResult { get; set; }
-        internal MemoryStream _bufferStream;
+        internal MemoryStream BufferStream { get; private set; }
         private bool _isDisposed = false;
 
         internal Decoder()
@@ -29,7 +29,7 @@ namespace System.IO.Compression
                 throw new System.IO.IOException(BrotliEx.DecoderInstanceCreate);
             }
             LastDecoderResult = BrotliDecoderResult.NeedsMoreInput;
-            _bufferStream = new MemoryStream();
+            BufferStream = new MemoryStream();
         }
 
         internal void Dispose()
@@ -37,7 +37,7 @@ namespace System.IO.Compression
             if (!_isDisposed && State != IntPtr.Zero)
             {
                 BrotliNative.BrotliDecoderDestroyInstance(State);
-                _bufferStream.Dispose();
+                BufferStream.Dispose();
             }
             _isDisposed = true;
         }
@@ -45,10 +45,10 @@ namespace System.IO.Compression
         internal void RemoveBytes(int numberOfBytes)
         {
             ArraySegment<byte> buf;
-            if (_bufferStream.TryGetBuffer(out buf))
+            if (BufferStream.TryGetBuffer(out buf))
             {
-                Buffer.BlockCopy(buf.Array, numberOfBytes, buf.Array, 0, (int)_bufferStream.Length - numberOfBytes);
-                _bufferStream.SetLength(_bufferStream.Length - numberOfBytes);
+                Buffer.BlockCopy(buf.Array, numberOfBytes, buf.Array, 0, (int)BufferStream.Length - numberOfBytes);
+                BufferStream.SetLength(BufferStream.Length - numberOfBytes);
             }
             else
             {

--- a/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/Decoder.cs
+++ b/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/Decoder.cs
@@ -12,7 +12,8 @@ namespace System.IO.Compression
     {
         internal IntPtr State { get; private set; }
         internal BrotliDecoderResult LastDecoderResult { get; set; }
-        internal MemoryStream BufferStream { get; private set; }
+        internal Stream BufferStream => _bufferStream;
+        private MemoryStream _bufferStream;
         private bool _isDisposed = false;
 
         internal Decoder()
@@ -29,7 +30,7 @@ namespace System.IO.Compression
                 throw new System.IO.IOException(BrotliEx.DecoderInstanceCreate);
             }
             LastDecoderResult = BrotliDecoderResult.NeedsMoreInput;
-            BufferStream = new MemoryStream();
+            _bufferStream = new MemoryStream();
         }
 
         internal void Dispose()
@@ -37,7 +38,7 @@ namespace System.IO.Compression
             if (!_isDisposed && State != IntPtr.Zero)
             {
                 BrotliNative.BrotliDecoderDestroyInstance(State);
-                BufferStream.Dispose();
+                _bufferStream.Dispose();
             }
             _isDisposed = true;
         }
@@ -45,10 +46,10 @@ namespace System.IO.Compression
         internal void RemoveBytes(int numberOfBytes)
         {
             ArraySegment<byte> buf;
-            if (BufferStream.TryGetBuffer(out buf))
+            if (_bufferStream.TryGetBuffer(out buf))
             {
-                Buffer.BlockCopy(buf.Array, numberOfBytes, buf.Array, 0, (int)BufferStream.Length - numberOfBytes);
-                BufferStream.SetLength(BufferStream.Length - numberOfBytes);
+                Buffer.BlockCopy(buf.Array, numberOfBytes, buf.Array, 0, (int)_bufferStream.Length - numberOfBytes);
+                _bufferStream.SetLength(BufferStream.Length - numberOfBytes);
             }
             else
             {

--- a/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/Decoder.cs
+++ b/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/Decoder.cs
@@ -10,9 +10,9 @@ namespace System.IO.Compression
 {
     internal sealed class Decoder
     {
-        internal IntPtr State = IntPtr.Zero;
-        internal BrotliDecoderResult LastDecoderResult = BrotliDecoderResult.NeedsMoreInput;
-        internal MemoryStream BufferStream;
+        internal IntPtr _state = IntPtr.Zero;
+        internal BrotliDecoderResult _lastDecoderResult = BrotliDecoderResult.NeedsMoreInput;
+        internal MemoryStream _bufferStream;
         private bool _isDisposed = false;
 
         internal Decoder()
@@ -23,20 +23,20 @@ namespace System.IO.Compression
 
         private void InitializeDecoder()
         {
-            State = BrotliNative.BrotliDecoderCreateInstance();
-            if (State == IntPtr.Zero)
+            _state = BrotliNative.BrotliDecoderCreateInstance();
+            if (_state == IntPtr.Zero)
             {
                 throw new System.IO.IOException(BrotliEx.DecoderInstanceCreate);//TODO Create exception
             }
-            BufferStream = new MemoryStream();
+            _bufferStream = new MemoryStream();
         }
 
         internal void Dispose()
         {
-            if (!_isDisposed && State != IntPtr.Zero)
+            if (!_isDisposed && _state != IntPtr.Zero)
             {
-                BrotliNative.BrotliDecoderDestroyInstance(State);
-                BufferStream.Dispose();
+                BrotliNative.BrotliDecoderDestroyInstance(_state);
+                _bufferStream.Dispose();
             }
             _isDisposed = true;
         }
@@ -44,10 +44,10 @@ namespace System.IO.Compression
         internal void RemoveBytes(int numberOfBytes)
         {
             ArraySegment<byte> buf;
-            if (BufferStream.TryGetBuffer(out buf))
+            if (_bufferStream.TryGetBuffer(out buf))
             {
-                Buffer.BlockCopy(buf.Array, numberOfBytes, buf.Array, 0, (int)BufferStream.Length - numberOfBytes);
-                BufferStream.SetLength(BufferStream.Length - numberOfBytes);
+                Buffer.BlockCopy(buf.Array, numberOfBytes, buf.Array, 0, (int)_bufferStream.Length - numberOfBytes);
+                _bufferStream.SetLength(_bufferStream.Length - numberOfBytes);
             }
             else
             {

--- a/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/Encoder.cs
+++ b/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/Encoder.cs
@@ -17,7 +17,6 @@ namespace System.IO.Compression
         private const int MaxQuality = 11;
         private bool _isDisposed = false;
 
-
         internal Encoder()
         {
             _isDisposed = false;

--- a/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/Encoder.cs
+++ b/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/Encoder.cs
@@ -15,7 +15,7 @@ namespace System.IO.Compression
         private const int MinQuality = 0;
         private const int MaxQuality = 11;
         private bool _isDisposed = false;
-        internal IntPtr State = IntPtr.Zero;
+        internal IntPtr _state = IntPtr.Zero;
 
         internal Encoder()
         {
@@ -29,7 +29,7 @@ namespace System.IO.Compression
             {
                 throw new ArgumentException(BrotliEx.WrongQuality);//TODO
             }
-            BrotliNative.BrotliEncoderSetParameter(State, BrotliEncoderParameter.Quality, quality);
+            BrotliNative.BrotliEncoderSetParameter(_state, BrotliEncoderParameter.Quality, quality);
         }
 
         public void SetQuality()
@@ -43,7 +43,7 @@ namespace System.IO.Compression
             {
                 throw new ArgumentException(BrotliEx.WrongWindowSize);//TODO
             }
-            BrotliNative.BrotliEncoderSetParameter(State, BrotliEncoderParameter.LGWin, window);
+            BrotliNative.BrotliEncoderSetParameter(_state, BrotliEncoderParameter.LGWin, window);
         }
 
         public void SetWindow()
@@ -53,8 +53,8 @@ namespace System.IO.Compression
 
         private void InitializeEncoder()
         {
-            State = BrotliNative.BrotliEncoderCreateInstance();
-            if (State == IntPtr.Zero)
+            _state = BrotliNative.BrotliEncoderCreateInstance();
+            if (_state == IntPtr.Zero)
             {
                 throw new System.IO.IOException(BrotliEx.EncoderInstanceCreate);
             }
@@ -62,9 +62,9 @@ namespace System.IO.Compression
 
         internal void Dispose()
         {
-            if (!_isDisposed && State != IntPtr.Zero)
+            if (!_isDisposed && _state != IntPtr.Zero)
             {
-                BrotliNative.BrotliEncoderDestroyInstance(State);
+                BrotliNative.BrotliEncoderDestroyInstance(_state);
             }
             _isDisposed = true;
         }

--- a/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/Encoder.cs
+++ b/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli/Encoder.cs
@@ -10,12 +10,13 @@ namespace System.IO.Compression
 {
     internal sealed class Encoder
     {
+        internal IntPtr State { get; private set; }
         private const int MinWindowBits = 10;
         private const int MaxWindowBits = 24;
         private const int MinQuality = 0;
         private const int MaxQuality = 11;
         private bool _isDisposed = false;
-        internal IntPtr _state = IntPtr.Zero;
+
 
         internal Encoder()
         {
@@ -27,9 +28,9 @@ namespace System.IO.Compression
         {
             if (quality < MinQuality || quality > MaxQuality)
             {
-                throw new ArgumentException(BrotliEx.WrongQuality);//TODO
+                throw new ArgumentException(BrotliEx.WrongQuality);
             }
-            BrotliNative.BrotliEncoderSetParameter(_state, BrotliEncoderParameter.Quality, quality);
+            BrotliNative.BrotliEncoderSetParameter(State, BrotliEncoderParameter.Quality, quality);
         }
 
         public void SetQuality()
@@ -41,9 +42,9 @@ namespace System.IO.Compression
         {
             if (window < MinWindowBits || window > MaxWindowBits)
             {
-                throw new ArgumentException(BrotliEx.WrongWindowSize);//TODO
+                throw new ArgumentException(BrotliEx.WrongWindowSize);
             }
-            BrotliNative.BrotliEncoderSetParameter(_state, BrotliEncoderParameter.LGWin, window);
+            BrotliNative.BrotliEncoderSetParameter(State, BrotliEncoderParameter.LGWin, window);
         }
 
         public void SetWindow()
@@ -53,8 +54,8 @@ namespace System.IO.Compression
 
         private void InitializeEncoder()
         {
-            _state = BrotliNative.BrotliEncoderCreateInstance();
-            if (_state == IntPtr.Zero)
+            State = BrotliNative.BrotliEncoderCreateInstance();
+            if (State == IntPtr.Zero)
             {
                 throw new System.IO.IOException(BrotliEx.EncoderInstanceCreate);
             }
@@ -62,9 +63,9 @@ namespace System.IO.Compression
 
         internal void Dispose()
         {
-            if (!_isDisposed && _state != IntPtr.Zero)
+            if (!_isDisposed && State != IntPtr.Zero)
             {
-                BrotliNative.BrotliEncoderDestroyInstance(_state);
+                BrotliNative.BrotliEncoderDestroyInstance(State);
             }
             _isDisposed = true;
         }

--- a/src/System.IO.Compression.Brotli/System/Interop/Interop.Brotli.cs
+++ b/src/System.IO.Compression.Brotli/System/Interop/Interop.Brotli.cs
@@ -19,73 +19,73 @@ namespace System.IO.Compression
     {
         internal static partial class Brotli
         {
-            internal const string LibNameEncoder = Library.BrotliEnc;
-            internal const string LibNameDecoder = Library.BrotliDec;
+            internal const string _libNameEncoder = Library._brotliEncoder;
+            internal const string _libNameDecoder = Library._brotliDecoder;
 
             #region Encoder
 
-            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern bool BrotliEncoderCompress(int quality, int lgwin, BrotliEncoderMode mode, nuint input_size,
                 IntPtr input_buffer, ref nuint encoded_size, IntPtr encoded_buffer);
 
-            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern IntPtr BrotliEncoderCreateInstance(IntPtr allocFunc, IntPtr freeFunc, IntPtr opaque);
 
-            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern bool BrotliEncoderSetParameter(IntPtr state, BrotliEncoderParameter parameter, UInt32 value);
 
-            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern void BrotliEncoderSetCustomDictionary(IntPtr state, nuint size, IntPtr dict);
 
-            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern bool BrotliEncoderCompressStream(
                 IntPtr state, BrotliEncoderOperation op, ref nuint availableIn,
                 ref IntPtr nextIn, ref nuint availableOut, ref IntPtr nextOut, out nuint totalOut);
 
-            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern bool BrotliEncoderIsFinished(IntPtr state);
 
-            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern void BrotliEncoderDestroyInstance(IntPtr state);
 
-            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern UInt32 BrotliEncoderVersion();
 
             #endregion
 
             #region Decoder
 
-            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern BrotliDecoderResult BrotliDecoderDecompress(ref nuint availableIn, IntPtr nextIn,
                 ref nuint availableOut, IntPtr nextOut);
 
-            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern IntPtr BrotliDecoderCreateInstance(IntPtr allocFunc, IntPtr freeFunc, IntPtr opaque);
 
-            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern void BrotliDecoderSetCustomDictionary(IntPtr state, nuint size, IntPtr dict);
 
-            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern BrotliDecoderResult BrotliDecoderDecompressStream(
                 IntPtr state, ref nuint availableIn, ref IntPtr nextIn,
                 ref nuint availableOut, ref IntPtr nextOut, out nuint totalOut);
 
-            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern void BrotliDecoderDestroyInstance(IntPtr state);
 
-            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern nuint BrotliDecoderVersion();
 
-            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern bool BrotliDecoderIsUsed(IntPtr state);
 
-            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern bool BrotliDecoderIsFinished(IntPtr state);
 
-            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern Int32 BrotliDecoderGetErrorCode(IntPtr state);
 
-            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
             internal static extern IntPtr BrotliDecoderErrorString(Int32 code);
 
             #endregion

--- a/src/System.IO.Compression.Brotli/System/Interop/Interop.Brotli.cs
+++ b/src/System.IO.Compression.Brotli/System/Interop/Interop.Brotli.cs
@@ -19,73 +19,73 @@ namespace System.IO.Compression
     {
         internal static partial class Brotli
         {
-            internal const string _libNameEncoder = Library._brotliEncoder;
-            internal const string _libNameDecoder = Library._brotliDecoder;
+            internal const string LibNameEncoder = Library.BrotliEncoder;
+            internal const string LibNameDecoder = Library.BrotliDecoder;
 
             #region Encoder
 
-            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern bool BrotliEncoderCompress(int quality, int lgwin, BrotliEncoderMode mode, nuint input_size,
                 IntPtr input_buffer, ref nuint encoded_size, IntPtr encoded_buffer);
 
-            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern IntPtr BrotliEncoderCreateInstance(IntPtr allocFunc, IntPtr freeFunc, IntPtr opaque);
 
-            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern bool BrotliEncoderSetParameter(IntPtr state, BrotliEncoderParameter parameter, UInt32 value);
 
-            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern void BrotliEncoderSetCustomDictionary(IntPtr state, nuint size, IntPtr dict);
 
-            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern bool BrotliEncoderCompressStream(
                 IntPtr state, BrotliEncoderOperation op, ref nuint availableIn,
                 ref IntPtr nextIn, ref nuint availableOut, ref IntPtr nextOut, out nuint totalOut);
 
-            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern bool BrotliEncoderIsFinished(IntPtr state);
 
-            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern void BrotliEncoderDestroyInstance(IntPtr state);
 
-            [DllImport(_libNameEncoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameEncoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern UInt32 BrotliEncoderVersion();
 
             #endregion
 
             #region Decoder
 
-            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern BrotliDecoderResult BrotliDecoderDecompress(ref nuint availableIn, IntPtr nextIn,
                 ref nuint availableOut, IntPtr nextOut);
 
-            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern IntPtr BrotliDecoderCreateInstance(IntPtr allocFunc, IntPtr freeFunc, IntPtr opaque);
 
-            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern void BrotliDecoderSetCustomDictionary(IntPtr state, nuint size, IntPtr dict);
 
-            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern BrotliDecoderResult BrotliDecoderDecompressStream(
                 IntPtr state, ref nuint availableIn, ref IntPtr nextIn,
                 ref nuint availableOut, ref IntPtr nextOut, out nuint totalOut);
 
-            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern void BrotliDecoderDestroyInstance(IntPtr state);
 
-            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern nuint BrotliDecoderVersion();
 
-            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern bool BrotliDecoderIsUsed(IntPtr state);
 
-            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern bool BrotliDecoderIsFinished(IntPtr state);
 
-            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl)]
+            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl)]
             internal static extern Int32 BrotliDecoderGetErrorCode(IntPtr state);
 
-            [DllImport(_libNameDecoder, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+            [DllImport(LibNameDecoder, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
             internal static extern IntPtr BrotliDecoderErrorString(Int32 code);
 
             #endregion

--- a/src/System.IO.Compression.Brotli/System/Interop/Library.OSX.cs
+++ b/src/System.IO.Compression.Brotli/System/Interop/Library.OSX.cs
@@ -6,7 +6,7 @@ namespace System.IO.Compression
 {
     internal static partial class Library
     {
-        internal const string BrotliEnc = "libbrotlienc.dylib.1.0.0";
-        internal const string BrotliDec = "libbrotlidec.dylib.1.0.0";
+        internal const string BrotliEncoder = "libbrotlienc.dylib.1.0.0";
+        internal const string BrotliDecoder = "libbrotlidec.dylib.1.0.0";
     }
 }

--- a/src/System.IO.Compression.Brotli/System/Interop/Library.Unix.cs
+++ b/src/System.IO.Compression.Brotli/System/Interop/Library.Unix.cs
@@ -6,7 +6,7 @@ namespace System.IO.Compression
 {
     internal static partial class Library
     {
-        internal const string BrotliEnc = "libbrotlienc.so.1.0.0";
-        internal const string BrotliDec = "libbrotlidec.so.1.0.0";
+        internal const string BrotliEncoder = "libbrotlienc.so.1.0.0";
+        internal const string BrotliDecoder = "libbrotlidec.so.1.0.0";
     }
 }

--- a/src/System.IO.Compression.Brotli/System/Interop/Library.Windows.cs
+++ b/src/System.IO.Compression.Brotli/System/Interop/Library.Windows.cs
@@ -6,7 +6,7 @@ namespace System.IO.Compression
 {
     internal static partial class Library
     {
-        internal const string BrotliEnc = "brotlienc.dll";
-        internal const string BrotliDec = "brotlidec.dll";
+        internal const string _brotliEncoder = "brotlienc.dll";
+        internal const string _brotliDecoder = "brotlidec.dll";
     }
 }

--- a/src/System.IO.Compression.Brotli/System/Interop/Library.Windows.cs
+++ b/src/System.IO.Compression.Brotli/System/Interop/Library.Windows.cs
@@ -6,7 +6,7 @@ namespace System.IO.Compression
 {
     internal static partial class Library
     {
-        internal const string _brotliEncoder = "brotlienc.dll";
-        internal const string _brotliDecoder = "brotlidec.dll";
+        internal const string BrotliEncoder = "brotlienc.dll";
+        internal const string BrotliDecoder = "brotlidec.dll";
     }
 }

--- a/tests/System.IO.Compression.Tests/BrotliPerfomanceTests.cs
+++ b/tests/System.IO.Compression.Tests/BrotliPerfomanceTests.cs
@@ -145,12 +145,12 @@ namespace System.IO.Compression.Tests
             foreach (var iteration in Benchmark.Iterations)
             {
                 string filePath = GetTestFilePath();
-                using (FileStream output = File.Create(filePath))
+                FileStream output = File.Create(filePath);
                 using (BrotliStream brotliCompressStream = new BrotliStream(output, CompressionMode.Compress))
-                using (iteration.StartMeasurement())
-                {
-                    brotliCompressStream.Write(bytes, 0, bytes.Length);
-                }
+                    using (iteration.StartMeasurement())
+                    {
+                        brotliCompressStream.Write(bytes, 0, bytes.Length);
+                    }
                 File.Delete(filePath);
             }
         }

--- a/tests/System.IO.Compression.Tests/BrotliPerfomanceTests.cs
+++ b/tests/System.IO.Compression.Tests/BrotliPerfomanceTests.cs
@@ -105,7 +105,9 @@ namespace System.IO.Compression.Tests
             NormalData
         }
 
-        [Benchmark(InnerIterationCount = 10000)]
+        private const int Iter = 10000;
+
+        [Benchmark(InnerIterationCount = Iter)]
         [InlineData(CompressionType.CryptoRandom)]
         [InlineData(CompressionType.RepeatedSegments)]
         [InlineData(CompressionType.NormalData)]
@@ -113,13 +115,13 @@ namespace System.IO.Compression.Tests
         {
             string testFilePath = CreateCompressedFile(type);
             int bufferSize = 1024;
-            int retCount = -1;
             var bytes = new byte[bufferSize];
             using (MemoryStream brStream = new MemoryStream(File.ReadAllBytes(testFilePath)))
                 foreach (var iteration in Benchmark.Iterations)
                     using (iteration.StartMeasurement())
                         for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                         {
+                            int retCount = -1;
                             using (BrotliStream zip = new BrotliStream(brStream, CompressionMode.Decompress, true))
                             {
                                 while (retCount != 0)
@@ -153,7 +155,7 @@ namespace System.IO.Compression.Tests
             }
         }
 
-        [Benchmark(InnerIterationCount = 10000)]
+        [Benchmark(InnerIterationCount = Iter)]
         [InlineData(CompressionType.CryptoRandom)]
         [InlineData(CompressionType.RepeatedSegments)]
         [InlineData(CompressionType.NormalData)]
@@ -164,11 +166,11 @@ namespace System.IO.Compression.Tests
             byte[] data = File.ReadAllBytes(testFilePath);
             var bytes = new byte[bufferSize];
             foreach (var iteration in Benchmark.Iterations)
-                    using (iteration.StartMeasurement())
-                        for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                        {
-                            BrotliPrimitives.Decompress(data, bytes, out int consumed, out int written);
-                        }
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                    {
+                        BrotliPrimitives.Decompress(data, bytes, out int consumed, out int written);
+                    }
             File.Delete(testFilePath);
         }
 

--- a/tests/System.IO.Compression.Tests/BrotliPerfomanceTests.cs
+++ b/tests/System.IO.Compression.Tests/BrotliPerfomanceTests.cs
@@ -122,11 +122,11 @@ namespace System.IO.Compression.Tests
                         for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                         {
                             int retCount = -1;
-                            using (BrotliStream zip = new BrotliStream(brStream, CompressionMode.Decompress, true))
+                            using (BrotliStream brotliDecompressStream = new BrotliStream(brStream, CompressionMode.Decompress, true))
                             {
                                 while (retCount != 0)
                                 {
-                                    retCount = zip.Read(bytes, 0, bufferSize);
+                                    retCount = brotliDecompressStream.Read(bytes, 0, bufferSize);
                                 }
                             }
                             brStream.Seek(0, SeekOrigin.Begin);
@@ -146,10 +146,10 @@ namespace System.IO.Compression.Tests
             {
                 string filePath = GetTestFilePath();
                 using (FileStream output = File.Create(filePath))
-                using (BrotliStream zip = new BrotliStream(output, CompressionMode.Compress))
+                using (BrotliStream brotliCompressStream = new BrotliStream(output, CompressionMode.Compress))
                 using (iteration.StartMeasurement())
                 {
-                    zip.Write(bytes, 0, bytes.Length);
+                    brotliCompressStream.Write(bytes, 0, bytes.Length);
                 }
                 File.Delete(filePath);
             }
@@ -168,9 +168,7 @@ namespace System.IO.Compression.Tests
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                    {
                         BrotliPrimitives.Decompress(data, bytes, out int consumed, out int written);
-                    }
             File.Delete(testFilePath);
         }
 

--- a/tests/System.IO.Compression.Tests/BrotliPerfomanceTests.cs
+++ b/tests/System.IO.Compression.Tests/BrotliPerfomanceTests.cs
@@ -105,7 +105,7 @@ namespace System.IO.Compression.Tests
             NormalData
         }
 
-        private const int Iter = 10000;
+        private const int Iter = 1;
 
         [Benchmark(InnerIterationCount = Iter)]
         [InlineData(CompressionType.CryptoRandom)]

--- a/tests/System.IO.Compression.Tests/BrotliPerfomanceTests.cs
+++ b/tests/System.IO.Compression.Tests/BrotliPerfomanceTests.cs
@@ -147,10 +147,12 @@ namespace System.IO.Compression.Tests
                 string filePath = GetTestFilePath();
                 FileStream output = File.Create(filePath);
                 using (BrotliStream brotliCompressStream = new BrotliStream(output, CompressionMode.Compress))
+                {
                     using (iteration.StartMeasurement())
                     {
                         brotliCompressStream.Write(bytes, 0, bytes.Length);
                     }
+                }
                 File.Delete(filePath);
             }
         }


### PR DESCRIPTION
The result for static Decompress is awful and I don't understand what can be wrong. 
![image](https://user-images.githubusercontent.com/22378647/26998601-e73a052c-4d3a-11e7-8de0-292fb7c169da.png)


and to compare with DeflateStream:
![image](https://user-images.githubusercontent.com/22378647/26998593-d84c8cce-4d3a-11e7-8540-01e0cbefbfb9.png)




As We can see the compress is slower, but decompress is faster (InnerIterationCount = 10000). 

Thus, I should optimize both Compress and Decompress realization and understand why static realizations are so much worse than simple. 
