### PR TITLE
Added CosmosDbAuthorizationHeader

### DIFF
--- a/src/System.Azure.Experimental/System.Azure.Experimental.csproj
+++ b/src/System.Azure.Experimental/System.Azure.Experimental.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Description>Tensor class which represents and extends multi-dimensional arrays</Description>
+    <Description>Set of building blocks for Azure SDK</Description>
     <TargetFramework>netstandard1.3</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>BCL for Azure SDK </PackageTags>
@@ -16,7 +16,9 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="System\Azure\Authentication.cs" />
+    <Compile Include="System\Azure\CosmosDbAuthorizationHeader.cs" />
+    <Compile Include="System\Azure\Key.cs" />
+    <Compile Include="System\Azure\StorageAccessSignature.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Compile Include="System\Azure\Sha256.Unix.cs" />    

--- a/src/System.Azure.Experimental/System/Azure/CosmosDbAuthorizationHeader.cs
+++ b/src/System.Azure.Experimental/System/Azure/CosmosDbAuthorizationHeader.cs
@@ -9,29 +9,7 @@ using System.Text.Encoders;
 using System.Text.Encodings.Web.Utf8;
 
 namespace System.Azure.Authentication
-{
-    public static class Key {
-        public unsafe static byte[] ComputeKeyBytes(string key)
-        {
-            const int bufferLength = 128;
-
-            byte* pBuffer = stackalloc byte[bufferLength];
-            int written, consumed;
-            var buffer = new Span<byte>(pBuffer, bufferLength);
-            if (Utf16.ToUtf8(key.AsReadOnlySpan().AsBytes(), buffer, out consumed, out written) != TransformationStatus.Done)
-            {
-                throw new NotImplementedException("need to resize buffer");
-            }
-            var keyBytes = new byte[64];
-            var result = Base64.Decode(buffer.Slice(0, written), keyBytes, out consumed, out written);
-            if (result != TransformationStatus.Done || written != 64)
-            {
-                throw new NotImplementedException("need to resize buffer");
-            }
-            return keyBytes;
-        }
-    }
-    
+{   
     public struct CosmosDbAuthorizationHeader : IBufferFormattable {
         public Sha256 Hash;
         public string KeyType;
@@ -183,75 +161,5 @@ namespace System.Azure.Authentication
         static readonly byte[] s_delete = Encoding.UTF8.GetBytes("delete\n");
 
         const int AuthenticationHeaderBufferSize = 256;
-    }
-
-    public static class StorageAccessSignature
-    {
-        public static bool TryWrite(Span<byte> output, Sha256 hash, string verb, string canonicalizedResource, DateTime utc, out int bytesWritten)
-        {
-            int written, consumed;
-            bytesWritten = 0;
-
-            if (verb.Equals("GET", StringComparison.Ordinal))
-            {
-                if (output.Length < 3)
-                {
-                    bytesWritten = 0;
-                    return false;
-                }
-                s_GET.CopyTo(output);
-                bytesWritten += s_GET.Length;
-            }
-            else
-            {
-                if (Utf16.ToUtf8(verb.AsReadOnlySpan().AsBytes(), output, out consumed, out written) != TransformationStatus.Done)
-                {
-                    bytesWritten = 0;
-                    return false;
-                }
-
-                output[written] = (byte)'\n';
-                bytesWritten += written + 1;
-            }
-
-            var free = output.Slice(bytesWritten);
-            s_emptyHeaders.CopyTo(free);
-            bytesWritten += s_emptyHeaders.Length;
-
-            free = output.Slice(bytesWritten);
-            if (!PrimitiveFormatter.TryFormat(utc, free, out written, 'R'))
-            {
-                bytesWritten = 0;
-                return false;
-            }
-            free[written] = (byte)'\n';
-            bytesWritten += written + 1;
-            free = output.Slice(bytesWritten);
-
-            if (Utf16.ToUtf8(canonicalizedResource.AsReadOnlySpan().AsBytes(), free, out consumed, out written) != TransformationStatus.Done)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-            bytesWritten += written;
-
-            var formatted = output.Slice(0, bytesWritten);
-
-            hash.Append(formatted);
-            hash.GetHash(output.Slice(0, hash.OutputSize));
-
-            if (!Base64.EncodeInPlace(output, hash.OutputSize, out written))
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            bytesWritten = written;
-            return true;
-        }
-
-        static readonly byte[] s_GET = Encoding.UTF8.GetBytes("GET\n");
-
-        static readonly byte[] s_emptyHeaders = Encoding.UTF8.GetBytes("\n\n\n\n\n\n\n\n\n\n\nx-ms-date:");
     }
 }

--- a/src/System.Azure.Experimental/System/Azure/Key.cs
+++ b/src/System.Azure.Experimental/System/Azure/Key.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Binary.Base64;
+using System.Buffers;
+using System.Buffers.Cryptography;
+using System.Text;
+using System.Text.Encoders;
+using System.Text.Encodings.Web.Utf8;
+
+namespace System.Azure.Authentication
+{
+    public static class Key {
+        public unsafe static byte[] ComputeKeyBytes(string key)
+        {
+            const int bufferLength = 128;
+
+            byte* pBuffer = stackalloc byte[bufferLength];
+            int written, consumed;
+            var buffer = new Span<byte>(pBuffer, bufferLength);
+            if (Utf16.ToUtf8(key.AsReadOnlySpan().AsBytes(), buffer, out consumed, out written) != TransformationStatus.Done)
+            {
+                throw new NotImplementedException("need to resize buffer");
+            }
+            var keyBytes = new byte[64];
+            var result = Base64.Decode(buffer.Slice(0, written), keyBytes, out consumed, out written);
+            if (result != TransformationStatus.Done || written != 64)
+            {
+                throw new NotImplementedException("need to resize buffer");
+            }
+            return keyBytes;
+        }
+    }
+}

--- a/src/System.Azure.Experimental/System/Azure/StorageAccessSignature.cs
+++ b/src/System.Azure.Experimental/System/Azure/StorageAccessSignature.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Binary.Base64;
+using System.Buffers;
+using System.Buffers.Cryptography;
+using System.Text;
+using System.Text.Encoders;
+using System.Text.Encodings.Web.Utf8;
+
+namespace System.Azure.Authentication
+{
+    public static class StorageAccessSignature
+    {
+        public static bool TryWrite(Span<byte> output, Sha256 hash, string verb, string canonicalizedResource, DateTime utc, out int bytesWritten)
+        {
+            int written, consumed;
+            bytesWritten = 0;
+
+            if (verb.Equals("GET", StringComparison.Ordinal))
+            {
+                if (output.Length < 3)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+                s_GET.CopyTo(output);
+                bytesWritten += s_GET.Length;
+            }
+            else
+            {
+                if (Utf16.ToUtf8(verb.AsReadOnlySpan().AsBytes(), output, out consumed, out written) != TransformationStatus.Done)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                output[written] = (byte)'\n';
+                bytesWritten += written + 1;
+            }
+
+            var free = output.Slice(bytesWritten);
+            s_emptyHeaders.CopyTo(free);
+            bytesWritten += s_emptyHeaders.Length;
+
+            free = output.Slice(bytesWritten);
+            if (!PrimitiveFormatter.TryFormat(utc, free, out written, 'R'))
+            {
+                bytesWritten = 0;
+                return false;
+            }
+            free[written] = (byte)'\n';
+            bytesWritten += written + 1;
+            free = output.Slice(bytesWritten);
+
+            if (Utf16.ToUtf8(canonicalizedResource.AsReadOnlySpan().AsBytes(), free, out consumed, out written) != TransformationStatus.Done)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+            bytesWritten += written;
+
+            var formatted = output.Slice(0, bytesWritten);
+
+            hash.Append(formatted);
+            hash.GetHash(output.Slice(0, hash.OutputSize));
+
+            if (!Base64.EncodeInPlace(output, hash.OutputSize, out written))
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            bytesWritten = written;
+            return true;
+        }
+
+        static readonly byte[] s_GET = Encoding.UTF8.GetBytes("GET\n");
+
+        static readonly byte[] s_emptyHeaders = Encoding.UTF8.GetBytes("\n\n\n\n\n\n\n\n\n\n\nx-ms-date:");
+    }
+}


### PR DESCRIPTION
Added CosmosDbAuthorizationHeader implementing IBufferFormattable, which makes it easy to write to various formattable buffers (as one of the tests illustrates).

@joshfree, @ahsonkhan, @shiftylogic 