### PR TITLE
Encoder Design Changes

### DIFF
--- a/src/System.Text.Formatting.Globalization/System/Text/Formatting/FormattingDataProvider.cs
+++ b/src/System.Text.Formatting.Globalization/System/Text/Formatting/FormattingDataProvider.cs
@@ -43,7 +43,7 @@ namespace System.Text.Formatting
             resourceStream.Read(index, 0, indexSize);
 
             byte[] idBytes = new byte[maxIdLength];
-            var status = Encoders.Utf8.ConvertFromUtf16(localeId.AsSpan().AsBytes(), idBytes, out int consumed, out int idByteCount);
+            var status = Encoders.Utf16.ToUtf8(localeId.AsSpan().AsBytes(), idBytes, out int consumed, out int idByteCount);
             if (status != System.Buffers.TransformationStatus.Done)
                 throw new Exception("bad locale id");
 

--- a/src/System.Text.Http.Parser/HttpUtilities.cs
+++ b/src/System.Text.Http.Parser/HttpUtilities.cs
@@ -73,7 +73,7 @@ namespace System.Text.Http.Parser.Internal
 
             var buffer = stackalloc byte[8];
             Span<byte> span = new Span<byte>(buffer, 8);
-            Encoders.Utf8.ConvertFromUtf16(str.AsSpan().AsBytes(), span, out int consumed, out int written);
+            Encoders.Utf16.ToUtf8(str.AsSpan().AsBytes(), span, out int consumed, out int written);
             return span.Read<ulong>();
         }
 
@@ -83,7 +83,7 @@ namespace System.Text.Http.Parser.Internal
 
             var buffer = stackalloc byte[4];
             Span<byte> span = new Span<byte>(buffer, 4);
-            Encoders.Utf8.ConvertFromUtf16(str.AsSpan().AsBytes(), span, out int consumed, out int written);
+            Encoders.Utf16.ToUtf8(str.AsSpan().AsBytes(), span, out int consumed, out int written);
             return span.Read<uint>();
         }
 

