### PR TITLE
Fixed a small bug in Trie creation logic

### DIFF
--- a/src/System.Text.Primitives/System/Text/Encoding/Internal/ParsingTrie.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Internal/ParsingTrie.cs
@@ -304,7 +304,7 @@ namespace System.Text
             //   a) each symbol must be unique
             //   b) a symbol cannot be a prefix of another symbol
             //   c) symbols cannot be empty
-            for(int i=1; i<symbolList.Count; i++)
+            for(int i = 1; i < symbolList.Count; i++)
             {
                 var first = symbolList[i - 1];
                 var second = symbolList[i];

--- a/src/System.Text.Primitives/System/Text/Encoding/Internal/ParsingTrie.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Internal/ParsingTrie.cs
@@ -103,7 +103,7 @@ namespace System.Text
             public int CompareTo(Suffix other)
             {
                 var shorter = Math.Min(other.Bytes.Length, Bytes.Length);
-                for(int index=0; index<shorter; index++)
+                for(int index = 0; index < shorter; index++)
                 {
                     if (Bytes[index] == other.Bytes[index]) continue;
                     return Bytes[index].CompareTo(other.Bytes[index]);
@@ -316,7 +316,7 @@ namespace System.Text
                 var firstSpan = first.Bytes.AsSpan();
                 if (firstSpan.SequenceEqual(second.Bytes))
                 {
-                    throw new ArgumentException(String.Format("Symbols cannot be identical"));
+                    throw new ArgumentException("Symbols cannot be identical");
                 }
                 if (first.Bytes.Length > second.Bytes.Length)
                 {


### PR DESCRIPTION
List.Sort seems to be comparing the same item (as this and other) sometimes during List.Sort
This means that the tie validation logic (which was done in the comparer) could sometimes fail.
This PR moves the validation after the array is sorted with a comparer that never fails.