### PR TITLE
Added 'l' format to DateTime formatting

### DIFF
--- a/src/System.Text.Primitives/System/Text/Formatting/Internal/TimeFormatter.Utf16.cs
+++ b/src/System.Text.Primitives/System/Text/Formatting/Internal/TimeFormatter.Utf16.cs
@@ -26,6 +26,10 @@ namespace System.Text
         private const char GMT2 = 'M';
         private const char GMT3 = 'T';
 
+        private const char GMT1Lowercase = 'g';
+        private const char GMT2Lowercase = 'm';
+        private const char GMT3Lowercase = 't';
+
         private static readonly char[][] DayAbbreviations = new char[][]
         {
                 new char[] { 'S', 'u', 'n' },
@@ -51,6 +55,33 @@ namespace System.Text
                 new char[] { 'O', 'c', 't' },
                 new char[] { 'N', 'o', 'v' },
                 new char[] { 'D', 'e', 'c' },
+        };
+
+        private static readonly char[][] DayAbbreviationsLowercase = new char[][]
+        {
+                new char[] { 's', 'u', 'n' },
+                new char[] { 'm', 'o', 'n' },
+                new char[] { 't', 'u', 'e' },
+                new char[] { 'w', 'e', 'd' },
+                new char[] { 't', 'h', 'u' },
+                new char[] { 'f', 'r', 'i' },
+                new char[] { 's', 'a', 't' },
+        };
+
+        private static readonly char[][] MonthAbbreviationsLowercase = new char[][]
+        {
+                new char[] { 'j', 'a', 'n' },
+                new char[] { 'f', 'e', 'b' },
+                new char[] { 'm', 'a', 'r' },
+                new char[] { 'a', 'p', 'r' },
+                new char[] { 'm', 'a', 'y' },
+                new char[] { 'j', 'u', 'n' },
+                new char[] { 'j', 'u', 'l' },
+                new char[] { 'a', 'u', 'g' },
+                new char[] { 's', 'e', 'p' },
+                new char[] { 'o', 'c', 't' },
+                new char[] { 'n', 'o', 'v' },
+                new char[] { 'd', 'e', 'c' },
         };
 
         #endregion Constants
@@ -240,6 +271,55 @@ namespace System.Text
             Unsafe.Add(ref utf16Bytes, 26) = GMT1;
             Unsafe.Add(ref utf16Bytes, 27) = GMT2;
             Unsafe.Add(ref utf16Bytes, 28) = GMT3;
+
+            return true;
+        }
+
+        public static bool TryFormatRfc1123Lowercase(DateTime value, Span<byte> buffer, out int bytesWritten)
+        {
+            const int CharsNeeded = 29;
+
+            bytesWritten = CharsNeeded * sizeof(char);
+            if (buffer.Length < bytesWritten)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            Span<char> dst = buffer.NonPortableCast<byte, char>();
+            ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
+
+            var dayAbbrev = DayAbbreviationsLowercase[(int)value.DayOfWeek];
+            Unsafe.Add(ref utf16Bytes, 0) = dayAbbrev[0];
+            Unsafe.Add(ref utf16Bytes, 1) = dayAbbrev[1];
+            Unsafe.Add(ref utf16Bytes, 2) = dayAbbrev[2];
+            Unsafe.Add(ref utf16Bytes, 3) = Comma;
+            Unsafe.Add(ref utf16Bytes, 4) = Space;
+
+            FormattingHelpers.WriteDigits(value.Day, 2, ref utf16Bytes, 5);
+            Unsafe.Add(ref utf16Bytes, 7) = ' ';
+
+            var monthAbbrev = MonthAbbreviationsLowercase[value.Month - 1];
+            Unsafe.Add(ref utf16Bytes, 8) = monthAbbrev[0];
+            Unsafe.Add(ref utf16Bytes, 9) = monthAbbrev[1];
+            Unsafe.Add(ref utf16Bytes, 10) = monthAbbrev[2];
+            Unsafe.Add(ref utf16Bytes, 11) = Space;
+
+            FormattingHelpers.WriteDigits(value.Year, 4, ref utf16Bytes, 12);
+            Unsafe.Add(ref utf16Bytes, 16) = Space;
+
+            FormattingHelpers.WriteDigits(value.Hour, 2, ref utf16Bytes, 17);
+            Unsafe.Add(ref utf16Bytes, 19) = Colon;
+
+            FormattingHelpers.WriteDigits(value.Minute, 2, ref utf16Bytes, 20);
+            Unsafe.Add(ref utf16Bytes, 22) = Colon;
+
+            FormattingHelpers.WriteDigits(value.Second, 2, ref utf16Bytes, 23);
+            Unsafe.Add(ref utf16Bytes, 25) = Space;
+
+            Unsafe.Add(ref utf16Bytes, 26) = GMT1Lowercase;
+            Unsafe.Add(ref utf16Bytes, 27) = GMT2Lowercase;
+            Unsafe.Add(ref utf16Bytes, 28) = GMT3Lowercase;
 
             return true;
         }