--- a/src/System.Text.Json/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonWriter.cs
@@ -427,7 +427,7 @@ namespace System.Text.Json
 
                 while (true)
                 {
-                    var status = Encoders.Utf8.ConvertFromUtf16(source, destination, out int consumed, out int written);
+                    var status = Encoders.Utf16.ToUtf8(source, destination, out int consumed, out int written);
                     if (status == Buffers.TransformationStatus.Done)
                     {
                         _output.Advance(written);

--- a/src/System.Text.Primitives/System/Text/Encoding/Encoders.Utf16.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Encoders.Utf16.cs
@@ -11,12 +11,42 @@ namespace System.Text.Encoders
     {
         #region UTF-8 Conversions
 
+        /// <summary>
+        /// Calculates the byte count needed to encode the UTF-16 bytes from the specified UTF-8 sequence.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
+        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the expected state of the conversion.</returns>
         public static TransformationStatus FromUtf8Length(ReadOnlySpan<byte> source, out int bytesNeeded)
             => Utf8.ToUtf16Length(source, out bytesNeeded);
 
+        /// <summary>
+        /// Converts a span containing a sequence of UTF-8 bytes into UTF-16 bytes.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        ///
+        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+        /// the <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
+        /// <param name="destination">A span to write the UTF-16 bytes into.</param>
+        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the state of the conversion.</returns>
         public static TransformationStatus FromUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
             => Utf8.ToUtf16(source, destination, out bytesConsumed, out bytesWritten);
 
+        /// <summary>
+        /// Calculates the byte count needed to encode the UTF-8 bytes from the specified UTF-16 sequence.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
+        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the expected state of the conversion.</returns>
         public static TransformationStatus ToUtf8Length(ReadOnlySpan<byte> source, out int bytesNeeded)
         {
             bytesNeeded = 0;
@@ -368,12 +398,42 @@ namespace System.Text.Encoders
 
         #region UTF-32 Conversions
 
+        /// <summary>
+        /// Calculates the byte count needed to encode the UTF-16 bytes from the specified UTF-32 sequence.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the expected state of the conversion.</returns>
         public static TransformationStatus FromUtf32Length(ReadOnlySpan<byte> source, out int bytesNeeded)
             => Utf32.ToUtf16Length(source, out bytesNeeded);
 
+        /// <summary>
+        /// Converts a span containing a sequence of UTF-32 bytes into UTF-16 bytes.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        ///
+        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+        /// the <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+        /// <param name="destination">A span to write the UTF-16 bytes into.</param>
+        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the state of the conversion.</returns>
         public static TransformationStatus FromUtf32(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
             => Utf32.ToUtf16(source, destination, out bytesConsumed, out bytesWritten);
 
+        /// <summary>
+        /// Calculates the byte count needed to encode the UTF-32 bytes from the specified UTF-16 sequence.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
+        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the expected state of the conversion.</returns>
         public static TransformationStatus ToUtf32Length(ReadOnlySpan<byte> source, out int bytesNeeded)
         {
             bytesNeeded = 0;
@@ -465,25 +525,5 @@ namespace System.Text.Encoders
         }
 
         #endregion UTF-32 Conversions
-
-        #region Utf-8 to Utf-16 conversion
-
-        public unsafe static TransformationStatus ComputeEncodedBytesFromUtf8(ReadOnlySpan<byte> source, out int bytesNeeded)
-            => Utf8.ToUtf16Length(source, out bytesNeeded);
-
-        public unsafe static TransformationStatus ConvertFromUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-            => Utf8.ToUtf16(source, destination, out bytesConsumed, out bytesWritten);
-
-        #endregion Utf-8 to Utf-16 conversion
-
-        #region Utf-32 to Utf-16 conversion
-
-        public static TransformationStatus ComputeEncodedBytesFromUtf32(ReadOnlySpan<byte> source, out int bytesNeeded)
-            => Utf32.ToUtf16Length(source, out bytesNeeded);
-
-        public static TransformationStatus ConvertFromUtf32(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-            => Utf32.ToUtf16(source, destination, out bytesConsumed, out bytesWritten);
-
-        #endregion Utf-32 to Utf-16 conversion
     }
 }

--- a/src/System.Text.Primitives/System/Text/Encoding/Encoders.Utf32.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Encoders.Utf32.cs
@@ -8,38 +8,38 @@ namespace System.Text.Encoders
 {
     public static class Utf32
     {
-        #region Utf-8 to Utf-32 conversion
+        #region UTF-8 Conversions
 
-        public static TransformationStatus ComputeEncodedBytesFromUtf8(ReadOnlySpan<byte> source, out int bytesNeeded)
+        public static TransformationStatus FromUtf8Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+            => Utf8.ToUtf32Length(source, out bytesNeeded);
+
+        public static TransformationStatus FromUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+            => Utf8.ToUtf32(source, destination, out bytesConsumed, out bytesWritten);
+
+        public static TransformationStatus ToUtf8Length(ReadOnlySpan<byte> source, out int bytesNeeded)
         {
             bytesNeeded = 0;
 
-            int index = 0;
-            int length = source.Length;
-            ref byte src = ref source.DangerousGetPinnableReference();
+            ref uint utf32 = ref Unsafe.As<byte, uint>(ref source.DangerousGetPinnableReference());
+            int utf32Length = source.Length >> 2; // byte => uint count
 
-            while (index < length)
+            for (int i = 0; i < utf32Length; i++)
             {
-                int count = EncodingHelper.GetUtf8DecodedBytes(Unsafe.Add(ref src, index));
-                if (count == 0)
-                    goto InvalidData;
-                if (length - index < count)
-                    goto NeedMoreData;
+                uint codePoint = Unsafe.Add(ref utf32, i);
+                if (!EncodingHelper.IsSupportedCodePoint(codePoint))
+                    return TransformationStatus.InvalidData;
 
-                bytesNeeded += count;
+                bytesNeeded += EncodingHelper.GetUtf8EncodedBytes(codePoint);
             }
 
-            return index < length ? TransformationStatus.DestinationTooSmall : TransformationStatus.Done;
+            if (utf32Length << 2 != source.Length)
+                return TransformationStatus.NeedMoreSourceData;
 
-        InvalidData:
-            return TransformationStatus.InvalidData;
-
-        NeedMoreData:
-            return TransformationStatus.NeedMoreSourceData;
+            return TransformationStatus.Done;
         }
 
         /// <summary>
-        /// Converts a span containing a sequence of UTF-8 bytes into UTF-32 bytes.
+        /// Converts a span containing a sequence of UTF-32 bytes into UTF-8 bytes.
         ///
         /// This method will consume as many of the input bytes as possible.
         ///
@@ -47,150 +47,179 @@ namespace System.Text.Encoders
         /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
         /// the <paramref name="destination"/>.
         /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
-        /// <param name="destination">A span to write the UTF-32 bytes into.</param>
+        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+        /// <param name="destination">A span to write the UTF-8 bytes into.</param>
         /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
         /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
         /// <returns>A <see cref="TransformationStatus"/> value representing the state of the conversion.</returns>
-        public static TransformationStatus ConvertFromUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+        public static TransformationStatus ToUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
         {
             bytesConsumed = 0;
             bytesWritten = 0;
 
-            int srcLength = source.Length;
-            int dstLength = destination.Length;
             ref byte src = ref source.DangerousGetPinnableReference();
+            int srcLength = source.Length;
+
             ref byte dst = ref destination.DangerousGetPinnableReference();
+            int dstLength = destination.Length;
 
-            while (bytesConsumed < srcLength && bytesWritten < dstLength)
+            while (srcLength - bytesConsumed >= sizeof(uint))
             {
-                uint codePoint = Unsafe.Add(ref src, bytesConsumed);
+                uint codePoint = Unsafe.As<byte, uint>(ref Unsafe.Add(ref src, bytesConsumed));
+                if (!EncodingHelper.IsSupportedCodePoint(codePoint))
+                    return TransformationStatus.InvalidData;
 
-                int byteCount = EncodingHelper.GetUtf8DecodedBytes((byte)codePoint);
-                if (byteCount == 0)
-                    goto InvalidData;
-                if (srcLength - bytesConsumed < byteCount)
-                    goto NeedMoreData;
+                int bytesNeeded = EncodingHelper.GetUtf8EncodedBytes(codePoint);
+                if (dstLength - bytesWritten < bytesNeeded)
+                    return TransformationStatus.DestinationTooSmall;
 
-                if (byteCount > 1)
-                    codePoint &= (byte)(0x7F >> byteCount);
-
-                for (var i = 1; i < byteCount; i++)
+                switch (bytesNeeded)
                 {
-                    ref byte next = ref Unsafe.Add(ref src, bytesConsumed + i);
-                    if ((next & EncodingHelper.b1100_0000U) != EncodingHelper.b1000_0000U)
-                        goto InvalidData;
+                    case 1:
+                        Unsafe.Add(ref dst, bytesWritten) = (byte)(EncodingHelper.b0111_1111U & codePoint);
+                        break;
 
-                    codePoint = (codePoint << 6) | (uint)(EncodingHelper.b0011_1111U & next);
+                    case 2:
+                        Unsafe.Add(ref dst, bytesWritten) = (byte)(((codePoint >> 6) & EncodingHelper.b0001_1111U) | EncodingHelper.b1100_0000U);
+                        Unsafe.Add(ref dst, bytesWritten + 1) = (byte)((codePoint & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
+                        break;
+
+                    case 3:
+                        Unsafe.Add(ref dst, bytesWritten) = (byte)(((codePoint >> 12) & EncodingHelper.b0000_1111U) | EncodingHelper.b1110_0000U);
+                        Unsafe.Add(ref dst, bytesWritten + 1) = (byte)(((codePoint >> 6) & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
+                        Unsafe.Add(ref dst, bytesWritten + 2) = (byte)((codePoint & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
+                        break;
+
+                    case 4:
+                        Unsafe.Add(ref dst, bytesWritten) = (byte)(((codePoint >> 18) & EncodingHelper.b0000_0111U) | EncodingHelper.b1111_0000U);
+                        Unsafe.Add(ref dst, bytesWritten + 1) = (byte)(((codePoint >> 12) & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
+                        Unsafe.Add(ref dst, bytesWritten + 2) = (byte)(((codePoint >> 6) & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
+                        Unsafe.Add(ref dst, bytesWritten + 3) = (byte)((codePoint & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
+                        break;
+
+                    default:
+                        return TransformationStatus.InvalidData;
                 }
 
-                Unsafe.As<byte, uint>(ref Unsafe.Add(ref dst, bytesWritten)) = codePoint;
-                bytesWritten += 4;
-                bytesConsumed += byteCount;
+                bytesConsumed += 4;
+                bytesWritten += bytesNeeded;
             }
 
-            return bytesConsumed < srcLength ? TransformationStatus.DestinationTooSmall : TransformationStatus.Done;
-
-        InvalidData:
-            return TransformationStatus.InvalidData;
-
-        NeedMoreData:
-            return TransformationStatus.NeedMoreSourceData;
+            return bytesConsumed < srcLength ? TransformationStatus.NeedMoreSourceData : TransformationStatus.Done;
         }
+
+        #endregion UTF-8 Conversions
+
+        #region UTF-16 Conversions
+
+        public static TransformationStatus FromUtf16Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+            => Utf16.ToUtf32Length(source, out bytesNeeded);
+
+        public static TransformationStatus FromUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+            => Utf16.ToUtf32(source, destination, out bytesConsumed, out bytesWritten);
+
+        /// <summary>
+        /// Calculates the byte count needed to encode the UTF-16 bytes from the specified UTF-32 sequence.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the expected state of the conversion.</returns>
+        public static TransformationStatus ToUtf16Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+        {
+            int index = 0;
+            int length = source.Length;
+            ref byte src = ref source.DangerousGetPinnableReference();
+
+            bytesNeeded = 0;
+
+            while (length - index >= 4)
+            {
+                ref uint codePoint = ref Unsafe.As<byte, uint>(ref Unsafe.Add(ref src, index));
+
+                if (!EncodingHelper.IsSupportedCodePoint(codePoint))
+                    return TransformationStatus.InvalidData;
+
+                bytesNeeded += EncodingHelper.IsBmp(codePoint) ? 2 : 4;
+                index += 4;
+            }
+
+            return index < length ? TransformationStatus.NeedMoreSourceData : TransformationStatus.Done;
+        }
+
+        /// <summary>
+        /// Converts a span containing a sequence of UTF-32 bytes into UTF-16 bytes.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        ///
+        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+        /// the <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+        /// <param name="destination">A span to write the UTF-16 bytes into.</param>
+        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the state of the conversion.</returns>
+        public static TransformationStatus ToUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+        {
+            ref byte src = ref source.DangerousGetPinnableReference();
+            ref byte dst = ref destination.DangerousGetPinnableReference();
+            int srcLength = source.Length;
+            int dstLength = destination.Length;
+
+            bytesConsumed = 0;
+            bytesWritten = 0;
+
+            while (srcLength - bytesConsumed >= sizeof(uint))
+            {
+                ref uint codePoint = ref Unsafe.As<byte, uint>(ref Unsafe.Add(ref src, bytesConsumed));
+
+                if (!EncodingHelper.IsSupportedCodePoint(codePoint))
+                    return TransformationStatus.InvalidData;
+
+                int written = EncodingHelper.IsBmp(codePoint) ? 2 : 4;
+                if (dstLength - bytesWritten < written)
+                    return TransformationStatus.DestinationTooSmall;
+
+                unchecked
+                {
+                    if (written == 2)
+                        Unsafe.As<byte, char>(ref Unsafe.Add(ref dst, bytesWritten)) = (char)codePoint;
+                    else
+                    {
+                        Unsafe.As<byte, char>(ref Unsafe.Add(ref dst, bytesWritten)) = (char)(((codePoint - 0x010000u) >> 10) + EncodingHelper.HighSurrogateStart);
+                        Unsafe.As<byte, char>(ref Unsafe.Add(ref dst, bytesWritten + 2)) = (char)((codePoint & 0x3FF) + EncodingHelper.LowSurrogateStart);
+                    }
+                }
+
+                bytesWritten += written;
+                bytesConsumed += 4;
+            }
+
+            return bytesConsumed < srcLength ? TransformationStatus.NeedMoreSourceData : TransformationStatus.Done;
+        }
+
+        #endregion UTF-16 Conversions
+
+        #region Utf-8 to Utf-32 conversion
+
+        public static TransformationStatus ComputeEncodedBytesFromUtf8(ReadOnlySpan<byte> source, out int bytesNeeded)
+            => Utf8.ToUtf32Length(source, out bytesNeeded);
+
+        public static TransformationStatus ConvertFromUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+            => Utf8.ToUtf32(source, destination, out bytesConsumed, out bytesWritten);
 
         #endregion Utf-8 to Utf-32 conversion
 
         #region Utf-16 to Utf-32 conversion
 
         public static TransformationStatus ComputeEncodedBytesFromUtf16(ReadOnlySpan<byte> source, out int bytesNeeded)
-        {
-            bytesNeeded = 0;
+            => Utf16.ToUtf32Length(source, out bytesNeeded);
 
-            ref byte src = ref source.DangerousGetPinnableReference();
-            int srcLength = source.Length;
-            int srcIndex = 0;
-
-            while (srcLength - srcIndex >= sizeof(char))
-            {
-                uint codePoint = Unsafe.As<byte, char>(ref Unsafe.Add(ref src, srcIndex));
-                if (EncodingHelper.IsSurrogate(codePoint))
-                {
-                    if (!EncodingHelper.IsHighSurrogate(codePoint))
-                        return TransformationStatus.InvalidData;
-
-                    if (srcLength - srcIndex < sizeof(char) * 2)
-                        return TransformationStatus.NeedMoreSourceData;
-
-                    uint lowSurrogate = Unsafe.As<byte, char>(ref Unsafe.Add(ref src, srcIndex + 2));
-                    if (!EncodingHelper.IsLowSurrogate(lowSurrogate))
-                        return TransformationStatus.InvalidData;
-
-                    srcIndex += 2;
-                }
-
-                srcIndex += 2;
-                bytesNeeded += 4;
-            }
-
-            return srcIndex < srcLength ? TransformationStatus.NeedMoreSourceData : TransformationStatus.Done;
-        }
-
-        /// <summary>
-        /// Converts a span containing a sequence of UTF-16 bytes into UTF-32 bytes.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
-        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
-        /// the <paramref name="destination"/>.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
-        /// <param name="destination">A span to write the UTF-32 bytes into.</param>
-        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
-        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
-        /// <returns>A <see cref="TransformationStatus"/> value representing the state of the conversion.</returns>
         public static TransformationStatus ConvertFromUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-        {
-            bytesConsumed = 0;
-            bytesWritten = 0;
-
-            ref byte src = ref source.DangerousGetPinnableReference();
-            int srcLength = source.Length;
-
-            ref byte dst = ref destination.DangerousGetPinnableReference();
-            int dstLength = destination.Length;
-
-            while (srcLength - bytesConsumed >= sizeof(char))
-            {
-                if (dstLength - bytesWritten < sizeof(uint))
-                    return TransformationStatus.DestinationTooSmall;
-
-                uint codePoint = Unsafe.As<byte, char>(ref Unsafe.Add(ref src, bytesConsumed));
-                if (EncodingHelper.IsSurrogate(codePoint))
-                {
-                    if (!EncodingHelper.IsHighSurrogate(codePoint))
-                        return TransformationStatus.InvalidData;
-
-                    if (srcLength - bytesConsumed < sizeof(char) * 2)
-                        return TransformationStatus.NeedMoreSourceData;
-
-                    uint lowSurrogate = Unsafe.As<byte, char>(ref Unsafe.Add(ref src, bytesConsumed + 2));
-                    if (!EncodingHelper.IsLowSurrogate(lowSurrogate))
-                        return TransformationStatus.InvalidData;
-
-                    codePoint -= EncodingHelper.HighSurrogateStart;
-                    lowSurrogate -= EncodingHelper.LowSurrogateStart;
-                    codePoint = ((codePoint << 10) | lowSurrogate) + 0x010000u;
-                    bytesConsumed += 2;
-                }
-
-                Unsafe.As<byte, uint>(ref Unsafe.Add(ref dst, bytesWritten)) = codePoint;
-                bytesConsumed += 2;
-                bytesWritten += 4;
-            }
-
-            return bytesConsumed < srcLength ? TransformationStatus.NeedMoreSourceData : TransformationStatus.Done;
-        }
+            => Utf16.ToUtf32(source, destination, out bytesConsumed, out bytesWritten);
 
         #endregion Utf-16 to Utf-32 conversion
     }

--- a/src/System.Text.Primitives/System/Text/Encoding/Encoders.Utf32.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Encoders.Utf32.cs
@@ -10,12 +10,42 @@ namespace System.Text.Encoders
     {
         #region UTF-8 Conversions
 
+        /// <summary>
+        /// Calculates the byte count needed to encode the UTF-32 bytes from the specified UTF-8 sequence.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
+        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the expected state of the conversion.</returns>
         public static TransformationStatus FromUtf8Length(ReadOnlySpan<byte> source, out int bytesNeeded)
             => Utf8.ToUtf32Length(source, out bytesNeeded);
 
+        /// <summary>
+        /// Converts a span containing a sequence of UTF-8 bytes into UTF-32 bytes.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        ///
+        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+        /// the <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
+        /// <param name="destination">A span to write the UTF-32 bytes into.</param>
+        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the state of the conversion.</returns>
         public static TransformationStatus FromUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
             => Utf8.ToUtf32(source, destination, out bytesConsumed, out bytesWritten);
 
+        /// <summary>
+        /// Calculates the byte count needed to encode the UTF-8 bytes from the specified UTF-32 sequence.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the expected state of the conversion.</returns>
         public static TransformationStatus ToUtf8Length(ReadOnlySpan<byte> source, out int bytesNeeded)
         {
             bytesNeeded = 0;
@@ -112,9 +142,31 @@ namespace System.Text.Encoders
 
         #region UTF-16 Conversions
 
+        /// <summary>
+        /// Calculates the byte count needed to encode the UTF-32 bytes from the specified UTF-16 sequence.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
+        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the expected state of the conversion.</returns>
         public static TransformationStatus FromUtf16Length(ReadOnlySpan<byte> source, out int bytesNeeded)
             => Utf16.ToUtf32Length(source, out bytesNeeded);
 
+        /// <summary>
+        /// Converts a span containing a sequence of UTF-16 bytes into UTF-32 bytes.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        ///
+        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+        /// the <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
+        /// <param name="destination">A span to write the UTF-32 bytes into.</param>
+        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the state of the conversion.</returns>
         public static TransformationStatus FromUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
             => Utf16.ToUtf32(source, destination, out bytesConsumed, out bytesWritten);
 
@@ -202,25 +254,5 @@ namespace System.Text.Encoders
         }
 
         #endregion UTF-16 Conversions
-
-        #region Utf-8 to Utf-32 conversion
-
-        public static TransformationStatus ComputeEncodedBytesFromUtf8(ReadOnlySpan<byte> source, out int bytesNeeded)
-            => Utf8.ToUtf32Length(source, out bytesNeeded);
-
-        public static TransformationStatus ConvertFromUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-            => Utf8.ToUtf32(source, destination, out bytesConsumed, out bytesWritten);
-
-        #endregion Utf-8 to Utf-32 conversion
-
-        #region Utf-16 to Utf-32 conversion
-
-        public static TransformationStatus ComputeEncodedBytesFromUtf16(ReadOnlySpan<byte> source, out int bytesNeeded)
-            => Utf16.ToUtf32Length(source, out bytesNeeded);
-
-        public static TransformationStatus ConvertFromUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-            => Utf16.ToUtf32(source, destination, out bytesConsumed, out bytesWritten);
-
-        #endregion Utf-16 to Utf-32 conversion
     }
 }

--- a/src/System.Text.Primitives/System/Text/Encoding/Encoders.Utf8.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Encoders.Utf8.cs
@@ -11,9 +11,31 @@ namespace System.Text.Encoders
     {
         #region UTF-16 Conversions
 
+        /// <summary>
+        /// Calculates the byte count needed to encode the UTF-8 bytes from the specified UTF-16 sequence.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
+        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the expected state of the conversion.</returns>
         public static TransformationStatus FromUtf16Length(ReadOnlySpan<byte> source, out int bytesNeeded)
             => Utf16.ToUtf8Length(source, out bytesNeeded);
 
+        /// <summary>
+        /// Converts a span containing a sequence of UTF-16 bytes into UTF-8 bytes.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        ///
+        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+        /// the <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
+        /// <param name="destination">A span to write the UTF-8 bytes into.</param>
+        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the state of the conversion.</returns>
         public static TransformationStatus FromUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
             => Utf16.ToUtf8(source, destination, out bytesConsumed, out bytesWritten);
 
@@ -687,12 +709,42 @@ namespace System.Text.Encoders
 
         #region UTF-32 Conversions
 
+        /// <summary>
+        /// Calculates the byte count needed to encode the UTF-8 bytes from the specified UTF-32 sequence.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the expected state of the conversion.</returns>
         public static TransformationStatus FromUtf32Length(ReadOnlySpan<byte> source, out int bytesNeeded)
             => Utf32.ToUtf8Length(source, out bytesNeeded);
 
+        /// <summary>
+        /// Converts a span containing a sequence of UTF-32 bytes into UTF-8 bytes.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        ///
+        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+        /// the <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+        /// <param name="destination">A span to write the UTF-8 bytes into.</param>
+        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the state of the conversion.</returns>
         public static TransformationStatus FromUtf32(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
             => Utf32.ToUtf8(source, destination, out bytesConsumed, out bytesWritten);
 
+        /// <summary>
+        /// Calculates the byte count needed to encode the UTF-32 bytes from the specified UTF-8 sequence.
+        ///
+        /// This method will consume as many of the input bytes as possible.
+        /// </summary>
+        /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
+        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+        /// <returns>A <see cref="TransformationStatus"/> value representing the expected state of the conversion.</returns>
         public static TransformationStatus ToUtf32Length(ReadOnlySpan<byte> source, out int bytesNeeded)
         {
             bytesNeeded = 0;
@@ -782,25 +834,5 @@ namespace System.Text.Encoders
         }
 
         #endregion UTF-32 Conversions
-
-        #region Utf-16 to Utf-8 conversion
-
-        public static TransformationStatus ComputeEncodedBytesFromUtf16(ReadOnlySpan<byte> source, out int bytesNeeded)
-            => Utf16.ToUtf8Length(source, out bytesNeeded);
-
-        public static TransformationStatus ConvertFromUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-            => Utf16.ToUtf8(source, destination, out bytesConsumed, out bytesWritten);
-
-        #endregion Utf-16 to Utf-8 conversion
-
-        #region Utf-32 to Utf-8 conversion
-
-        public static TransformationStatus ComputeEncodedBytesFromUtf32(ReadOnlySpan<byte> source, out int bytesNeeded)
-            => Utf32.ToUtf8Length(source, out bytesNeeded);
-
-        public static TransformationStatus ConvertFromUtf32(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-            => Utf32.ToUtf8(source, destination, out bytesConsumed, out bytesWritten);
-
-        #endregion Utf-32 to Utf-8 conversion
     }
 }

--- a/src/System.Text.Primitives/System/Text/Encoding/SymbolTable.Utf16.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/SymbolTable.Utf16.cs
@@ -53,7 +53,7 @@ namespace System.Text
 
             public override bool TryEncode(ReadOnlySpan<byte> utf8, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
             {
-                var status = Encoders.Utf16.ConvertFromUtf8(utf8, destination, out bytesConsumed, out bytesWritten);
+                var status = Encoders.Utf8.ToUtf16(utf8, destination, out bytesConsumed, out bytesWritten);
                 if (status != TransformationStatus.Done)
                 {
                     bytesConsumed = bytesWritten = 0;
@@ -84,7 +84,7 @@ namespace System.Text
 
             public override bool TryParse(ReadOnlySpan<byte> source, Span<byte> utf8, out int bytesConsumed, out int bytesWritten)
             {
-                var status = Encoders.Utf8.ConvertFromUtf16(source, utf8, out bytesConsumed, out bytesWritten);
+                var status = Encoders.Utf16.ToUtf8(source, utf8, out bytesConsumed, out bytesWritten);
                 if (status != TransformationStatus.Done)
                 {
                     bytesConsumed = bytesWritten = 0;

--- a/src/System.Text.Primitives/System/Text/Encoding/SymbolTable.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/SymbolTable.cs
@@ -136,7 +136,7 @@ namespace System.Text
             bytesConsumed = 0;
             while (srcLength > bytesConsumed)
             {
-                var status = Encoders.Utf8.ConvertFromUtf16(srcBytes, temp, out int consumed, out int written);
+                var status = Encoders.Utf16.ToUtf8(srcBytes, temp, out int consumed, out int written);
                 if (status == Buffers.TransformationStatus.InvalidData)
                     goto ExitFailed;
 

--- a/src/System.Text.Primitives/System/Text/Formatting/FloatFormatter.cs
+++ b/src/System.Text.Primitives/System/Text/Formatting/FloatFormatter.cs
@@ -47,7 +47,7 @@ namespace System.Text
             var utf16Bytes = hack.AsSpan().AsBytes();
             if (symbolTable == SymbolTable.InvariantUtf8)
             {
-                var status = Encoders.Utf8.ConvertFromUtf16(utf16Bytes, buffer, out int consumed, out bytesWritten);
+                var status = Encoders.Utf16.ToUtf8(utf16Bytes, buffer, out int consumed, out bytesWritten);
                 return status == Buffers.TransformationStatus.Done;
             }
             else if (symbolTable == SymbolTable.InvariantUtf16)
@@ -63,7 +63,7 @@ namespace System.Text
             {
                 // TODO: This is currently pretty expensive. Can this be done more efficiently?
                 //       Note: removing the hack might solve this problem a very different way.
-                var status = Encoders.Utf8.ComputeEncodedBytesFromUtf16(utf16Bytes, out int needed);
+                var status = Encoders.Utf16.ToUtf8Length(utf16Bytes, out int needed);
                 if (status != Buffers.TransformationStatus.Done)
                 {
                     bytesWritten = 0;
@@ -77,7 +77,7 @@ namespace System.Text
                     temp = new Span<byte>(buf, needed);
                 }
 
-                status = Encoders.Utf8.ConvertFromUtf16(utf16Bytes, temp, out int consumed, out written);
+                status = Encoders.Utf16.ToUtf8(utf16Bytes, temp, out int consumed, out written);
                 if (status != Buffers.TransformationStatus.Done)
                 {
                     bytesWritten = 0;

--- a/src/System.Text.Utf8String/System/Text/Utf8String.cs
+++ b/src/System.Text.Utf8String/System/Text/Utf8String.cs
@@ -127,14 +127,14 @@ namespace System.Text.Utf8
 
         public override string ToString()
         {
-            var status = Encoders.Utf16.ComputeEncodedBytesFromUtf8(this.Bytes, out int needed);
+            var status = Encoders.Utf8.ToUtf16Length(this.Bytes, out int needed);
             if (status != Buffers.TransformationStatus.Done)
                 return string.Empty;
 
             // UTF-16 is 2 bytes per char
             var chars = new char[needed >> 1];
             var utf16 = new Span<char>(chars).AsBytes();
-            status = Encoders.Utf16.ConvertFromUtf8(this.Bytes, utf16, out int consumed, out int written);
+            status = Encoders.Utf8.ToUtf16(this.Bytes, utf16, out int consumed, out int written);
             if (status != Buffers.TransformationStatus.Done)
                 return string.Empty;
 
@@ -554,12 +554,12 @@ namespace System.Text.Utf8
         private static byte[] GetUtf8BytesFromString(string str)
         {
             var utf16 = str.AsSpan().AsBytes();
-            var status = Encoders.Utf8.ComputeEncodedBytesFromUtf16(utf16, out int needed);
+            var status = Encoders.Utf16.ToUtf8Length(utf16, out int needed);
             if (status != Buffers.TransformationStatus.Done)
                 return null;
 
             var utf8 = new byte[needed];
-            status = Encoders.Utf8.ConvertFromUtf16(utf16, utf8, out int consumed, out int written);
+            status = Encoders.Utf16.ToUtf8(utf16, utf8, out int consumed, out int written);
             if (status != Buffers.TransformationStatus.Done)
                 // This shouldn't happen...
                 return null;

--- a/tests/System.Text.Json.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.Json.Tests/JsonReaderTests.cs
@@ -410,7 +410,7 @@ namespace System.Text.Json.Tests
         {
             if (jsonReader.SymbolTable == SymbolTable.InvariantUtf8)
             {
-                var status = Encoders.Utf16.ComputeEncodedBytesFromUtf8(jsonReader.Value, out int needed);
+                var status = Encoders.Utf8.ToUtf16Length(jsonReader.Value, out int needed);
                 Assert.Equal(Buffers.TransformationStatus.Done, status);
 
                 var text = new string(' ', needed);
@@ -420,7 +420,7 @@ namespace System.Text.Json.Tests
                     {
                         var dst = new Span<byte>((byte*)pChars, needed);
 
-                        status = Encoders.Utf16.ConvertFromUtf8(jsonReader.Value, dst, out int consumed, out int written);
+                        status = Encoders.Utf8.ToUtf16(jsonReader.Value, dst, out int consumed, out int written);
                         Assert.Equal(Buffers.TransformationStatus.Done, status);
                     }
                 }

--- a/tests/System.Text.Primitives.Tests/Encoding/EncodeIntoUtf8Tests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/EncodeIntoUtf8Tests.cs
@@ -15,12 +15,12 @@ namespace System.Text.Primitives.Tests.Encoding
         public void InputEmptyFromUtf16()
         {
             // Destination has zero storage
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf16(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, out int consumed, out int written));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf16.ToUtf8(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, out int consumed, out int written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
 
             // Destination has non-zero storage
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf16(ReadOnlySpan<byte>.Empty, new byte[1], out consumed, out written));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf16.ToUtf8(ReadOnlySpan<byte>.Empty, new byte[1], out consumed, out written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
         }
@@ -29,12 +29,12 @@ namespace System.Text.Primitives.Tests.Encoding
         public void InputEmptyFromUtf32()
         {
             // Destination has zero storage
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf32(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, out int consumed, out int written));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf32.ToUtf8(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, out int consumed, out int written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
 
             // Destination has non-zero storage
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf32(ReadOnlySpan<byte>.Empty, new byte[1], out consumed, out written));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf32.ToUtf8(ReadOnlySpan<byte>.Empty, new byte[1], out consumed, out written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
         }
@@ -45,7 +45,7 @@ namespace System.Text.Primitives.Tests.Encoding
             string inputString = TextEncoderTestHelper.GenerateValidString(TextEncoderConstants.DataLength, 0, TextEncoderConstants.Utf8ThreeBytesLastCodePoint);
             ReadOnlySpan<byte> input = Text.Encoding.Unicode.GetBytes(inputString);
 
-            Assert.Equal(TransformationStatus.DestinationTooSmall, Encoders.Utf8.ConvertFromUtf16(input, Span<byte>.Empty, out int consumed, out int written));
+            Assert.Equal(TransformationStatus.DestinationTooSmall, Encoders.Utf16.ToUtf8(input, Span<byte>.Empty, out int consumed, out int written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
         }
@@ -56,7 +56,7 @@ namespace System.Text.Primitives.Tests.Encoding
             string inputString = TextEncoderTestHelper.GenerateValidString(TextEncoderConstants.DataLength, 0, TextEncoderConstants.Utf8ThreeBytesLastCodePoint);
             ReadOnlySpan<byte> input = Text.Encoding.UTF32.GetBytes(inputString);
 
-            Assert.Equal(TransformationStatus.DestinationTooSmall, Encoders.Utf8.ConvertFromUtf32(input, Span<byte>.Empty, out int consumed, out int written));
+            Assert.Equal(TransformationStatus.DestinationTooSmall, Encoders.Utf32.ToUtf8(input, Span<byte>.Empty, out int consumed, out int written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
         }
@@ -74,7 +74,7 @@ namespace System.Text.Primitives.Tests.Encoding
                 for (int j = 0; j < BufferSizeRange * 4; j++)
                 {
                     Span<byte> output = new byte[j];
-                    var status = Encoders.Utf8.ConvertFromUtf16(input, output, out int consumed, out int written);
+                    var status = Encoders.Utf16.ToUtf8(input, output, out int consumed, out int written);
                     if (status == TransformationStatus.DestinationTooSmall)
                     {
                         Assert.True(consumed < input.Length, "consumed is too large");
@@ -105,7 +105,7 @@ namespace System.Text.Primitives.Tests.Encoding
                 for (int j = 0; j < BufferSizeRange * 4; j++)
                 {
                     Span<byte> output = new byte[j];
-                    var status = Encoders.Utf8.ConvertFromUtf32(input, output, out int consumed, out int written);
+                    var status = Encoders.Utf32.ToUtf8(input, output, out int consumed, out int written);
                     if (status == TransformationStatus.DestinationTooSmall)
                     {
                         Assert.True(consumed < input.Length, "consumed is too large");
@@ -131,7 +131,7 @@ namespace System.Text.Primitives.Tests.Encoding
             Span<byte> expected = Text.Encoding.UTF8.GetBytes(inputString);
 
             Span<byte> output = new byte[expected.Length / 2];
-            Assert.Equal(TransformationStatus.DestinationTooSmall, Encoders.Utf8.ConvertFromUtf16(input, output, out int consumed, out int written));
+            Assert.Equal(TransformationStatus.DestinationTooSmall, Encoders.Utf16.ToUtf8(input, output, out int consumed, out int written));
             Assert.True(consumed < input.Length, "Unexpectedly consumed entire input");
             Assert.True(written < expected.Length, "Unexpectedly wrote entire output");
             Assert.True(expected.Slice(0, written).SequenceEqual(output.Slice(0, written)), "Incorrect byte sequence");
@@ -139,7 +139,7 @@ namespace System.Text.Primitives.Tests.Encoding
             input = input.Slice(consumed);
             expected = expected.Slice(written);
             output = new byte[expected.Length];
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf16(input, output, out consumed, out written));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf16.ToUtf8(input, output, out consumed, out written));
             Assert.Equal(input.Length, consumed);
             Assert.Equal(expected.Length, written);
             Assert.True(expected.SequenceEqual(output), "Incorrect byte sequence");
@@ -153,7 +153,7 @@ namespace System.Text.Primitives.Tests.Encoding
             Span<byte> expected = Text.Encoding.UTF8.GetBytes(inputString);
 
             Span<byte> output = new byte[expected.Length / 2];
-            Assert.Equal(TransformationStatus.DestinationTooSmall, Encoders.Utf8.ConvertFromUtf32(input, output, out int consumed, out int written));
+            Assert.Equal(TransformationStatus.DestinationTooSmall, Encoders.Utf32.ToUtf8(input, output, out int consumed, out int written));
             Assert.True(consumed < input.Length, "Unexpectedly consumed entire input");
             Assert.True(written < expected.Length, "Unexpectedly wrote entire output");
             Assert.True(expected.Slice(0, written).SequenceEqual(output.Slice(0, written)), "Incorrect byte sequence");
@@ -161,7 +161,7 @@ namespace System.Text.Primitives.Tests.Encoding
             input = input.Slice(consumed);
             expected = expected.Slice(written);
             output = new byte[expected.Length];
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf32(input, output, out consumed, out written));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf32.ToUtf8(input, output, out consumed, out written));
             Assert.Equal(input.Length, consumed);
             Assert.Equal(expected.Length, written);
             Assert.True(expected.SequenceEqual(output), "Incorrect byte sequence");
@@ -178,11 +178,11 @@ namespace System.Text.Primitives.Tests.Encoding
             Span<byte> expected2 = Text.Encoding.UTF8.GetBytes(inputString2);
 
             Span<byte> output = new byte[expected1.Length + expected2.Length];
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf16(input1, output, out int consumed1, out int written1));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf16.ToUtf8(input1, output, out int consumed1, out int written1));
             Assert.Equal(input1.Length, consumed1);
             Assert.Equal(expected1.Length, written1);
 
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf16(input2, output.Slice(written1), out int consumed2, out int written2));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf16.ToUtf8(input2, output.Slice(written1), out int consumed2, out int written2));
             Assert.Equal(input2.Length, consumed2);
             Assert.Equal(expected2.Length, written2);
 
@@ -201,11 +201,11 @@ namespace System.Text.Primitives.Tests.Encoding
             Span<byte> expected2 = Text.Encoding.UTF8.GetBytes(inputString2);
 
             Span<byte> output = new byte[expected1.Length + expected2.Length];
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf32(input1, output, out int consumed1, out int written1));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf32.ToUtf8(input1, output, out int consumed1, out int written1));
             Assert.Equal(input1.Length, consumed1);
             Assert.Equal(expected1.Length, written1);
 
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf32(input2, output.Slice(written1), out int consumed2, out int written2));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf32.ToUtf8(input2, output.Slice(written1), out int consumed2, out int written2));
             Assert.Equal(input2.Length, consumed2);
             Assert.Equal(expected2.Length, written2);
 
@@ -221,12 +221,12 @@ namespace System.Text.Primitives.Tests.Encoding
             Span<byte> output = new byte[16];
 
             ReadOnlySpan<byte> input = inputStringLow.AsSpan().AsBytes();
-            Assert.Equal(TransformationStatus.InvalidData, Encoders.Utf8.ConvertFromUtf16(input, output, out int consumed, out int written));
+            Assert.Equal(TransformationStatus.InvalidData, Encoders.Utf16.ToUtf8(input, output, out int consumed, out int written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
 
             input = inputStringHigh.AsSpan().AsBytes();
-            Assert.Equal(TransformationStatus.InvalidData, Encoders.Utf8.ConvertFromUtf16(input, output, out consumed, out written));
+            Assert.Equal(TransformationStatus.InvalidData, Encoders.Utf16.ToUtf8(input, output, out consumed, out written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
         }
@@ -238,7 +238,7 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> input = codepoints.AsSpan().AsBytes();
             Span<byte> output = new byte[16];
 
-            Assert.Equal(TransformationStatus.InvalidData, Encoders.Utf8.ConvertFromUtf32(input, output, out int consumed, out int written));
+            Assert.Equal(TransformationStatus.InvalidData, Encoders.Utf32.ToUtf8(input, output, out int consumed, out int written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
         }
@@ -252,7 +252,7 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> expected = Text.Encoding.Convert(Text.Encoding.Unicode, Text.Encoding.UTF8, inputBytes);
             int expectedWritten = TextEncoderTestHelper.GetUtf8ByteCount(inputStringEndsWithLow.AsSpan());
             Span<byte> output = new byte[expectedWritten + 10];
-            Assert.Equal(TransformationStatus.InvalidData, Encoders.Utf8.ConvertFromUtf16(input, output, out int consumed, out int written));
+            Assert.Equal(TransformationStatus.InvalidData, Encoders.Utf16.ToUtf8(input, output, out int consumed, out int written));
             Assert.True(consumed < input.Length, "Consumed too many input characters");
             Assert.Equal(expectedWritten, written);
             Assert.True(expected.Slice(0, written).SequenceEqual(output.Slice(0, written)), "Invalid output sequence [ends with low]");
@@ -263,7 +263,7 @@ namespace System.Text.Primitives.Tests.Encoding
             expected = Text.Encoding.Convert(Text.Encoding.Unicode, Text.Encoding.UTF8, inputBytes);
             expectedWritten = TextEncoderTestHelper.GetUtf8ByteCount(inputStringInvalid.AsSpan());
             output = new byte[expectedWritten + 10];
-            Assert.Equal(TransformationStatus.InvalidData, Encoders.Utf8.ConvertFromUtf16(input, output, out consumed, out written));
+            Assert.Equal(TransformationStatus.InvalidData, Encoders.Utf16.ToUtf8(input, output, out consumed, out written));
             Assert.True(consumed < input.Length, "Consumed more input than expected");
             Assert.Equal(expectedWritten, written);
             Assert.True(expected.Slice(0, written).SequenceEqual(output.Slice(0, written)), "Invalid output sequence [invalid]");
@@ -278,7 +278,7 @@ namespace System.Text.Primitives.Tests.Encoding
             int expectedWritten = TextEncoderTestHelper.GetUtf8ByteCount(codepoints);
             Span<byte> output = new byte[expectedWritten];
 
-            Assert.Equal(TransformationStatus.InvalidData, Encoders.Utf8.ConvertFromUtf32(input, output, out int consumed, out int written));
+            Assert.Equal(TransformationStatus.InvalidData, Encoders.Utf32.ToUtf8(input, output, out int consumed, out int written));
             Assert.True(consumed < input.Length, "Consumed more input than expected");
             Assert.Equal(expectedWritten, written);
             Assert.True(expected.Slice(0, expectedWritten).SequenceEqual(output));
@@ -300,13 +300,13 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> expected = Text.Encoding.UTF8.GetBytes(inputString1 + inputString2);
             Span<byte> output = new byte[expected.Length];
 
-            Assert.Equal(TransformationStatus.NeedMoreSourceData, Encoders.Utf8.ConvertFromUtf16(input1, output, out int consumed, out int written));
+            Assert.Equal(TransformationStatus.NeedMoreSourceData, Encoders.Utf16.ToUtf8(input1, output, out int consumed, out int written));
             Assert.Equal(input1.Length - 2, consumed);
             Assert.NotEqual(expected.Length, written);
             Assert.True(expected.Slice(0, written).SequenceEqual(output.Slice(0, written)), "Invalid output sequence [first half]");
 
             expected = expected.Slice(written);
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf16(input2, output, out consumed, out written));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf16.ToUtf8(input2, output, out consumed, out written));
             Assert.Equal(input2.Length, consumed);
             Assert.Equal(expected.Length, written);
             Assert.True(expected.SequenceEqual(output.Slice(0, written)), "Invalid output sequence [second half]");
@@ -327,14 +327,14 @@ namespace System.Text.Primitives.Tests.Encoding
 
             ReadOnlySpan<byte> input = inputAll.AsSpan().Slice(0, codepoints1.Length).AsBytes();
             input = input.Slice(0, input.Length - 2); // Strip a couple bytes from last good code point
-            Assert.Equal(TransformationStatus.NeedMoreSourceData, Encoders.Utf8.ConvertFromUtf32(input, output, out int consumed, out int written));
+            Assert.Equal(TransformationStatus.NeedMoreSourceData, Encoders.Utf32.ToUtf8(input, output, out int consumed, out int written));
             Assert.True(input.Length > consumed, "Consumed too many bytes [first half]");
             Assert.NotEqual(expected.Length, written);
             Assert.True(expected.Slice(0, written).SequenceEqual(output.Slice(0, written)), "Invalid output sequence [first half]");
 
             input = inputAll.AsSpan().AsBytes().Slice(consumed);
             expected = expected.Slice(written);
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf32(input, output, out consumed, out written));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf32.ToUtf8(input, output, out consumed, out written));
             Assert.Equal(input.Length, consumed);
             Assert.Equal(expected.Length, written);
             Assert.True(expected.SequenceEqual(output.Slice(0, written)), "Invalid output sequence [second half]");
@@ -369,7 +369,7 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> expected = Text.Encoding.UTF8.GetBytes(inputString);
             Span<byte> output = new byte[expected.Length];
 
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf16(input, output, out int consumed, out int written));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf16.ToUtf8(input, output, out int consumed, out int written));
             Assert.Equal(input.Length, consumed);
             Assert.Equal(expected.Length, written);
             Assert.True(expected.SequenceEqual(output), "Invalid output sequence");
@@ -381,7 +381,7 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> expected = Text.Encoding.UTF8.GetBytes(inputString);
             Span<byte> output = new byte[expected.Length];
 
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf32(input, output, out int consumed, out int written));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf32.ToUtf8(input, output, out int consumed, out int written));
             Assert.Equal(input.Length, consumed);
             Assert.Equal(expected.Length, written);
             Assert.True(expected.SequenceEqual(output), "Invalid output sequence");

--- a/tests/System.Text.Primitives.Tests/Encoding/Performance/PerfTests.Span.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/Performance/PerfTests.Span.cs
@@ -47,7 +47,7 @@ namespace System.Text.Primitives.Tests
             string inputString = GenerateStringData(length, minCodePoint, maxCodePoint, special);
             ReadOnlySpan<byte> utf16 = inputString.AsSpan().AsBytes();
 
-            var status = Encoders.Utf8.ComputeEncodedBytesFromUtf16(utf16, out int needed);
+            var status = Encoders.Utf16.ToUtf8Length(utf16, out int needed);
             Assert.Equal(TransformationStatus.Done, status);
 
             Span<byte> utf8 = new byte[needed];
@@ -58,7 +58,7 @@ namespace System.Text.Primitives.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        status = Encoders.Utf8.ConvertFromUtf16(utf16, utf8, out int consumed, out int written);
+                        status = Encoders.Utf16.ToUtf8(utf16, utf8, out int consumed, out int written);
                         if (status != TransformationStatus.Done)
                             throw new Exception();
                     }
@@ -73,7 +73,7 @@ namespace System.Text.Primitives.Tests
             string inputString = GenerateStringData(length, minCodePoint, maxCodePoint, special);
             ReadOnlySpan<byte> utf32 = Text.Encoding.UTF32.GetBytes(inputString);
 
-            var status = Encoders.Utf8.ComputeEncodedBytesFromUtf32(utf32, out int needed);
+            var status = Encoders.Utf32.ToUtf8Length(utf32, out int needed);
             Assert.Equal(TransformationStatus.Done, status);
 
             Span<byte> utf8 = new byte[needed];
@@ -84,7 +84,7 @@ namespace System.Text.Primitives.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        status = Encoders.Utf8.ConvertFromUtf32(utf32, utf8, out int consumed, out int written);
+                        status = Encoders.Utf32.ToUtf8(utf32, utf8, out int consumed, out int written);
                         if (status != TransformationStatus.Done)
                             throw new Exception();
                     }
@@ -99,7 +99,7 @@ namespace System.Text.Primitives.Tests
             string inputString = GenerateStringData(length, minCodePoint, maxCodePoint, special);
             ReadOnlySpan<byte> utf8 = Text.Encoding.UTF8.GetBytes(inputString);
 
-            var status = Encoders.Utf16.ComputeEncodedBytesFromUtf8(utf8, out int needed);
+            var status = Encoders.Utf8.ToUtf16Length(utf8, out int needed);
             Assert.Equal(TransformationStatus.Done, status);
 
             Span<byte> utf16 = new byte[needed];
@@ -110,7 +110,7 @@ namespace System.Text.Primitives.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        status = Encoders.Utf16.ConvertFromUtf8(utf8, utf16, out int consumed, out int written);
+                        status = Encoders.Utf8.ToUtf16(utf8, utf16, out int consumed, out int written);
                         if (status != TransformationStatus.Done)
                             throw new Exception();
                     }
@@ -125,7 +125,7 @@ namespace System.Text.Primitives.Tests
             string inputString = GenerateStringData(length, minCodePoint, maxCodePoint, special);
             ReadOnlySpan<byte> utf32 = Text.Encoding.UTF32.GetBytes(inputString);
 
-            var status = Encoders.Utf16.ComputeEncodedBytesFromUtf32(utf32, out int needed);
+            var status = Encoders.Utf32.ToUtf16Length(utf32, out int needed);
             Assert.Equal(TransformationStatus.Done, status);
 
             Span<byte> utf16 = new byte[needed];
@@ -136,7 +136,7 @@ namespace System.Text.Primitives.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        status = Encoders.Utf16.ConvertFromUtf32(utf32, utf16, out int consumed, out int written);
+                        status = Encoders.Utf32.ToUtf16(utf32, utf16, out int consumed, out int written);
                         if (status != TransformationStatus.Done)
                             throw new Exception();
                     }

--- a/tests/System.Text.Primitives.Tests/Encoding/Utf8EncoderTests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/Utf8EncoderTests.cs
@@ -23,7 +23,7 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> utf16 = new ReadOnlySpan<char>(chars).NonPortableCast<char, byte>();
             Span<byte> buffer = new byte[expectedBytes.Length];
 
-            Assert.Equal(expectedReturnVal, Encoders.Utf8.ConvertFromUtf16(utf16, buffer, out int consumed, out int written));
+            Assert.Equal(expectedReturnVal, Encoders.Utf16.ToUtf8(utf16, buffer, out int consumed, out int written));
             Assert.Equal(expectedBytes.Length, written);
 
             if (expectedBytes.Length > 0)
@@ -59,9 +59,9 @@ namespace System.Text.Primitives.Tests.Encoding
             Buffers.TransformationStatus result;
 
             if (useUtf8Encoder)
-                result = Encoders.Utf8.ConvertFromUtf32(codePoints, buffer, out consumed, out written);
+                result = Encoders.Utf32.ToUtf8(codePoints, buffer, out consumed, out written);
             else
-                result = Encoders.Utf16.ConvertFromUtf32(codePoints, buffer, out consumed, out written);
+                result = Encoders.Utf32.ToUtf16(codePoints, buffer, out consumed, out written);
 
             Assert.Equal(expectedReturnVal, result);
             Assert.Equal(expectedBytes.Length, written);
@@ -94,9 +94,9 @@ namespace System.Text.Primitives.Tests.Encoding
             Buffers.TransformationStatus result;
 
             if (useUtf8Encoder)
-                result = Encoders.Utf32.ConvertFromUtf8(inputBytes, codePoints, out consumed, out written);
+                result = Encoders.Utf8.ToUtf32(inputBytes, codePoints, out consumed, out written);
             else
-                result = Encoders.Utf32.ConvertFromUtf16(inputBytes, codePoints, out consumed, out written);
+                result = Encoders.Utf16.ToUtf32(inputBytes, codePoints, out consumed, out written);
 
             Assert.Equal(expectedReturnVal, result);
             Assert.Equal(inputBytes.Length, consumed);
@@ -129,9 +129,9 @@ namespace System.Text.Primitives.Tests.Encoding
             int written;
 
             if (useUtf8Encoder)
-                Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf32(allCodePoints.AsBytes(), buffer, out consumed, out written));
+                Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf32.ToUtf8(allCodePoints.AsBytes(), buffer, out consumed, out written));
             else
-                Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf16.ConvertFromUtf32(allCodePoints.AsBytes(), buffer, out consumed, out written));
+                Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf32.ToUtf16(allCodePoints.AsBytes(), buffer, out consumed, out written));
 
             Assert.Equal(allCodePoints.AsBytes().Length, consumed);
             buffer = buffer.Slice(0, written);
@@ -139,9 +139,9 @@ namespace System.Text.Primitives.Tests.Encoding
             Span<uint> utf32 = new uint[maximumValidCodePoint + 1];
 
             if (useUtf8Encoder)
-                Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf32.ConvertFromUtf8(buffer, utf32.AsBytes(), out consumed, out written));
+                Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf8.ToUtf32(buffer, utf32.AsBytes(), out consumed, out written));
             else
-                Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf32.ConvertFromUtf16(buffer, utf32.AsBytes(), out consumed, out written));
+                Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf16.ToUtf32(buffer, utf32.AsBytes(), out consumed, out written));
 
             Assert.Equal(buffer.Length, consumed);
             Assert.Equal((maximumValidCodePoint + 1) * sizeof(uint), written);
@@ -186,9 +186,9 @@ namespace System.Text.Primitives.Tests.Encoding
             int consumed;
 
             if (useUtf8Encoder)
-                Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf32(allCodePoints.AsBytes(), buffer, out consumed, out written));
+                Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf32.ToUtf8(allCodePoints.AsBytes(), buffer, out consumed, out written));
             else
-                Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf16.ConvertFromUtf32(allCodePoints.AsBytes(), buffer, out consumed, out written));
+                Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf32.ToUtf16(allCodePoints.AsBytes(), buffer, out consumed, out written));
 
             buffer = buffer.Slice(0, written);
 
@@ -237,14 +237,14 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> input = inputBytes;
             Span<byte> output = new byte[outputSize];
 
-            Assert.Equal(Buffers.TransformationStatus.DestinationTooSmall, Encoders.Utf16.ConvertFromUtf8(input, output, out consumed, out written));
+            Assert.Equal(Buffers.TransformationStatus.DestinationTooSmall, Encoders.Utf8.ToUtf16(input, output, out consumed, out written));
             Assert.Equal(expected1.Length, written);
             Assert.Equal(expectedConsumed, consumed);
             Assert.True(output.Slice(0, written).SequenceEqual(expected1), "Bad first segment of partial sequence");
 
             input = input.Slice(consumed);
             output = new byte[expected2.Length];
-            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf16.ConvertFromUtf8(input, output, out consumed, out written));
+            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf8.ToUtf16(input, output, out consumed, out written));
             Assert.Equal(expected2.Length, written);
             Assert.Equal(input.Length, consumed);
             Assert.True(output.Slice(0, written).SequenceEqual(expected2), "Bad second segment of partial sequence");
