### PR TITLE
Fixed a bug in the IOutput implementation of WritableBuffer

### DIFF
--- a/src/System.IO.Pipelines/WritableBuffer.cs
+++ b/src/System.IO.Pipelines/WritableBuffer.cs
@@ -30,16 +30,13 @@ namespace System.IO.Pipelines
 
         Span<byte> IOutput.Buffer => Buffer.Span;
 
-        void IOutput.Enlarge(int desiredBufferLength) => Ensure(NewSize(desiredBufferLength));
+        void IOutput.Enlarge(int desiredBufferLength) => Ensure(ComputeActualSize(desiredBufferLength));
 
-        private int NewSize(int desiredBufferLength)
+        private int ComputeActualSize(int desiredBufferLength)
         {
-            var currentSize = Buffer.Length;
-            if(desiredBufferLength == 0) {
-                if (currentSize <= 0) return 256;
-                else return currentSize * 2;
-            }
-            return desiredBufferLength < currentSize ? currentSize : desiredBufferLength;
+            if (desiredBufferLength < 256) desiredBufferLength = 256;
+            if (desiredBufferLength < Buffer.Length) desiredBufferLength = Buffer.Length * 2;
+            return desiredBufferLength;
         }
 
         /// <summary>

--- a/src/System.IO.Pipelines/WritableBuffer.cs
+++ b/src/System.IO.Pipelines/WritableBuffer.cs
@@ -36,7 +36,7 @@ namespace System.IO.Pipelines
         {
             if (desiredBufferLength < 256) desiredBufferLength = 256;
             if (desiredBufferLength < Buffer.Length) desiredBufferLength = Buffer.Length * 2;
-            return desiredBufferLength;
+            return desiredBufferLength; 
         }
 
         /// <summary>


### PR DESCRIPTION
The current implementation often results in very small segments. The new implementation will ensure that segments are never smaller than 256 bytes.

@davidfowl