--- a/src/System.Text.Primitives/System/Text/Formatting/Internal/TimeFormatter.Utf8.cs
+++ b/src/System.Text.Primitives/System/Text/Formatting/Internal/TimeFormatter.Utf8.cs
@@ -26,6 +26,10 @@ namespace System.Text
         private const byte GMT2 = (byte)'M';
         private const byte GMT3 = (byte)'T';
 
+        private const byte GMT1Lowercase = (byte)'g';
+        private const byte GMT2Lowercase = (byte)'m';
+        private const byte GMT3Lowercase = (byte)'t';
+
         private static readonly byte[][] DayAbbreviations = new byte[][]
         {
                 new byte[] { (byte)'S', (byte)'u', (byte)'n' },
@@ -35,6 +39,17 @@ namespace System.Text
                 new byte[] { (byte)'T', (byte)'h', (byte)'u' },
                 new byte[] { (byte)'F', (byte)'r', (byte)'i' },
                 new byte[] { (byte)'S', (byte)'a', (byte)'t' },
+        };
+
+        private static readonly byte[][] DayAbbreviationsLowercase = new byte[][]
+        {
+                new byte[] { (byte)'s', (byte)'u', (byte)'n' },
+                new byte[] { (byte)'m', (byte)'o', (byte)'n' },
+                new byte[] { (byte)'t', (byte)'u', (byte)'e' },
+                new byte[] { (byte)'w', (byte)'e', (byte)'d' },
+                new byte[] { (byte)'t', (byte)'h', (byte)'u' },
+                new byte[] { (byte)'f', (byte)'r', (byte)'i' },
+                new byte[] { (byte)'s', (byte)'a', (byte)'t' },
         };
 
         private static readonly byte[][] MonthAbbreviations = new byte[][]
@@ -52,6 +67,22 @@ namespace System.Text
                 new byte[] { (byte)'N', (byte)'o', (byte)'v' },
                 new byte[] { (byte)'D', (byte)'e', (byte)'c' },
         };
+
+        private static readonly byte[][] MonthAbbreviationsLowercase = new byte[][]
+{
+                new byte[] { (byte)'j', (byte)'a', (byte)'n' },
+                new byte[] { (byte)'f', (byte)'e', (byte)'b' },
+                new byte[] { (byte)'m', (byte)'a', (byte)'r' },
+                new byte[] { (byte)'a', (byte)'p', (byte)'r' },
+                new byte[] { (byte)'m', (byte)'a', (byte)'y' },
+                new byte[] { (byte)'j', (byte)'u', (byte)'n' },
+                new byte[] { (byte)'j', (byte)'u', (byte)'l' },
+                new byte[] { (byte)'a', (byte)'u', (byte)'g' },
+                new byte[] { (byte)'s', (byte)'e', (byte)'p' },
+                new byte[] { (byte)'o', (byte)'c', (byte)'t' },
+                new byte[] { (byte)'n', (byte)'o', (byte)'v' },
+                new byte[] { (byte)'d', (byte)'e', (byte)'c' },
+};
 
         #endregion Constants
 
@@ -235,6 +266,54 @@ namespace System.Text
             Unsafe.Add(ref utf8Bytes, 26) = GMT1;
             Unsafe.Add(ref utf8Bytes, 27) = GMT2;
             Unsafe.Add(ref utf8Bytes, 28) = GMT3;