@@ -284,14 +284,14 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> input = inputBytes.AsSpan().AsBytes();
             Span<byte> output = new byte[outputSize];
 
-            Assert.Equal(Buffers.TransformationStatus.DestinationTooSmall, Encoders.Utf8.ConvertFromUtf16(input, output, out consumed, out written));
+            Assert.Equal(Buffers.TransformationStatus.DestinationTooSmall, Encoders.Utf16.ToUtf8(input, output, out consumed, out written));
             Assert.Equal(expected1.Length, written);
             Assert.Equal(expectedConsumed, consumed);
             Assert.True(output.Slice(0, written).SequenceEqual(expected1), "Bad first segment of partial sequence");
 
             input = input.Slice(consumed);
             output = new byte[expected2.Length];
-            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf16(input, output, out consumed, out written));
+            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf16.ToUtf8(input, output, out consumed, out written));
             Assert.Equal(expected2.Length, written);
             Assert.Equal(input.Length, consumed);
             Assert.True(output.Slice(0, written).SequenceEqual(expected2), "Bad second segment of partial sequence");

--- a/tests/System.Text.Primitives.Tests/Encoding/Utf8Utf16ConversionTests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/Utf8Utf16ConversionTests.cs
@@ -140,7 +140,7 @@ namespace System.Text.Primitives.Tests
             int bytesNeeded = (expectedOutput.Length + 10) * sizeof(char);
             Span<byte> actualOutput = new byte[bytesNeeded];
 
