### PR TITLE
New toolset compiler

### DIFF
--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <CoreFxVersion>4.3.0</CoreFxVersion>
-    <RoslynVersion>2.6.0-rdonly-ref-61810-01</RoslynVersion>
+    <RoslynVersion>2.6.0-rdonly-ref-61822-03</RoslynVersion>
     <SystemMemoryVersion>4.4.0-preview2-25317-01</SystemMemoryVersion>
     <SystemCompilerServicesUnsafeVersion>4.4.0-preview2-25317-01</SystemCompilerServicesUnsafeVersion>
     <SystemNumericsVectorsVersion>4.4.0-preview2-25317-01</SystemNumericsVectorsVersion>


### PR DESCRIPTION
Microsoft.NETCore.Compilers 2.6.0-rdonly-ref-61822-03

This build brings bug fixes and support for ref extension methods -
Ex:   ` public static void Ext(ref this MyStruct self, int arg) `

The corresponding VSIX is at:
https://dotnet.myget.org/F/roslyn/vsix/0b48e25b-9903-4d8b-ad39-d4cca196e3c7-2.6.0.6182203.vsix

Diret link:
https://dotnet.myget.org/F/roslyn/vsix/0b48e25b-9903-4d8b-ad39-d4cca196e3c7-2.6.0.6182203.vsix