+
+            return true;
+        }
+
+        public static bool TryFormatRfc1123Lowercase(DateTime value, Span<byte> buffer, out int bytesWritten)
+        {
+            const int BytesNeeded = 29;
+
+            bytesWritten = BytesNeeded;
+            if (buffer.Length < bytesWritten)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
+
+            var dayAbbrev = DayAbbreviationsLowercase[(int)value.DayOfWeek];
+            Unsafe.Add(ref utf8Bytes, 0) = dayAbbrev[0];
+            Unsafe.Add(ref utf8Bytes, 1) = dayAbbrev[1];
+            Unsafe.Add(ref utf8Bytes, 2) = dayAbbrev[2];
+            Unsafe.Add(ref utf8Bytes, 3) = Comma;
+            Unsafe.Add(ref utf8Bytes, 4) = Space;
+
+            FormattingHelpers.WriteDigits(value.Day, 2, ref utf8Bytes, 5);
+            Unsafe.Add(ref utf8Bytes, 7) = (byte)' ';
+
+            var monthAbbrev = MonthAbbreviationsLowercase[value.Month - 1];
+            Unsafe.Add(ref utf8Bytes, 8) = monthAbbrev[0];
+            Unsafe.Add(ref utf8Bytes, 9) = monthAbbrev[1];
+            Unsafe.Add(ref utf8Bytes, 10) = monthAbbrev[2];
+            Unsafe.Add(ref utf8Bytes, 11) = Space;
+
+            FormattingHelpers.WriteDigits(value.Year, 4, ref utf8Bytes, 12);
+            Unsafe.Add(ref utf8Bytes, 16) = Space;
+
+            FormattingHelpers.WriteDigits(value.Hour, 2, ref utf8Bytes, 17);
+            Unsafe.Add(ref utf8Bytes, 19) = Colon;
+
+            FormattingHelpers.WriteDigits(value.Minute, 2, ref utf8Bytes, 20);
+            Unsafe.Add(ref utf8Bytes, 22) = Colon;
+
+            FormattingHelpers.WriteDigits(value.Second, 2, ref utf8Bytes, 23);
+            Unsafe.Add(ref utf8Bytes, 25) = Space;
+
+            Unsafe.Add(ref utf8Bytes, 26) = GMT1Lowercase;
+            Unsafe.Add(ref utf8Bytes, 27) = GMT2Lowercase;
+            Unsafe.Add(ref utf8Bytes, 28) = GMT3Lowercase;
 
             return true;
         }

--- a/src/System.Text.Primitives/System/Text/Formatting/PrimitiveFormatter.Time.cs
+++ b/src/System.Text.Primitives/System/Text/Formatting/PrimitiveFormatter.Time.cs
@@ -19,14 +19,15 @@ namespace System.Text
                 offset = value.Offset;
             }
 
-            Precondition.Require(format.Symbol == 'R' || format.Symbol == 'O' || format.Symbol == 'G');
-
             symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
 
             switch (format.Symbol)
             {
                 case 'R':
                     return TryFormatDateTimeRfc1123(value.UtcDateTime, buffer, out bytesWritten, symbolTable);
+
+                case 'l':
+                    return TryFormatDateTimeRfc1123Lowercase(value.UtcDateTime, buffer, out bytesWritten, symbolTable);
 
                 case 'O':
                     return TryFormatDateTimeFormatO(value.DateTime, value.Offset, buffer, out bytesWritten, symbolTable);
@@ -46,14 +47,15 @@ namespace System.Text
                 format.Symbol = 'G';
             }
 