-            var result = Encoders.Utf16.ConvertFromUtf8(input, actualOutput, out int consumed, out int written);
+            var result = Encoders.Utf8.ToUtf16(input, actualOutput, out int consumed, out int written);
             Assert.Equal(expectedResult, result);
 
             Assert.Equal(expectedConsumed, consumed);
@@ -174,7 +174,7 @@ namespace System.Text.Primitives.Tests
 
             // Encoders.Utf16 version
             Span<byte> encodedData = data;
-            Assert.Equal(TransformationStatus.Done, Encoders.Utf16.ComputeEncodedBytesFromUtf8(encodedData, out int neededBytes));
+            Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ToUtf16Length(encodedData, out int neededBytes));
 
             // System version
             int expectedBytes = Text.Encoding.UTF8.GetCharCount(data) * sizeof(char);
@@ -206,12 +206,12 @@ namespace System.Text.Primitives.Tests
             byte[] data = GenerateUtf8String(count, minCodePoint, maxCodePoint);
 
             Span<byte> encodedData = data;
-            var result = Encoders.Utf16.ComputeEncodedBytesFromUtf8(encodedData, out int needed);
+            var result = Encoders.Utf8.ToUtf16Length(encodedData, out int needed);
             Assert.Equal(TransformationStatus.Done, result);
 
             // Encoders.Utf16 version
             Span<byte> actual = new byte[needed];
