### PR TITLE
Updating to new toolset compiler.

### DIFF
--- a/src/System.Text.Http.Parser/IHttpParser.cs
+++ b/src/System.Text.Http.Parser/IHttpParser.cs
@@ -7,9 +7,9 @@ namespace System.Text.Http.Parser
 {
     public interface IHttpParser
     {
-        bool ParseRequestLine<T>(T handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined) where T : IHttpRequestLineHandler;
+        bool ParseRequestLine<T>(T handler, in ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined) where T : IHttpRequestLineHandler;
 
-        bool ParseHeaders<T>(T handler, ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes) where T : IHttpHeadersHandler;
+        bool ParseHeaders<T>(T handler, in ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes) where T : IHttpHeadersHandler;
 
         void Reset();
     }

--- a/src/System.Text.Http/System/Text/Http/Obsolete/HttpHeaderBuffer.cs
+++ b/src/System.Text.Http/System/Text/Http/Obsolete/HttpHeaderBuffer.cs
@@ -39,64 +39,62 @@ namespace System.Text.Http.SingleSegment
             }
         }
 
-        internal static ReadOnlySpan<byte> SliceTo(this ReadOnlySpan<byte> buffer, char terminator, out int consumedBytes)
+        internal static int SliceTo(this ReadOnlySpan<byte> buffer, char terminator, out ReadOnlySpan<byte> slice)
         {
-            return buffer.SliceTo((byte)terminator, out consumedBytes);
+            return buffer.SliceTo((byte)terminator, out slice);
         }
 
-        internal static ReadOnlySpan<byte> SliceTo(this ReadOnlySpan<byte> buffer, int start, char terminator, out int consumedBytes)
+        internal static int SliceTo(this ReadOnlySpan<byte> buffer, int start, char terminator, out ReadOnlySpan<byte> slice)
         {
-            return buffer.SliceTo(start, (byte)terminator, out consumedBytes);
+            return buffer.SliceTo(start, (byte)terminator, out slice);
         }
 
-        internal static ReadOnlySpan<byte> SliceTo(this ReadOnlySpan<byte> buffer, byte terminator, out int consumedBytes)
+        internal static int SliceTo(this ReadOnlySpan<byte> buffer, byte terminator, out ReadOnlySpan<byte> slice)
         {
-            return buffer.SliceTo(0, terminator, out consumedBytes);
+            return buffer.SliceTo(0, terminator, out slice);
         }
 
-        internal static ReadOnlySpan<byte> SliceTo(this ReadOnlySpan<byte> buffer, int start, byte terminator, out int consumedBytes)
+        internal static int SliceTo(this ReadOnlySpan<byte> buffer, int start, byte terminator, out ReadOnlySpan<byte> slice)
         {
-            var slice = buffer.Slice(start);
+            slice = buffer.Slice(start);
             var index = System.SpanExtensions.IndexOf(slice, terminator);
             if (index == -1) {
-                consumedBytes = 0;
-                return Span<byte>.Empty;
+                return 0;
             }
-            consumedBytes = index;
-            return slice.Slice(0, index);
+            slice = slice.Slice(0, index);
+            return index;
         }
 
-        internal static ReadOnlySpan<byte> SliceTo(this ReadOnlySpan<byte> buffer, char terminatorFirst, char terminatorSecond, out int consumedBytes)
+        internal static int SliceTo(this ReadOnlySpan<byte> buffer, char terminatorFirst, char terminatorSecond, out ReadOnlySpan<byte> slice)
         {
-            return buffer.SliceTo((byte)terminatorFirst, (byte)terminatorSecond, out consumedBytes);
+            return buffer.SliceTo((byte)terminatorFirst, (byte)terminatorSecond, out slice);
         }
 
-        internal static ReadOnlySpan<byte> SliceTo(this ReadOnlySpan<byte> buffer, int start, char terminatorFirst, char terminatorSecond, out int consumedBytes)
+        internal static int SliceTo(this ReadOnlySpan<byte> buffer, int start, char terminatorFirst, char terminatorSecond, out ReadOnlySpan<byte> slice)
         {
-            return buffer.SliceTo(start, (byte)terminatorFirst, (byte)terminatorSecond, out consumedBytes);
+            return buffer.SliceTo(start, (byte)terminatorFirst, (byte)terminatorSecond, out slice);
         }
 
-        internal static ReadOnlySpan<byte> SliceTo(this ReadOnlySpan<byte> buffer, byte terminatorFirst, byte terminatorSecond, out int consumedBytes)
+        internal static int SliceTo(this ReadOnlySpan<byte> buffer, byte terminatorFirst, byte terminatorSecond, out ReadOnlySpan<byte> slice)
         {
-            return buffer.SliceTo(0, terminatorFirst, terminatorSecond, out consumedBytes);
+            return buffer.SliceTo(0, terminatorFirst, terminatorSecond, out slice);
         }
 
