### PR TITLE
Added System.Azure.Experimental Project

### DIFF
--- a/corefxlab.sln
+++ b/corefxlab.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26507.0
+VisualStudioVersion = 15.0.26730.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5E7EB061-B9BC-4DA2-B5E5-859AA7C67695}"
 	ProjectSection(SolutionItems) = preProject
@@ -147,6 +147,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Numerics.Tensors", "src\System.Numerics.Tensors\System.Numerics.Tensors.csproj", "{662968A7-5BCC-467B-A814-38584D0184CD}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Numerics.Tensors.Tests", "tests\System.Numerics.Tensors.Tests\System.Numerics.Tensors.Tests.csproj", "{C11F232A-ED36-4DCE-A18D-BF90CED8D1B4}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Azure.Experimental.Tests", "tests\System.Azure.Experimental.Tests\System.Azure.Experimental.Tests.csproj", "{0BA3C0A9-64B9-445D-B085-8FFAC09D6E37}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Azure.Experimental", "src\System.Azure.Experimental\System.Azure.Experimental.csproj", "{916370AB-B0D3-4136-850B-AA12FAB23ECD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -962,6 +966,30 @@ Global
 		{C11F232A-ED36-4DCE-A18D-BF90CED8D1B4}.Release|x64.Build.0 = Release|Any CPU
 		{C11F232A-ED36-4DCE-A18D-BF90CED8D1B4}.Release|x86.ActiveCfg = Release|Any CPU
 		{C11F232A-ED36-4DCE-A18D-BF90CED8D1B4}.Release|x86.Build.0 = Release|Any CPU
+		{0BA3C0A9-64B9-445D-B085-8FFAC09D6E37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BA3C0A9-64B9-445D-B085-8FFAC09D6E37}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BA3C0A9-64B9-445D-B085-8FFAC09D6E37}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0BA3C0A9-64B9-445D-B085-8FFAC09D6E37}.Debug|x64.Build.0 = Debug|Any CPU
+		{0BA3C0A9-64B9-445D-B085-8FFAC09D6E37}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0BA3C0A9-64B9-445D-B085-8FFAC09D6E37}.Debug|x86.Build.0 = Debug|Any CPU
+		{0BA3C0A9-64B9-445D-B085-8FFAC09D6E37}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BA3C0A9-64B9-445D-B085-8FFAC09D6E37}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BA3C0A9-64B9-445D-B085-8FFAC09D6E37}.Release|x64.ActiveCfg = Release|Any CPU
+		{0BA3C0A9-64B9-445D-B085-8FFAC09D6E37}.Release|x64.Build.0 = Release|Any CPU
+		{0BA3C0A9-64B9-445D-B085-8FFAC09D6E37}.Release|x86.ActiveCfg = Release|Any CPU
+		{0BA3C0A9-64B9-445D-B085-8FFAC09D6E37}.Release|x86.Build.0 = Release|Any CPU
+		{916370AB-B0D3-4136-850B-AA12FAB23ECD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{916370AB-B0D3-4136-850B-AA12FAB23ECD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{916370AB-B0D3-4136-850B-AA12FAB23ECD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{916370AB-B0D3-4136-850B-AA12FAB23ECD}.Debug|x64.Build.0 = Debug|Any CPU
+		{916370AB-B0D3-4136-850B-AA12FAB23ECD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{916370AB-B0D3-4136-850B-AA12FAB23ECD}.Debug|x86.Build.0 = Debug|Any CPU
+		{916370AB-B0D3-4136-850B-AA12FAB23ECD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{916370AB-B0D3-4136-850B-AA12FAB23ECD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{916370AB-B0D3-4136-850B-AA12FAB23ECD}.Release|x64.ActiveCfg = Release|Any CPU
+		{916370AB-B0D3-4136-850B-AA12FAB23ECD}.Release|x64.Build.0 = Release|Any CPU
+		{916370AB-B0D3-4136-850B-AA12FAB23ECD}.Release|x86.ActiveCfg = Release|Any CPU
+		{916370AB-B0D3-4136-850B-AA12FAB23ECD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1034,5 +1062,10 @@ Global
 		{C6F061D6-18D6-41E3-A692-C0603A994F30} = {3079E458-D0E6-4F99-8CAB-80011D35C7DA}
 		{662968A7-5BCC-467B-A814-38584D0184CD} = {4B000021-5278-4F2A-B734-DE49F55D4024}
 		{C11F232A-ED36-4DCE-A18D-BF90CED8D1B4} = {3079E458-D0E6-4F99-8CAB-80011D35C7DA}
+		{0BA3C0A9-64B9-445D-B085-8FFAC09D6E37} = {3079E458-D0E6-4F99-8CAB-80011D35C7DA}
+		{916370AB-B0D3-4136-850B-AA12FAB23ECD} = {4B000021-5278-4F2A-B734-DE49F55D4024}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9DD4022C-A010-4A9B-BCC5-171566D4CB17}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Azure.Experimental/System.Azure.Experimental.csproj
+++ b/src/System.Azure.Experimental/System.Azure.Experimental.csproj
@@ -1,5 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\tools\common.props" />
+
+    <!-- Platform detection -->
+  <PropertyGroup>
+    <TargetsUnix Condition="'$(OS)'=='Windows_NT'">false</TargetsUnix>
+    <TargetsUnix Condition="'$(OS)'=='Unix'">true</TargetsUnix>
+  </PropertyGroup>
+
   <PropertyGroup>
     <Description>Tensor class which represents and extends multi-dimensional arrays</Description>
     <TargetFramework>netstandard1.3</TargetFramework>
@@ -7,7 +14,6 @@
     <PackageTags>BCL for Azure SDK </PackageTags>
     <!-- disable automatic compile item inclusion so that we can set the correct metadata on TextTemplate-generated sources -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <TargetsUnix>false</TargetsUnix>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Azure\Authentication.cs" />

--- a/src/System.Azure.Experimental/System.Azure.Experimental.csproj
+++ b/src/System.Azure.Experimental/System.Azure.Experimental.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\tools\common.props" />
+  <PropertyGroup>
+    <Description>Tensor class which represents and extends multi-dimensional arrays</Description>
+    <TargetFramework>netstandard1.3</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PackageTags>BCL for Azure SDK </PackageTags>
+    <!-- disable automatic compile item inclusion so that we can set the correct metadata on TextTemplate-generated sources -->
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <TargetsUnix>false</TargetsUnix>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="System\Azure\Authentication.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Compile Include="System\Azure\Sha256.Unix.cs" />    
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)' == 'false'">
+    <Compile Include="System\Azure\Sha256.Windows.cs" />   
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\System.Binary.Base64\System.Binary.Base64.csproj" />
+    <ProjectReference Include="..\System.Buffers.Primitives\System.Buffers.Primitives.csproj" />
+    <ProjectReference Include="..\System.Text.Primitives\System.Text.Primitives.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/System.Azure.Experimental/System/Azure/Authentication.cs
+++ b/src/System.Azure.Experimental/System/Azure/Authentication.cs
@@ -1,0 +1,249 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Binary.Base64;
+using System.Buffers;
+using System.Buffers.Cryptography;
+using System.Text;
+using System.Text.Encoders;
+
+namespace System.Azure.Authentication
+{
+    public class Signature
+    {
+        static readonly byte[] s_type = Encoding.UTF8.GetBytes("type=");
+        static readonly byte[] s_ver = Encoding.UTF8.GetBytes("&ver=");
+        static readonly byte[] s_sig = Encoding.UTF8.GetBytes("&sig=");
+
+        static readonly byte[] s_get = Encoding.UTF8.GetBytes("get\n");
+        static readonly byte[] s_post = Encoding.UTF8.GetBytes("post\n");
+        static readonly byte[] s_delete = Encoding.UTF8.GetBytes("delete\n");
+
+        public static unsafe int Generate(Span<byte> output, Sha256 hash, string keyType, string verb, string resourceId, string resourceType, string tokenVersion, DateTime utc)
+        {
+            int written, consumed, totalWritten = 0;
+
+            var pBuffer = stackalloc byte[256];
+            var buffer = new Span<byte>(pBuffer, 256);
+
+            s_type.CopyTo(buffer);
+            totalWritten += s_type.Length;
+            var span = buffer.Slice(totalWritten);
+
+            if (Utf16.ToUtf8(keyType.AsSpan().AsBytes(), span, out consumed, out written) != TransformationStatus.Done)
+            {
+                throw new NotImplementedException();
+            }
+            totalWritten += written;
+            span = buffer.Slice(totalWritten);
+
+            s_ver.CopyTo(span);
+            totalWritten += s_ver.Length;
+
+            span = buffer.Slice(totalWritten);
+
+            if (Utf16.ToUtf8(tokenVersion.AsSpan().AsBytes(), span, out consumed, out written) != TransformationStatus.Done)
+            {
+                throw new NotImplementedException();
+            }
+            totalWritten += written;
+            span = buffer.Slice(totalWritten);
+
+            s_sig.CopyTo(span);
+            totalWritten += s_sig.Length;
+
+            var front = buffer.Slice(0, totalWritten);
+
+            var payload = buffer.Slice(totalWritten);
+            totalWritten = 0;
+
+            if (verb.Equals("GET", StringComparison.Ordinal) || verb.Equals("get", StringComparison.Ordinal))
+            {
+                s_get.CopyTo(payload);
+                totalWritten += s_get.Length;
+            }
+            else if (verb.Equals("POST", StringComparison.Ordinal) || verb.Equals("post", StringComparison.Ordinal))
+            {
+                s_post.CopyTo(payload);
+                totalWritten += s_post.Length;
+            }
+            else if (verb.Equals("DELETE", StringComparison.Ordinal) || verb.Equals("delete", StringComparison.Ordinal))
+            {
+                s_delete.CopyTo(payload);
+                totalWritten += s_delete.Length;
+            }
+            else
+            {
+                if (Utf16.ToUtf8(verb.AsSpan().AsBytes(), payload, out consumed, out written) != TransformationStatus.Done)
+                {
+                    throw new NotImplementedException();
+                }
+                if (Ascii.ToLowerInPlace(payload.Slice(0, written), out written) != TransformationStatus.Done)
+                {
+                    throw new NotImplementedException();
+                }
+
+                payload[written] = (byte)'\n';
+                totalWritten += written + 1;
+            }
+
+            span = payload.Slice(totalWritten);
+
+            if (Utf16.ToUtf8(resourceType.AsSpan().AsBytes(), span, out consumed, out written) != TransformationStatus.Done)
+            {
+                throw new NotImplementedException();
+            }
+            if (Ascii.ToLowerInPlace(span.Slice(0, written), out written) != TransformationStatus.Done)
+            {
+                throw new NotImplementedException();
+            }
+            span[written] = (byte)'\n';
+            totalWritten += written + 1;
+            span = payload.Slice(totalWritten);
+
+            if (Utf16.ToUtf8(resourceId.AsSpan().AsBytes(), span, out consumed, out written) != TransformationStatus.Done)
+            {
+                throw new NotImplementedException();
+            }
+            span[written] = (byte)'\n';
+            totalWritten += written + 1;
+            span = payload.Slice(totalWritten);
+
+            if (!PrimitiveFormatter.TryFormat(utc, span, out written, 'l'))
+            {
+                throw new NotImplementedException();
+            }
+            span[written] = (byte)'\n';
+            totalWritten += written + 1;
+            span = payload.Slice(totalWritten);
+
+            span[0] = (byte)'\n';
+            totalWritten += 1;
+
+            hash.Append(buffer.Slice(front.Length, totalWritten));
+            hash.GetHash(buffer.Slice(front.Length, hash.OutputSize));
+            if (!Base64.EncodeInPlace(buffer.Slice(front.Length), hash.OutputSize, out written))
+            {
+                throw new NotImplementedException();
+            }
+
+            var len = front.Length + written;
+            UrlEncode(buffer.Slice(0, len), output, out int encodedBytes);
+            return encodedBytes;
+        }
+
+        public unsafe static byte[] ComputeKeyBytes(string key)
+        {
+            const int bufferLength = 128;
+
+            byte* pBuffer = stackalloc byte[bufferLength];
+            int written, consumed;
+            var buffer = new Span<byte>(pBuffer, bufferLength);
+            if (Utf16.ToUtf8(key.AsSpan().AsBytes(), buffer, out consumed, out written) != TransformationStatus.Done)
+            {
+                throw new NotImplementedException();
+            }
+            var keyBytes = new byte[64];
+            var result = Base64.Decode(buffer.Slice(0, written), keyBytes, out consumed, out written);
+            if (result != TransformationStatus.Done || written != 64)
+            {
+                throw new NotImplementedException();
+            }
+            return keyBytes;
+        }
+
+        static void UrlEncode(ReadOnlySpan<byte> input, Span<byte> output, out int written)
+        {
+            written = 0;
+            for (int inputIndex = 0; inputIndex < input.Length; inputIndex++)
+            {
+                var next = input[inputIndex];
+                if (IsAllowed[next])
+                {
+                    output[written++] = input[inputIndex];
+                }
+                else
+                {
+                    output[written++] = (byte)'%';
+                    PrimitiveFormatter.TryFormat(next, output.Slice(written), out int formatted, 'X');
+                    written += formatted;
+                }
+            }
+        }
+
+        static Signature()
+        {
+            // Unreserved
+            IsAllowed['A'] = true;
+            IsAllowed['B'] = true;
+            IsAllowed['C'] = true;
+            IsAllowed['D'] = true;
+            IsAllowed['E'] = true;
+            IsAllowed['F'] = true;
+            IsAllowed['G'] = true;
+            IsAllowed['H'] = true;
+            IsAllowed['I'] = true;
+            IsAllowed['J'] = true;
+            IsAllowed['K'] = true;
+            IsAllowed['L'] = true;
+            IsAllowed['M'] = true;
+            IsAllowed['N'] = true;
+            IsAllowed['O'] = true;
+            IsAllowed['P'] = true;
+            IsAllowed['Q'] = true;
+            IsAllowed['R'] = true;
+            IsAllowed['S'] = true;
+            IsAllowed['T'] = true;
+            IsAllowed['U'] = true;
+            IsAllowed['V'] = true;
+            IsAllowed['W'] = true;
+            IsAllowed['X'] = true;
+            IsAllowed['Y'] = true;
+            IsAllowed['Z'] = true;
+
+            IsAllowed['a'] = true;
+            IsAllowed['b'] = true;
+            IsAllowed['c'] = true;
+            IsAllowed['d'] = true;
+            IsAllowed['e'] = true;
+            IsAllowed['f'] = true;
+            IsAllowed['g'] = true;
+            IsAllowed['h'] = true;
+            IsAllowed['i'] = true;
+            IsAllowed['j'] = true;
+            IsAllowed['k'] = true;
+            IsAllowed['l'] = true;
+            IsAllowed['m'] = true;
+            IsAllowed['n'] = true;
+            IsAllowed['o'] = true;
+            IsAllowed['p'] = true;
+            IsAllowed['q'] = true;
+            IsAllowed['r'] = true;
+            IsAllowed['s'] = true;
+            IsAllowed['t'] = true;
+            IsAllowed['u'] = true;
+            IsAllowed['v'] = true;
+            IsAllowed['w'] = true;
+            IsAllowed['x'] = true;
+            IsAllowed['y'] = true;
+            IsAllowed['z'] = true;
+
+            IsAllowed['0'] = true;
+            IsAllowed['1'] = true;
+            IsAllowed['2'] = true;
+            IsAllowed['3'] = true;
+            IsAllowed['4'] = true;
+            IsAllowed['5'] = true;
+            IsAllowed['6'] = true;
+            IsAllowed['7'] = true;
+            IsAllowed['8'] = true;
+            IsAllowed['9'] = true;
+
+            IsAllowed['-'] = true;
+            IsAllowed['_'] = true;
+            IsAllowed['.'] = true;
+            IsAllowed['~'] = true;
+        }
+        static bool[] IsAllowed = new bool[256];
+    }
+}

--- a/src/System.Azure.Experimental/System/Azure/Authentication.cs
+++ b/src/System.Azure.Experimental/System/Azure/Authentication.cs
@@ -19,12 +19,13 @@ namespace System.Azure.Authentication
         static readonly byte[] s_post = Encoding.UTF8.GetBytes("post\n");
         static readonly byte[] s_delete = Encoding.UTF8.GetBytes("delete\n");
 
+        const int AuthenticationHeaderBufferSize = 256; 
         public static unsafe int Generate(Span<byte> output, Sha256 hash, string keyType, string verb, string resourceId, string resourceType, string tokenVersion, DateTime utc)
         {
             int written, consumed, totalWritten = 0;
 
-            var pBuffer = stackalloc byte[256];
-            var buffer = new Span<byte>(pBuffer, 256);
+            var pBuffer = stackalloc byte[AuthenticationHeaderBufferSize];
+            var buffer = new Span<byte>(pBuffer, AuthenticationHeaderBufferSize);
 
             s_type.CopyTo(buffer);
             totalWritten += s_type.Length;

--- a/src/System.Azure.Experimental/System/Azure/Sha256.Unix.cs
+++ b/src/System.Azure.Experimental/System/Azure/Sha256.Unix.cs
@@ -6,13 +6,13 @@ using System.Security.Cryptography;
 
 namespace System.Buffers.Cryptography
 {
-    public struct Sha256_Unix
+    public struct Sha256
     {
         IncrementalHash _hash; 
-        public static Sha256_Unix Create(byte[] seed)
+        public static Sha256 Create(byte[] seed)
         {
-            var sha = new Sha256_Unix();
-            sha._hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            var sha = new Sha256();
+            sha._hash = IncrementalHash.CreateHMAC(HashAlgorithmName.SHA256, seed);
             return sha;
         }
 

--- a/src/System.Azure.Experimental/System/Azure/Sha256.Unix.cs
+++ b/src/System.Azure.Experimental/System/Azure/Sha256.Unix.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Security.Cryptography;
+
+namespace System.Buffers.Cryptography
+{
+    public struct Sha256_Unix
+    {
+        IncrementalHash _hash; 
+        public static Sha256_Unix Create(byte[] seed)
+        {
+            var sha = new Sha256_Unix();
+            sha._hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            return sha;
+        }
+
+        public int OutputSize => 256 / 8;
+        public unsafe void Append(ReadOnlySpan<byte> input)
+        {
+            _hash.AppendData(input.ToArray());
+        }
+
+        public unsafe void GetHash(Span<byte> output)
+        {
+            var hash = _hash.GetHashAndReset();
+            if (hash.Length > output.Length) throw new ArgumentException();
+            hash.AsSpan().CopyTo(output);
+        }
+
+        public void Dispose()
+        {
+            _hash.Dispose();
+            _hash = null;
+        }
+    }
+}

--- a/src/System.Azure.Experimental/System/Azure/Sha256.Windows.cs
+++ b/src/System.Azure.Experimental/System/Azure/Sha256.Windows.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace System.Buffers.Cryptography
+{
+    public struct Sha256
+    {
+        IntPtr _algorithm;
+        IntPtr _hash;
+
+        public static Sha256 Create(byte[] seed)
+        {
+            var sha = new Sha256();
+            var result = BCryptOpenAlgorithmProvider(out sha._algorithm, "SHA256", null, BCryptFlags.BCRYPT_ALG_HANDLE_HMAC);
+            if (result != 0) throw new Exception();
+            unsafe
+            {
+                fixed (byte* pSeed = seed)
+                {
+                    result = BCryptCreateHash(sha._algorithm, out sha._hash, IntPtr.Zero, 0, pSeed, seed.Length, BCryptFlags.BCRYPT_HASH_REUSABLE_FLAG);
+                }
+            }
+            if (result != 0) throw new Exception();
+            return sha;
+        }
+
+        public int OutputSize => 256 / 8;
+        public unsafe void Append(ReadOnlySpan<byte> input)
+        {
+            fixed (byte* pInput = &input.DangerousGetPinnableReference())
+            {
+                var result = BCryptHashData(_hash, pInput, input.Length, 0);
+                if (result != 0) throw new Exception();
+            }
+        }
+
+        public unsafe void GetHash(Span<byte> output)
+        {
+            fixed (byte* pOutput = &output.DangerousGetPinnableReference())
+            {
+                var result = BCryptFinishHash(_hash, pOutput, output.Length, 0);
+                if (result != 0) throw new Exception();
+            }
+        }
+
+        public void Dispose()
+        {
+            var result = BCryptDestroyHash(_hash);
+            if (result != 0) throw new Exception();
+            result = BCryptCloseAlgorithmProvider(_algorithm, 0);
+            if (result != 0) throw new Exception();
+        }
+
+        [DllImport("bcrypt.dll", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        extern static int BCryptOpenAlgorithmProvider(out IntPtr handle, string algId, string implementation, BCryptFlags flags);
+
+        [DllImport("bcrypt.dll", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        extern static int BCryptCloseAlgorithmProvider(IntPtr handle, uint flags);
+
+        [DllImport("bcrypt.dll", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        extern static unsafe int BCryptCreateHash(IntPtr hAlgorithm, out IntPtr phHash, IntPtr pbHashObject, int cbHashObject, byte* pbSecret, int cbSecret, BCryptFlags dwFlags);
+
+        [DllImport("bcrypt.dll", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        extern static int BCryptDestroyHash(IntPtr hHash);
+
+        [DllImport("bcrypt.dll", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        extern static unsafe int BCryptHashData(IntPtr hHash, byte* pbInput, int cbInput, int dwFlags);
+
+        [DllImport("bcrypt.dll", SetLastError = true, ExactSpelling = true, CharSet = CharSet.Unicode)]
+        extern static unsafe int BCryptFinishHash(IntPtr hHash, byte* pbOutput, int cbOutput, int dwFlags);
+
+        [Flags]
+        enum BCryptFlags : int
+        {
+            None = 0x00000000,
+            BCRYPT_ALG_HANDLE_HMAC = 0x00000008,
+            BCRYPT_HASH_REUSABLE_FLAG = 0x00000020,
+        }
+    }
+}

--- a/tests/System.Azure.Experimental.Tests/AuthenticationTests.cs
+++ b/tests/System.Azure.Experimental.Tests/AuthenticationTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Azure.Authentication;
+using System.Buffers.Cryptography;
+using System.Text;
+using Xunit;
+
+namespace tests
+{
+    public class AzureSdk
+    {
+        DateTime utc = DateTime.UtcNow;
+        string fakeKey = "TjW7xr4kKR67qgt2y3fAAMxvC2neMHT6cKawiliGCsDkxSS34V0EnwL8GKrA6ZTIfNrXK91t1Ey3RmEKQLrrCA==";
+        string keyType = "master";
+        string resourceType = "dbs";
+        string version = "1.0";
+        string resourceId = "";
+
+        [Fact]
+        public void GenerateSignature()
+        {
+            var keyBytes = Signature.ComputeKeyBytes(fakeKey);
+            var sha = Sha256.Create(keyBytes);
+
+            // Generate using non-allocating APIs
+            var buffer = new byte[256];
+            var bytesWritten = Signature.Generate(buffer, sha, keyType, "GET", resourceId, resourceType, version, utc);
+            var signatureAsString = Encoding.UTF8.GetString(buffer, 0, bytesWritten);
+
+            // Generate using existing .NET APIs (sample from Asure documentation)
+            var expected = GenerateMasterKeyAuthorizationSignatureMsdn(fakeKey, keyType, "GET", resourceId, resourceType, version, utc);
+
+            Assert.Equal(expected, signatureAsString);
+        }
+
+        static string GenerateMasterKeyAuthorizationSignatureMsdn(string key, string keyType, string verb, string resourceId, string resourceType, string tokenVersion, DateTime utc)
+        {
+            var keyBytes = Convert.FromBase64String(key);
+            var hmacSha256 = new System.Security.Cryptography.HMACSHA256 { Key = keyBytes };
+            string utc_date = utc.ToString("r");
+
+            string payLoad = string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}\n{1}\n{2}\n{3}\n{4}\n",
+                    verb.ToLowerInvariant(),
+                    resourceType.ToLowerInvariant(),
+                    resourceId,
+                    utc_date.ToLowerInvariant(),
+                    ""
+            );
+
+            byte[] hashPayLoad = hmacSha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(payLoad));
+            string signature = Convert.ToBase64String(hashPayLoad);
+
+            var full = String.Format(System.Globalization.CultureInfo.InvariantCulture, "type={0}&ver={1}&sig={2}",
+                keyType,
+                tokenVersion,
+                signature);
+
+            var result = System.Text.Encodings.Web.UrlEncoder.Default.Encode(full);
+
+            return result;
+        }
+    }
+}

--- a/tests/System.Azure.Experimental.Tests/System.Azure.Experimental.Tests.csproj
+++ b/tests/System.Azure.Experimental.Tests/System.Azure.Experimental.Tests.csproj
@@ -17,5 +17,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Azure.Experimental\System.Azure.Experimental.csproj" />
   </ItemGroup>
-  <!-- register for test discovery in Visual Studio -->
 </Project>

--- a/tests/System.Azure.Experimental.Tests/System.Azure.Experimental.Tests.csproj
+++ b/tests/System.Azure.Experimental.Tests/System.Azure.Experimental.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\tools\common.props" />
+  <PropertyGroup>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <AssemblyOriginatorKeyFile>../../tools/test_key.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.3.1" />
+    <PackageReference Include="xunit" Version="$(XunitVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+  </ItemGroup>
+  <!-- Project references -->
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Azure.Experimental\System.Azure.Experimental.csproj" />
+  </ItemGroup>
+  <!-- register for test discovery in Visual Studio -->
+</Project>


### PR DESCRIPTION
This adds a new corfxlab project where we want to experiment with building blocks for Azure SDK.

The initial commit contains an API to general CosmosDB authentication header without allocations.
The currently recommended way to generate the headers is described at https://docs.microsoft.com/en-us/rest/api/documentdb/access-control-on-documentdb-resources

The following is a result of a micro benchmark run comparing the currently recommended methods and the experimental corfxlab API:

| Method            | Mean    | Error      | StdDev   | Scaled | Gen 0 | Allocated |
|-------------------|---------:|----------:|----------:|-------:|-------:|----------:|
| SignatureGenerate | 2.236 us | 0.0009 us | 0.0007 us |   0.36 |      - |       0 B |
| MsdnSample        | 6.292 us | 0.0051 us | 0.0045 us |   1.00 | 0.7248 |    3056 B |

The improvements are mainly due to using non-allocating System.Text.Primitives APIs for text manipulation, Spans for slicing, non-allocating SHA256 generation, and native UTF8 text generation.

Note: Do not merge the PR. It does not work on Linux. I will have an update to make it work.

@AlexGhiondea, @joshfree, @shiftylogic, @ahsonkhan