-            result = Encoders.Utf16.ConvertFromUtf8(encodedData, actual, out int consumed, out int written);
+            result = Encoders.Utf8.ToUtf16(encodedData, actual, out int consumed, out int written);
             Assert.Equal(TransformationStatus.Done, result);
 
             // System version

--- a/tests/System.Text.Primitives.Tests/RandomTests.cs
+++ b/tests/System.Text.Primitives.Tests/RandomTests.cs
@@ -34,17 +34,17 @@ namespace System.Text.Primitives.Tests
             int actual;
 
             // test via string input
-            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf8.ComputeEncodedBytesFromUtf16(value.AsSpan().AsBytes(), out actual));
+            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf16.ToUtf8Length(value.AsSpan().AsBytes(), out actual));
             Assert.Equal(expectedBytes, actual);
 
             // test via utf16 input
             ReadOnlySpan<byte> bytes = Text.Encoding.Unicode.GetBytes(value);
-            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf8.ComputeEncodedBytesFromUtf16(bytes, out actual));
+            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf16.ToUtf8Length(bytes, out actual));
             Assert.Equal(expectedBytes, actual);
 
             // test via utf32 input
             bytes = Text.Encoding.UTF32.GetBytes(value);
-            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf8.ComputeEncodedBytesFromUtf32(bytes, out actual));
+            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf32.ToUtf8Length(bytes, out actual));
             Assert.Equal(expectedBytes, actual);
         }
 
