### PR TITLE
Only run test that are failing on Linux, on Windows and Mac

### DIFF
--- a/tests/System.IO.Pipelines.Tests/SocketsFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/SocketsFacts.cs
@@ -23,7 +23,7 @@ namespace System.IO.Pipelines.Tests
             Assert.Equal(0, SocketConnection.SmallBuffersInUse);
         }
 
-#if Windows // "The test hangs on linux"
+#if (Windows || OSX) // "The test hangs on linux"
         [Fact]
 #endif
         public async Task CanCreateWorkingEchoServer_PipelineLibuvServer_NonPipelineClient()
@@ -93,7 +93,7 @@ namespace System.IO.Pipelines.Tests
             Assert.Equal(MessageToSend, reply);
         }
 
-#if Windows // "The test hangs on linux"
+#if (Windows || OSX) // "The test hangs on linux"
         [Fact]
 #endif
         public void CanCreateWorkingEchoServer_PipelineSocketServer_NonPipelineClient()
@@ -114,7 +114,7 @@ namespace System.IO.Pipelines.Tests
 
 // Issue #1687 - The test intermittently fails on linux - 
 // Reason: Unhandled Exception: System.IO.Pipelines.Networking.Libuv.Interop.UvException: Error -16 EBUSY resource busy or locked
-#if Windows
+#if (Windows || OSX)
         [Fact]
 #endif
         public async Task RunStressPingPongTest_Libuv()

--- a/tests/System.IO.Pipelines.Tests/SocketsFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/SocketsFacts.cs
@@ -112,7 +112,11 @@ namespace System.IO.Pipelines.Tests
             Assert.Equal(MessageToSend, reply);
         }
 
+// Issue #1687 - The test intermittently fails on linux - 
+// Reason: Unhandled Exception: System.IO.Pipelines.Networking.Libuv.Interop.UvException: Error -16 EBUSY resource busy or locked
+#if Windows
         [Fact]
+#endif
         public async Task RunStressPingPongTest_Libuv()
         {
             var endpoint = new IPEndPoint(IPAddress.Loopback, 5040);

--- a/tests/System.IO.Pipelines.Tests/System.IO.Pipelines.Tests.csproj
+++ b/tests/System.IO.Pipelines.Tests/System.IO.Pipelines.Tests.csproj
@@ -7,6 +7,7 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <DefineConstants Condition=" '$(OS)' == 'Windows_NT' ">$(DefineConstants);Windows</DefineConstants>
+    <DefineConstants Condition=" '$(OS)' == 'OSX' ">$(DefineConstants);OSX</DefineConstants>
     <Description></Description>
     <Copyright>Microsoft Corporation, All rights reserved</Copyright>
     <PackageTags></PackageTags>

--- a/tests/System.IO.Pipelines.Tests/System.IO.Pipelines.Tests.csproj
+++ b/tests/System.IO.Pipelines.Tests/System.IO.Pipelines.Tests.csproj
@@ -6,6 +6,7 @@
     <AssemblyOriginatorKeyFile>../../tools/test_key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <DefineConstants Condition=" '$(OS)' == 'Windows_NT' ">$(DefineConstants);Windows</DefineConstants>
     <Description></Description>
     <Copyright>Microsoft Corporation, All rights reserved</Copyright>
     <PackageTags></PackageTags>


### PR DESCRIPTION
cc @shiftylogic, @pakrym, @davidfowl 

- Disabling the test on linux - issue #1687 
- Fixing so that previously marked #if Windows tests run on windows.