### PR TITLE
Changing ITransformation to abstract class and TryGetArray arg rename

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
@@ -124,10 +124,10 @@ namespace Microsoft.Net.Http
             _next = null;
         }
 
-        protected override bool TryGetArray(out ArraySegment<byte> buffer)
+        protected override bool TryGetArray(out ArraySegment<byte> arraySegment)
         {
             if (IsDisposed) throw new ObjectDisposedException(nameof(OwnedBuffer));
-            buffer = new ArraySegment<byte>(_array);
+            arraySegment = new ArraySegment<byte>(_array);
             return true;
         }
 

--- a/src/System.Binary.Base64/System/Binary/Base64.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64.cs
@@ -6,7 +6,7 @@ namespace System.Binary.Base64
 {
     public static partial class Base64
     {
-        public static readonly ITransformation Encoder = new ToBase64();
-        public static readonly ITransformation Decoder = new FromBase64();
+        public static readonly Transformation Encoder = new ToBase64();
+        public static readonly Transformation Decoder = new FromBase64();
     }
 }

--- a/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
@@ -282,9 +282,9 @@ namespace System.Binary.Base64
             return TransformationStatus.InvalidData;
         }
 
-        class FromBase64 : ITransformation
+        class FromBase64 : Transformation
         {
-            public TransformationStatus Transform(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+            public override TransformationStatus Transform(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
                 => Decode(source, destination, out bytesConsumed, out bytesWritten);
         }
     }

--- a/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
@@ -282,7 +282,7 @@ namespace System.Binary.Base64
             return TransformationStatus.InvalidData;
         }
 
-        class FromBase64 : Transformation
+        sealed class FromBase64 : Transformation
         {
             public override TransformationStatus Transform(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
                 => Decode(source, destination, out bytesConsumed, out bytesWritten);

--- a/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
@@ -192,7 +192,7 @@ namespace System.Binary.Base64
             return false;
         }
 
-        class ToBase64 : Transformation
+        sealed class ToBase64 : Transformation
         {
             public override TransformationStatus Transform(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
                 => Encode(source, destination, out bytesConsumed, out bytesWritten);

--- a/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
@@ -192,9 +192,9 @@ namespace System.Binary.Base64
             return false;
         }
 
-        class ToBase64 : ITransformation
+        class ToBase64 : Transformation
         {
-            public TransformationStatus Transform(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+            public override TransformationStatus Transform(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
                 => Encode(source, destination, out bytesConsumed, out bytesWritten);
         }
     }

--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -12,7 +12,7 @@ namespace System.Buffers
     {
         const int stackLength = 32;
 
-        public static void Pipe(this ITransformation transformation, ReadOnlyBytes source, IOutput destination)
+        public static void Pipe(this Transformation transformation, ReadOnlyBytes source, IOutput destination)
         {
             int afterMergeSlice = 0;
             ReadOnlySpan<byte> remainder;

--- a/src/System.Buffers.Experimental/System/Buffers/BufferManager.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferManager.cs
@@ -31,9 +31,9 @@ namespace System.Buffers.Pools
                 base.Dispose(disposing);
             }
 
-            protected override bool TryGetArray(out ArraySegment<byte> buffer)
+            protected override bool TryGetArray(out ArraySegment<byte> arraySegment)
             {
-                buffer = default(ArraySegment<byte>);
+                arraySegment = default(ArraySegment<byte>);
                 return false;
             }
 

--- a/src/System.Buffers.Experimental/System/Buffers/OwnedNativeBuffer.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/OwnedNativeBuffer.cs
@@ -44,9 +44,9 @@ namespace System.Buffers
                 return new BufferHandle(this, Add(_pointer.ToPointer(), index));
             }
         }
-        protected override bool TryGetArray(out ArraySegment<byte> buffer)
+        protected override bool TryGetArray(out ArraySegment<byte> arraySegment)
         {
-            buffer = default(ArraySegment<byte>);
+            arraySegment = default(ArraySegment<byte>);
             return false;
         }
 

--- a/src/System.Buffers.Experimental/System/Buffers/OwnedPinnedBuffer.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/OwnedPinnedBuffer.cs
@@ -61,10 +61,10 @@ namespace System.Buffers
             return new BufferHandle(this, Add(_pointer.ToPointer(), index));
         }
 
-        protected override bool TryGetArray(out ArraySegment<T> buffer)
+        protected override bool TryGetArray(out ArraySegment<T> arraySegment)
         {
             if (IsDisposed) BuffersExperimentalThrowHelper.ThrowObjectDisposedException(nameof(OwnedPinnedBuffer<T>));
-            buffer = new ArraySegment<T>(_array);
+            arraySegment = new ArraySegment<T>(_array);
             return true;
         }
 

--- a/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace System.Buffers
+namespace System
 {
     [DebuggerTypeProxy(typeof(BufferDebuggerView<>))]
     public struct Buffer<T> : IEquatable<Buffer<T>>, IEquatable<ReadOnlyBuffer<T>>
@@ -150,21 +151,21 @@ namespace System.Buffers
             }
         }
 
