### PR TITLE
Made Ascii 'encoding' APIs consistent with other encodings

### DIFF
--- a/src/System.IO.Pipelines.Text.Primitives/ReadableBufferExtensions.cs
+++ b/src/System.IO.Pipelines.Text.Primitives/ReadableBufferExtensions.cs
@@ -135,7 +135,7 @@ namespace System.IO.Pipelines.Text.Primitives
             return value;
         }
 
-        [Obsolete("Use System.Text.PrimitiveEncoder.DecodeAscii method")]
+        [Obsolete("Use System.Text.Encoders.Ascii.ToUtf16String method")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe static string GetAsciiString(this Span<byte> span)
         {

--- a/src/System.Text.Primitives/System/Text/Encoding/Ascii/PrimitiveEncoder_ascii.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Ascii/PrimitiveEncoder_ascii.cs
@@ -9,7 +9,7 @@ namespace System.Text.Encoders
     public static partial class Ascii
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string ToUtf16String(this ReadOnlySpan<byte> bytes)
+        public static string ToUtf16String(ReadOnlySpan<byte> bytes)
         {
             var len = bytes.Length;
             if (len == 0) {
@@ -32,7 +32,7 @@ namespace System.Text.Encoders
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string ToUtf16String(this Span<byte> bytes)
+        public static string ToUtf16String(Span<byte> bytes)
         {
             var len = bytes.Length;
             if (len == 0) {

--- a/src/System.Text.Primitives/System/Text/Encoding/Ascii/PrimitiveEncoder_ascii.cs
+++ b/src/System.Text.Primitives/System/Text/Encoding/Ascii/PrimitiveEncoder_ascii.cs
@@ -4,12 +4,12 @@
 
 using System.Runtime.CompilerServices;
 
-namespace System.Text
+namespace System.Text.Encoders
 {
-    public static partial class PrimitiveEncoder
+    public static partial class Ascii
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string DecodeAscii(this ReadOnlySpan<byte> bytes)
+        public static string ToUtf16String(this ReadOnlySpan<byte> bytes)
         {
             var len = bytes.Length;
             if (len == 0) {
@@ -32,7 +32,7 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string DecodeAscii(this Span<byte> bytes)
+        public static string ToUtf16String(this Span<byte> bytes)
         {
             var len = bytes.Length;
             if (len == 0) {

--- a/tests/Benchmarks/GetAsciiStringBench.cs
+++ b/tests/Benchmarks/GetAsciiStringBench.cs
@@ -6,6 +6,7 @@ using Xunit;
 using Microsoft.Xunit.Performance;
 using System;
 using System.Text;
+using System.Text.Encoders;
 using System.Text.Utf8;
 
 public class AsciiDecodingBench
@@ -21,7 +22,7 @@ public class AsciiDecodingBench
         foreach (var iteration in Benchmark.Iterations) {
             using (iteration.StartMeasurement()) {
                 for (int i = 0; i < Benchmark.InnerIterationCount; i++) {
-                    str = bytes.DecodeAscii();
+                    str = Ascii.ToUtf16String(bytes);
                     len += str.Length;
                 }
             }

--- a/tests/System.Text.Http.Parser.Tests/HttpParserBasicTests.cs
+++ b/tests/System.Text.Http.Parser.Tests/HttpParserBasicTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using System.IO.Pipelines;
 using System.Collections.Generic;
 using System.Buffers;
+using System.Text.Encoders;
 
 namespace System.Text.Http.Parser.Tests
 {
@@ -150,8 +151,8 @@ namespace System.Text.Http.Parser.Tests
 
         public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
-            var nameString = PrimitiveEncoder.DecodeAscii(name);
-            var valueString = PrimitiveEncoder.DecodeAscii(value);
+            var nameString = Ascii.ToUtf16String(name);
+            var valueString = Ascii.ToUtf16String(value);
             Headers.Add(nameString, valueString);
         }
 
@@ -159,9 +160,9 @@ namespace System.Text.Http.Parser.Tests
         {
             Method = method;
             Version = version;
-            Path = PrimitiveEncoder.DecodeAscii(path);
-            Query = PrimitiveEncoder.DecodeAscii(query);
-            Target = PrimitiveEncoder.DecodeAscii(target);
+            Path = Ascii.ToUtf16String(path);
+            Query = Ascii.ToUtf16String(query);
+            Target = Ascii.ToUtf16String(target);
         }
     }
 }

--- a/tests/System.Text.Http.Parser.Tests/HttpParserTests.cs
+++ b/tests/System.Text.Http.Parser.Tests/HttpParserTests.cs
@@ -5,6 +5,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Linq;
+using System.Text.Encoders;
 using Xunit;
 
 namespace System.Text.Http.Parser.Tests
@@ -409,16 +410,16 @@ namespace System.Text.Http.Parser.Tests
 
             public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
             {
-                Headers[PrimitiveEncoder.DecodeAscii(name)] = PrimitiveEncoder.DecodeAscii(value);
+                Headers[Ascii.ToUtf16String(name)] = Ascii.ToUtf16String(value);
             }
 
             public void OnStartLine(Http.Method method, Http.Version version, ReadOnlySpan<byte> target, ReadOnlySpan<byte> path, ReadOnlySpan<byte> query, ReadOnlySpan<byte> customMethod, bool pathEncoded)
             {
-                Method = method != Http.Method.Custom ? method.ToString().ToUpper() : PrimitiveEncoder.DecodeAscii(customMethod);
+                Method = method != Http.Method.Custom ? method.ToString().ToUpper() : Ascii.ToUtf16String(customMethod);
                 Version = ToString(version);
-                RawTarget = PrimitiveEncoder.DecodeAscii(target);
-                RawPath = PrimitiveEncoder.DecodeAscii(path);
-                Query = PrimitiveEncoder.DecodeAscii(query);
+                RawTarget = Ascii.ToUtf16String(target);
+                RawPath = Ascii.ToUtf16String(path);
+                Query = Ascii.ToUtf16String(query);
                 PathEncoded = pathEncoded;
             }
 

--- a/tests/System.Text.Primitives.Tests/PrimitiveEncoderTests_ascii.cs
+++ b/tests/System.Text.Primitives.Tests/PrimitiveEncoderTests_ascii.cs
@@ -2,36 +2,37 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Text.Encoders;
 using Xunit;
 
-namespace System.Text.Primitives.Tests
+namespace System.Text.Encoders.Tests
 {
     public class PrimitiveEncoderTestsAscii
     {
         [Theory]
         [InlineData("")]
         [InlineData("Hello World")]
-        public void DecodeAsciiToStringBasics(string original)
+        public void AsciiToUtf16StringBasics(string original)
         {
             var encoded = (Span<byte>)Text.Encoding.ASCII.GetBytes(original);
-            var decoded = encoded.DecodeAscii();
+            var decoded = Ascii.ToUtf16String(encoded);
             Assert.Equal(original, decoded);
         }
 
         [Fact]
-        public void DecodeAsciiWorksOnAllAsciiChars()
+        public void AsciiToUtf16StringWorksOnAllAsciiChars()
         {
             for (int index = 0; index < 100; index++) {
                 var encoded = (Span<byte>)new byte[100];
                 for (int encodedByte = 0; encodedByte < 128; encodedByte++) {
                     encoded[index] = (byte)encodedByte;
-                    var result = encoded.DecodeAscii();
+                    var result = Ascii.ToUtf16String(encoded);
                 }
             }
         }
 
         [Fact]
-        public void DecodeAsciiToStringFailsOnNonAscii()
+        public void AsciiToUtf16StringFailsOnNonAscii()
         {
             for (int index = 0; index < 100; index++) {
                 var encoded = (Span<byte>)new byte[100];
@@ -39,7 +40,7 @@ namespace System.Text.Primitives.Tests
                     encoded[0] = (byte)encodedByte;
                     bool exception = false;
                     try {
-                        var result = encoded.DecodeAscii();
+                        var result = Ascii.ToUtf16String(encoded);
                     }
                     catch(ArgumentException) {
                         exception = true;


### PR DESCRIPTION
Renamed PrimitiveEncoding to Ascii and placed the type in System.Text.Encoders.

cc: @shiftylogic, @ahsonkhan, @joshfree 