### PR TITLE
System.IO.Compression.Brotli: .NET Standard 1.4 -> 1.1

### DIFF
--- a/src/System.IO.Compression.Brotli/System.IO.Compression.Brotli.csproj
+++ b/src/System.IO.Compression.Brotli/System.IO.Compression.Brotli.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <Description>Brotli compression APIs</Description>
     <Copyright>Microsoft Corporation, All rights reserved.</Copyright>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard1.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>


### PR DESCRIPTION
It would be nice in the `System.IO.Compression.Brotli` library to downgrade .NET Standard version from 1.4 to 1.1. In general, class libraries which target a lower [.NET Platform Standard](https://github.com/dotnet/standard/blob/master/docs/versions.md) version, can be loaded by the largest number of existing platforms. Key libraries are still targeted on .NET Standard 1.1  (e.g., [`System.IO.Compression`](https://www.nuget.org/packages/System.IO.Compression/)).