### PR TITLE
downgrading compiler version temporarily

### DIFF
--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <CoreFxVersion>4.3.0</CoreFxVersion>
-    <RoslynVersion>2.6.0-rdonly-ref-61826-08</RoslynVersion>
+    <RoslynVersion>2.6.0-rdonly-ref-61825-01</RoslynVersion>
     <SystemMemoryVersion>4.4.0-preview2-25317-01</SystemMemoryVersion>
     <SystemCompilerServicesUnsafeVersion>4.4.0-preview2-25317-01</SystemCompilerServicesUnsafeVersion>
     <SystemNumericsVectorsVersion>4.4.0-preview2-25317-01</SystemNumericsVectorsVersion>


### PR DESCRIPTION
This will still have all the 7.2 features, but will not match the most recent VSIX

It seems like we brought in a race condition via the last integration and it affects this repo more than any other.