### PR TITLE
Add the Owner property to BufferHandle

### DIFF
--- a/src/System.Buffers.Primitives/System/Buffers/BufferHandle.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/BufferHandle.cs
@@ -22,6 +22,8 @@ namespace System.Buffers
 
         public BufferHandle(IRetainable owner) : this(owner, null) { }
 
+        public IRetainable Owner => _owner;
+
         public void* PinnedPointer {
             get {
                 if (_pointer == null) BufferPrimitivesThrowHelper.ThrowInvalidOperationException();


### PR DESCRIPTION
This would stop having to carry around the buffer with the pinned handle. This is already carried around by the Handle anyway, so it seems a waste to have to have "BufferHandle" + "Buffer" be passed through when calling functions.