### PR TITLE
Remove offset from OwnedBuffer.Pin

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
@@ -131,14 +131,13 @@ namespace Microsoft.Net.Http
             return true;
         }
 
-        public override BufferHandle Pin(int index = 0)
+        public override BufferHandle Pin()
         {
             unsafe
             {
                 Retain();
                 var handle = GCHandle.Alloc(_array, GCHandleType.Pinned);
-                var pointer = Unsafe.Add<byte>((void*)handle.AddrOfPinnedObject(), index);
-                return new BufferHandle(this, pointer, handle);
+                return new BufferHandle(this, (void*)handle.AddrOfPinnedObject(), handle);
             }
         }
 

--- a/src/System.Buffers.Experimental/System/Buffers/BufferManager.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferManager.cs
@@ -39,10 +39,10 @@ namespace System.Buffers.Pools
                 return false;
             }
 
-            public override BufferHandle Pin(int index = 0)
+            public override BufferHandle Pin()
             {
                 Retain();
-                return new BufferHandle(this, Unsafe.Add<byte>(_pointer.ToPointer(), index));
+                return new BufferHandle(this, _pointer.ToPointer());
             }
 
             private readonly NativeBufferPool _pool;

--- a/src/System.Buffers.Experimental/System/Buffers/OwnedNativeBuffer.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/OwnedNativeBuffer.cs
@@ -37,12 +37,12 @@ namespace System.Buffers
             _pointer = IntPtr.Zero;
         }
 
-        public override BufferHandle Pin(int index = 0)
+        public override BufferHandle Pin()
         {
             Retain();
             unsafe
             {
-                return new BufferHandle(this, Unsafe.Add<byte>(_pointer.ToPointer(), index));
+                return new BufferHandle(this, _pointer.ToPointer());
             }
         }
         protected override bool TryGetArray(out ArraySegment<byte> arraySegment)

--- a/src/System.Buffers.Experimental/System/Buffers/OwnedPinnedBuffer.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/OwnedPinnedBuffer.cs
@@ -56,9 +56,9 @@ namespace System.Buffers
             base.Dispose(disposing);
         }
 
-        public unsafe override BufferHandle Pin(int index = 0)
+        public unsafe override BufferHandle Pin()
         {
-            return new BufferHandle(this, Unsafe.Add<T>(_pointer.ToPointer(), index));
+            return new BufferHandle(this, _pointer.ToPointer());
         }
 
         protected override bool TryGetArray(out ArraySegment<T> arraySegment)

--- a/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Buffer.cs
@@ -147,7 +147,7 @@ namespace System
             {
                 if (_index < 0)
                 {
-                    bufferHandle = Unsafe.As<OwnedBuffer<T>>(_arrayOrOwnedBuffer).Pin(_index & bitMask);
+                    bufferHandle = Unsafe.As<OwnedBuffer<T>>(_arrayOrOwnedBuffer).Pin();
                 }
                 else
                 {

--- a/src/System.Buffers.Primitives/System/Buffers/OwnedBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/OwnedBuffer.cs
@@ -43,7 +43,7 @@ namespace System.Buffers
             }
         }
 
-        public abstract BufferHandle Pin(int index = 0);
+        public abstract BufferHandle Pin();
 
         protected internal abstract bool TryGetArray(out ArraySegment<T> arraySegment);
 

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -131,7 +131,7 @@ namespace System
             {
                 if (_index < 0)
                 {
-                    bufferHandle = Unsafe.As<OwnedBuffer<T>>(_arrayOrOwnedBuffer).Pin(_index & bitMask);
+                    bufferHandle = Unsafe.As<OwnedBuffer<T>>(_arrayOrOwnedBuffer).Pin();
                 }
                 else
                 {

--- a/src/System.Buffers.Primitives/System/Internal/ManagedBufferPool.cs
+++ b/src/System.Buffers.Primitives/System/Internal/ManagedBufferPool.cs
@@ -69,14 +69,13 @@ namespace System.Buffers.Internal
                 return true;
             }
 
-            public override BufferHandle Pin(int index = 0)
+            public override BufferHandle Pin()
             {
                 unsafe
                 {
                     Retain(); // this checks IsDisposed
                     var handle = GCHandle.Alloc(_array, GCHandleType.Pinned);
-                    var pointer = Unsafe.Add<byte>((void*)handle.AddrOfPinnedObject(), index);
-                    return new BufferHandle(this, pointer, handle);
+                    return new BufferHandle(this, (void*)handle.AddrOfPinnedObject(), handle);
                 }
             }
 

--- a/src/System.Buffers.Primitives/System/Internal/OwnedArray.cs
+++ b/src/System.Buffers.Primitives/System/Internal/OwnedArray.cs
@@ -40,14 +40,13 @@ namespace System.Buffers.Internal
             return new Span<T>(_array, 0, _array.Length);
         }
 
-        public override BufferHandle Pin(int index = 0)
+        public override BufferHandle Pin()
         {
             unsafe
             {
                 Retain();
                 var handle = GCHandle.Alloc(_array, GCHandleType.Pinned);
-                var pointer = Unsafe.Add<T>((void*)handle.AddrOfPinnedObject(), index);
-                return new BufferHandle(this, pointer, handle);
+                return new BufferHandle(this, (void*)handle.AddrOfPinnedObject(), handle);
             }
         }
 