@@ -57,12 +57,12 @@ namespace System.Text.Primitives.Tests
 
             // test via utf8 input
             ReadOnlySpan<byte> bytes = Text.Encoding.UTF8.GetBytes(value);
-            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf16.ComputeEncodedBytesFromUtf8(bytes, out actual));
+            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf8.ToUtf16Length(bytes, out actual));
             Assert.Equal(expectedBytes, actual);
 
             // test via utf32 input
             bytes = Text.Encoding.UTF32.GetBytes(value);
-            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf16.ComputeEncodedBytesFromUtf32(bytes, out actual));
+            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf32.ToUtf16Length(bytes, out actual));
             Assert.Equal(expectedBytes, actual);
         }
 
@@ -70,7 +70,7 @@ namespace System.Text.Primitives.Tests
         public void TryComputeEncodedBytesIllegal_Utf8()
         {
             string text = Encoding.TextEncoderTestHelper.GenerateOnlyInvalidString(20);
-            Assert.Equal(Buffers.TransformationStatus.InvalidData, Encoders.Utf8.ComputeEncodedBytesFromUtf16(text.AsSpan().AsBytes(), out int needed));
+            Assert.Equal(Buffers.TransformationStatus.InvalidData, Encoders.Utf16.ToUtf8Length(text.AsSpan().AsBytes(), out int needed));
         }
     }
 }

