### PR TITLE
Skipping brotli tests that are failing in VS.

### DIFF
--- a/tests/System.IO.Compression.Tests/BrotliPrimitivesTests.cs
+++ b/tests/System.IO.Compression.Tests/BrotliPrimitivesTests.cs
@@ -25,7 +25,7 @@ namespace System.IO.Compression.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => BrotliPrimitives.Compress(new byte[1], new byte[1], out int consumed, out int written, quality, lgWinSize));
         }
 
-        [Theory]
+        [Theory(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         [InlineData(1)]
         [InlineData(5)]
         [InlineData(1023)]

--- a/tests/System.IO.Compression.Tests/BrotliStreamTests.cs
+++ b/tests/System.IO.Compression.Tests/BrotliStreamTests.cs
@@ -14,7 +14,7 @@ namespace System.IO.Compression.Tests
     {
         static string brTestFile(string fileName) => Path.Combine("BrotliTestData", fileName);
 
-        [Fact]
+        [Fact(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         public void BaseStreamCompress()
         {
             var writeStream = new MemoryStream();
@@ -22,7 +22,7 @@ namespace System.IO.Compression.Tests
             writeStream.Dispose();
         }
 
-        [Fact]
+        [Fact(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         public void BaseStreamDecompress()
         {
             var writeStream = new MemoryStream();
@@ -30,7 +30,7 @@ namespace System.IO.Compression.Tests
             writeStream.Dispose();
         }
 
-        [Fact]
+        [Fact(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         public void DecompressCanRead()
         {
             var memoryInputStream = new MemoryStream();
@@ -40,7 +40,7 @@ namespace System.IO.Compression.Tests
             Assert.False(brotliCompressStream.CanRead);
         }
 
-        [Fact]
+        [Fact(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         public void CompressCanWrite()
         {
             var memoryInputStream = new MemoryStream();
@@ -51,7 +51,7 @@ namespace System.IO.Compression.Tests
             Assert.False(brotliCompressStream.CanWrite);
         }
 
-        [Fact]
+        [Fact(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         public void CanDisposeBaseStream()
         {
             var memoryInputStream = new MemoryStream();
@@ -59,7 +59,7 @@ namespace System.IO.Compression.Tests
             memoryInputStream.Dispose(); // This would throw if this was invalid
         }
 
-        [Fact]
+        [Fact(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         public void CanDisposeBrotliStream()
         {
             var memoryInputStream = new MemoryStream();
@@ -78,7 +78,7 @@ namespace System.IO.Compression.Tests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         public void Flush()
         {
             var memoryInputStream = new MemoryStream();
@@ -86,7 +86,7 @@ namespace System.IO.Compression.Tests
             brotliCompressStream.Flush();
         }
 
-        [Fact]
+        [Fact(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         public void DoubleFlush()
         {
             var memoryInputStream = new MemoryStream();
@@ -95,7 +95,7 @@ namespace System.IO.Compression.Tests
             brotliCompressStream.Flush();
         }
 
-        [Fact]
+        [Fact(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         public void DoubleDispose()
         {
             var memoryInputStream = new MemoryStream();
@@ -111,7 +111,7 @@ namespace System.IO.Compression.Tests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         public void FlushThenDispose()
         {
             var memoryInputStream = new MemoryStream();
@@ -127,7 +127,7 @@ namespace System.IO.Compression.Tests
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         public void TestSeekMethobrotliCompressStreamDecompress()
         {
             var memoryInputStream = new MemoryStream();
@@ -140,7 +140,7 @@ namespace System.IO.Compression.Tests
             Assert.Throws<NotSupportedException>(delegate { brotliCompressStream.Seek(100L, SeekOrigin.Begin); });
         }
 
-        [Fact]
+        [Fact(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         public void TestSeekMethobrotliCompressStreamCompress()
         {
             var memoryInputStream = new MemoryStream();
@@ -153,7 +153,7 @@ namespace System.IO.Compression.Tests
             Assert.Throws<NotSupportedException>(delegate { brotliCompressStream.Seek(100L, SeekOrigin.Begin); });
         }
 
-        [Fact]
+        [Fact(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         public void CanReadBaseStreamAfterDispose()
         {
             var memoryInputStream = new MemoryStream(File.ReadAllBytes(brTestFile("BrotliTest.txt.br")));
@@ -165,7 +165,7 @@ namespace System.IO.Compression.Tests
             baseStream.Read(bytes, 0, size); // This will throw if the underlying stream is not writable as expected
         }
 
-        [Fact]
+        [Fact(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         public void ReadWriteArgumentValidation()
         {
             using (var brotliCompressStream = new BrotliStream(new MemoryStream(), CompressionMode.Compress))
@@ -192,7 +192,7 @@ namespace System.IO.Compression.Tests
             }
         }
 
-        [Theory]
+        [Theory(Skip = "Fails in VS - System.BadImageFormatException : An attempt was made to load a program with an incorrect format.")]
         [InlineData(1, 5)]
         [InlineData(1023, 1023 * 10)]
         [InlineData(1024 * 1024, 1024 * 1024)]


### PR DESCRIPTION
Filed an issue: https://github.com/dotnet/corefxlab/issues/1611

cc @Vedin, @shiftylogic, @KrzysztofCwalina 