--- a/src/System.IO.Pipelines/MemoryPoolBlock.cs
+++ b/src/System.IO.Pipelines/MemoryPoolBlock.cs
@@ -129,14 +129,13 @@ namespace System.IO.Pipelines
             return true;
         }
 
-        public override BufferHandle Pin(int index = 0)
+        public override BufferHandle Pin()
         {
             if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(nameof(MemoryPoolBlock));
-            if (index > _length) PipelinesThrowHelper.ThrowArgumentOutOfRangeException(_length, index);
             Retain();
             unsafe
             {
-                return new BufferHandle(this, (Slab.NativePointer + _offset + index).ToPointer());
+                return new BufferHandle(this, (Slab.NativePointer + _offset).ToPointer());
             }
         }
     }

--- a/src/System.IO.Pipelines/UnownedBuffer.cs
+++ b/src/System.IO.Pipelines/UnownedBuffer.cs
@@ -48,13 +48,13 @@ namespace System.IO.Pipelines
             return true;
         }
 
-        public override BufferHandle Pin(int index = 0)
+        public override BufferHandle Pin()
         {
             unsafe
             {
                 Retain();
                 var handle = GCHandle.Alloc(_buffer.Array, GCHandleType.Pinned);
-                var pointer = Unsafe.Add<byte>((void*)handle.AddrOfPinnedObject(), index + _buffer.Offset);
+                var pointer = Unsafe.Add<byte>((void*)handle.AddrOfPinnedObject(), _buffer.Offset);
                 return new BufferHandle(this, pointer, handle);
             }
         }

--- a/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/MemoryTests.cs
@@ -210,14 +210,13 @@ namespace System.Buffers.Tests
             return new Span<T>(_array, 0, _array.Length);
         }
 
-        public override BufferHandle Pin(int index = 0)
+        public override BufferHandle Pin()
         {
             unsafe
             {
                 Retain();
                 var handle = GCHandle.Alloc(_array, GCHandleType.Pinned);
-                var pointer = Unsafe.Add<T>((void*)handle.AddrOfPinnedObject(), index);
-                return new BufferHandle(this, pointer, handle);
+                return new BufferHandle(this, (void*)handle.AddrOfPinnedObject(), handle);
             }
         }
 
@@ -284,14 +283,13 @@ namespace System.Buffers.Tests
             return true;
         }
 
-        public override BufferHandle Pin(int index = 0)
+        public override BufferHandle Pin()
         {
             unsafe
             {
                 Retain();
                 var handle = GCHandle.Alloc(_array, GCHandleType.Pinned);
-                var pointer = Unsafe.Add<T>((void*)handle.AddrOfPinnedObject(), index);
-                return new BufferHandle(this, pointer, handle);
+                return new BufferHandle(this, (void*)handle.AddrOfPinnedObject(), handle);
             }
         }
 

--- a/tests/System.IO.Pipelines.Tests/PipePoolTests.cs
+++ b/tests/System.IO.Pipelines.Tests/PipePoolTests.cs
@@ -139,7 +139,7 @@ namespace System.IO.Pipelines.Tests
                     return _array;
                 }
 
-                public override BufferHandle Pin(int index = 0)
+                public override BufferHandle Pin()
                 {
                     throw new NotImplementedException();
                 }

--- a/tests/System.IO.Pipelines.Tests/ReadableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/ReadableBufferFacts.cs
@@ -20,6 +20,8 @@ namespace System.IO.Pipelines.Tests
 {
     public class ReadableBufferFacts
     {
+        const int BlockSize = 4032;
+
         [Fact]
         public void EmptyIsCorrect()
         {
@@ -34,7 +36,7 @@ namespace System.IO.Pipelines.Tests
             using (var factory = new PipeFactory())
             {
                 var readerWriter = factory.Create();
-                const int Size = 5 * 4032; // multiple blocks
+                const int Size = 5 * BlockSize; // multiple blocks
 
                 // populate with a pile of dummy data
                 byte[] data = new byte[512];
@@ -238,7 +240,10 @@ namespace System.IO.Pipelines.Tests
                 var remaining = readBuffer.Slice(cursor);
                 var handle = remaining.First.Retain(pin: true);
                 Assert.True(handle.PinnedPointer != null);
-                Assert.True((byte*)handle.PinnedPointer == addresses[i]);
+                if (i % BlockSize == 0)
+                {
+                    Assert.True((byte*)handle.PinnedPointer == addresses[i]);
+                }
                 handle.Dispose();
             }
 
@@ -262,7 +267,7 @@ namespace System.IO.Pipelines.Tests
                 var ptr = (byte*)handle.PinnedPointer;
                 for (int i = 0; i < memory.Length; i++)
                 {
-                    addresses[index++] = ptr;
+                    addresses[index++] = ptr++;
                 }
             }
             return addresses;

--- a/tests/System.IO.Pipelines.Tests/ReadableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/ReadableBufferFacts.cs
@@ -262,7 +262,7 @@ namespace System.IO.Pipelines.Tests
                 var ptr = (byte*)handle.PinnedPointer;
                 for (int i = 0; i < memory.Length; i++)
                 {
-                    addresses[index++] = ptr++;
+                    addresses[index++] = ptr;
                 }
             }
             return addresses;


### PR DESCRIPTION
Remove offset from OwnedBuffer.Pin
Addresses part of https://github.com/dotnet/corefxlab/issues/1711

cc @davidfowl, @KrzysztofCwalina, @shiftylogic 