-            Precondition.Require(format.Symbol == 'R' || format.Symbol == 'O' || format.Symbol == 'G');
-
             symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
 
             switch (format.Symbol)
             {
                 case 'R':
                     return TryFormatDateTimeRfc1123(value, buffer, out bytesWritten, symbolTable);
+
+                case 'l':
+                    return TryFormatDateTimeRfc1123Lowercase(value, buffer, out bytesWritten, symbolTable);
 
                 case 'O':
                     return TryFormatDateTimeFormatO(value, NullOffset, buffer, out bytesWritten, symbolTable);
@@ -112,6 +114,18 @@ namespace System.Text
                 return InvariantUtf8TimeFormatter.TryFormatRfc1123(value, buffer, out bytesWritten);
             else if (symbolTable == SymbolTable.InvariantUtf16)
                 return InvariantUtf16TimeFormatter.TryFormatRfc1123(value, buffer, out bytesWritten);
+            else
+                throw new NotImplementedException();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static bool TryFormatDateTimeRfc1123Lowercase(DateTime value, Span<byte> buffer, out int bytesWritten, SymbolTable symbolTable)
+        {
+            // for now it only works for invariant culture
+            if (symbolTable == SymbolTable.InvariantUtf8)
+                return InvariantUtf8TimeFormatter.TryFormatRfc1123Lowercase(value, buffer, out bytesWritten);
+            else if (symbolTable == SymbolTable.InvariantUtf16)
+                return InvariantUtf16TimeFormatter.TryFormatRfc1123Lowercase(value, buffer, out bytesWritten);
             else
                 throw new NotImplementedException();
         }

--- a/tests/System.Text.Primitives.Tests/Formatting/TimeTests.cs
+++ b/tests/System.Text.Primitives.Tests/Formatting/TimeTests.cs
@@ -20,6 +20,7 @@ namespace System.Text.Primitives.Tests
         [InlineData('G')]
         [InlineData('O')]
         [InlineData('R')]
+        [InlineData('l')]
         public void SpecificDateTimeTests(char format)
         {
             foreach (var symbolTable in SymbolTables)
@@ -36,6 +37,7 @@ namespace System.Text.Primitives.Tests
         [InlineData('G')]
         [InlineData('O')]
         [InlineData('R')]
+        [InlineData('l')]
         public void RandomDateTimeTests(char format)
         {
             for (var i = 0; i < NumberOfRandomSamples; i++)
@@ -50,7 +52,11 @@ namespace System.Text.Primitives.Tests
 
         static void TestDateTimeFormat(DateTime dt, char format, SymbolTable symbolTable)
         {
-            var expected = dt.ToString(format.ToString(), CultureInfo.InvariantCulture);
+            string expected;
+            if (format == 'l')
+                expected = dt.ToString("R", CultureInfo.InvariantCulture).ToLowerInvariant();
+            else
+                expected = dt.ToString(format.ToString(), CultureInfo.InvariantCulture);           
 
             var span = new Span<byte>(new byte[256]);
             Assert.True(PrimitiveFormatter.TryFormat(dt, span, out int written, format, symbolTable));
@@ -64,6 +70,7 @@ namespace System.Text.Primitives.Tests
         [InlineData('G')]
         [InlineData('O')]
         [InlineData('R')]
+        [InlineData('l')]
         public void RandomDateTimeOffsetTests(char format)
         {
             for (var i = 0; i < NumberOfRandomSamples; i++)
@@ -79,9 +86,14 @@ namespace System.Text.Primitives.Tests
         static void TestDateTimeOffsetFormat(DateTimeOffset dto, char formatChar, SymbolTable symbolTable)
         {
             TextFormat format = (formatChar == 0) ? default(TextFormat) : formatChar;
-            string expected = (format.IsDefault)
-                ? dto.ToString(CultureInfo.InvariantCulture)
-                : dto.ToString(formatChar.ToString(), CultureInfo.InvariantCulture);
+
+            string expected;
+            if (formatChar == 'l') {
+                expected = dto.ToString("R", CultureInfo.InvariantCulture).ToLowerInvariant();
+            }
+            else {
+                expected = (format.IsDefault) ? dto.ToString(CultureInfo.InvariantCulture) : dto.ToString(formatChar.ToString(), CultureInfo.InvariantCulture);
+            }
 
             var span = new Span<byte>(new byte[256]);
             Assert.True(PrimitiveFormatter.TryFormat(dto, span, out int written, format, symbolTable));


### PR DESCRIPTION
This format is needed to produce Azure authentication tokens. When the tokens are created, they need lowercase RFC1123 representation of the current time.