### PR TITLE
Updating to a new toolset compiler.

### DIFF
--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <CoreFxVersion>4.3.0</CoreFxVersion>
-    <RoslynVersion>2.6.0-rdonly-ref-61822-03</RoslynVersion>
+    <RoslynVersion>2.6.0-rdonly-ref-61829-12</RoslynVersion>
     <SystemMemoryVersion>4.4.0-preview2-25317-01</SystemMemoryVersion>
     <SystemCompilerServicesUnsafeVersion>4.4.0-preview2-25317-01</SystemCompilerServicesUnsafeVersion>
     <SystemNumericsVectorsVersion>4.4.0-preview2-25317-01</SystemNumericsVectorsVersion>


### PR DESCRIPTION
The new version is:
2.6.0-rdonly-ref-61829-12

The difference from the previous one is bug fixes.

The corresponding VSIX is:
https://dotnet.myget.org/F/roslyn/vsix/0b48e25b-9903-4d8b-ad39-d4cca196e3c7-2.6.0.6182912.vsix