### PR TITLE
GenerateStorageSignature changed to TryWriteStorageSignature

### DIFF
--- a/src/System.Azure.Experimental/System.Azure.Experimental.csproj
+++ b/src/System.Azure.Experimental/System.Azure.Experimental.csproj
@@ -31,5 +31,6 @@
     <ProjectReference Include="..\System.Binary.Base64\System.Binary.Base64.csproj" />
     <ProjectReference Include="..\System.Buffers.Primitives\System.Buffers.Primitives.csproj" />
     <ProjectReference Include="..\System.Text.Primitives\System.Text.Primitives.csproj" />
+    <ProjectReference Include="..\System.Text.Encodings.Web.Utf8\System.Text.Encodings.Web.Utf8.csproj" />
   </ItemGroup>
 </Project>

--- a/src/System.Text.Encodings.Web.Utf8/System.Text.Encodings.Web.Utf8.csproj
+++ b/src/System.Text.Encodings.Web.Utf8/System.Text.Encodings.Web.Utf8.csproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Buffers.Primitives\System.Buffers.Primitives.csproj" />
+    <ProjectReference Include="..\System.Text.Primitives\System.Text.Primitives.csproj" />
   </ItemGroup>
 </Project>

--- a/src/System.Text.Encodings.Web.Utf8/UrlEncoder.cs
+++ b/src/System.Text.Encodings.Web.Utf8/UrlEncoder.cs
@@ -6,6 +6,32 @@ namespace System.Text.Encodings.Web.Utf8
 {
     public class UrlEncoder
     {
+        static bool[] IsAllowed = new bool[0x7F + 1];
+
+        public static void Encode(ReadOnlySpan<byte> input, Span<byte> output, out int written)
+        {
+            written = 0;
+            for (int inputIndex = 0; inputIndex < input.Length; inputIndex++)
+            {
+                var next = input[inputIndex];
+                if(next > 0x7F)
+                {
+                    throw new NotImplementedException();
+                }
+
+                if (IsAllowed[next])
+                {
+                    output[written++] = input[inputIndex];
+                }
+                else
+                {
+                    output[written++] = (byte)'%';
+                    PrimitiveFormatter.TryFormat(next, output.Slice(written), out int formatted, 'X');
+                    written += formatted;
+                }
+            }
+        }
+
         /// <summary>
         /// Unescape a URL path
         /// </summary>
@@ -329,6 +355,80 @@ namespace System.Text.Encodings.Web.Utf8
             }
 
             return false;
+        }
+
+        static UrlEncoder()
+        {
+            // Unreserved
+            IsAllowed['A'] = true;
+            IsAllowed['B'] = true;
+            IsAllowed['C'] = true;
+            IsAllowed['D'] = true;
+            IsAllowed['E'] = true;
+            IsAllowed['F'] = true;
+            IsAllowed['G'] = true;
+            IsAllowed['H'] = true;
+            IsAllowed['I'] = true;
+            IsAllowed['J'] = true;
+            IsAllowed['K'] = true;
+            IsAllowed['L'] = true;
+            IsAllowed['M'] = true;
+            IsAllowed['N'] = true;
+            IsAllowed['O'] = true;
+            IsAllowed['P'] = true;
+            IsAllowed['Q'] = true;
+            IsAllowed['R'] = true;
+            IsAllowed['S'] = true;
+            IsAllowed['T'] = true;
+            IsAllowed['U'] = true;
+            IsAllowed['V'] = true;
+            IsAllowed['W'] = true;
+            IsAllowed['X'] = true;
+            IsAllowed['Y'] = true;
+            IsAllowed['Z'] = true;
+
+            IsAllowed['a'] = true;
+            IsAllowed['b'] = true;
+            IsAllowed['c'] = true;
+            IsAllowed['d'] = true;
+            IsAllowed['e'] = true;
+            IsAllowed['f'] = true;
+            IsAllowed['g'] = true;
+            IsAllowed['h'] = true;
+            IsAllowed['i'] = true;
+            IsAllowed['j'] = true;
+            IsAllowed['k'] = true;
+            IsAllowed['l'] = true;
+            IsAllowed['m'] = true;
+            IsAllowed['n'] = true;
+            IsAllowed['o'] = true;
+            IsAllowed['p'] = true;
+            IsAllowed['q'] = true;
+            IsAllowed['r'] = true;
+            IsAllowed['s'] = true;
+            IsAllowed['t'] = true;
+            IsAllowed['u'] = true;
+            IsAllowed['v'] = true;
+            IsAllowed['w'] = true;
+            IsAllowed['x'] = true;
+            IsAllowed['y'] = true;
+            IsAllowed['z'] = true;
+
+            IsAllowed['0'] = true;
+            IsAllowed['1'] = true;
+            IsAllowed['2'] = true;
+            IsAllowed['3'] = true;
+            IsAllowed['4'] = true;
+            IsAllowed['5'] = true;
+            IsAllowed['6'] = true;
+            IsAllowed['7'] = true;
+            IsAllowed['8'] = true;
+            IsAllowed['9'] = true;
+
+            IsAllowed['-'] = true;
+            IsAllowed['_'] = true;
+            IsAllowed['.'] = true;
+            IsAllowed['~'] = true;
         }
     }
 }

--- a/tests/System.Azure.Experimental.Tests/AuthenticationTests.cs
+++ b/tests/System.Azure.Experimental.Tests/AuthenticationTests.cs
@@ -46,7 +46,7 @@ namespace tests
 
             // Generate using non-allocating APIs
             var buffer = new byte[256];
-            var bytesWritten = Signature.GenerateStorageSignature(buffer, sha, "GET", canonicalizedResource, utc);
+            Assert.True(Signature.TryWriteStorageSignature(buffer, sha, "GET", canonicalizedResource, utc, out int bytesWritten));
             var signatureAsString = Encoding.UTF8.GetString(buffer, 0, bytesWritten);
 
             // Generate using existing .NET APIs (sample from Asure documentation)


### PR DESCRIPTION
Made the API resilient to small output buffer size

Also, moved URI encoding to System.Text.Encodings.Web.Utf8