--- a/tests/System.Text.Primitives.Tests/TestHelper.cs
+++ b/tests/System.Text.Primitives.Tests/TestHelper.cs
@@ -45,9 +45,9 @@ namespace System.Text.Primitives.Tests
         {
             if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
             {
-                Assert.Equal(TransformationStatus.Done, Encoders.Utf16.ComputeEncodedBytesFromUtf8(span, out int needed));
+                Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ToUtf16Length(span, out int needed));
                 Span<byte> output = new byte[needed];
-                Assert.Equal(TransformationStatus.Done, Encoders.Utf16.ConvertFromUtf8(span, output, out int consumed, out int written));
+                Assert.Equal(TransformationStatus.Done, Encoders.Utf8.ToUtf16(span, output, out int consumed, out int written));
                 return new string(output.NonPortableCast<byte, char>().ToArray());
             }
             else if (symbolTable == SymbolTable.InvariantUtf16)

--- a/tests/System.Text.Utf8String.Tests/RandomTests.cs
+++ b/tests/System.Text.Utf8String.Tests/RandomTests.cs
@@ -347,10 +347,10 @@ namespace System.Text.Utf8.Tests
         private byte[] GetUtf8BytesFromCodePoints(List<uint> codePoints)
         {
             ReadOnlySpan<byte> utf32 = codePoints.ToArray().AsSpan().AsBytes();
-            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf8.ComputeEncodedBytesFromUtf32(utf32, out int needed));
+            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf32.ToUtf8Length(utf32, out int needed));
 
             byte[] utf8 = new byte[needed];
-            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf8.ConvertFromUtf32(utf32, utf8, out int consumed, out int written));
+            Assert.Equal(Buffers.TransformationStatus.Done, Encoders.Utf32.ToUtf8(utf32, utf8, out int consumed, out int written));
             Assert.Equal(needed, written);
 
             return utf8;


### PR DESCRIPTION
* UtfXx.ConvertFromUtfYy => UtfYy.ToUtfXx
* UtfXx.ComputeEncodedBytesFromUtfYy => UtfYy.ToUtfXxLength
* Added UtfXx.FromUtfYy variants that route directly to corresponding UtfYy.ToUtfXx version.
* Filled out the public method header comment blocks on the encoders.

NOTE: None of the implementations changed. They were just shifted around in the 3 encoder implementation files. All other changes are just patching to the new APIs.

@ahsonkhan @KrzysztofCwalina 