-        public bool TryGetArray(out ArraySegment<T> buffer)
+        public bool TryGetArray(out ArraySegment<T> arraySegment)
         {
             if (_owner != null && _owner.TryGetArray(out var segment))
             {
-                buffer = new ArraySegment<T>(segment.Array, segment.Offset + _index, _length);
+                arraySegment = new ArraySegment<T>(segment.Array, segment.Offset + _index, _length);
                 return true;
             }
 
             if (_array != null)
             {
-                buffer = new ArraySegment<T>(_array, _index, _length);
+                arraySegment = new ArraySegment<T>(_array, _index, _length);
                 return true;
             }
 
-            buffer = default(ArraySegment<T>);
+            arraySegment = default(ArraySegment<T>);
             return false;
         }
 

--- a/src/System.Buffers.Primitives/System/Buffers/OwnedBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/OwnedBuffer.cs
@@ -45,7 +45,7 @@ namespace System.Buffers
 
         public abstract BufferHandle Pin(int index = 0);
 
-        protected internal abstract bool TryGetArray(out ArraySegment<T> buffer);
+        protected internal abstract bool TryGetArray(out ArraySegment<T> arraySegment);
 
         #region Lifetime Management
         public abstract bool IsDisposed { get; }

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -2,13 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-namespace System.Buffers
+namespace System
 {
     [DebuggerTypeProxy(typeof(ReadOnlyBufferDebuggerView<>))]
     public struct ReadOnlyBuffer<T> : IEquatable<ReadOnlyBuffer<T>>, IEquatable<Buffer<T>>

--- a/src/System.Buffers.Primitives/System/Buffers/Transformation.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Transformation.cs
@@ -3,9 +3,9 @@
 
 namespace System.Buffers
 {
-    public interface ITransformation
+    public abstract class Transformation
     {
-        TransformationStatus Transform(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten);
+        public abstract TransformationStatus Transform(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten);
     }
 
     public enum TransformationStatus

--- a/src/System.Buffers.Primitives/System/Internal/ManagedBufferPool.cs
+++ b/src/System.Buffers.Primitives/System/Internal/ManagedBufferPool.cs
@@ -62,10 +62,10 @@ namespace System.Buffers.Internal
                 }
             }
 
-            protected internal override bool TryGetArray(out ArraySegment<byte> buffer)
+            protected internal override bool TryGetArray(out ArraySegment<byte> arraySegment)
             {
                 if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(ManagedBufferPool));
-                buffer = new ArraySegment<byte>(_array);
+                arraySegment = new ArraySegment<byte>(_array);
                 return true;
             }
 

