### PR TITLE
Fixing implementation of Buffers.Equals(obj) and adding tests.

### DIFF
--- a/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
@@ -194,12 +194,20 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj)
         {
-            if(!(obj is Buffer<T>)) {
+            if (obj is ReadOnlyBuffer<T>)
+            {
+                var other = (ReadOnlyBuffer<T>)obj;
+                return other.Equals(this);
+            }
+            else if (obj is Buffer<T>)
+            {
+                var other = (Buffer<T>)obj;
+                return Equals(other);
+            }
+            else
+            {
                 return false;
             }
-
-            var other = (Buffer<T>)obj;
-            return Equals(other);
         }
 
         public bool Equals(Buffer<T> other)

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -164,12 +164,20 @@ namespace System
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj)
         {
-            if (!(obj is ReadOnlyBuffer<T>)) {
+            if (obj is ReadOnlyBuffer<T>)
+            {
+                var other = (ReadOnlyBuffer<T>)obj;
+                return Equals(other);
+            }
+            else if (obj is Buffer<T>)
+            {
+                var other = (Buffer<T>)obj;
+                return Equals(other);
+            }
+            else
+            {
                 return false;
             }
-
-            var other = (ReadOnlyBuffer<T>)obj;
-            return Equals(other);
         }
         
         public bool Equals(ReadOnlyBuffer<T> other)

--- a/tests/System.Buffers.Primitives.Tests/BufferEqualityTests.cs
+++ b/tests/System.Buffers.Primitives.Tests/BufferEqualityTests.cs
@@ -19,6 +19,15 @@ namespace System.Buffers.Tests
             var readOnlyBuffer = ReadOnlyBuffer<byte>.Empty;
             object readOnlyBufferAsObject = readOnlyBuffer;
             Assert.True(readOnlyBuffer.Equals(readOnlyBufferAsObject));
+
+            Assert.False(buffer.Equals(new object()));
+            Assert.False(readOnlyBuffer.Equals(new object()));
+
+            Assert.False(buffer.Equals((object)(new Buffer<byte>(new byte[] { 1, 2 }))));
+            Assert.False(readOnlyBuffer.Equals((object)(new ReadOnlyBuffer<byte>(new byte[] { 1, 2 }))));
+
+            Assert.True(buffer.Equals(readOnlyBufferAsObject));
+            Assert.True(readOnlyBuffer.Equals(bufferAsObject));
         }
 
         [Theory]

--- a/tests/System.Buffers.Primitives.Tests/TestHelpers.cs
+++ b/tests/System.Buffers.Primitives.Tests/TestHelpers.cs
@@ -24,12 +24,6 @@ namespace System.Buffers.Tests
 
         public sealed class TestClass
         {
-            private double _d;
-            public char C0;
-            public char C1;
-            public char C2;
-            public char C3;
-            public char C4;
         }
     }
 }


### PR DESCRIPTION
cc @KrzysztofCwalina, @shiftylogic 