-        internal static ReadOnlySpan<byte> SliceTo(this ReadOnlySpan<byte> buffer, int start, byte terminatorFirst, byte terminatorSecond, out int consumedBytes)
+        internal static int SliceTo(this ReadOnlySpan<byte> buffer, int start, byte terminatorFirst, byte terminatorSecond, out ReadOnlySpan<byte> slice)
         {
             int offset = 0;
             while (true)
             {
-                var slice = buffer.Slice(start + offset);
+                slice = buffer.Slice(start + offset);
                 var index = System.SpanExtensions.IndexOf(slice, terminatorFirst);
                 if (index == -1 || index == slice.Length - 1)
                 {
-                    consumedBytes = 0;
-                    return Span<byte>.Empty;
+                    return 0;
                 }
                 if (slice[index + 1] == terminatorSecond)
                 {
-                    consumedBytes = index;
-                    return slice.Slice(0, index + offset);
+                    slice = slice.Slice(0, index + offset);
+                    return index;
                 }
                 else
                 {

--- a/src/System.Text.Json/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonReader.cs
@@ -97,7 +97,7 @@ namespace System.Text.Json
             ref byte next = ref Unsafe.Add(ref bytes, skip);
             length -= skip;
 
-            int step = GetNextCharAscii(ref next, length, out char ch);
+            int step = GetNextCharAscii(this, ref next, length, out char ch);
             if (step == 0) return false;
 
             switch (TokenType)
@@ -206,7 +206,7 @@ namespace System.Text.Json
                             return skip + ConsumePropertyName(ref next, length);
                         else if (InArray)
                         {
-                            int step = GetNextCharAscii(ref next, length, out char ch);
+                            int step = GetNextCharAscii(this, ref next, length, out char ch);
                             if (step == 0) return 0;
                             return skip + ConsumeValue(ch, step, ref next, length);
                         }
@@ -264,7 +264,7 @@ namespace System.Text.Json
                     return ConsumeNumber(ref src, length);
 
                 case '-':
-                    int step = GetNextCharAscii(ref src, length, out char ch);
+                    int step = GetNextCharAscii(this, ref src, length, out char ch);
                     if (step == 0) throw new JsonReaderException();
                     return (ch == 'I')
                         ? ConsumeInfinity(ref src, length, true)
@@ -777,7 +777,7 @@ namespace System.Text.Json
             int idx = 0;
             while (idx < length)
             {
-                int skip = GetNextCharAscii(ref Unsafe.Add(ref src, idx), length, out char ch);
+                int skip = GetNextCharAscii(this, ref Unsafe.Add(ref src, idx), length, out char ch);
                 if (skip == 0)
                     break;
 
@@ -799,9 +799,9 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int GetNextCharAscii(ref byte src, int length, out char ch)
+        private static int GetNextCharAscii(in JsonReader reader, ref byte src, int length, out char ch)
         {
-            if (UseFastUtf8)
+            if (reader.UseFastUtf8)
             {
                 if (length < 1)
                 {
@@ -812,7 +812,7 @@ namespace System.Text.Json
                 ch = (char)src;
                 return 1;
             }
-            else if (UseFastUtf16)
+            else if (reader.UseFastUtf16)
             {
                 if (length < 2)
                 {

--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RuntimeFrameworkVersion>2.1.0-preview2-25610-02</RuntimeFrameworkVersion>
     <CoreFxVersion>4.3.0</CoreFxVersion>
-    <RoslynVersion>2.6.0-rdonly-ref-61915-01</RoslynVersion>
+    <RoslynVersion>2.6.0-rdonly-ref-62101-05</RoslynVersion>
     <SystemMemoryVersion>4.5.0-preview2-25610-02</SystemMemoryVersion>
     <SystemCompilerServicesUnsafeVersion>4.5.0-preview2-25610-02</SystemCompilerServicesUnsafeVersion>
     <SystemNumericsVectorsVersion>4.5.0-preview2-25610-02</SystemNumericsVectorsVersion>

--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RuntimeFrameworkVersion>2.1.0-preview2-25610-02</RuntimeFrameworkVersion>
     <CoreFxVersion>4.3.0</CoreFxVersion>
-    <RoslynVersion>2.6.0-rdonly-ref-62101-05</RoslynVersion>
+    <RoslynVersion>2.6.0-rdonly-ref-62106-01</RoslynVersion>
     <SystemMemoryVersion>4.5.0-preview2-25610-02</SystemMemoryVersion>
     <SystemCompilerServicesUnsafeVersion>4.5.0-preview2-25610-02</SystemCompilerServicesUnsafeVersion>
     <SystemNumericsVectorsVersion>4.5.0-preview2-25610-02</SystemNumericsVectorsVersion>


### PR DESCRIPTION
Version 2.6.0-rdonly-ref-62106-01

Now includes:
- support for stackallocated spans and 
- escape analysis to make sure spans that refer to local data do not outlive the referenced data.

The corresponding VSIX is at 
https://dotnet.myget.org/feed/roslyn/package/vsix/0b48e25b-9903-4d8b-ad39-d4cca196e3c7/2.6.0.6210601