--- a/src/System.Buffers.Primitives/System/Internal/OwnedArray.cs
+++ b/src/System.Buffers.Primitives/System/Internal/OwnedArray.cs
@@ -51,10 +51,10 @@ namespace System.Buffers.Internal
             }
         }
 
-        protected internal override bool TryGetArray(out ArraySegment<T> buffer)
+        protected internal override bool TryGetArray(out ArraySegment<T> arraySegment)
         {
             if (IsDisposed) BufferPrimitivesThrowHelper.ThrowObjectDisposedException(nameof(OwnedArray<T>));
-            buffer = new ArraySegment<T>(_array);
+            arraySegment = new ArraySegment<T>(_array);
             return true;
         }
 

--- a/src/System.IO.Pipelines/MemoryPoolBlock.cs
+++ b/src/System.IO.Pipelines/MemoryPoolBlock.cs
@@ -124,10 +124,10 @@ namespace System.IO.Pipelines
 #if KESTREL_BY_SOURCE
         internal
 #endif
-        protected override bool TryGetArray(out ArraySegment<byte> buffer)
+        protected override bool TryGetArray(out ArraySegment<byte> arraySegment)
         {
             if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(nameof(MemoryPoolBlock));
-            buffer = new ArraySegment<byte>(Slab.Array, _offset, _length);
+            arraySegment = new ArraySegment<byte>(Slab.Array, _offset, _length);
             return true;
         }
 

--- a/src/System.IO.Pipelines/UnownedBuffer.cs
+++ b/src/System.IO.Pipelines/UnownedBuffer.cs
@@ -45,10 +45,10 @@ namespace System.IO.Pipelines
 #if KESTREL_BY_SOURCE
         internal
 #endif
-        protected override bool TryGetArray(out ArraySegment<byte> buffer)
+        protected override bool TryGetArray(out ArraySegment<byte> arraySegment)
         {
             if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(nameof(UnownedBuffer));
-            buffer = _buffer;
+            arraySegment = _buffer;
             return true;
         }
 

--- a/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
@@ -222,10 +222,10 @@ namespace System.Buffers.Tests
             }
         }
 
-        protected override bool TryGetArray(out ArraySegment<T> buffer)
+        protected override bool TryGetArray(out ArraySegment<T> arraySegment)
         {
             if (IsDisposed) throw new ObjectDisposedException(nameof(CustomBuffer<T>));
-            buffer = new ArraySegment<T>(_array);
+            arraySegment = new ArraySegment<T>(_array);
             return true;
         }
 
@@ -278,10 +278,10 @@ namespace System.Buffers.Tests
             Dispose();
         }
 
-        protected override bool TryGetArray(out ArraySegment<T> buffer)
+        protected override bool TryGetArray(out ArraySegment<T> arraySegment)
         {
             if (IsDisposed) throw new ObjectDisposedException(nameof(AutoDisposeBuffer<T>));
-            buffer = new ArraySegment<T>(_array);
+            arraySegment = new ArraySegment<T>(_array);
             return true;
         }
 

--- a/tests/System.IO.Pipelines.Tests/PipelineReaderWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/PipelineReaderWriterFacts.cs
@@ -544,10 +544,10 @@ namespace System.IO.Pipelines.Tests
                     base.Dispose(disposing);
                 }
 
-                protected override bool TryGetArray(out ArraySegment<byte> buffer)
+                protected override bool TryGetArray(out ArraySegment<byte> arraySegment)
                 {
                     if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(nameof(DisposeTrackingBufferPool));
-                    buffer = new ArraySegment<byte>(_array);
+                    arraySegment = new ArraySegment<byte>(_array);
                     return true;
                 }
 


### PR DESCRIPTION
- TryGetArray(out ArraySegment<byte> buffer) => TryGetArray(out ArraySegment<byte> arraySegment)
- Moving Buffer\<T\> & ReadOnlyBuffer\<T\> to System namespace (from System.Buffers)
- interface ITransformation => abstract class Transformation

cc @shiftylogic, @KrzysztofCwalina 