### PR TITLE
Add sparse tensors

### DIFF
--- a/src/System.Numerics.Tensors/System.Numerics.Tensors.csproj
+++ b/src/System.Numerics.Tensors/System.Numerics.Tensors.csproj
@@ -12,6 +12,7 @@
     <Compile Include="System\Numerics\ArrayUtilities.cs" />
     <Compile Include="System\Numerics\DenseTensor.cs" />
     <Compile Include="System\Numerics\RefUtilities.cs" />
+    <Compile Include="System\Numerics\SparseTensor.cs" />
     <Compile Include="System\Numerics\Tensor.cs" />
     <Compile Include="System\Numerics\TensorArithmetic.cs">
       <DesignTime>True</DesignTime>

--- a/src/System.Numerics.Tensors/System.Numerics.Tensors.csproj
+++ b/src/System.Numerics.Tensors/System.Numerics.Tensors.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Numerics\ArrayUtilities.cs" />
+    <Compile Include="System\Numerics\DenseTensor.cs" />
     <Compile Include="System\Numerics\RefUtilities.cs" />
     <Compile Include="System\Numerics\Tensor.cs" />
     <Compile Include="System\Numerics\TensorArithmetic.cs">
@@ -43,6 +44,9 @@
       <LastGenOutput>Tensor.Operations.cs</LastGenOutput>
     </None>
     <None Update="System\Numerics\TensorTemplate.ttinclude" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\System.Buffers.Primitives\System.Buffers.Primitives.csproj" />
   </ItemGroup>
   <ItemGroup>
     <!-- enable the TextTemplating extension -->

--- a/src/System.Numerics.Tensors/System.Numerics.Tensors.sln
+++ b/src/System.Numerics.Tensors/System.Numerics.Tensors.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26723.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Numerics.Tensors", "System.Numerics.Tensors.csproj", "{C05390D3-ECD0-49F6-A2F6-10EC26CF62DA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Numerics.Tensors.Tests", "..\..\tests\System.Numerics.Tensors.Tests\System.Numerics.Tensors.Tests.csproj", "{4CCDEC28-E32C-4D90-A140-87E45254CDC0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Buffers.Primitives", "..\System.Buffers.Primitives\System.Buffers.Primitives.csproj", "{0A345006-D361-4BDF-934C-4293DBC5A111}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,8 +23,15 @@ Global
 		{4CCDEC28-E32C-4D90-A140-87E45254CDC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4CCDEC28-E32C-4D90-A140-87E45254CDC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4CCDEC28-E32C-4D90-A140-87E45254CDC0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A345006-D361-4BDF-934C-4293DBC5A111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A345006-D361-4BDF-934C-4293DBC5A111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A345006-D361-4BDF-934C-4293DBC5A111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A345006-D361-4BDF-934C-4293DBC5A111}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {13D12508-D252-4FD4-A8AA-1DD44F666914}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Numerics.Tensors/System/Numerics/ArrayUtilities.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/ArrayUtilities.cs
@@ -198,9 +198,8 @@ namespace System.Numerics
         /// <param name="index"></param>
         /// <param name="indices"></param>
         /// <param name="startFromDimension"></param>
-        public static void GetIndices(int[] strides, int index, int[] indices, int startFromDimension = 0)
+        public static void GetIndices(int[] strides, bool reverseStride, int index, int[] indices, int startFromDimension = 0)
         {
-            bool reverseStride = strides.Length > 1 && strides[0] == 1;
             Debug.Assert(reverseStride ? IsAscending(strides) : IsDescending(strides), "Index decomposition requires ordered strides");
             Debug.Assert(strides.Length == indices.Length);
 
@@ -223,9 +222,8 @@ namespace System.Numerics
         /// <param name="index"></param>
         /// <param name="indices"></param>
         /// <param name="startFromDimension"></param>
-        public static void GetIndices(int[] strides, int index, Span<int> indices, int startFromDimension = 0)
+        public static void GetIndices(int[] strides, bool reverseStride, int index, Span<int> indices, int startFromDimension = 0)
         {
-            bool reverseStride = strides.Length > 1 && strides[0] == 1;
             Debug.Assert(reverseStride ? IsAscending(strides) : IsDescending(strides), "Index decomposition requires ordered strides");
             Debug.Assert(strides.Length == indices.Length);
 
@@ -244,9 +242,8 @@ namespace System.Numerics
         /// <summary>
         /// Takes an 1-d index over n-d sourceStrides and recalculates it assuming same n-d coordinates over a different n-d strides
         /// </summary>
-        public static int TransformIndexByStrides(int index, int[] sourceStrides, int[] transformStrides)
+        public static int TransformIndexByStrides(int index, int[] sourceStrides, bool sourceReverseStride, int[] transformStrides)
         {
-            bool sourceReverseStride = sourceStrides.Length > 1 && sourceStrides[0] == 1;
             Debug.Assert(index >= 0);
             Debug.Assert(sourceReverseStride ? IsAscending(sourceStrides) : IsDescending(sourceStrides), "Index decomposition requires ordered strides");
             Debug.Assert(sourceStrides.Length == transformStrides.Length);

--- a/src/System.Numerics.Tensors/System/Numerics/ArrayUtilities.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/ArrayUtilities.cs
@@ -75,12 +75,12 @@ namespace System.Numerics
         /// </summary>
         /// <param name="dimensions"></param>
         /// <returns></returns>
-        public static int[] GetStrides(int[] dimensions, bool columnMajor = false)
+        public static int[] GetStrides(int[] dimensions, bool reverseStride = false)
         {
             int[] strides = new int[dimensions.Length];
 
             int stride = 1;
-            if (columnMajor)
+            if (reverseStride)
             {
                 for (int i = 0; i < strides.Length; i++)
                 {
@@ -95,6 +95,20 @@ namespace System.Numerics
                     strides[i] = stride;
                     stride *= dimensions[i];
                 }
+            }
+
+            return strides;
+        }
+
+        public static int[] GetStrides(Array array)
+        {
+            int[] strides = new int[array.Rank];
+
+            int stride = 1;
+            for (int i = strides.Length - 1; i >= 0; i--)
+            {
+                strides[i] = stride;
+                stride *= array.GetLength(i);
             }
 
             return strides;
@@ -145,6 +159,26 @@ namespace System.Numerics
         }
 
         /// <summary>
+        /// Calculates the 1-d index for n-d indices in layout specified by strides.
+        /// </summary>
+        /// <param name="strides"></param>
+        /// <param name="indices"></param>
+        /// <param name="startFromDimension"></param>
+        /// <returns></returns>
+        public static int GetIndex(int[] strides, Span<int> indices, int startFromDimension = 0)
+        {
+            Debug.Assert(strides.Length == indices.Length);
+
+            int index = 0;
+            for (int i = startFromDimension; i < indices.Length; i++)
+            {
+                index += strides[i] * indices[i];
+            }
+
+            return index;
+        }
+
+        /// <summary>
         /// Calculates the 1-d index for 2-d indices in layout specified by strides.
         /// </summary>
         /// <param name="strides"></param>
@@ -166,15 +200,40 @@ namespace System.Numerics
         /// <param name="startFromDimension"></param>
         public static void GetIndices(int[] strides, int index, int[] indices, int startFromDimension = 0)
         {
-            bool columnMajor = strides.Length > 1 && strides[0] == 1;
-            Debug.Assert(columnMajor ? IsAscending(strides) : IsDescending(strides), "Index decomposition requires ordered strides");
+            bool reverseStride = strides.Length > 1 && strides[0] == 1;
+            Debug.Assert(reverseStride ? IsAscending(strides) : IsDescending(strides), "Index decomposition requires ordered strides");
             Debug.Assert(strides.Length == indices.Length);
 
             int remainder = index;
             for (int i = startFromDimension; i < strides.Length; i++)
             {
-                // reverse the index for column major so that we divide by largest stride first
-                var nIndex = columnMajor ? strides.Length - 1 - i : i;
+                // reverse the index for reverseStride so that we divide by largest stride first
+                var nIndex = reverseStride ? strides.Length - 1 - i : i;
+
+                var stride = strides[nIndex];
+                indices[nIndex] = remainder / stride;
+                remainder %= stride;
+            }
+        }
+
+        /// <summary>
+        /// Calculates the n-d indices from the 1-d index in a layoyut specificed by strides
+        /// </summary>
+        /// <param name="strides"></param>
+        /// <param name="index"></param>
+        /// <param name="indices"></param>
+        /// <param name="startFromDimension"></param>
+        public static void GetIndices(int[] strides, int index, Span<int> indices, int startFromDimension = 0)
+        {
+            bool reverseStride = strides.Length > 1 && strides[0] == 1;
+            Debug.Assert(reverseStride ? IsAscending(strides) : IsDescending(strides), "Index decomposition requires ordered strides");
+            Debug.Assert(strides.Length == indices.Length);
+
+            int remainder = index;
+            for (int i = startFromDimension; i < strides.Length; i++)
+            {
+                // reverse the index for reverseStride so that we divide by largest stride first
+                var nIndex = reverseStride ? strides.Length - 1 - i : i;
 
                 var stride = strides[nIndex];
                 indices[nIndex] = remainder / stride;
@@ -187,9 +246,9 @@ namespace System.Numerics
         /// </summary>
         public static int TransformIndexByStrides(int index, int[] sourceStrides, int[] transformStrides)
         {
-            bool sourceColumnMajor = sourceStrides.Length > 1 && sourceStrides[0] == 1;
+            bool sourceReverseStride = sourceStrides.Length > 1 && sourceStrides[0] == 1;
             Debug.Assert(index >= 0);
-            Debug.Assert(sourceColumnMajor ? IsAscending(sourceStrides) : IsDescending(sourceStrides), "Index decomposition requires ordered strides");
+            Debug.Assert(sourceReverseStride ? IsAscending(sourceStrides) : IsDescending(sourceStrides), "Index decomposition requires ordered strides");
             Debug.Assert(sourceStrides.Length == transformStrides.Length);
 
             int transformIndex = 0;
@@ -197,8 +256,8 @@ namespace System.Numerics
 
             for (int i = 0; i < sourceStrides.Length; i++)
             {
-                // reverse the index for column major so that we divide by largest stride first
-                var nIndex = sourceColumnMajor ? sourceStrides.Length - 1 - i: i;
+                // reverse the index for reverseStride so that we divide by largest stride first
+                var nIndex = sourceReverseStride ? sourceStrides.Length - 1 - i: i;
 
                 var sourceStride = sourceStrides[nIndex];
                 var transformStride = transformStrides[nIndex];

--- a/src/System.Numerics.Tensors/System/Numerics/DenseTensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/DenseTensor.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Numerics
+{
+    public class DenseTensor<T> : Tensor<T>
+    {
+        private readonly T[] backingArray;
+
+        public DenseTensor(Array fromArray, bool reverseStride = false) : base(GetDimensionsFromArray(fromArray), reverseStride)
+        {
+            // copy initial array
+            backingArray = new T[fromArray.Length];
+
+            int index = 0;
+            if (reverseStride)
+            {
+                // Array is always row-major
+                var sourceStrides = ArrayUtilities.GetStrides(dimensions);
+
+                foreach (var item in fromArray)
+                {
+                    var destIndex = ArrayUtilities.TransformIndexByStrides(index++, sourceStrides, strides);
+                    backingArray[destIndex] = (T)item;
+                }
+            }
+            else
+            {
+                foreach (var item in fromArray)
+                {
+                    backingArray[index++] = (T)item;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Initializes a rank-1 Tensor using the specified <paramref name="size"/>.
+        /// </summary>
+        /// <param name="size">Size of the tensor</param>
+        public DenseTensor(int size, bool reverseStride = false) : base(new [] { size }, reverseStride)
+        {
+            backingArray = new T[size];
+        }
+
+        /// <summary>
+        /// Initializes a rank-n Tensor using the dimensions specified in <paramref name="dimensions"/>.
+        /// </summary>
+        /// <param name="dimensions"></param>
+        public DenseTensor(int[] dimensions, bool reverseStride = false) : base(dimensions, reverseStride)
+        {
+            backingArray = new T[Length];
+        }
+
+        public DenseTensor(T[] fromBackingArray, int[] dimensions, bool reverseStride = false) : base(dimensions, reverseStride)
+        {
+            // keep a reference to the backing array
+            backingArray = fromBackingArray ?? throw new ArgumentNullException(nameof(fromBackingArray));
+
+            if (Length != fromBackingArray.Length)
+            {
+                throw new ArgumentException($"Length of {nameof(fromBackingArray)} ({fromBackingArray.Length}) must match product of {nameof(dimensions)} ({Length}).");
+            }
+        }
+
+        /// <summary>
+        /// Returns a single dimensional view of this Tensor, in C-style ordering
+        /// </summary>
+        public T[] Buffer => backingArray;
+        
+        public override T this[Span<int> indices]
+        {
+            get
+            {
+                return Buffer[ArrayUtilities.GetIndex(strides, indices)];
+            }
+            set
+            {
+                Buffer[ArrayUtilities.GetIndex(strides, indices)] = value;
+            }
+        }
+
+        public override Tensor<T> Clone()
+        {
+            return new DenseTensor<T>((T[])backingArray.Clone(), dimensions, IsReversedStride);
+        }
+
+        public override Tensor<TResult> CloneEmpty<TResult>(int[] dimensions)
+        {
+            return new DenseTensor<TResult>(dimensions, IsReversedStride);
+        }
+
+        private static int[] GetDimensionsFromArray(Array fromArray)
+        {
+            if (fromArray == null)
+            {
+                throw new ArgumentNullException(nameof(fromArray));
+            }
+
+            var dimensions = new int[fromArray.Rank];
+            for (int i = 0; i < dimensions.Length; i++)
+            {
+                dimensions[i] = fromArray.GetLength(i);
+            }
+
+            return dimensions;
+        }
+
+        private int GetOffset(int index0, int index1)
+        {
+            if (Rank != 2)
+            {
+                throw new ArgumentOutOfRangeException($"Cannot use 2 dimension indexer on {nameof(Tensor<T>)} with {Rank} dimensions.");
+            }
+
+            if (index0 < 0 || index0 >= dimensions[0])
+            {
+                throw new ArgumentOutOfRangeException(nameof(index0));
+            }
+
+            if (index1 < 0 || index1 >= dimensions[1])
+            {
+                throw new ArgumentOutOfRangeException(nameof(index1));
+            }
+
+            return index0 * strides[0] + index1 * strides[1];
+        }
+
+        private int GetOffsetFromIndices(int[] indices)
+        {
+            if (indices == null)
+            {
+                throw new ArgumentNullException(nameof(indices));
+            }
+
+            if (indices.Length != dimensions?.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(indices));
+            }
+
+            return ArrayUtilities.GetIndex(strides, indices);
+        }
+
+        public override Tensor<T> Reshape(params int[] dimensions)
+        {
+            if (dimensions == null)
+            {
+                throw new ArgumentNullException(nameof(dimensions));
+            }
+
+            if (dimensions.Length == 0)
+            {
+                throw new ArgumentException("Dimensions must contain elements.", nameof(dimensions));
+            }
+
+            var newSize = ArrayUtilities.GetProduct(dimensions);
+
+            if (newSize != Length)
+            {
+                throw new ArgumentException($"Cannot reshape array due to mismatch in lengths, currently {Length} would become {newSize}.", nameof(dimensions));
+            }
+
+            return new DenseTensor<T>(Buffer, dimensions, IsReversedStride);
+        }
+    }
+}

--- a/src/System.Numerics.Tensors/System/Numerics/DenseTensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/DenseTensor.cs
@@ -21,7 +21,7 @@ namespace System.Numerics
 
                 foreach (var item in fromArray)
                 {
-                    var destIndex = ArrayUtilities.TransformIndexByStrides(index++, sourceStrides, strides);
+                    var destIndex = ArrayUtilities.TransformIndexByStrides(index++, sourceStrides, false, strides);
                     backingArray[destIndex] = (T)item;
                 }
             }

--- a/src/System.Numerics.Tensors/System/Numerics/SparseTensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/SparseTensor.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Numerics
+{
+    public class SparseTensor<T> : Tensor<T>
+    {
+        private readonly Dictionary<int, T> values;
+
+        public SparseTensor(int[] dimensions, bool reverseStride= false) : base(dimensions, reverseStride)
+        {
+            values = new Dictionary<int, T>();
+        }
+
+        internal SparseTensor(Dictionary<int, T> values, int[] dimensions, bool reverseStride = false) : base(dimensions, reverseStride)
+        {
+            this.values = values;
+        }
+
+        public SparseTensor(Array fromArray, bool reverseStride = false) : base(GetDimensionsFromArray(fromArray), reverseStride)
+        {
+            values = new Dictionary<int, T>();
+
+            int index = 0;
+            if (reverseStride)
+            {
+                // Array is always row-major
+                var sourceStrides = ArrayUtilities.GetStrides(dimensions);
+
+                foreach (var item in fromArray)
+                {
+                    var destIndex = ArrayUtilities.TransformIndexByStrides(index++, sourceStrides, strides);
+                    values[destIndex] = (T)item;
+                }
+            }
+            else
+            {
+                foreach (var item in fromArray)
+                {
+                    values[index++] = (T)item;
+                }
+            }
+        }
+
+        public override T this[Span<int> indices]
+        {
+            get
+            {
+                var index = ArrayUtilities.GetIndex(strides, indices);
+
+                T value;
+
+                if (!values.TryGetValue(index, out value))
+                {
+                    value = arithmetic.Zero;
+                }
+
+                return value;
+            }
+
+            set
+            {
+                var index = ArrayUtilities.GetIndex(strides, indices);
+
+                values[index] = value;
+            }
+        }
+
+        private static int[] GetDimensionsFromArray(Array fromArray)
+        {
+            if (fromArray == null)
+            {
+                throw new ArgumentNullException(nameof(fromArray));
+            }
+
+            var dimensions = new int[fromArray.Rank];
+            for (int i = 0; i < dimensions.Length; i++)
+            {
+                dimensions[i] = fromArray.GetLength(i);
+            }
+
+            return dimensions;
+        }
+
+        public override Tensor<T> Clone()
+        {
+            var valueCopy = new Dictionary<int, T>(values);
+            return new SparseTensor<T>(valueCopy, dimensions, IsReversedStride);
+        }
+
+        public override Tensor<TResult> CloneEmpty<TResult>(int[] dimensions)
+        {
+            return new SparseTensor<TResult>(dimensions, IsReversedStride);
+        }
+
+        public override Tensor<T> Reshape(params int[] dimensions)
+        {
+            return new SparseTensor<T>(values, dimensions, IsReversedStride);
+        }
+
+        private int GetOffset(int index0, int index1)
+        {
+            if (Rank != 2)
+            {
+                throw new ArgumentOutOfRangeException($"Cannot use 2 dimension indexer on {nameof(Tensor<T>)} with {Rank} dimensions.");
+            }
+
+            if (index0 < 0 || index0 >= dimensions[0])
+            {
+                throw new ArgumentOutOfRangeException(nameof(index0));
+            }
+
+            if (index1 < 0 || index1 >= dimensions[1])
+            {
+                throw new ArgumentOutOfRangeException(nameof(index1));
+            }
+
+            return index0 * strides[0] + index1 * strides[1];
+        }
+
+        private int GetOffsetFromIndices(int[] indices)
+        {
+            if (indices == null)
+            {
+                throw new ArgumentNullException(nameof(indices));
+            }
+
+            if (indices.Length != dimensions?.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(indices));
+            }
+
+            return ArrayUtilities.GetIndex(strides, indices);
+        }
+    }
+}

--- a/src/System.Numerics.Tensors/System/Numerics/SparseTensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/SparseTensor.cs
@@ -28,17 +28,27 @@ namespace System.Numerics
                 // Array is always row-major
                 var sourceStrides = ArrayUtilities.GetStrides(dimensions);
 
-                foreach (var item in fromArray)
+                foreach (T item in fromArray)
                 {
-                    var destIndex = ArrayUtilities.TransformIndexByStrides(index++, sourceStrides, false, strides);
-                    values[destIndex] = (T)item;
+                    if (!item.Equals(arithmetic.Zero))
+                    {
+                        var destIndex = ArrayUtilities.TransformIndexByStrides(index, sourceStrides, false, strides);
+                        values[destIndex] = item;
+                    }
+
+                    index++;
                 }
             }
             else
             {
-                foreach (var item in fromArray)
+                foreach (T item in fromArray)
                 {
-                    values[index++] = (T)item;
+                    if (!item.Equals(arithmetic.Zero))
+                    {
+                        values[index] = item;
+                    }
+
+                    index++;
                 }
             }
         }
@@ -63,7 +73,14 @@ namespace System.Numerics
             {
                 var index = ArrayUtilities.GetIndex(strides, indices);
 
-                values[index] = value;
+                if (value.Equals(arithmetic.Zero))
+                {
+                    values.Remove(index);
+                }
+                else
+                {
+                    values[index] = value;
+                }
             }
         }
 

--- a/src/System.Numerics.Tensors/System/Numerics/SparseTensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/SparseTensor.cs
@@ -30,7 +30,7 @@ namespace System.Numerics
 
                 foreach (var item in fromArray)
                 {
-                    var destIndex = ArrayUtilities.TransformIndexByStrides(index++, sourceStrides, strides);
+                    var destIndex = ArrayUtilities.TransformIndexByStrides(index++, sourceStrides, false, strides);
                     values[destIndex] = (T)item;
                 }
             }

--- a/src/System.Numerics.Tensors/System/Numerics/Tensor.Operations.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/Tensor.Operations.cs
@@ -88,7 +88,7 @@ namespace System.Numerics
         {
             var resultDimensions = ValidateContractArgs(left, right, leftAxes, rightAxes);
 
-            var result = new DenseTensor<T>(dimensions:resultDimensions);
+            var result = left.CloneEmpty(resultDimensions);
             
             TensorArithmetic<T>.Instance.Contract(left, right, leftAxes, rightAxes, result);
 

--- a/src/System.Numerics.Tensors/System/Numerics/Tensor.Operations.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/Tensor.Operations.cs
@@ -88,7 +88,7 @@ namespace System.Numerics
         {
             var resultDimensions = ValidateContractArgs(left, right, leftAxes, rightAxes);
 
-            var result = new Tensor<T>(resultDimensions);
+            var result = new DenseTensor<T>(dimensions:resultDimensions);
             
             TensorArithmetic<T>.Instance.Contract(left, right, leftAxes, rightAxes, result);
 

--- a/src/System.Numerics.Tensors/System/Numerics/Tensor.Operations.tt
+++ b/src/System.Numerics.Tensors/System/Numerics/Tensor.Operations.tt
@@ -9,14 +9,14 @@ namespace System.Numerics
     public static partial class Tensor
     { 
 <# foreach (MethodConfiguration method in methodConfiguration) { #>
-        public static <#= method.GetGenericResultMethodSignature("T")#>
+        public static <#= method.GetGenericResultMethodSignature("Tensor", "T")#>
         {
             <#= method.GetValidationMethod(true) #>
 
             TensorArithmetic<T>.Instance.<#=method.MethodName#>(<#=method.GetCallArguments()#>, <#= method.ResultName #>);
         }
 
-        public static <#= method.GetGenericMethodSignature("T")#>
+        public static <#= method.GetGenericMethodSignature("Tensor", "T")#>
         {
             <#= method.GetValidationMethod(false) #>
 

--- a/src/System.Numerics.Tensors/System/Numerics/TensorArithmetic.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/TensorArithmetic.cs
@@ -126,7 +126,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (bool)(left[indices] & right[indices]);
             }
             
@@ -137,7 +137,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (bool)(tensor[indices] & scalar);
             }
             
@@ -164,7 +164,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] == right[indices];
             }
             
@@ -215,7 +215,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] != right[indices];
             }
             
@@ -226,7 +226,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (bool)(left[indices] | right[indices]);
             }
             
@@ -237,7 +237,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (bool)(tensor[indices] | scalar);
             }
             
@@ -268,7 +268,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (bool)(left[indices] ^ right[indices]);
             }
             
@@ -279,7 +279,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (bool)(tensor[indices] ^ scalar);
             }
             
@@ -321,7 +321,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (bool)(left.Buffer[op1Index] & right.Buffer[op2Index]);
 
@@ -352,7 +352,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (bool)(tensor.Buffer[op1Index] & scalar);
 
@@ -403,7 +403,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
 
@@ -478,7 +478,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
 
@@ -513,7 +513,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (bool)(left.Buffer[op1Index] | right.Buffer[op2Index]);
 
@@ -544,7 +544,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (bool)(tensor.Buffer[op1Index] | scalar);
 
@@ -599,7 +599,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (bool)(left.Buffer[op1Index] ^ right.Buffer[op2Index]);
 
@@ -630,7 +630,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (bool)(tensor.Buffer[op1Index] ^ scalar);
 
@@ -649,7 +649,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(left[indices] + right[indices]);
             }
             
@@ -660,7 +660,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(tensor[indices] + scalar);
             }
             
@@ -671,7 +671,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(left[indices] & right[indices]);
             }
             
@@ -682,7 +682,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(tensor[indices] & scalar);
             }
             
@@ -713,9 +713,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -725,22 +725,22 @@ namespace System.Numerics
             {
                 byte sum = (byte)0;
                 
-                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, resultIndex, resultIndices);
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
 
                     // todo, make this more efficient
-                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
-                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+                    ArrayUtilities.GetIndices(left.strides, left.IsReversedStride, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, right.IsReversedStride, rightIndex, rightIndices);
 
                     sum += (byte)(left[leftIndices] * right[rightIndices]);
                 }
@@ -754,7 +754,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]--;
             }
             
@@ -765,7 +765,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(left[indices] / right[indices]);
             }
             
@@ -776,7 +776,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(tensor[indices] / scalar);
             }
             
@@ -787,7 +787,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] == right[indices];
             }
             
@@ -798,7 +798,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] > right[indices];
             }
             
@@ -809,7 +809,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] >= right[indices];
             }
             
@@ -820,7 +820,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]++;
             }
             
@@ -831,7 +831,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(tensor[indices] << value);
             }
             
@@ -842,7 +842,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] < right[indices];
             }
             
@@ -853,7 +853,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] <= right[indices];
             }
             
@@ -864,7 +864,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(left[indices] % right[indices]);
             }
             
@@ -875,7 +875,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(tensor[indices] % scalar);
             }
             
@@ -886,7 +886,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(left[indices] * right[indices]);
             }
             
@@ -897,7 +897,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(tensor[indices] * scalar);
             }
             
@@ -908,7 +908,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] != right[indices];
             }
             
@@ -919,7 +919,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(left[indices] | right[indices]);
             }
             
@@ -930,7 +930,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(tensor[indices] | scalar);
             }
             
@@ -941,7 +941,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(tensor[indices] >> value);
             }
             
@@ -952,7 +952,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(left[indices] - right[indices]);
             }
             
@@ -963,7 +963,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(tensor[indices] - scalar);
             }
             
@@ -974,7 +974,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)-tensor[indices];
             }
             
@@ -985,7 +985,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)+tensor[indices];
             }
             
@@ -996,7 +996,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(left[indices] ^ right[indices]);
             }
             
@@ -1007,7 +1007,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (byte)(tensor[indices] ^ scalar);
             }
             
@@ -1041,7 +1041,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(left.Buffer[op1Index] + right.Buffer[op2Index]);
 
@@ -1072,7 +1072,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(tensor.Buffer[op1Index] + scalar);
 
@@ -1107,7 +1107,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(left.Buffer[op1Index] & right.Buffer[op2Index]);
 
@@ -1138,7 +1138,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(tensor.Buffer[op1Index] & scalar);
 
@@ -1167,9 +1167,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begingin is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -1179,13 +1179,13 @@ namespace System.Numerics
             {
                 byte sum = (byte)0;
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
@@ -1232,7 +1232,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(left.Buffer[op1Index] / right.Buffer[op2Index]);
 
@@ -1263,7 +1263,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(tensor.Buffer[op1Index] / scalar);
 
@@ -1298,7 +1298,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
 
@@ -1333,7 +1333,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] > right.Buffer[op2Index];
 
@@ -1368,7 +1368,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] >= right.Buffer[op2Index];
 
@@ -1407,7 +1407,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(tensor.Buffer[op1Index] << value);
 
@@ -1442,7 +1442,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] < right.Buffer[op2Index];
 
@@ -1477,7 +1477,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] <= right.Buffer[op2Index];
 
@@ -1512,7 +1512,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(left.Buffer[op1Index] % right.Buffer[op2Index]);
 
@@ -1543,7 +1543,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(tensor.Buffer[op1Index] % scalar);
 
@@ -1578,7 +1578,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(left.Buffer[op1Index] * right.Buffer[op2Index]);
 
@@ -1609,7 +1609,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(tensor.Buffer[op1Index] * scalar);
 
@@ -1644,7 +1644,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
 
@@ -1679,7 +1679,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(left.Buffer[op1Index] | right.Buffer[op2Index]);
 
@@ -1710,7 +1710,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(tensor.Buffer[op1Index] | scalar);
 
@@ -1741,7 +1741,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(tensor.Buffer[op1Index] >> value);
 
@@ -1776,7 +1776,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(left.Buffer[op1Index] - right.Buffer[op2Index]);
 
@@ -1807,7 +1807,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(tensor.Buffer[op1Index] - scalar);
 
@@ -1838,7 +1838,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)-tensor.Buffer[op1Index];
 
@@ -1869,7 +1869,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)+tensor.Buffer[op1Index];
 
@@ -1904,7 +1904,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(left.Buffer[op1Index] ^ right.Buffer[op2Index]);
 
@@ -1935,7 +1935,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (byte)(tensor.Buffer[op1Index] ^ scalar);
 
@@ -1954,7 +1954,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(left[indices] + right[indices]);
             }
             
@@ -1965,7 +1965,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(tensor[indices] + scalar);
             }
             
@@ -1976,7 +1976,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(left[indices] & right[indices]);
             }
             
@@ -1987,7 +1987,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(tensor[indices] & scalar);
             }
             
@@ -2018,9 +2018,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -2030,22 +2030,22 @@ namespace System.Numerics
             {
                 char sum = (char)0;
                 
-                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, resultIndex, resultIndices);
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
 
                     // todo, make this more efficient
-                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
-                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+                    ArrayUtilities.GetIndices(left.strides, left.IsReversedStride, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, right.IsReversedStride, rightIndex, rightIndices);
 
                     sum += (char)(left[leftIndices] * right[rightIndices]);
                 }
@@ -2059,7 +2059,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]--;
             }
             
@@ -2070,7 +2070,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(left[indices] / right[indices]);
             }
             
@@ -2081,7 +2081,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(tensor[indices] / scalar);
             }
             
@@ -2092,7 +2092,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] == right[indices];
             }
             
@@ -2103,7 +2103,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] > right[indices];
             }
             
@@ -2114,7 +2114,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] >= right[indices];
             }
             
@@ -2125,7 +2125,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]++;
             }
             
@@ -2136,7 +2136,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(tensor[indices] << value);
             }
             
@@ -2147,7 +2147,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] < right[indices];
             }
             
@@ -2158,7 +2158,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] <= right[indices];
             }
             
@@ -2169,7 +2169,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(left[indices] % right[indices]);
             }
             
@@ -2180,7 +2180,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(tensor[indices] % scalar);
             }
             
@@ -2191,7 +2191,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(left[indices] * right[indices]);
             }
             
@@ -2202,7 +2202,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(tensor[indices] * scalar);
             }
             
@@ -2213,7 +2213,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] != right[indices];
             }
             
@@ -2224,7 +2224,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(left[indices] | right[indices]);
             }
             
@@ -2235,7 +2235,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(tensor[indices] | scalar);
             }
             
@@ -2246,7 +2246,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(tensor[indices] >> value);
             }
             
@@ -2257,7 +2257,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(left[indices] - right[indices]);
             }
             
@@ -2268,7 +2268,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(tensor[indices] - scalar);
             }
             
@@ -2279,7 +2279,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)-tensor[indices];
             }
             
@@ -2290,7 +2290,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)+tensor[indices];
             }
             
@@ -2301,7 +2301,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(left[indices] ^ right[indices]);
             }
             
@@ -2312,7 +2312,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (char)(tensor[indices] ^ scalar);
             }
             
@@ -2346,7 +2346,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(left.Buffer[op1Index] + right.Buffer[op2Index]);
 
@@ -2377,7 +2377,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(tensor.Buffer[op1Index] + scalar);
 
@@ -2412,7 +2412,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(left.Buffer[op1Index] & right.Buffer[op2Index]);
 
@@ -2443,7 +2443,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(tensor.Buffer[op1Index] & scalar);
 
@@ -2472,9 +2472,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begingin is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -2484,13 +2484,13 @@ namespace System.Numerics
             {
                 char sum = (char)0;
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
@@ -2537,7 +2537,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(left.Buffer[op1Index] / right.Buffer[op2Index]);
 
@@ -2568,7 +2568,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(tensor.Buffer[op1Index] / scalar);
 
@@ -2603,7 +2603,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
 
@@ -2638,7 +2638,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] > right.Buffer[op2Index];
 
@@ -2673,7 +2673,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] >= right.Buffer[op2Index];
 
@@ -2712,7 +2712,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(tensor.Buffer[op1Index] << value);
 
@@ -2747,7 +2747,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] < right.Buffer[op2Index];
 
@@ -2782,7 +2782,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] <= right.Buffer[op2Index];
 
@@ -2817,7 +2817,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(left.Buffer[op1Index] % right.Buffer[op2Index]);
 
@@ -2848,7 +2848,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(tensor.Buffer[op1Index] % scalar);
 
@@ -2883,7 +2883,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(left.Buffer[op1Index] * right.Buffer[op2Index]);
 
@@ -2914,7 +2914,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(tensor.Buffer[op1Index] * scalar);
 
@@ -2949,7 +2949,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
 
@@ -2984,7 +2984,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(left.Buffer[op1Index] | right.Buffer[op2Index]);
 
@@ -3015,7 +3015,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(tensor.Buffer[op1Index] | scalar);
 
@@ -3046,7 +3046,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(tensor.Buffer[op1Index] >> value);
 
@@ -3081,7 +3081,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(left.Buffer[op1Index] - right.Buffer[op2Index]);
 
@@ -3112,7 +3112,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(tensor.Buffer[op1Index] - scalar);
 
@@ -3143,7 +3143,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)-tensor.Buffer[op1Index];
 
@@ -3174,7 +3174,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)+tensor.Buffer[op1Index];
 
@@ -3209,7 +3209,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(left.Buffer[op1Index] ^ right.Buffer[op2Index]);
 
@@ -3240,7 +3240,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (char)(tensor.Buffer[op1Index] ^ scalar);
 
@@ -3259,7 +3259,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (decimal)(left[indices] + right[indices]);
             }
             
@@ -3270,7 +3270,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (decimal)(tensor[indices] + scalar);
             }
             
@@ -3309,9 +3309,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -3321,22 +3321,22 @@ namespace System.Numerics
             {
                 decimal sum = (decimal)0;
                 
-                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, resultIndex, resultIndices);
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
 
                     // todo, make this more efficient
-                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
-                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+                    ArrayUtilities.GetIndices(left.strides, left.IsReversedStride, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, right.IsReversedStride, rightIndex, rightIndices);
 
                     sum += (decimal)(left[leftIndices] * right[rightIndices]);
                 }
@@ -3350,7 +3350,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]--;
             }
             
@@ -3361,7 +3361,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (decimal)(left[indices] / right[indices]);
             }
             
@@ -3372,7 +3372,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (decimal)(tensor[indices] / scalar);
             }
             
@@ -3383,7 +3383,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] == right[indices];
             }
             
@@ -3394,7 +3394,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] > right[indices];
             }
             
@@ -3405,7 +3405,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] >= right[indices];
             }
             
@@ -3416,7 +3416,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]++;
             }
             
@@ -3431,7 +3431,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] < right[indices];
             }
             
@@ -3442,7 +3442,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] <= right[indices];
             }
             
@@ -3453,7 +3453,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (decimal)(left[indices] % right[indices]);
             }
             
@@ -3464,7 +3464,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (decimal)(tensor[indices] % scalar);
             }
             
@@ -3475,7 +3475,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (decimal)(left[indices] * right[indices]);
             }
             
@@ -3486,7 +3486,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (decimal)(tensor[indices] * scalar);
             }
             
@@ -3497,7 +3497,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] != right[indices];
             }
             
@@ -3520,7 +3520,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (decimal)(left[indices] - right[indices]);
             }
             
@@ -3531,7 +3531,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (decimal)(tensor[indices] - scalar);
             }
             
@@ -3542,7 +3542,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (decimal)-tensor[indices];
             }
             
@@ -3553,7 +3553,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (decimal)+tensor[indices];
             }
             
@@ -3595,7 +3595,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (decimal)(left.Buffer[op1Index] + right.Buffer[op2Index]);
 
@@ -3626,7 +3626,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (decimal)(tensor.Buffer[op1Index] + scalar);
 
@@ -3663,9 +3663,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begingin is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -3675,13 +3675,13 @@ namespace System.Numerics
             {
                 decimal sum = (decimal)0;
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
@@ -3728,7 +3728,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (decimal)(left.Buffer[op1Index] / right.Buffer[op2Index]);
 
@@ -3759,7 +3759,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (decimal)(tensor.Buffer[op1Index] / scalar);
 
@@ -3794,7 +3794,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
 
@@ -3829,7 +3829,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] > right.Buffer[op2Index];
 
@@ -3864,7 +3864,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] >= right.Buffer[op2Index];
 
@@ -3911,7 +3911,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] < right.Buffer[op2Index];
 
@@ -3946,7 +3946,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] <= right.Buffer[op2Index];
 
@@ -3981,7 +3981,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (decimal)(left.Buffer[op1Index] % right.Buffer[op2Index]);
 
@@ -4012,7 +4012,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (decimal)(tensor.Buffer[op1Index] % scalar);
 
@@ -4047,7 +4047,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (decimal)(left.Buffer[op1Index] * right.Buffer[op2Index]);
 
@@ -4078,7 +4078,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (decimal)(tensor.Buffer[op1Index] * scalar);
 
@@ -4113,7 +4113,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
 
@@ -4160,7 +4160,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (decimal)(left.Buffer[op1Index] - right.Buffer[op2Index]);
 
@@ -4191,7 +4191,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (decimal)(tensor.Buffer[op1Index] - scalar);
 
@@ -4222,7 +4222,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (decimal)-tensor.Buffer[op1Index];
 
@@ -4253,7 +4253,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (decimal)+tensor.Buffer[op1Index];
 
@@ -4280,7 +4280,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (double)(left[indices] + right[indices]);
             }
             
@@ -4291,7 +4291,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (double)(tensor[indices] + scalar);
             }
             
@@ -4330,9 +4330,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -4342,22 +4342,22 @@ namespace System.Numerics
             {
                 double sum = (double)0;
                 
-                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, resultIndex, resultIndices);
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
 
                     // todo, make this more efficient
-                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
-                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+                    ArrayUtilities.GetIndices(left.strides, left.IsReversedStride, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, right.IsReversedStride, rightIndex, rightIndices);
 
                     sum += (double)(left[leftIndices] * right[rightIndices]);
                 }
@@ -4371,7 +4371,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]--;
             }
             
@@ -4382,7 +4382,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (double)(left[indices] / right[indices]);
             }
             
@@ -4393,7 +4393,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (double)(tensor[indices] / scalar);
             }
             
@@ -4404,7 +4404,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] == right[indices];
             }
             
@@ -4415,7 +4415,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] > right[indices];
             }
             
@@ -4426,7 +4426,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] >= right[indices];
             }
             
@@ -4437,7 +4437,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]++;
             }
             
@@ -4452,7 +4452,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] < right[indices];
             }
             
@@ -4463,7 +4463,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] <= right[indices];
             }
             
@@ -4474,7 +4474,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (double)(left[indices] % right[indices]);
             }
             
@@ -4485,7 +4485,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (double)(tensor[indices] % scalar);
             }
             
@@ -4496,7 +4496,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (double)(left[indices] * right[indices]);
             }
             
@@ -4507,7 +4507,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (double)(tensor[indices] * scalar);
             }
             
@@ -4518,7 +4518,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] != right[indices];
             }
             
@@ -4541,7 +4541,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (double)(left[indices] - right[indices]);
             }
             
@@ -4552,7 +4552,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (double)(tensor[indices] - scalar);
             }
             
@@ -4563,7 +4563,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (double)-tensor[indices];
             }
             
@@ -4574,7 +4574,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (double)+tensor[indices];
             }
             
@@ -4616,7 +4616,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (double)(left.Buffer[op1Index] + right.Buffer[op2Index]);
 
@@ -4647,7 +4647,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (double)(tensor.Buffer[op1Index] + scalar);
 
@@ -4684,9 +4684,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begingin is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -4696,13 +4696,13 @@ namespace System.Numerics
             {
                 double sum = (double)0;
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
@@ -4749,7 +4749,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (double)(left.Buffer[op1Index] / right.Buffer[op2Index]);
 
@@ -4780,7 +4780,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (double)(tensor.Buffer[op1Index] / scalar);
 
@@ -4815,7 +4815,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
 
@@ -4850,7 +4850,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] > right.Buffer[op2Index];
 
@@ -4885,7 +4885,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] >= right.Buffer[op2Index];
 
@@ -4932,7 +4932,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] < right.Buffer[op2Index];
 
@@ -4967,7 +4967,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] <= right.Buffer[op2Index];
 
@@ -5002,7 +5002,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (double)(left.Buffer[op1Index] % right.Buffer[op2Index]);
 
@@ -5033,7 +5033,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (double)(tensor.Buffer[op1Index] % scalar);
 
@@ -5068,7 +5068,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (double)(left.Buffer[op1Index] * right.Buffer[op2Index]);
 
@@ -5099,7 +5099,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (double)(tensor.Buffer[op1Index] * scalar);
 
@@ -5134,7 +5134,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
 
@@ -5181,7 +5181,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (double)(left.Buffer[op1Index] - right.Buffer[op2Index]);
 
@@ -5212,7 +5212,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (double)(tensor.Buffer[op1Index] - scalar);
 
@@ -5243,7 +5243,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (double)-tensor.Buffer[op1Index];
 
@@ -5274,7 +5274,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (double)+tensor.Buffer[op1Index];
 
@@ -5301,7 +5301,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (float)(left[indices] + right[indices]);
             }
             
@@ -5312,7 +5312,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (float)(tensor[indices] + scalar);
             }
             
@@ -5351,9 +5351,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -5363,22 +5363,22 @@ namespace System.Numerics
             {
                 float sum = (float)0;
                 
-                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, resultIndex, resultIndices);
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
 
                     // todo, make this more efficient
-                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
-                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+                    ArrayUtilities.GetIndices(left.strides, left.IsReversedStride, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, right.IsReversedStride, rightIndex, rightIndices);
 
                     sum += (float)(left[leftIndices] * right[rightIndices]);
                 }
@@ -5392,7 +5392,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]--;
             }
             
@@ -5403,7 +5403,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (float)(left[indices] / right[indices]);
             }
             
@@ -5414,7 +5414,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (float)(tensor[indices] / scalar);
             }
             
@@ -5425,7 +5425,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] == right[indices];
             }
             
@@ -5436,7 +5436,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] > right[indices];
             }
             
@@ -5447,7 +5447,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] >= right[indices];
             }
             
@@ -5458,7 +5458,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]++;
             }
             
@@ -5473,7 +5473,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] < right[indices];
             }
             
@@ -5484,7 +5484,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] <= right[indices];
             }
             
@@ -5495,7 +5495,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (float)(left[indices] % right[indices]);
             }
             
@@ -5506,7 +5506,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (float)(tensor[indices] % scalar);
             }
             
@@ -5517,7 +5517,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (float)(left[indices] * right[indices]);
             }
             
@@ -5528,7 +5528,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (float)(tensor[indices] * scalar);
             }
             
@@ -5539,7 +5539,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] != right[indices];
             }
             
@@ -5562,7 +5562,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (float)(left[indices] - right[indices]);
             }
             
@@ -5573,7 +5573,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (float)(tensor[indices] - scalar);
             }
             
@@ -5584,7 +5584,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (float)-tensor[indices];
             }
             
@@ -5595,7 +5595,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (float)+tensor[indices];
             }
             
@@ -5637,7 +5637,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (float)(left.Buffer[op1Index] + right.Buffer[op2Index]);
 
@@ -5668,7 +5668,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (float)(tensor.Buffer[op1Index] + scalar);
 
@@ -5705,9 +5705,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begingin is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -5717,13 +5717,13 @@ namespace System.Numerics
             {
                 float sum = (float)0;
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
@@ -5770,7 +5770,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (float)(left.Buffer[op1Index] / right.Buffer[op2Index]);
 
@@ -5801,7 +5801,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (float)(tensor.Buffer[op1Index] / scalar);
 
@@ -5836,7 +5836,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
 
@@ -5871,7 +5871,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] > right.Buffer[op2Index];
 
@@ -5906,7 +5906,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] >= right.Buffer[op2Index];
 
@@ -5953,7 +5953,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] < right.Buffer[op2Index];
 
@@ -5988,7 +5988,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] <= right.Buffer[op2Index];
 
@@ -6023,7 +6023,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (float)(left.Buffer[op1Index] % right.Buffer[op2Index]);
 
@@ -6054,7 +6054,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (float)(tensor.Buffer[op1Index] % scalar);
 
@@ -6089,7 +6089,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (float)(left.Buffer[op1Index] * right.Buffer[op2Index]);
 
@@ -6120,7 +6120,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (float)(tensor.Buffer[op1Index] * scalar);
 
@@ -6155,7 +6155,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
 
@@ -6202,7 +6202,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (float)(left.Buffer[op1Index] - right.Buffer[op2Index]);
 
@@ -6233,7 +6233,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (float)(tensor.Buffer[op1Index] - scalar);
 
@@ -6264,7 +6264,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (float)-tensor.Buffer[op1Index];
 
@@ -6295,7 +6295,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (float)+tensor.Buffer[op1Index];
 
@@ -6322,7 +6322,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(left[indices] + right[indices]);
             }
             
@@ -6333,7 +6333,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(tensor[indices] + scalar);
             }
             
@@ -6344,7 +6344,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(left[indices] & right[indices]);
             }
             
@@ -6355,7 +6355,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(tensor[indices] & scalar);
             }
             
@@ -6386,9 +6386,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -6398,22 +6398,22 @@ namespace System.Numerics
             {
                 int sum = (int)0;
                 
-                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, resultIndex, resultIndices);
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
 
                     // todo, make this more efficient
-                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
-                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+                    ArrayUtilities.GetIndices(left.strides, left.IsReversedStride, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, right.IsReversedStride, rightIndex, rightIndices);
 
                     sum += (int)(left[leftIndices] * right[rightIndices]);
                 }
@@ -6427,7 +6427,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]--;
             }
             
@@ -6438,7 +6438,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(left[indices] / right[indices]);
             }
             
@@ -6449,7 +6449,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(tensor[indices] / scalar);
             }
             
@@ -6460,7 +6460,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] == right[indices];
             }
             
@@ -6471,7 +6471,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] > right[indices];
             }
             
@@ -6482,7 +6482,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] >= right[indices];
             }
             
@@ -6493,7 +6493,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]++;
             }
             
@@ -6504,7 +6504,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(tensor[indices] << value);
             }
             
@@ -6515,7 +6515,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] < right[indices];
             }
             
@@ -6526,7 +6526,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] <= right[indices];
             }
             
@@ -6537,7 +6537,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(left[indices] % right[indices]);
             }
             
@@ -6548,7 +6548,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(tensor[indices] % scalar);
             }
             
@@ -6559,7 +6559,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(left[indices] * right[indices]);
             }
             
@@ -6570,7 +6570,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(tensor[indices] * scalar);
             }
             
@@ -6581,7 +6581,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] != right[indices];
             }
             
@@ -6592,7 +6592,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(left[indices] | right[indices]);
             }
             
@@ -6603,7 +6603,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(tensor[indices] | scalar);
             }
             
@@ -6614,7 +6614,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(tensor[indices] >> value);
             }
             
@@ -6625,7 +6625,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(left[indices] - right[indices]);
             }
             
@@ -6636,7 +6636,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(tensor[indices] - scalar);
             }
             
@@ -6647,7 +6647,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)-tensor[indices];
             }
             
@@ -6658,7 +6658,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)+tensor[indices];
             }
             
@@ -6669,7 +6669,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(left[indices] ^ right[indices]);
             }
             
@@ -6680,7 +6680,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (int)(tensor[indices] ^ scalar);
             }
             
@@ -6714,7 +6714,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(left.Buffer[op1Index] + right.Buffer[op2Index]);
 
@@ -6745,7 +6745,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(tensor.Buffer[op1Index] + scalar);
 
@@ -6780,7 +6780,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(left.Buffer[op1Index] & right.Buffer[op2Index]);
 
@@ -6811,7 +6811,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(tensor.Buffer[op1Index] & scalar);
 
@@ -6840,9 +6840,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begingin is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -6852,13 +6852,13 @@ namespace System.Numerics
             {
                 int sum = (int)0;
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
@@ -6905,7 +6905,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(left.Buffer[op1Index] / right.Buffer[op2Index]);
 
@@ -6936,7 +6936,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(tensor.Buffer[op1Index] / scalar);
 
@@ -6971,7 +6971,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
 
@@ -7006,7 +7006,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] > right.Buffer[op2Index];
 
@@ -7041,7 +7041,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] >= right.Buffer[op2Index];
 
@@ -7080,7 +7080,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(tensor.Buffer[op1Index] << value);
 
@@ -7115,7 +7115,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] < right.Buffer[op2Index];
 
@@ -7150,7 +7150,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] <= right.Buffer[op2Index];
 
@@ -7185,7 +7185,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(left.Buffer[op1Index] % right.Buffer[op2Index]);
 
@@ -7216,7 +7216,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(tensor.Buffer[op1Index] % scalar);
 
@@ -7251,7 +7251,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(left.Buffer[op1Index] * right.Buffer[op2Index]);
 
@@ -7282,7 +7282,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(tensor.Buffer[op1Index] * scalar);
 
@@ -7317,7 +7317,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
 
@@ -7352,7 +7352,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(left.Buffer[op1Index] | right.Buffer[op2Index]);
 
@@ -7383,7 +7383,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(tensor.Buffer[op1Index] | scalar);
 
@@ -7414,7 +7414,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(tensor.Buffer[op1Index] >> value);
 
@@ -7449,7 +7449,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(left.Buffer[op1Index] - right.Buffer[op2Index]);
 
@@ -7480,7 +7480,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(tensor.Buffer[op1Index] - scalar);
 
@@ -7511,7 +7511,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)-tensor.Buffer[op1Index];
 
@@ -7542,7 +7542,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)+tensor.Buffer[op1Index];
 
@@ -7577,7 +7577,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(left.Buffer[op1Index] ^ right.Buffer[op2Index]);
 
@@ -7608,7 +7608,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (int)(tensor.Buffer[op1Index] ^ scalar);
 
@@ -7627,7 +7627,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(left[indices] + right[indices]);
             }
             
@@ -7638,7 +7638,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(tensor[indices] + scalar);
             }
             
@@ -7649,7 +7649,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(left[indices] & right[indices]);
             }
             
@@ -7660,7 +7660,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(tensor[indices] & scalar);
             }
             
@@ -7691,9 +7691,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -7703,22 +7703,22 @@ namespace System.Numerics
             {
                 long sum = (long)0;
                 
-                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, resultIndex, resultIndices);
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
 
                     // todo, make this more efficient
-                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
-                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+                    ArrayUtilities.GetIndices(left.strides, left.IsReversedStride, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, right.IsReversedStride, rightIndex, rightIndices);
 
                     sum += (long)(left[leftIndices] * right[rightIndices]);
                 }
@@ -7732,7 +7732,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]--;
             }
             
@@ -7743,7 +7743,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(left[indices] / right[indices]);
             }
             
@@ -7754,7 +7754,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(tensor[indices] / scalar);
             }
             
@@ -7765,7 +7765,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] == right[indices];
             }
             
@@ -7776,7 +7776,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] > right[indices];
             }
             
@@ -7787,7 +7787,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] >= right[indices];
             }
             
@@ -7798,7 +7798,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]++;
             }
             
@@ -7809,7 +7809,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(tensor[indices] << value);
             }
             
@@ -7820,7 +7820,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] < right[indices];
             }
             
@@ -7831,7 +7831,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] <= right[indices];
             }
             
@@ -7842,7 +7842,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(left[indices] % right[indices]);
             }
             
@@ -7853,7 +7853,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(tensor[indices] % scalar);
             }
             
@@ -7864,7 +7864,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(left[indices] * right[indices]);
             }
             
@@ -7875,7 +7875,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(tensor[indices] * scalar);
             }
             
@@ -7886,7 +7886,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] != right[indices];
             }
             
@@ -7897,7 +7897,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(left[indices] | right[indices]);
             }
             
@@ -7908,7 +7908,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(tensor[indices] | scalar);
             }
             
@@ -7919,7 +7919,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(tensor[indices] >> value);
             }
             
@@ -7930,7 +7930,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(left[indices] - right[indices]);
             }
             
@@ -7941,7 +7941,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(tensor[indices] - scalar);
             }
             
@@ -7952,7 +7952,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)-tensor[indices];
             }
             
@@ -7963,7 +7963,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)+tensor[indices];
             }
             
@@ -7974,7 +7974,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(left[indices] ^ right[indices]);
             }
             
@@ -7985,7 +7985,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (long)(tensor[indices] ^ scalar);
             }
             
@@ -8019,7 +8019,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(left.Buffer[op1Index] + right.Buffer[op2Index]);
 
@@ -8050,7 +8050,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(tensor.Buffer[op1Index] + scalar);
 
@@ -8085,7 +8085,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(left.Buffer[op1Index] & right.Buffer[op2Index]);
 
@@ -8116,7 +8116,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(tensor.Buffer[op1Index] & scalar);
 
@@ -8145,9 +8145,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begingin is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -8157,13 +8157,13 @@ namespace System.Numerics
             {
                 long sum = (long)0;
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
@@ -8210,7 +8210,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(left.Buffer[op1Index] / right.Buffer[op2Index]);
 
@@ -8241,7 +8241,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(tensor.Buffer[op1Index] / scalar);
 
@@ -8276,7 +8276,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
 
@@ -8311,7 +8311,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] > right.Buffer[op2Index];
 
@@ -8346,7 +8346,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] >= right.Buffer[op2Index];
 
@@ -8385,7 +8385,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(tensor.Buffer[op1Index] << value);
 
@@ -8420,7 +8420,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] < right.Buffer[op2Index];
 
@@ -8455,7 +8455,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] <= right.Buffer[op2Index];
 
@@ -8490,7 +8490,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(left.Buffer[op1Index] % right.Buffer[op2Index]);
 
@@ -8521,7 +8521,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(tensor.Buffer[op1Index] % scalar);
 
@@ -8556,7 +8556,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(left.Buffer[op1Index] * right.Buffer[op2Index]);
 
@@ -8587,7 +8587,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(tensor.Buffer[op1Index] * scalar);
 
@@ -8622,7 +8622,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
 
@@ -8657,7 +8657,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(left.Buffer[op1Index] | right.Buffer[op2Index]);
 
@@ -8688,7 +8688,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(tensor.Buffer[op1Index] | scalar);
 
@@ -8719,7 +8719,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(tensor.Buffer[op1Index] >> value);
 
@@ -8754,7 +8754,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(left.Buffer[op1Index] - right.Buffer[op2Index]);
 
@@ -8785,7 +8785,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(tensor.Buffer[op1Index] - scalar);
 
@@ -8816,7 +8816,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)-tensor.Buffer[op1Index];
 
@@ -8847,7 +8847,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)+tensor.Buffer[op1Index];
 
@@ -8882,7 +8882,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(left.Buffer[op1Index] ^ right.Buffer[op2Index]);
 
@@ -8913,7 +8913,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (long)(tensor.Buffer[op1Index] ^ scalar);
 
@@ -8932,7 +8932,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(left[indices] + right[indices]);
             }
             
@@ -8943,7 +8943,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(tensor[indices] + scalar);
             }
             
@@ -8954,7 +8954,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(left[indices] & right[indices]);
             }
             
@@ -8965,7 +8965,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(tensor[indices] & scalar);
             }
             
@@ -8996,9 +8996,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -9008,22 +9008,22 @@ namespace System.Numerics
             {
                 sbyte sum = (sbyte)0;
                 
-                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, resultIndex, resultIndices);
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
 
                     // todo, make this more efficient
-                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
-                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+                    ArrayUtilities.GetIndices(left.strides, left.IsReversedStride, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, right.IsReversedStride, rightIndex, rightIndices);
 
                     sum += (sbyte)(left[leftIndices] * right[rightIndices]);
                 }
@@ -9037,7 +9037,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]--;
             }
             
@@ -9048,7 +9048,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(left[indices] / right[indices]);
             }
             
@@ -9059,7 +9059,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(tensor[indices] / scalar);
             }
             
@@ -9070,7 +9070,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] == right[indices];
             }
             
@@ -9081,7 +9081,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] > right[indices];
             }
             
@@ -9092,7 +9092,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] >= right[indices];
             }
             
@@ -9103,7 +9103,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]++;
             }
             
@@ -9114,7 +9114,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(tensor[indices] << value);
             }
             
@@ -9125,7 +9125,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] < right[indices];
             }
             
@@ -9136,7 +9136,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] <= right[indices];
             }
             
@@ -9147,7 +9147,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(left[indices] % right[indices]);
             }
             
@@ -9158,7 +9158,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(tensor[indices] % scalar);
             }
             
@@ -9169,7 +9169,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(left[indices] * right[indices]);
             }
             
@@ -9180,7 +9180,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(tensor[indices] * scalar);
             }
             
@@ -9191,7 +9191,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] != right[indices];
             }
             
@@ -9202,7 +9202,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(left[indices] | right[indices]);
             }
             
@@ -9213,7 +9213,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(tensor[indices] | scalar);
             }
             
@@ -9224,7 +9224,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(tensor[indices] >> value);
             }
             
@@ -9235,7 +9235,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(left[indices] - right[indices]);
             }
             
@@ -9246,7 +9246,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(tensor[indices] - scalar);
             }
             
@@ -9257,7 +9257,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)-tensor[indices];
             }
             
@@ -9268,7 +9268,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)+tensor[indices];
             }
             
@@ -9279,7 +9279,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(left[indices] ^ right[indices]);
             }
             
@@ -9290,7 +9290,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (sbyte)(tensor[indices] ^ scalar);
             }
             
@@ -9324,7 +9324,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(left.Buffer[op1Index] + right.Buffer[op2Index]);
 
@@ -9355,7 +9355,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(tensor.Buffer[op1Index] + scalar);
 
@@ -9390,7 +9390,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(left.Buffer[op1Index] & right.Buffer[op2Index]);
 
@@ -9421,7 +9421,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(tensor.Buffer[op1Index] & scalar);
 
@@ -9450,9 +9450,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begingin is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -9462,13 +9462,13 @@ namespace System.Numerics
             {
                 sbyte sum = (sbyte)0;
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
@@ -9515,7 +9515,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(left.Buffer[op1Index] / right.Buffer[op2Index]);
 
@@ -9546,7 +9546,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(tensor.Buffer[op1Index] / scalar);
 
@@ -9581,7 +9581,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
 
@@ -9616,7 +9616,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] > right.Buffer[op2Index];
 
@@ -9651,7 +9651,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] >= right.Buffer[op2Index];
 
@@ -9690,7 +9690,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(tensor.Buffer[op1Index] << value);
 
@@ -9725,7 +9725,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] < right.Buffer[op2Index];
 
@@ -9760,7 +9760,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] <= right.Buffer[op2Index];
 
@@ -9795,7 +9795,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(left.Buffer[op1Index] % right.Buffer[op2Index]);
 
@@ -9826,7 +9826,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(tensor.Buffer[op1Index] % scalar);
 
@@ -9861,7 +9861,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(left.Buffer[op1Index] * right.Buffer[op2Index]);
 
@@ -9892,7 +9892,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(tensor.Buffer[op1Index] * scalar);
 
@@ -9927,7 +9927,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
 
@@ -9962,7 +9962,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(left.Buffer[op1Index] | right.Buffer[op2Index]);
 
@@ -9993,7 +9993,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(tensor.Buffer[op1Index] | scalar);
 
@@ -10024,7 +10024,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(tensor.Buffer[op1Index] >> value);
 
@@ -10059,7 +10059,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(left.Buffer[op1Index] - right.Buffer[op2Index]);
 
@@ -10090,7 +10090,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(tensor.Buffer[op1Index] - scalar);
 
@@ -10121,7 +10121,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)-tensor.Buffer[op1Index];
 
@@ -10152,7 +10152,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)+tensor.Buffer[op1Index];
 
@@ -10187,7 +10187,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(left.Buffer[op1Index] ^ right.Buffer[op2Index]);
 
@@ -10218,7 +10218,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (sbyte)(tensor.Buffer[op1Index] ^ scalar);
 
@@ -10237,7 +10237,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(left[indices] + right[indices]);
             }
             
@@ -10248,7 +10248,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(tensor[indices] + scalar);
             }
             
@@ -10259,7 +10259,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(left[indices] & right[indices]);
             }
             
@@ -10270,7 +10270,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(tensor[indices] & scalar);
             }
             
@@ -10301,9 +10301,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -10313,22 +10313,22 @@ namespace System.Numerics
             {
                 short sum = (short)0;
                 
-                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, resultIndex, resultIndices);
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
 
                     // todo, make this more efficient
-                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
-                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+                    ArrayUtilities.GetIndices(left.strides, left.IsReversedStride, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, right.IsReversedStride, rightIndex, rightIndices);
 
                     sum += (short)(left[leftIndices] * right[rightIndices]);
                 }
@@ -10342,7 +10342,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]--;
             }
             
@@ -10353,7 +10353,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(left[indices] / right[indices]);
             }
             
@@ -10364,7 +10364,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(tensor[indices] / scalar);
             }
             
@@ -10375,7 +10375,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] == right[indices];
             }
             
@@ -10386,7 +10386,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] > right[indices];
             }
             
@@ -10397,7 +10397,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] >= right[indices];
             }
             
@@ -10408,7 +10408,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]++;
             }
             
@@ -10419,7 +10419,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(tensor[indices] << value);
             }
             
@@ -10430,7 +10430,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] < right[indices];
             }
             
@@ -10441,7 +10441,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] <= right[indices];
             }
             
@@ -10452,7 +10452,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(left[indices] % right[indices]);
             }
             
@@ -10463,7 +10463,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(tensor[indices] % scalar);
             }
             
@@ -10474,7 +10474,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(left[indices] * right[indices]);
             }
             
@@ -10485,7 +10485,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(tensor[indices] * scalar);
             }
             
@@ -10496,7 +10496,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] != right[indices];
             }
             
@@ -10507,7 +10507,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(left[indices] | right[indices]);
             }
             
@@ -10518,7 +10518,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(tensor[indices] | scalar);
             }
             
@@ -10529,7 +10529,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(tensor[indices] >> value);
             }
             
@@ -10540,7 +10540,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(left[indices] - right[indices]);
             }
             
@@ -10551,7 +10551,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(tensor[indices] - scalar);
             }
             
@@ -10562,7 +10562,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)-tensor[indices];
             }
             
@@ -10573,7 +10573,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)+tensor[indices];
             }
             
@@ -10584,7 +10584,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(left[indices] ^ right[indices]);
             }
             
@@ -10595,7 +10595,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (short)(tensor[indices] ^ scalar);
             }
             
@@ -10629,7 +10629,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(left.Buffer[op1Index] + right.Buffer[op2Index]);
 
@@ -10660,7 +10660,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(tensor.Buffer[op1Index] + scalar);
 
@@ -10695,7 +10695,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(left.Buffer[op1Index] & right.Buffer[op2Index]);
 
@@ -10726,7 +10726,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(tensor.Buffer[op1Index] & scalar);
 
@@ -10755,9 +10755,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begingin is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -10767,13 +10767,13 @@ namespace System.Numerics
             {
                 short sum = (short)0;
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
@@ -10820,7 +10820,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(left.Buffer[op1Index] / right.Buffer[op2Index]);
 
@@ -10851,7 +10851,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(tensor.Buffer[op1Index] / scalar);
 
@@ -10886,7 +10886,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
 
@@ -10921,7 +10921,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] > right.Buffer[op2Index];
 
@@ -10956,7 +10956,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] >= right.Buffer[op2Index];
 
@@ -10995,7 +10995,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(tensor.Buffer[op1Index] << value);
 
@@ -11030,7 +11030,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] < right.Buffer[op2Index];
 
@@ -11065,7 +11065,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] <= right.Buffer[op2Index];
 
@@ -11100,7 +11100,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(left.Buffer[op1Index] % right.Buffer[op2Index]);
 
@@ -11131,7 +11131,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(tensor.Buffer[op1Index] % scalar);
 
@@ -11166,7 +11166,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(left.Buffer[op1Index] * right.Buffer[op2Index]);
 
@@ -11197,7 +11197,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(tensor.Buffer[op1Index] * scalar);
 
@@ -11232,7 +11232,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
 
@@ -11267,7 +11267,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(left.Buffer[op1Index] | right.Buffer[op2Index]);
 
@@ -11298,7 +11298,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(tensor.Buffer[op1Index] | scalar);
 
@@ -11329,7 +11329,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(tensor.Buffer[op1Index] >> value);
 
@@ -11364,7 +11364,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(left.Buffer[op1Index] - right.Buffer[op2Index]);
 
@@ -11395,7 +11395,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(tensor.Buffer[op1Index] - scalar);
 
@@ -11426,7 +11426,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)-tensor.Buffer[op1Index];
 
@@ -11457,7 +11457,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)+tensor.Buffer[op1Index];
 
@@ -11492,7 +11492,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(left.Buffer[op1Index] ^ right.Buffer[op2Index]);
 
@@ -11523,7 +11523,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (short)(tensor.Buffer[op1Index] ^ scalar);
 
@@ -11542,7 +11542,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(left[indices] + right[indices]);
             }
             
@@ -11553,7 +11553,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(tensor[indices] + scalar);
             }
             
@@ -11564,7 +11564,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(left[indices] & right[indices]);
             }
             
@@ -11575,7 +11575,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(tensor[indices] & scalar);
             }
             
@@ -11606,9 +11606,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -11618,22 +11618,22 @@ namespace System.Numerics
             {
                 uint sum = (uint)0;
                 
-                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, resultIndex, resultIndices);
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
 
                     // todo, make this more efficient
-                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
-                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+                    ArrayUtilities.GetIndices(left.strides, left.IsReversedStride, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, right.IsReversedStride, rightIndex, rightIndices);
 
                     sum += (uint)(left[leftIndices] * right[rightIndices]);
                 }
@@ -11647,7 +11647,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]--;
             }
             
@@ -11658,7 +11658,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(left[indices] / right[indices]);
             }
             
@@ -11669,7 +11669,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(tensor[indices] / scalar);
             }
             
@@ -11680,7 +11680,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] == right[indices];
             }
             
@@ -11691,7 +11691,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] > right[indices];
             }
             
@@ -11702,7 +11702,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] >= right[indices];
             }
             
@@ -11713,7 +11713,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]++;
             }
             
@@ -11724,7 +11724,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(tensor[indices] << value);
             }
             
@@ -11735,7 +11735,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] < right[indices];
             }
             
@@ -11746,7 +11746,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] <= right[indices];
             }
             
@@ -11757,7 +11757,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(left[indices] % right[indices]);
             }
             
@@ -11768,7 +11768,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(tensor[indices] % scalar);
             }
             
@@ -11779,7 +11779,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(left[indices] * right[indices]);
             }
             
@@ -11790,7 +11790,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(tensor[indices] * scalar);
             }
             
@@ -11801,7 +11801,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] != right[indices];
             }
             
@@ -11812,7 +11812,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(left[indices] | right[indices]);
             }
             
@@ -11823,7 +11823,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(tensor[indices] | scalar);
             }
             
@@ -11834,7 +11834,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(tensor[indices] >> value);
             }
             
@@ -11845,7 +11845,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(left[indices] - right[indices]);
             }
             
@@ -11856,7 +11856,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(tensor[indices] - scalar);
             }
             
@@ -11871,7 +11871,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)+tensor[indices];
             }
             
@@ -11882,7 +11882,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(left[indices] ^ right[indices]);
             }
             
@@ -11893,7 +11893,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (uint)(tensor[indices] ^ scalar);
             }
             
@@ -11927,7 +11927,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(left.Buffer[op1Index] + right.Buffer[op2Index]);
 
@@ -11958,7 +11958,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(tensor.Buffer[op1Index] + scalar);
 
@@ -11993,7 +11993,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(left.Buffer[op1Index] & right.Buffer[op2Index]);
 
@@ -12024,7 +12024,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(tensor.Buffer[op1Index] & scalar);
 
@@ -12053,9 +12053,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begingin is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -12065,13 +12065,13 @@ namespace System.Numerics
             {
                 uint sum = (uint)0;
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
@@ -12118,7 +12118,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(left.Buffer[op1Index] / right.Buffer[op2Index]);
 
@@ -12149,7 +12149,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(tensor.Buffer[op1Index] / scalar);
 
@@ -12184,7 +12184,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
 
@@ -12219,7 +12219,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] > right.Buffer[op2Index];
 
@@ -12254,7 +12254,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] >= right.Buffer[op2Index];
 
@@ -12293,7 +12293,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(tensor.Buffer[op1Index] << value);
 
@@ -12328,7 +12328,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] < right.Buffer[op2Index];
 
@@ -12363,7 +12363,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] <= right.Buffer[op2Index];
 
@@ -12398,7 +12398,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(left.Buffer[op1Index] % right.Buffer[op2Index]);
 
@@ -12429,7 +12429,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(tensor.Buffer[op1Index] % scalar);
 
@@ -12464,7 +12464,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(left.Buffer[op1Index] * right.Buffer[op2Index]);
 
@@ -12495,7 +12495,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(tensor.Buffer[op1Index] * scalar);
 
@@ -12530,7 +12530,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
 
@@ -12565,7 +12565,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(left.Buffer[op1Index] | right.Buffer[op2Index]);
 
@@ -12596,7 +12596,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(tensor.Buffer[op1Index] | scalar);
 
@@ -12627,7 +12627,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(tensor.Buffer[op1Index] >> value);
 
@@ -12662,7 +12662,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(left.Buffer[op1Index] - right.Buffer[op2Index]);
 
@@ -12693,7 +12693,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(tensor.Buffer[op1Index] - scalar);
 
@@ -12728,7 +12728,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)+tensor.Buffer[op1Index];
 
@@ -12763,7 +12763,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(left.Buffer[op1Index] ^ right.Buffer[op2Index]);
 
@@ -12794,7 +12794,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (uint)(tensor.Buffer[op1Index] ^ scalar);
 
@@ -12813,7 +12813,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(left[indices] + right[indices]);
             }
             
@@ -12824,7 +12824,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(tensor[indices] + scalar);
             }
             
@@ -12835,7 +12835,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(left[indices] & right[indices]);
             }
             
@@ -12846,7 +12846,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(tensor[indices] & scalar);
             }
             
@@ -12877,9 +12877,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -12889,22 +12889,22 @@ namespace System.Numerics
             {
                 ulong sum = (ulong)0;
                 
-                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, resultIndex, resultIndices);
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
 
                     // todo, make this more efficient
-                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
-                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+                    ArrayUtilities.GetIndices(left.strides, left.IsReversedStride, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, right.IsReversedStride, rightIndex, rightIndices);
 
                     sum += (ulong)(left[leftIndices] * right[rightIndices]);
                 }
@@ -12918,7 +12918,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]--;
             }
             
@@ -12929,7 +12929,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(left[indices] / right[indices]);
             }
             
@@ -12940,7 +12940,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(tensor[indices] / scalar);
             }
             
@@ -12951,7 +12951,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] == right[indices];
             }
             
@@ -12962,7 +12962,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] > right[indices];
             }
             
@@ -12973,7 +12973,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] >= right[indices];
             }
             
@@ -12984,7 +12984,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]++;
             }
             
@@ -12995,7 +12995,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(tensor[indices] << value);
             }
             
@@ -13006,7 +13006,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] < right[indices];
             }
             
@@ -13017,7 +13017,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] <= right[indices];
             }
             
@@ -13028,7 +13028,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(left[indices] % right[indices]);
             }
             
@@ -13039,7 +13039,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(tensor[indices] % scalar);
             }
             
@@ -13050,7 +13050,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(left[indices] * right[indices]);
             }
             
@@ -13061,7 +13061,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(tensor[indices] * scalar);
             }
             
@@ -13072,7 +13072,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] != right[indices];
             }
             
@@ -13083,7 +13083,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(left[indices] | right[indices]);
             }
             
@@ -13094,7 +13094,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(tensor[indices] | scalar);
             }
             
@@ -13105,7 +13105,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(tensor[indices] >> value);
             }
             
@@ -13116,7 +13116,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(left[indices] - right[indices]);
             }
             
@@ -13127,7 +13127,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(tensor[indices] - scalar);
             }
             
@@ -13142,7 +13142,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)+tensor[indices];
             }
             
@@ -13153,7 +13153,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(left[indices] ^ right[indices]);
             }
             
@@ -13164,7 +13164,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ulong)(tensor[indices] ^ scalar);
             }
             
@@ -13198,7 +13198,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(left.Buffer[op1Index] + right.Buffer[op2Index]);
 
@@ -13229,7 +13229,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(tensor.Buffer[op1Index] + scalar);
 
@@ -13264,7 +13264,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(left.Buffer[op1Index] & right.Buffer[op2Index]);
 
@@ -13295,7 +13295,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(tensor.Buffer[op1Index] & scalar);
 
@@ -13324,9 +13324,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begingin is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -13336,13 +13336,13 @@ namespace System.Numerics
             {
                 ulong sum = (ulong)0;
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
@@ -13389,7 +13389,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(left.Buffer[op1Index] / right.Buffer[op2Index]);
 
@@ -13420,7 +13420,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(tensor.Buffer[op1Index] / scalar);
 
@@ -13455,7 +13455,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
 
@@ -13490,7 +13490,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] > right.Buffer[op2Index];
 
@@ -13525,7 +13525,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] >= right.Buffer[op2Index];
 
@@ -13564,7 +13564,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(tensor.Buffer[op1Index] << value);
 
@@ -13599,7 +13599,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] < right.Buffer[op2Index];
 
@@ -13634,7 +13634,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] <= right.Buffer[op2Index];
 
@@ -13669,7 +13669,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(left.Buffer[op1Index] % right.Buffer[op2Index]);
 
@@ -13700,7 +13700,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(tensor.Buffer[op1Index] % scalar);
 
@@ -13735,7 +13735,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(left.Buffer[op1Index] * right.Buffer[op2Index]);
 
@@ -13766,7 +13766,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(tensor.Buffer[op1Index] * scalar);
 
@@ -13801,7 +13801,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
 
@@ -13836,7 +13836,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(left.Buffer[op1Index] | right.Buffer[op2Index]);
 
@@ -13867,7 +13867,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(tensor.Buffer[op1Index] | scalar);
 
@@ -13898,7 +13898,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(tensor.Buffer[op1Index] >> value);
 
@@ -13933,7 +13933,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(left.Buffer[op1Index] - right.Buffer[op2Index]);
 
@@ -13964,7 +13964,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(tensor.Buffer[op1Index] - scalar);
 
@@ -13999,7 +13999,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)+tensor.Buffer[op1Index];
 
@@ -14034,7 +14034,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(left.Buffer[op1Index] ^ right.Buffer[op2Index]);
 
@@ -14065,7 +14065,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ulong)(tensor.Buffer[op1Index] ^ scalar);
 
@@ -14084,7 +14084,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(left[indices] + right[indices]);
             }
             
@@ -14095,7 +14095,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(tensor[indices] + scalar);
             }
             
@@ -14106,7 +14106,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(left[indices] & right[indices]);
             }
             
@@ -14117,7 +14117,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(tensor[indices] & scalar);
             }
             
@@ -14148,9 +14148,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -14160,22 +14160,22 @@ namespace System.Numerics
             {
                 ushort sum = (ushort)0;
                 
-                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, resultIndex, resultIndices);
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
 
                     // todo, make this more efficient
-                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
-                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+                    ArrayUtilities.GetIndices(left.strides, left.IsReversedStride, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, right.IsReversedStride, rightIndex, rightIndices);
 
                     sum += (ushort)(left[leftIndices] * right[rightIndices]);
                 }
@@ -14189,7 +14189,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]--;
             }
             
@@ -14200,7 +14200,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(left[indices] / right[indices]);
             }
             
@@ -14211,7 +14211,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(tensor[indices] / scalar);
             }
             
@@ -14222,7 +14222,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] == right[indices];
             }
             
@@ -14233,7 +14233,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] > right[indices];
             }
             
@@ -14244,7 +14244,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] >= right[indices];
             }
             
@@ -14255,7 +14255,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices]++;
             }
             
@@ -14266,7 +14266,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(tensor[indices] << value);
             }
             
@@ -14277,7 +14277,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] < right[indices];
             }
             
@@ -14288,7 +14288,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] <= right[indices];
             }
             
@@ -14299,7 +14299,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(left[indices] % right[indices]);
             }
             
@@ -14310,7 +14310,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(tensor[indices] % scalar);
             }
             
@@ -14321,7 +14321,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(left[indices] * right[indices]);
             }
             
@@ -14332,7 +14332,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(tensor[indices] * scalar);
             }
             
@@ -14343,7 +14343,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = left[indices] != right[indices];
             }
             
@@ -14354,7 +14354,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(left[indices] | right[indices]);
             }
             
@@ -14365,7 +14365,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(tensor[indices] | scalar);
             }
             
@@ -14376,7 +14376,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(tensor[indices] >> value);
             }
             
@@ -14387,7 +14387,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(left[indices] - right[indices]);
             }
             
@@ -14398,7 +14398,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(tensor[indices] - scalar);
             }
             
@@ -14413,7 +14413,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)+tensor[indices];
             }
             
@@ -14424,7 +14424,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(left[indices] ^ right[indices]);
             }
             
@@ -14435,7 +14435,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < result.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 result[indices] = (ushort)(tensor[indices] ^ scalar);
             }
             
@@ -14469,7 +14469,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(left.Buffer[op1Index] + right.Buffer[op2Index]);
 
@@ -14500,7 +14500,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(tensor.Buffer[op1Index] + scalar);
 
@@ -14535,7 +14535,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(left.Buffer[op1Index] & right.Buffer[op2Index]);
 
@@ -14566,7 +14566,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(tensor.Buffer[op1Index] & scalar);
 
@@ -14595,9 +14595,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begingin is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -14607,13 +14607,13 @@ namespace System.Numerics
             {
                 ushort sum = (ushort)0;
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
@@ -14660,7 +14660,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(left.Buffer[op1Index] / right.Buffer[op2Index]);
 
@@ -14691,7 +14691,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(tensor.Buffer[op1Index] / scalar);
 
@@ -14726,7 +14726,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
 
@@ -14761,7 +14761,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] > right.Buffer[op2Index];
 
@@ -14796,7 +14796,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] >= right.Buffer[op2Index];
 
@@ -14835,7 +14835,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(tensor.Buffer[op1Index] << value);
 
@@ -14870,7 +14870,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] < right.Buffer[op2Index];
 
@@ -14905,7 +14905,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] <= right.Buffer[op2Index];
 
@@ -14940,7 +14940,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(left.Buffer[op1Index] % right.Buffer[op2Index]);
 
@@ -14971,7 +14971,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(tensor.Buffer[op1Index] % scalar);
 
@@ -15006,7 +15006,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(left.Buffer[op1Index] * right.Buffer[op2Index]);
 
@@ -15037,7 +15037,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(tensor.Buffer[op1Index] * scalar);
 
@@ -15072,7 +15072,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
 
@@ -15107,7 +15107,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(left.Buffer[op1Index] | right.Buffer[op2Index]);
 
@@ -15138,7 +15138,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(tensor.Buffer[op1Index] | scalar);
 
@@ -15169,7 +15169,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(tensor.Buffer[op1Index] >> value);
 
@@ -15204,7 +15204,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(left.Buffer[op1Index] - right.Buffer[op2Index]);
 
@@ -15235,7 +15235,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(tensor.Buffer[op1Index] - scalar);
 
@@ -15270,7 +15270,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)+tensor.Buffer[op1Index];
 
@@ -15305,7 +15305,7 @@ namespace System.Numerics
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(left.Buffer[op1Index] ^ right.Buffer[op2Index]);
 
@@ -15336,7 +15336,7 @@ namespace System.Numerics
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     result.Buffer[resultIndex] = (ushort)(tensor.Buffer[op1Index] ^ scalar);
 

--- a/src/System.Numerics.Tensors/System/Numerics/TensorArithmetic.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/TensorArithmetic.cs
@@ -10,6 +10,7 @@ namespace System.Numerics
     internal interface ITensorArithmetic<T>
     {
         T One { get; }
+        T Zero { get; }
         void Add(Tensor<T> left, Tensor<T> right, Tensor<T> result);
         void Add(Tensor<T> tensor, T scalar, Tensor<T> result);
         void And(Tensor<T> left, Tensor<T> right, Tensor<T> result);
@@ -109,6 +110,7 @@ namespace System.Numerics
     internal class BoolArithmetic : ITensorArithmetic<bool>
     {
         public bool One => true;
+        public bool Zero => false;
 
         public void Add(Tensor<bool> left, Tensor<bool> right, Tensor<bool> result)
         {
@@ -121,68 +123,24 @@ namespace System.Numerics
         public void And(Tensor<bool> left, Tensor<bool> right, Tensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
             {
-                for(int i = 0; i < result.Length; i++)
-                {
-                    result.Buffer[i] = (bool)(left.Buffer[i] & right.Buffer[i]);
-                }
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (bool)(left[indices] & right[indices]);
             }
-            else
-            {
-                int rowMajorIndex = 0;
-                int colMajorIndex = 0;
-                
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
-                                      right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
-                                         right.strides;
-                for(;rowMajorIndex < result.Length; rowMajorIndex++)
-                {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
-                    
-                    result.Buffer[resultIndex] = (bool)(left.Buffer[op1Index] & right.Buffer[op2Index]);
-
-                }
-            }
+            
         }
         public void And(Tensor<bool> tensor, bool scalar, Tensor<bool> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
             {
-                for(int i = 0; i < result.Length; i++)
-                {
-                    result.Buffer[i] = (bool)(tensor.Buffer[i] & scalar);
-                }
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (bool)(tensor[indices] & scalar);
             }
-            else
-            {
-                int rowMajorIndex = 0;
-                int colMajorIndex = 0;
-                
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         tensor.strides;
-                for(;rowMajorIndex < result.Length; rowMajorIndex++)
-                {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
-                    
-                    result.Buffer[resultIndex] = (bool)(tensor.Buffer[op1Index] & scalar);
-
-                }
-            }
+            
         }
         public void Contract(Tensor<bool> left, Tensor<bool> right, int[] leftAxes, int[] rightAxes, Tensor<bool> result)
         {
@@ -203,37 +161,13 @@ namespace System.Numerics
         public void Equals(Tensor<bool> left, Tensor<bool> right, Tensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
             {
-                for(int i = 0; i < result.Length; i++)
-                {
-                    result.Buffer[i] = left.Buffer[i] == right.Buffer[i];
-                }
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] == right[indices];
             }
-            else
-            {
-                int rowMajorIndex = 0;
-                int colMajorIndex = 0;
-                
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
-                                      right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
-                                         right.strides;
-                for(;rowMajorIndex < result.Length; rowMajorIndex++)
-                {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
-                    
-                    result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
-
-                }
-            }
+            
         }
         public void GreaterThan(Tensor<bool> left, Tensor<bool> right, Tensor<bool> result)
         {
@@ -278,103 +212,35 @@ namespace System.Numerics
         public void NotEquals(Tensor<bool> left, Tensor<bool> right, Tensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
             {
-                for(int i = 0; i < result.Length; i++)
-                {
-                    result.Buffer[i] = left.Buffer[i] != right.Buffer[i];
-                }
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] != right[indices];
             }
-            else
-            {
-                int rowMajorIndex = 0;
-                int colMajorIndex = 0;
-                
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
-                                      right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
-                                         right.strides;
-                for(;rowMajorIndex < result.Length; rowMajorIndex++)
-                {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
-                    
-                    result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
-
-                }
-            }
+            
         }
         public void Or(Tensor<bool> left, Tensor<bool> right, Tensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
             {
-                for(int i = 0; i < result.Length; i++)
-                {
-                    result.Buffer[i] = (bool)(left.Buffer[i] | right.Buffer[i]);
-                }
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (bool)(left[indices] | right[indices]);
             }
-            else
-            {
-                int rowMajorIndex = 0;
-                int colMajorIndex = 0;
-                
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
-                                      right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
-                                         right.strides;
-                for(;rowMajorIndex < result.Length; rowMajorIndex++)
-                {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
-                    
-                    result.Buffer[resultIndex] = (bool)(left.Buffer[op1Index] | right.Buffer[op2Index]);
-
-                }
-            }
+            
         }
         public void Or(Tensor<bool> tensor, bool scalar, Tensor<bool> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
             {
-                for(int i = 0; i < result.Length; i++)
-                {
-                    result.Buffer[i] = (bool)(tensor.Buffer[i] | scalar);
-                }
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (bool)(tensor[indices] | scalar);
             }
-            else
-            {
-                int rowMajorIndex = 0;
-                int colMajorIndex = 0;
-                
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         tensor.strides;
-                for(;rowMajorIndex < result.Length; rowMajorIndex++)
-                {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
-                    
-                    result.Buffer[resultIndex] = (bool)(tensor.Buffer[op1Index] | scalar);
-
-                }
-            }
+            
         }
         public void RightShift(Tensor<bool> tensor, int value, Tensor<bool> result)
         {
@@ -399,7 +265,316 @@ namespace System.Numerics
         public void Xor(Tensor<bool> left, Tensor<bool> right, Tensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (bool)(left[indices] ^ right[indices]);
+            }
+            
+        }
+        public void Xor(Tensor<bool> tensor, bool scalar, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (bool)(tensor[indices] ^ scalar);
+            }
+            
+        }
+
+        public void Add(DenseTensor<bool> left, DenseTensor<bool> right, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Add(DenseTensor<bool> tensor, bool scalar, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void And(DenseTensor<bool> left, DenseTensor<bool> right, DenseTensor<bool> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
+            {
+                for(int i = 0; i < result.Length; i++)
+                {
+                    result.Buffer[i] = (bool)(left.Buffer[i] & right.Buffer[i]);
+                }
+            }
+            else
+            {
+                int rowMajorIndex = 0;
+                int colMajorIndex = 0;
+                
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
+                
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
+
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
+                                      right.strides;
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
+                                         right.strides;
+                for(;rowMajorIndex < result.Length; rowMajorIndex++)
+                {
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    
+                    result.Buffer[resultIndex] = (bool)(left.Buffer[op1Index] & right.Buffer[op2Index]);
+
+                }
+            }
+        }
+        public void And(DenseTensor<bool> tensor, bool scalar, DenseTensor<bool> result)
+        {
+
+            if  (result.IsReversedStride == tensor.IsReversedStride)
+            {
+                for(int i = 0; i < result.Length; i++)
+                {
+                    result.Buffer[i] = (bool)(tensor.Buffer[i] & scalar);
+                }
+            }
+            else
+            {
+                int rowMajorIndex = 0;
+                int colMajorIndex = 0;
+                
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
+                
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      tensor.strides;
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         tensor.strides;
+                for(;rowMajorIndex < result.Length; rowMajorIndex++)
+                {
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    
+                    result.Buffer[resultIndex] = (bool)(tensor.Buffer[op1Index] & scalar);
+
+                }
+            }
+        }
+        public void Contract(DenseTensor<bool> left, DenseTensor<bool> right, int[] leftAxes, int[] rightAxes, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Decrement(DenseTensor<bool> tensor, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Divide(DenseTensor<bool> left, DenseTensor<bool> right, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Divide(DenseTensor<bool> tensor, bool scalar, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Equals(DenseTensor<bool> left, DenseTensor<bool> right, DenseTensor<bool> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
+            {
+                for(int i = 0; i < result.Length; i++)
+                {
+                    result.Buffer[i] = left.Buffer[i] == right.Buffer[i];
+                }
+            }
+            else
+            {
+                int rowMajorIndex = 0;
+                int colMajorIndex = 0;
+                
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
+                
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
+
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
+                                      right.strides;
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
+                                         right.strides;
+                for(;rowMajorIndex < result.Length; rowMajorIndex++)
+                {
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    
+                    result.Buffer[resultIndex] = left.Buffer[op1Index] == right.Buffer[op2Index];
+
+                }
+            }
+        }
+        public void GreaterThan(DenseTensor<bool> left, DenseTensor<bool> right, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void GreaterThanOrEqual(DenseTensor<bool> left, DenseTensor<bool> right, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Increment(DenseTensor<bool> tensor, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void LeftShift(DenseTensor<bool> tensor, int value, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void LessThan(DenseTensor<bool> left, DenseTensor<bool> right, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void LessThanOrEqual(DenseTensor<bool> left, DenseTensor<bool> right, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Modulo(DenseTensor<bool> left, DenseTensor<bool> right, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Modulo(DenseTensor<bool> tensor, bool scalar, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Multiply(DenseTensor<bool> left, DenseTensor<bool> right, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Multiply(DenseTensor<bool> tensor, bool scalar, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void NotEquals(DenseTensor<bool> left, DenseTensor<bool> right, DenseTensor<bool> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
+            {
+                for(int i = 0; i < result.Length; i++)
+                {
+                    result.Buffer[i] = left.Buffer[i] != right.Buffer[i];
+                }
+            }
+            else
+            {
+                int rowMajorIndex = 0;
+                int colMajorIndex = 0;
+                
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
+                
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
+
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
+                                      right.strides;
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
+                                         right.strides;
+                for(;rowMajorIndex < result.Length; rowMajorIndex++)
+                {
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    
+                    result.Buffer[resultIndex] = left.Buffer[op1Index] != right.Buffer[op2Index];
+
+                }
+            }
+        }
+        public void Or(DenseTensor<bool> left, DenseTensor<bool> right, DenseTensor<bool> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
+            {
+                for(int i = 0; i < result.Length; i++)
+                {
+                    result.Buffer[i] = (bool)(left.Buffer[i] | right.Buffer[i]);
+                }
+            }
+            else
+            {
+                int rowMajorIndex = 0;
+                int colMajorIndex = 0;
+                
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
+                
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
+
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
+                                      right.strides;
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
+                                         right.strides;
+                for(;rowMajorIndex < result.Length; rowMajorIndex++)
+                {
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    
+                    result.Buffer[resultIndex] = (bool)(left.Buffer[op1Index] | right.Buffer[op2Index]);
+
+                }
+            }
+        }
+        public void Or(DenseTensor<bool> tensor, bool scalar, DenseTensor<bool> result)
+        {
+
+            if  (result.IsReversedStride == tensor.IsReversedStride)
+            {
+                for(int i = 0; i < result.Length; i++)
+                {
+                    result.Buffer[i] = (bool)(tensor.Buffer[i] | scalar);
+                }
+            }
+            else
+            {
+                int rowMajorIndex = 0;
+                int colMajorIndex = 0;
+                
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
+                
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      tensor.strides;
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         tensor.strides;
+                for(;rowMajorIndex < result.Length; rowMajorIndex++)
+                {
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    
+                    result.Buffer[resultIndex] = (bool)(tensor.Buffer[op1Index] | scalar);
+
+                }
+            }
+        }
+        public void RightShift(DenseTensor<bool> tensor, int value, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Subtract(DenseTensor<bool> left, DenseTensor<bool> right, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Subtract(DenseTensor<bool> tensor, bool scalar, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void UnaryMinus(DenseTensor<bool> tensor, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void UnaryPlus(DenseTensor<bool> tensor, DenseTensor<bool> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Xor(DenseTensor<bool> left, DenseTensor<bool> right, DenseTensor<bool> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -411,16 +586,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -431,10 +606,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<bool> tensor, bool scalar, Tensor<bool> result)
+        public void Xor(DenseTensor<bool> tensor, bool scalar, DenseTensor<bool> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -446,12 +621,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -466,11 +641,382 @@ namespace System.Numerics
     internal class ByteArithmetic : ITensorArithmetic<byte>
     {
         public byte One => 1;
+        public byte Zero => 0;
 
         public void Add(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(left[indices] + right[indices]);
+            }
+            
+        }
+        public void Add(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(tensor[indices] + scalar);
+            }
+            
+        }
+        public void And(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(left[indices] & right[indices]);
+            }
+            
+        }
+        public void And(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(tensor[indices] & scalar);
+            }
+            
+        }
+        public void Contract(Tensor<byte> left, Tensor<byte> right, int[] leftAxes, int[] rightAxes, Tensor<byte> result)
+        {
+            var leftIndices = new int[left.Rank];
+            var rightIndices = new int[right.Rank];
+            var resultIndices = new int[result.Rank];
+
+            var summingDimensions = new int[leftAxes.Length];
+            for(int i = 0; i < leftAxes.Length; i++)
+            {
+                summingDimensions[i] = left.dimensions[leftAxes[i]];
+            }
+
+            var summingStrides = ArrayUtilities.GetStrides(summingDimensions);
+            int summingLength = (int)ArrayUtilities.GetProduct(summingDimensions);
+
+            var resultStrides = result.strides;
+
+            // translates from result index to left non-summing dimensions' index portion
+            // since left non-summing dimensions are given precedence in result, the end is zero-padded
+            int[] leftNonSummingStrides = new int[result.Rank];
+
+            // translates from summing index to left summing dimensions' index portion
+            int[] leftSummingStrides = new int[leftAxes.Length];
+            ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
+
+            // translates from result index to right non-summing dimensions' index portion
+            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
+            int[] rightNonSummingStrides = new int[result.Rank];
+            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+
+            // translates from summing index to right summing dimensions' index portion
+            int[] rightSummingStrides = new int[rightAxes.Length];
+            ArrayUtilities.SplitStrides(right.strides, rightAxes, rightNonSummingStrides, rightNonSummingStridesOffset, rightSummingStrides, 0);
+
+            for (int resultIndex = 0; resultIndex < result.Length; resultIndex++)
+            {
+                byte sum = (byte)0;
+                
+                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+
+                for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
+                {
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+
+                    int leftIndex = leftIndexNonSumming + leftIndexSumming;
+                    int rightIndex = rightIndexNonSumming + rightIndexSumming;
+
+                    // todo, make this more efficient
+                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+
+                    sum += (byte)(left[leftIndices] * right[rightIndices]);
+                }
+                
+                result[resultIndices] = sum;
+            }
+        }
+        public void Decrement(Tensor<byte> tensor, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]--;
+            }
+            
+        }
+        public void Divide(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(left[indices] / right[indices]);
+            }
+            
+        }
+        public void Divide(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(tensor[indices] / scalar);
+            }
+            
+        }
+        public void Equals(Tensor<byte> left, Tensor<byte> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] == right[indices];
+            }
+            
+        }
+        public void GreaterThan(Tensor<byte> left, Tensor<byte> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] > right[indices];
+            }
+            
+        }
+        public void GreaterThanOrEqual(Tensor<byte> left, Tensor<byte> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] >= right[indices];
+            }
+            
+        }
+        public void Increment(Tensor<byte> tensor, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]++;
+            }
+            
+        }
+        public void LeftShift(Tensor<byte> tensor, int value, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(tensor[indices] << value);
+            }
+            
+        }
+        public void LessThan(Tensor<byte> left, Tensor<byte> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] < right[indices];
+            }
+            
+        }
+        public void LessThanOrEqual(Tensor<byte> left, Tensor<byte> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] <= right[indices];
+            }
+            
+        }
+        public void Modulo(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(left[indices] % right[indices]);
+            }
+            
+        }
+        public void Modulo(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(tensor[indices] % scalar);
+            }
+            
+        }
+        public void Multiply(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(left[indices] * right[indices]);
+            }
+            
+        }
+        public void Multiply(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(tensor[indices] * scalar);
+            }
+            
+        }
+        public void NotEquals(Tensor<byte> left, Tensor<byte> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] != right[indices];
+            }
+            
+        }
+        public void Or(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(left[indices] | right[indices]);
+            }
+            
+        }
+        public void Or(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(tensor[indices] | scalar);
+            }
+            
+        }
+        public void RightShift(Tensor<byte> tensor, int value, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(tensor[indices] >> value);
+            }
+            
+        }
+        public void Subtract(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(left[indices] - right[indices]);
+            }
+            
+        }
+        public void Subtract(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(tensor[indices] - scalar);
+            }
+            
+        }
+        public void UnaryMinus(Tensor<byte> tensor, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)-tensor[indices];
+            }
+            
+        }
+        public void UnaryPlus(Tensor<byte> tensor, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)+tensor[indices];
+            }
+            
+        }
+        public void Xor(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(left[indices] ^ right[indices]);
+            }
+            
+        }
+        public void Xor(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (byte)(tensor[indices] ^ scalar);
+            }
+            
+        }
+
+        public void Add(DenseTensor<byte> left, DenseTensor<byte> right, DenseTensor<byte> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -482,16 +1028,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -502,10 +1048,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Add(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        public void Add(DenseTensor<byte> tensor, byte scalar, DenseTensor<byte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -517,12 +1063,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -533,10 +1079,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
+        public void And(DenseTensor<byte> left, DenseTensor<byte> right, DenseTensor<byte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -548,16 +1094,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -568,10 +1114,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        public void And(DenseTensor<byte> tensor, byte scalar, DenseTensor<byte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -583,12 +1129,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -599,7 +1145,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Contract(Tensor<byte> left, Tensor<byte> right, int[] leftAxes, int[] rightAxes, Tensor<byte> result)
+        public void Contract(DenseTensor<byte> left, DenseTensor<byte> right, int[] leftAxes, int[] rightAxes, DenseTensor<byte> result)
         {
             var summingDimensions = new int[leftAxes.Length];
             for(int i = 0; i < leftAxes.Length; i++)
@@ -650,7 +1196,7 @@ namespace System.Numerics
                 result.Buffer[resultIndex] = sum;
             }
         }
-        public void Decrement(Tensor<byte> tensor, Tensor<byte> result)
+        public void Decrement(DenseTensor<byte> tensor, DenseTensor<byte> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -658,10 +1204,10 @@ namespace System.Numerics
                 result.Buffer[i]--;
             }
         }
-        public void Divide(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
+        public void Divide(DenseTensor<byte> left, DenseTensor<byte> right, DenseTensor<byte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -673,16 +1219,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -693,10 +1239,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Divide(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        public void Divide(DenseTensor<byte> tensor, byte scalar, DenseTensor<byte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -708,12 +1254,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -724,10 +1270,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Equals(Tensor<byte> left, Tensor<byte> right, Tensor<bool> result)
+        public void Equals(DenseTensor<byte> left, DenseTensor<byte> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -739,16 +1285,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -759,10 +1305,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThan(Tensor<byte> left, Tensor<byte> right, Tensor<bool> result)
+        public void GreaterThan(DenseTensor<byte> left, DenseTensor<byte> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -774,16 +1320,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -794,10 +1340,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThanOrEqual(Tensor<byte> left, Tensor<byte> right, Tensor<bool> result)
+        public void GreaterThanOrEqual(DenseTensor<byte> left, DenseTensor<byte> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -809,16 +1355,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -829,7 +1375,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Increment(Tensor<byte> tensor, Tensor<byte> result)
+        public void Increment(DenseTensor<byte> tensor, DenseTensor<byte> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -837,10 +1383,10 @@ namespace System.Numerics
                 result.Buffer[i]++;
             }
         }
-        public void LeftShift(Tensor<byte> tensor, int value, Tensor<byte> result)
+        public void LeftShift(DenseTensor<byte> tensor, int value, DenseTensor<byte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -852,12 +1398,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -868,10 +1414,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThan(Tensor<byte> left, Tensor<byte> right, Tensor<bool> result)
+        public void LessThan(DenseTensor<byte> left, DenseTensor<byte> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -883,16 +1429,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -903,10 +1449,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThanOrEqual(Tensor<byte> left, Tensor<byte> right, Tensor<bool> result)
+        public void LessThanOrEqual(DenseTensor<byte> left, DenseTensor<byte> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -918,16 +1464,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -938,10 +1484,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
+        public void Modulo(DenseTensor<byte> left, DenseTensor<byte> right, DenseTensor<byte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -953,16 +1499,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -973,10 +1519,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        public void Modulo(DenseTensor<byte> tensor, byte scalar, DenseTensor<byte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -988,12 +1534,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1004,10 +1550,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
+        public void Multiply(DenseTensor<byte> left, DenseTensor<byte> right, DenseTensor<byte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1019,16 +1565,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1039,10 +1585,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        public void Multiply(DenseTensor<byte> tensor, byte scalar, DenseTensor<byte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1054,12 +1600,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1070,10 +1616,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void NotEquals(Tensor<byte> left, Tensor<byte> right, Tensor<bool> result)
+        public void NotEquals(DenseTensor<byte> left, DenseTensor<byte> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1085,16 +1631,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1105,10 +1651,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
+        public void Or(DenseTensor<byte> left, DenseTensor<byte> right, DenseTensor<byte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1120,16 +1666,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1140,10 +1686,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        public void Or(DenseTensor<byte> tensor, byte scalar, DenseTensor<byte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1155,12 +1701,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1171,10 +1717,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void RightShift(Tensor<byte> tensor, int value, Tensor<byte> result)
+        public void RightShift(DenseTensor<byte> tensor, int value, DenseTensor<byte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1186,12 +1732,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1202,10 +1748,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
+        public void Subtract(DenseTensor<byte> left, DenseTensor<byte> right, DenseTensor<byte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1217,16 +1763,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1237,10 +1783,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        public void Subtract(DenseTensor<byte> tensor, byte scalar, DenseTensor<byte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1252,12 +1798,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1268,10 +1814,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryMinus(Tensor<byte> tensor, Tensor<byte> result)
+        public void UnaryMinus(DenseTensor<byte> tensor, DenseTensor<byte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1283,12 +1829,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1299,10 +1845,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryPlus(Tensor<byte> tensor, Tensor<byte> result)
+        public void UnaryPlus(DenseTensor<byte> tensor, DenseTensor<byte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1314,12 +1860,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1330,10 +1876,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<byte> left, Tensor<byte> right, Tensor<byte> result)
+        public void Xor(DenseTensor<byte> left, DenseTensor<byte> right, DenseTensor<byte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1345,16 +1891,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1365,10 +1911,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<byte> tensor, byte scalar, Tensor<byte> result)
+        public void Xor(DenseTensor<byte> tensor, byte scalar, DenseTensor<byte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1380,12 +1926,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1400,11 +1946,382 @@ namespace System.Numerics
     internal class CharArithmetic : ITensorArithmetic<char>
     {
         public char One => (char)1;
+        public char Zero => (char)0;
 
         public void Add(Tensor<char> left, Tensor<char> right, Tensor<char> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(left[indices] + right[indices]);
+            }
+            
+        }
+        public void Add(Tensor<char> tensor, char scalar, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(tensor[indices] + scalar);
+            }
+            
+        }
+        public void And(Tensor<char> left, Tensor<char> right, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(left[indices] & right[indices]);
+            }
+            
+        }
+        public void And(Tensor<char> tensor, char scalar, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(tensor[indices] & scalar);
+            }
+            
+        }
+        public void Contract(Tensor<char> left, Tensor<char> right, int[] leftAxes, int[] rightAxes, Tensor<char> result)
+        {
+            var leftIndices = new int[left.Rank];
+            var rightIndices = new int[right.Rank];
+            var resultIndices = new int[result.Rank];
+
+            var summingDimensions = new int[leftAxes.Length];
+            for(int i = 0; i < leftAxes.Length; i++)
+            {
+                summingDimensions[i] = left.dimensions[leftAxes[i]];
+            }
+
+            var summingStrides = ArrayUtilities.GetStrides(summingDimensions);
+            int summingLength = (int)ArrayUtilities.GetProduct(summingDimensions);
+
+            var resultStrides = result.strides;
+
+            // translates from result index to left non-summing dimensions' index portion
+            // since left non-summing dimensions are given precedence in result, the end is zero-padded
+            int[] leftNonSummingStrides = new int[result.Rank];
+
+            // translates from summing index to left summing dimensions' index portion
+            int[] leftSummingStrides = new int[leftAxes.Length];
+            ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
+
+            // translates from result index to right non-summing dimensions' index portion
+            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
+            int[] rightNonSummingStrides = new int[result.Rank];
+            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+
+            // translates from summing index to right summing dimensions' index portion
+            int[] rightSummingStrides = new int[rightAxes.Length];
+            ArrayUtilities.SplitStrides(right.strides, rightAxes, rightNonSummingStrides, rightNonSummingStridesOffset, rightSummingStrides, 0);
+
+            for (int resultIndex = 0; resultIndex < result.Length; resultIndex++)
+            {
+                char sum = (char)0;
+                
+                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+
+                for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
+                {
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+
+                    int leftIndex = leftIndexNonSumming + leftIndexSumming;
+                    int rightIndex = rightIndexNonSumming + rightIndexSumming;
+
+                    // todo, make this more efficient
+                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+
+                    sum += (char)(left[leftIndices] * right[rightIndices]);
+                }
+                
+                result[resultIndices] = sum;
+            }
+        }
+        public void Decrement(Tensor<char> tensor, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]--;
+            }
+            
+        }
+        public void Divide(Tensor<char> left, Tensor<char> right, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(left[indices] / right[indices]);
+            }
+            
+        }
+        public void Divide(Tensor<char> tensor, char scalar, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(tensor[indices] / scalar);
+            }
+            
+        }
+        public void Equals(Tensor<char> left, Tensor<char> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] == right[indices];
+            }
+            
+        }
+        public void GreaterThan(Tensor<char> left, Tensor<char> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] > right[indices];
+            }
+            
+        }
+        public void GreaterThanOrEqual(Tensor<char> left, Tensor<char> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] >= right[indices];
+            }
+            
+        }
+        public void Increment(Tensor<char> tensor, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]++;
+            }
+            
+        }
+        public void LeftShift(Tensor<char> tensor, int value, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(tensor[indices] << value);
+            }
+            
+        }
+        public void LessThan(Tensor<char> left, Tensor<char> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] < right[indices];
+            }
+            
+        }
+        public void LessThanOrEqual(Tensor<char> left, Tensor<char> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] <= right[indices];
+            }
+            
+        }
+        public void Modulo(Tensor<char> left, Tensor<char> right, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(left[indices] % right[indices]);
+            }
+            
+        }
+        public void Modulo(Tensor<char> tensor, char scalar, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(tensor[indices] % scalar);
+            }
+            
+        }
+        public void Multiply(Tensor<char> left, Tensor<char> right, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(left[indices] * right[indices]);
+            }
+            
+        }
+        public void Multiply(Tensor<char> tensor, char scalar, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(tensor[indices] * scalar);
+            }
+            
+        }
+        public void NotEquals(Tensor<char> left, Tensor<char> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] != right[indices];
+            }
+            
+        }
+        public void Or(Tensor<char> left, Tensor<char> right, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(left[indices] | right[indices]);
+            }
+            
+        }
+        public void Or(Tensor<char> tensor, char scalar, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(tensor[indices] | scalar);
+            }
+            
+        }
+        public void RightShift(Tensor<char> tensor, int value, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(tensor[indices] >> value);
+            }
+            
+        }
+        public void Subtract(Tensor<char> left, Tensor<char> right, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(left[indices] - right[indices]);
+            }
+            
+        }
+        public void Subtract(Tensor<char> tensor, char scalar, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(tensor[indices] - scalar);
+            }
+            
+        }
+        public void UnaryMinus(Tensor<char> tensor, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)-tensor[indices];
+            }
+            
+        }
+        public void UnaryPlus(Tensor<char> tensor, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)+tensor[indices];
+            }
+            
+        }
+        public void Xor(Tensor<char> left, Tensor<char> right, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(left[indices] ^ right[indices]);
+            }
+            
+        }
+        public void Xor(Tensor<char> tensor, char scalar, Tensor<char> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (char)(tensor[indices] ^ scalar);
+            }
+            
+        }
+
+        public void Add(DenseTensor<char> left, DenseTensor<char> right, DenseTensor<char> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1416,16 +2333,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1436,10 +2353,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Add(Tensor<char> tensor, char scalar, Tensor<char> result)
+        public void Add(DenseTensor<char> tensor, char scalar, DenseTensor<char> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1451,12 +2368,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1467,10 +2384,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<char> left, Tensor<char> right, Tensor<char> result)
+        public void And(DenseTensor<char> left, DenseTensor<char> right, DenseTensor<char> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1482,16 +2399,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1502,10 +2419,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<char> tensor, char scalar, Tensor<char> result)
+        public void And(DenseTensor<char> tensor, char scalar, DenseTensor<char> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1517,12 +2434,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1533,7 +2450,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Contract(Tensor<char> left, Tensor<char> right, int[] leftAxes, int[] rightAxes, Tensor<char> result)
+        public void Contract(DenseTensor<char> left, DenseTensor<char> right, int[] leftAxes, int[] rightAxes, DenseTensor<char> result)
         {
             var summingDimensions = new int[leftAxes.Length];
             for(int i = 0; i < leftAxes.Length; i++)
@@ -1584,7 +2501,7 @@ namespace System.Numerics
                 result.Buffer[resultIndex] = sum;
             }
         }
-        public void Decrement(Tensor<char> tensor, Tensor<char> result)
+        public void Decrement(DenseTensor<char> tensor, DenseTensor<char> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -1592,10 +2509,10 @@ namespace System.Numerics
                 result.Buffer[i]--;
             }
         }
-        public void Divide(Tensor<char> left, Tensor<char> right, Tensor<char> result)
+        public void Divide(DenseTensor<char> left, DenseTensor<char> right, DenseTensor<char> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1607,16 +2524,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1627,10 +2544,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Divide(Tensor<char> tensor, char scalar, Tensor<char> result)
+        public void Divide(DenseTensor<char> tensor, char scalar, DenseTensor<char> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1642,12 +2559,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1658,10 +2575,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Equals(Tensor<char> left, Tensor<char> right, Tensor<bool> result)
+        public void Equals(DenseTensor<char> left, DenseTensor<char> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1673,16 +2590,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1693,10 +2610,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThan(Tensor<char> left, Tensor<char> right, Tensor<bool> result)
+        public void GreaterThan(DenseTensor<char> left, DenseTensor<char> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1708,16 +2625,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1728,10 +2645,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThanOrEqual(Tensor<char> left, Tensor<char> right, Tensor<bool> result)
+        public void GreaterThanOrEqual(DenseTensor<char> left, DenseTensor<char> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1743,16 +2660,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1763,7 +2680,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Increment(Tensor<char> tensor, Tensor<char> result)
+        public void Increment(DenseTensor<char> tensor, DenseTensor<char> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -1771,10 +2688,10 @@ namespace System.Numerics
                 result.Buffer[i]++;
             }
         }
-        public void LeftShift(Tensor<char> tensor, int value, Tensor<char> result)
+        public void LeftShift(DenseTensor<char> tensor, int value, DenseTensor<char> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1786,12 +2703,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1802,10 +2719,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThan(Tensor<char> left, Tensor<char> right, Tensor<bool> result)
+        public void LessThan(DenseTensor<char> left, DenseTensor<char> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1817,16 +2734,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1837,10 +2754,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThanOrEqual(Tensor<char> left, Tensor<char> right, Tensor<bool> result)
+        public void LessThanOrEqual(DenseTensor<char> left, DenseTensor<char> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1852,16 +2769,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1872,10 +2789,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<char> left, Tensor<char> right, Tensor<char> result)
+        public void Modulo(DenseTensor<char> left, DenseTensor<char> right, DenseTensor<char> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1887,16 +2804,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1907,10 +2824,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<char> tensor, char scalar, Tensor<char> result)
+        public void Modulo(DenseTensor<char> tensor, char scalar, DenseTensor<char> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1922,12 +2839,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1938,10 +2855,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<char> left, Tensor<char> right, Tensor<char> result)
+        public void Multiply(DenseTensor<char> left, DenseTensor<char> right, DenseTensor<char> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1953,16 +2870,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -1973,10 +2890,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<char> tensor, char scalar, Tensor<char> result)
+        public void Multiply(DenseTensor<char> tensor, char scalar, DenseTensor<char> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -1988,12 +2905,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2004,10 +2921,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void NotEquals(Tensor<char> left, Tensor<char> right, Tensor<bool> result)
+        public void NotEquals(DenseTensor<char> left, DenseTensor<char> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2019,16 +2936,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2039,10 +2956,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<char> left, Tensor<char> right, Tensor<char> result)
+        public void Or(DenseTensor<char> left, DenseTensor<char> right, DenseTensor<char> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2054,16 +2971,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2074,10 +2991,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<char> tensor, char scalar, Tensor<char> result)
+        public void Or(DenseTensor<char> tensor, char scalar, DenseTensor<char> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2089,12 +3006,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2105,10 +3022,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void RightShift(Tensor<char> tensor, int value, Tensor<char> result)
+        public void RightShift(DenseTensor<char> tensor, int value, DenseTensor<char> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2120,12 +3037,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2136,10 +3053,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<char> left, Tensor<char> right, Tensor<char> result)
+        public void Subtract(DenseTensor<char> left, DenseTensor<char> right, DenseTensor<char> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2151,16 +3068,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2171,10 +3088,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<char> tensor, char scalar, Tensor<char> result)
+        public void Subtract(DenseTensor<char> tensor, char scalar, DenseTensor<char> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2186,12 +3103,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2202,10 +3119,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryMinus(Tensor<char> tensor, Tensor<char> result)
+        public void UnaryMinus(DenseTensor<char> tensor, DenseTensor<char> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2217,12 +3134,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2233,10 +3150,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryPlus(Tensor<char> tensor, Tensor<char> result)
+        public void UnaryPlus(DenseTensor<char> tensor, DenseTensor<char> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2248,12 +3165,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2264,10 +3181,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<char> left, Tensor<char> right, Tensor<char> result)
+        public void Xor(DenseTensor<char> left, DenseTensor<char> right, DenseTensor<char> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2279,16 +3196,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2299,10 +3216,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<char> tensor, char scalar, Tensor<char> result)
+        public void Xor(DenseTensor<char> tensor, char scalar, DenseTensor<char> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2314,12 +3231,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2334,11 +3251,326 @@ namespace System.Numerics
     internal class DecimalArithmetic : ITensorArithmetic<decimal>
     {
         public decimal One => 1;
+        public decimal Zero => 0;
 
         public void Add(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (decimal)(left[indices] + right[indices]);
+            }
+            
+        }
+        public void Add(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (decimal)(tensor[indices] + scalar);
+            }
+            
+        }
+        public void And(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void And(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Contract(Tensor<decimal> left, Tensor<decimal> right, int[] leftAxes, int[] rightAxes, Tensor<decimal> result)
+        {
+            var leftIndices = new int[left.Rank];
+            var rightIndices = new int[right.Rank];
+            var resultIndices = new int[result.Rank];
+
+            var summingDimensions = new int[leftAxes.Length];
+            for(int i = 0; i < leftAxes.Length; i++)
+            {
+                summingDimensions[i] = left.dimensions[leftAxes[i]];
+            }
+
+            var summingStrides = ArrayUtilities.GetStrides(summingDimensions);
+            int summingLength = (int)ArrayUtilities.GetProduct(summingDimensions);
+
+            var resultStrides = result.strides;
+
+            // translates from result index to left non-summing dimensions' index portion
+            // since left non-summing dimensions are given precedence in result, the end is zero-padded
+            int[] leftNonSummingStrides = new int[result.Rank];
+
+            // translates from summing index to left summing dimensions' index portion
+            int[] leftSummingStrides = new int[leftAxes.Length];
+            ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
+
+            // translates from result index to right non-summing dimensions' index portion
+            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
+            int[] rightNonSummingStrides = new int[result.Rank];
+            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+
+            // translates from summing index to right summing dimensions' index portion
+            int[] rightSummingStrides = new int[rightAxes.Length];
+            ArrayUtilities.SplitStrides(right.strides, rightAxes, rightNonSummingStrides, rightNonSummingStridesOffset, rightSummingStrides, 0);
+
+            for (int resultIndex = 0; resultIndex < result.Length; resultIndex++)
+            {
+                decimal sum = (decimal)0;
+                
+                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+
+                for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
+                {
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+
+                    int leftIndex = leftIndexNonSumming + leftIndexSumming;
+                    int rightIndex = rightIndexNonSumming + rightIndexSumming;
+
+                    // todo, make this more efficient
+                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+
+                    sum += (decimal)(left[leftIndices] * right[rightIndices]);
+                }
+                
+                result[resultIndices] = sum;
+            }
+        }
+        public void Decrement(Tensor<decimal> tensor, Tensor<decimal> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]--;
+            }
+            
+        }
+        public void Divide(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (decimal)(left[indices] / right[indices]);
+            }
+            
+        }
+        public void Divide(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (decimal)(tensor[indices] / scalar);
+            }
+            
+        }
+        public void Equals(Tensor<decimal> left, Tensor<decimal> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] == right[indices];
+            }
+            
+        }
+        public void GreaterThan(Tensor<decimal> left, Tensor<decimal> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] > right[indices];
+            }
+            
+        }
+        public void GreaterThanOrEqual(Tensor<decimal> left, Tensor<decimal> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] >= right[indices];
+            }
+            
+        }
+        public void Increment(Tensor<decimal> tensor, Tensor<decimal> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]++;
+            }
+            
+        }
+        public void LeftShift(Tensor<decimal> tensor, int value, Tensor<decimal> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void LessThan(Tensor<decimal> left, Tensor<decimal> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] < right[indices];
+            }
+            
+        }
+        public void LessThanOrEqual(Tensor<decimal> left, Tensor<decimal> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] <= right[indices];
+            }
+            
+        }
+        public void Modulo(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (decimal)(left[indices] % right[indices]);
+            }
+            
+        }
+        public void Modulo(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (decimal)(tensor[indices] % scalar);
+            }
+            
+        }
+        public void Multiply(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (decimal)(left[indices] * right[indices]);
+            }
+            
+        }
+        public void Multiply(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (decimal)(tensor[indices] * scalar);
+            }
+            
+        }
+        public void NotEquals(Tensor<decimal> left, Tensor<decimal> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] != right[indices];
+            }
+            
+        }
+        public void Or(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Or(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void RightShift(Tensor<decimal> tensor, int value, Tensor<decimal> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Subtract(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (decimal)(left[indices] - right[indices]);
+            }
+            
+        }
+        public void Subtract(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (decimal)(tensor[indices] - scalar);
+            }
+            
+        }
+        public void UnaryMinus(Tensor<decimal> tensor, Tensor<decimal> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (decimal)-tensor[indices];
+            }
+            
+        }
+        public void UnaryPlus(Tensor<decimal> tensor, Tensor<decimal> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (decimal)+tensor[indices];
+            }
+            
+        }
+        public void Xor(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Xor(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Add(DenseTensor<decimal> left, DenseTensor<decimal> right, DenseTensor<decimal> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2350,16 +3582,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2370,10 +3602,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Add(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        public void Add(DenseTensor<decimal> tensor, decimal scalar, DenseTensor<decimal> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2385,12 +3617,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2401,15 +3633,15 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
+        public void And(DenseTensor<decimal> left, DenseTensor<decimal> right, DenseTensor<decimal> result)
         {
             throw new NotSupportedException();
         }
-        public void And(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        public void And(DenseTensor<decimal> tensor, decimal scalar, DenseTensor<decimal> result)
         {
             throw new NotSupportedException();
         }
-        public void Contract(Tensor<decimal> left, Tensor<decimal> right, int[] leftAxes, int[] rightAxes, Tensor<decimal> result)
+        public void Contract(DenseTensor<decimal> left, DenseTensor<decimal> right, int[] leftAxes, int[] rightAxes, DenseTensor<decimal> result)
         {
             var summingDimensions = new int[leftAxes.Length];
             for(int i = 0; i < leftAxes.Length; i++)
@@ -2460,7 +3692,7 @@ namespace System.Numerics
                 result.Buffer[resultIndex] = sum;
             }
         }
-        public void Decrement(Tensor<decimal> tensor, Tensor<decimal> result)
+        public void Decrement(DenseTensor<decimal> tensor, DenseTensor<decimal> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -2468,10 +3700,10 @@ namespace System.Numerics
                 result.Buffer[i]--;
             }
         }
-        public void Divide(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
+        public void Divide(DenseTensor<decimal> left, DenseTensor<decimal> right, DenseTensor<decimal> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2483,16 +3715,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2503,10 +3735,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Divide(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        public void Divide(DenseTensor<decimal> tensor, decimal scalar, DenseTensor<decimal> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2518,12 +3750,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2534,10 +3766,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Equals(Tensor<decimal> left, Tensor<decimal> right, Tensor<bool> result)
+        public void Equals(DenseTensor<decimal> left, DenseTensor<decimal> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2549,16 +3781,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2569,10 +3801,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThan(Tensor<decimal> left, Tensor<decimal> right, Tensor<bool> result)
+        public void GreaterThan(DenseTensor<decimal> left, DenseTensor<decimal> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2584,16 +3816,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2604,10 +3836,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThanOrEqual(Tensor<decimal> left, Tensor<decimal> right, Tensor<bool> result)
+        public void GreaterThanOrEqual(DenseTensor<decimal> left, DenseTensor<decimal> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2619,16 +3851,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2639,7 +3871,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Increment(Tensor<decimal> tensor, Tensor<decimal> result)
+        public void Increment(DenseTensor<decimal> tensor, DenseTensor<decimal> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -2647,14 +3879,14 @@ namespace System.Numerics
                 result.Buffer[i]++;
             }
         }
-        public void LeftShift(Tensor<decimal> tensor, int value, Tensor<decimal> result)
+        public void LeftShift(DenseTensor<decimal> tensor, int value, DenseTensor<decimal> result)
         {
             throw new NotSupportedException();
         }
-        public void LessThan(Tensor<decimal> left, Tensor<decimal> right, Tensor<bool> result)
+        public void LessThan(DenseTensor<decimal> left, DenseTensor<decimal> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2666,16 +3898,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2686,10 +3918,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThanOrEqual(Tensor<decimal> left, Tensor<decimal> right, Tensor<bool> result)
+        public void LessThanOrEqual(DenseTensor<decimal> left, DenseTensor<decimal> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2701,16 +3933,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2721,10 +3953,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
+        public void Modulo(DenseTensor<decimal> left, DenseTensor<decimal> right, DenseTensor<decimal> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2736,16 +3968,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2756,10 +3988,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        public void Modulo(DenseTensor<decimal> tensor, decimal scalar, DenseTensor<decimal> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2771,12 +4003,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2787,10 +4019,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
+        public void Multiply(DenseTensor<decimal> left, DenseTensor<decimal> right, DenseTensor<decimal> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2802,16 +4034,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2822,10 +4054,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        public void Multiply(DenseTensor<decimal> tensor, decimal scalar, DenseTensor<decimal> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2837,12 +4069,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2853,10 +4085,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void NotEquals(Tensor<decimal> left, Tensor<decimal> right, Tensor<bool> result)
+        public void NotEquals(DenseTensor<decimal> left, DenseTensor<decimal> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2868,16 +4100,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2888,22 +4120,22 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
+        public void Or(DenseTensor<decimal> left, DenseTensor<decimal> right, DenseTensor<decimal> result)
         {
             throw new NotSupportedException();
         }
-        public void Or(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        public void Or(DenseTensor<decimal> tensor, decimal scalar, DenseTensor<decimal> result)
         {
             throw new NotSupportedException();
         }
-        public void RightShift(Tensor<decimal> tensor, int value, Tensor<decimal> result)
+        public void RightShift(DenseTensor<decimal> tensor, int value, DenseTensor<decimal> result)
         {
             throw new NotSupportedException();
         }
-        public void Subtract(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
+        public void Subtract(DenseTensor<decimal> left, DenseTensor<decimal> right, DenseTensor<decimal> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2915,16 +4147,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2935,10 +4167,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        public void Subtract(DenseTensor<decimal> tensor, decimal scalar, DenseTensor<decimal> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2950,12 +4182,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2966,10 +4198,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryMinus(Tensor<decimal> tensor, Tensor<decimal> result)
+        public void UnaryMinus(DenseTensor<decimal> tensor, DenseTensor<decimal> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -2981,12 +4213,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -2997,10 +4229,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryPlus(Tensor<decimal> tensor, Tensor<decimal> result)
+        public void UnaryPlus(DenseTensor<decimal> tensor, DenseTensor<decimal> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3012,12 +4244,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3028,11 +4260,11 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<decimal> left, Tensor<decimal> right, Tensor<decimal> result)
+        public void Xor(DenseTensor<decimal> left, DenseTensor<decimal> right, DenseTensor<decimal> result)
         {
             throw new NotSupportedException();
         }
-        public void Xor(Tensor<decimal> tensor, decimal scalar, Tensor<decimal> result)
+        public void Xor(DenseTensor<decimal> tensor, decimal scalar, DenseTensor<decimal> result)
         {
             throw new NotSupportedException();
         }
@@ -3040,11 +4272,326 @@ namespace System.Numerics
     internal class DoubleArithmetic : ITensorArithmetic<double>
     {
         public double One => 1.0;
+        public double Zero => 0;
 
         public void Add(Tensor<double> left, Tensor<double> right, Tensor<double> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (double)(left[indices] + right[indices]);
+            }
+            
+        }
+        public void Add(Tensor<double> tensor, double scalar, Tensor<double> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (double)(tensor[indices] + scalar);
+            }
+            
+        }
+        public void And(Tensor<double> left, Tensor<double> right, Tensor<double> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void And(Tensor<double> tensor, double scalar, Tensor<double> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Contract(Tensor<double> left, Tensor<double> right, int[] leftAxes, int[] rightAxes, Tensor<double> result)
+        {
+            var leftIndices = new int[left.Rank];
+            var rightIndices = new int[right.Rank];
+            var resultIndices = new int[result.Rank];
+
+            var summingDimensions = new int[leftAxes.Length];
+            for(int i = 0; i < leftAxes.Length; i++)
+            {
+                summingDimensions[i] = left.dimensions[leftAxes[i]];
+            }
+
+            var summingStrides = ArrayUtilities.GetStrides(summingDimensions);
+            int summingLength = (int)ArrayUtilities.GetProduct(summingDimensions);
+
+            var resultStrides = result.strides;
+
+            // translates from result index to left non-summing dimensions' index portion
+            // since left non-summing dimensions are given precedence in result, the end is zero-padded
+            int[] leftNonSummingStrides = new int[result.Rank];
+
+            // translates from summing index to left summing dimensions' index portion
+            int[] leftSummingStrides = new int[leftAxes.Length];
+            ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
+
+            // translates from result index to right non-summing dimensions' index portion
+            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
+            int[] rightNonSummingStrides = new int[result.Rank];
+            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+
+            // translates from summing index to right summing dimensions' index portion
+            int[] rightSummingStrides = new int[rightAxes.Length];
+            ArrayUtilities.SplitStrides(right.strides, rightAxes, rightNonSummingStrides, rightNonSummingStridesOffset, rightSummingStrides, 0);
+
+            for (int resultIndex = 0; resultIndex < result.Length; resultIndex++)
+            {
+                double sum = (double)0;
+                
+                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+
+                for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
+                {
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+
+                    int leftIndex = leftIndexNonSumming + leftIndexSumming;
+                    int rightIndex = rightIndexNonSumming + rightIndexSumming;
+
+                    // todo, make this more efficient
+                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+
+                    sum += (double)(left[leftIndices] * right[rightIndices]);
+                }
+                
+                result[resultIndices] = sum;
+            }
+        }
+        public void Decrement(Tensor<double> tensor, Tensor<double> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]--;
+            }
+            
+        }
+        public void Divide(Tensor<double> left, Tensor<double> right, Tensor<double> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (double)(left[indices] / right[indices]);
+            }
+            
+        }
+        public void Divide(Tensor<double> tensor, double scalar, Tensor<double> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (double)(tensor[indices] / scalar);
+            }
+            
+        }
+        public void Equals(Tensor<double> left, Tensor<double> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] == right[indices];
+            }
+            
+        }
+        public void GreaterThan(Tensor<double> left, Tensor<double> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] > right[indices];
+            }
+            
+        }
+        public void GreaterThanOrEqual(Tensor<double> left, Tensor<double> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] >= right[indices];
+            }
+            
+        }
+        public void Increment(Tensor<double> tensor, Tensor<double> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]++;
+            }
+            
+        }
+        public void LeftShift(Tensor<double> tensor, int value, Tensor<double> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void LessThan(Tensor<double> left, Tensor<double> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] < right[indices];
+            }
+            
+        }
+        public void LessThanOrEqual(Tensor<double> left, Tensor<double> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] <= right[indices];
+            }
+            
+        }
+        public void Modulo(Tensor<double> left, Tensor<double> right, Tensor<double> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (double)(left[indices] % right[indices]);
+            }
+            
+        }
+        public void Modulo(Tensor<double> tensor, double scalar, Tensor<double> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (double)(tensor[indices] % scalar);
+            }
+            
+        }
+        public void Multiply(Tensor<double> left, Tensor<double> right, Tensor<double> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (double)(left[indices] * right[indices]);
+            }
+            
+        }
+        public void Multiply(Tensor<double> tensor, double scalar, Tensor<double> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (double)(tensor[indices] * scalar);
+            }
+            
+        }
+        public void NotEquals(Tensor<double> left, Tensor<double> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] != right[indices];
+            }
+            
+        }
+        public void Or(Tensor<double> left, Tensor<double> right, Tensor<double> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Or(Tensor<double> tensor, double scalar, Tensor<double> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void RightShift(Tensor<double> tensor, int value, Tensor<double> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Subtract(Tensor<double> left, Tensor<double> right, Tensor<double> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (double)(left[indices] - right[indices]);
+            }
+            
+        }
+        public void Subtract(Tensor<double> tensor, double scalar, Tensor<double> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (double)(tensor[indices] - scalar);
+            }
+            
+        }
+        public void UnaryMinus(Tensor<double> tensor, Tensor<double> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (double)-tensor[indices];
+            }
+            
+        }
+        public void UnaryPlus(Tensor<double> tensor, Tensor<double> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (double)+tensor[indices];
+            }
+            
+        }
+        public void Xor(Tensor<double> left, Tensor<double> right, Tensor<double> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Xor(Tensor<double> tensor, double scalar, Tensor<double> result)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Add(DenseTensor<double> left, DenseTensor<double> right, DenseTensor<double> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3056,16 +4603,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3076,10 +4623,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Add(Tensor<double> tensor, double scalar, Tensor<double> result)
+        public void Add(DenseTensor<double> tensor, double scalar, DenseTensor<double> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3091,12 +4638,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3107,15 +4654,15 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<double> left, Tensor<double> right, Tensor<double> result)
+        public void And(DenseTensor<double> left, DenseTensor<double> right, DenseTensor<double> result)
         {
             throw new NotSupportedException();
         }
-        public void And(Tensor<double> tensor, double scalar, Tensor<double> result)
+        public void And(DenseTensor<double> tensor, double scalar, DenseTensor<double> result)
         {
             throw new NotSupportedException();
         }
-        public void Contract(Tensor<double> left, Tensor<double> right, int[] leftAxes, int[] rightAxes, Tensor<double> result)
+        public void Contract(DenseTensor<double> left, DenseTensor<double> right, int[] leftAxes, int[] rightAxes, DenseTensor<double> result)
         {
             var summingDimensions = new int[leftAxes.Length];
             for(int i = 0; i < leftAxes.Length; i++)
@@ -3166,7 +4713,7 @@ namespace System.Numerics
                 result.Buffer[resultIndex] = sum;
             }
         }
-        public void Decrement(Tensor<double> tensor, Tensor<double> result)
+        public void Decrement(DenseTensor<double> tensor, DenseTensor<double> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -3174,10 +4721,10 @@ namespace System.Numerics
                 result.Buffer[i]--;
             }
         }
-        public void Divide(Tensor<double> left, Tensor<double> right, Tensor<double> result)
+        public void Divide(DenseTensor<double> left, DenseTensor<double> right, DenseTensor<double> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3189,16 +4736,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3209,10 +4756,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Divide(Tensor<double> tensor, double scalar, Tensor<double> result)
+        public void Divide(DenseTensor<double> tensor, double scalar, DenseTensor<double> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3224,12 +4771,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3240,10 +4787,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Equals(Tensor<double> left, Tensor<double> right, Tensor<bool> result)
+        public void Equals(DenseTensor<double> left, DenseTensor<double> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3255,16 +4802,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3275,10 +4822,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThan(Tensor<double> left, Tensor<double> right, Tensor<bool> result)
+        public void GreaterThan(DenseTensor<double> left, DenseTensor<double> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3290,16 +4837,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3310,10 +4857,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThanOrEqual(Tensor<double> left, Tensor<double> right, Tensor<bool> result)
+        public void GreaterThanOrEqual(DenseTensor<double> left, DenseTensor<double> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3325,16 +4872,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3345,7 +4892,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Increment(Tensor<double> tensor, Tensor<double> result)
+        public void Increment(DenseTensor<double> tensor, DenseTensor<double> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -3353,14 +4900,14 @@ namespace System.Numerics
                 result.Buffer[i]++;
             }
         }
-        public void LeftShift(Tensor<double> tensor, int value, Tensor<double> result)
+        public void LeftShift(DenseTensor<double> tensor, int value, DenseTensor<double> result)
         {
             throw new NotSupportedException();
         }
-        public void LessThan(Tensor<double> left, Tensor<double> right, Tensor<bool> result)
+        public void LessThan(DenseTensor<double> left, DenseTensor<double> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3372,16 +4919,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3392,10 +4939,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThanOrEqual(Tensor<double> left, Tensor<double> right, Tensor<bool> result)
+        public void LessThanOrEqual(DenseTensor<double> left, DenseTensor<double> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3407,16 +4954,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3427,10 +4974,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<double> left, Tensor<double> right, Tensor<double> result)
+        public void Modulo(DenseTensor<double> left, DenseTensor<double> right, DenseTensor<double> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3442,16 +4989,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3462,10 +5009,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<double> tensor, double scalar, Tensor<double> result)
+        public void Modulo(DenseTensor<double> tensor, double scalar, DenseTensor<double> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3477,12 +5024,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3493,10 +5040,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<double> left, Tensor<double> right, Tensor<double> result)
+        public void Multiply(DenseTensor<double> left, DenseTensor<double> right, DenseTensor<double> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3508,16 +5055,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3528,10 +5075,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<double> tensor, double scalar, Tensor<double> result)
+        public void Multiply(DenseTensor<double> tensor, double scalar, DenseTensor<double> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3543,12 +5090,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3559,10 +5106,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void NotEquals(Tensor<double> left, Tensor<double> right, Tensor<bool> result)
+        public void NotEquals(DenseTensor<double> left, DenseTensor<double> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3574,16 +5121,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3594,22 +5141,22 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<double> left, Tensor<double> right, Tensor<double> result)
+        public void Or(DenseTensor<double> left, DenseTensor<double> right, DenseTensor<double> result)
         {
             throw new NotSupportedException();
         }
-        public void Or(Tensor<double> tensor, double scalar, Tensor<double> result)
+        public void Or(DenseTensor<double> tensor, double scalar, DenseTensor<double> result)
         {
             throw new NotSupportedException();
         }
-        public void RightShift(Tensor<double> tensor, int value, Tensor<double> result)
+        public void RightShift(DenseTensor<double> tensor, int value, DenseTensor<double> result)
         {
             throw new NotSupportedException();
         }
-        public void Subtract(Tensor<double> left, Tensor<double> right, Tensor<double> result)
+        public void Subtract(DenseTensor<double> left, DenseTensor<double> right, DenseTensor<double> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3621,16 +5168,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3641,10 +5188,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<double> tensor, double scalar, Tensor<double> result)
+        public void Subtract(DenseTensor<double> tensor, double scalar, DenseTensor<double> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3656,12 +5203,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3672,10 +5219,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryMinus(Tensor<double> tensor, Tensor<double> result)
+        public void UnaryMinus(DenseTensor<double> tensor, DenseTensor<double> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3687,12 +5234,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3703,10 +5250,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryPlus(Tensor<double> tensor, Tensor<double> result)
+        public void UnaryPlus(DenseTensor<double> tensor, DenseTensor<double> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3718,12 +5265,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3734,11 +5281,11 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<double> left, Tensor<double> right, Tensor<double> result)
+        public void Xor(DenseTensor<double> left, DenseTensor<double> right, DenseTensor<double> result)
         {
             throw new NotSupportedException();
         }
-        public void Xor(Tensor<double> tensor, double scalar, Tensor<double> result)
+        public void Xor(DenseTensor<double> tensor, double scalar, DenseTensor<double> result)
         {
             throw new NotSupportedException();
         }
@@ -3746,11 +5293,326 @@ namespace System.Numerics
     internal class FloatArithmetic : ITensorArithmetic<float>
     {
         public float One => 1.0f;
+        public float Zero => 0;
 
         public void Add(Tensor<float> left, Tensor<float> right, Tensor<float> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (float)(left[indices] + right[indices]);
+            }
+            
+        }
+        public void Add(Tensor<float> tensor, float scalar, Tensor<float> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (float)(tensor[indices] + scalar);
+            }
+            
+        }
+        public void And(Tensor<float> left, Tensor<float> right, Tensor<float> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void And(Tensor<float> tensor, float scalar, Tensor<float> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Contract(Tensor<float> left, Tensor<float> right, int[] leftAxes, int[] rightAxes, Tensor<float> result)
+        {
+            var leftIndices = new int[left.Rank];
+            var rightIndices = new int[right.Rank];
+            var resultIndices = new int[result.Rank];
+
+            var summingDimensions = new int[leftAxes.Length];
+            for(int i = 0; i < leftAxes.Length; i++)
+            {
+                summingDimensions[i] = left.dimensions[leftAxes[i]];
+            }
+
+            var summingStrides = ArrayUtilities.GetStrides(summingDimensions);
+            int summingLength = (int)ArrayUtilities.GetProduct(summingDimensions);
+
+            var resultStrides = result.strides;
+
+            // translates from result index to left non-summing dimensions' index portion
+            // since left non-summing dimensions are given precedence in result, the end is zero-padded
+            int[] leftNonSummingStrides = new int[result.Rank];
+
+            // translates from summing index to left summing dimensions' index portion
+            int[] leftSummingStrides = new int[leftAxes.Length];
+            ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
+
+            // translates from result index to right non-summing dimensions' index portion
+            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
+            int[] rightNonSummingStrides = new int[result.Rank];
+            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+
+            // translates from summing index to right summing dimensions' index portion
+            int[] rightSummingStrides = new int[rightAxes.Length];
+            ArrayUtilities.SplitStrides(right.strides, rightAxes, rightNonSummingStrides, rightNonSummingStridesOffset, rightSummingStrides, 0);
+
+            for (int resultIndex = 0; resultIndex < result.Length; resultIndex++)
+            {
+                float sum = (float)0;
+                
+                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+
+                for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
+                {
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+
+                    int leftIndex = leftIndexNonSumming + leftIndexSumming;
+                    int rightIndex = rightIndexNonSumming + rightIndexSumming;
+
+                    // todo, make this more efficient
+                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+
+                    sum += (float)(left[leftIndices] * right[rightIndices]);
+                }
+                
+                result[resultIndices] = sum;
+            }
+        }
+        public void Decrement(Tensor<float> tensor, Tensor<float> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]--;
+            }
+            
+        }
+        public void Divide(Tensor<float> left, Tensor<float> right, Tensor<float> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (float)(left[indices] / right[indices]);
+            }
+            
+        }
+        public void Divide(Tensor<float> tensor, float scalar, Tensor<float> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (float)(tensor[indices] / scalar);
+            }
+            
+        }
+        public void Equals(Tensor<float> left, Tensor<float> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] == right[indices];
+            }
+            
+        }
+        public void GreaterThan(Tensor<float> left, Tensor<float> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] > right[indices];
+            }
+            
+        }
+        public void GreaterThanOrEqual(Tensor<float> left, Tensor<float> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] >= right[indices];
+            }
+            
+        }
+        public void Increment(Tensor<float> tensor, Tensor<float> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]++;
+            }
+            
+        }
+        public void LeftShift(Tensor<float> tensor, int value, Tensor<float> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void LessThan(Tensor<float> left, Tensor<float> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] < right[indices];
+            }
+            
+        }
+        public void LessThanOrEqual(Tensor<float> left, Tensor<float> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] <= right[indices];
+            }
+            
+        }
+        public void Modulo(Tensor<float> left, Tensor<float> right, Tensor<float> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (float)(left[indices] % right[indices]);
+            }
+            
+        }
+        public void Modulo(Tensor<float> tensor, float scalar, Tensor<float> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (float)(tensor[indices] % scalar);
+            }
+            
+        }
+        public void Multiply(Tensor<float> left, Tensor<float> right, Tensor<float> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (float)(left[indices] * right[indices]);
+            }
+            
+        }
+        public void Multiply(Tensor<float> tensor, float scalar, Tensor<float> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (float)(tensor[indices] * scalar);
+            }
+            
+        }
+        public void NotEquals(Tensor<float> left, Tensor<float> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] != right[indices];
+            }
+            
+        }
+        public void Or(Tensor<float> left, Tensor<float> right, Tensor<float> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Or(Tensor<float> tensor, float scalar, Tensor<float> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void RightShift(Tensor<float> tensor, int value, Tensor<float> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Subtract(Tensor<float> left, Tensor<float> right, Tensor<float> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (float)(left[indices] - right[indices]);
+            }
+            
+        }
+        public void Subtract(Tensor<float> tensor, float scalar, Tensor<float> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (float)(tensor[indices] - scalar);
+            }
+            
+        }
+        public void UnaryMinus(Tensor<float> tensor, Tensor<float> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (float)-tensor[indices];
+            }
+            
+        }
+        public void UnaryPlus(Tensor<float> tensor, Tensor<float> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (float)+tensor[indices];
+            }
+            
+        }
+        public void Xor(Tensor<float> left, Tensor<float> right, Tensor<float> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void Xor(Tensor<float> tensor, float scalar, Tensor<float> result)
+        {
+            throw new NotSupportedException();
+        }
+
+        public void Add(DenseTensor<float> left, DenseTensor<float> right, DenseTensor<float> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3762,16 +5624,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3782,10 +5644,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Add(Tensor<float> tensor, float scalar, Tensor<float> result)
+        public void Add(DenseTensor<float> tensor, float scalar, DenseTensor<float> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3797,12 +5659,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3813,15 +5675,15 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<float> left, Tensor<float> right, Tensor<float> result)
+        public void And(DenseTensor<float> left, DenseTensor<float> right, DenseTensor<float> result)
         {
             throw new NotSupportedException();
         }
-        public void And(Tensor<float> tensor, float scalar, Tensor<float> result)
+        public void And(DenseTensor<float> tensor, float scalar, DenseTensor<float> result)
         {
             throw new NotSupportedException();
         }
-        public void Contract(Tensor<float> left, Tensor<float> right, int[] leftAxes, int[] rightAxes, Tensor<float> result)
+        public void Contract(DenseTensor<float> left, DenseTensor<float> right, int[] leftAxes, int[] rightAxes, DenseTensor<float> result)
         {
             var summingDimensions = new int[leftAxes.Length];
             for(int i = 0; i < leftAxes.Length; i++)
@@ -3872,7 +5734,7 @@ namespace System.Numerics
                 result.Buffer[resultIndex] = sum;
             }
         }
-        public void Decrement(Tensor<float> tensor, Tensor<float> result)
+        public void Decrement(DenseTensor<float> tensor, DenseTensor<float> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -3880,10 +5742,10 @@ namespace System.Numerics
                 result.Buffer[i]--;
             }
         }
-        public void Divide(Tensor<float> left, Tensor<float> right, Tensor<float> result)
+        public void Divide(DenseTensor<float> left, DenseTensor<float> right, DenseTensor<float> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3895,16 +5757,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3915,10 +5777,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Divide(Tensor<float> tensor, float scalar, Tensor<float> result)
+        public void Divide(DenseTensor<float> tensor, float scalar, DenseTensor<float> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3930,12 +5792,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3946,10 +5808,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Equals(Tensor<float> left, Tensor<float> right, Tensor<bool> result)
+        public void Equals(DenseTensor<float> left, DenseTensor<float> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3961,16 +5823,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -3981,10 +5843,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThan(Tensor<float> left, Tensor<float> right, Tensor<bool> result)
+        public void GreaterThan(DenseTensor<float> left, DenseTensor<float> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -3996,16 +5858,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4016,10 +5878,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThanOrEqual(Tensor<float> left, Tensor<float> right, Tensor<bool> result)
+        public void GreaterThanOrEqual(DenseTensor<float> left, DenseTensor<float> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4031,16 +5893,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4051,7 +5913,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Increment(Tensor<float> tensor, Tensor<float> result)
+        public void Increment(DenseTensor<float> tensor, DenseTensor<float> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -4059,14 +5921,14 @@ namespace System.Numerics
                 result.Buffer[i]++;
             }
         }
-        public void LeftShift(Tensor<float> tensor, int value, Tensor<float> result)
+        public void LeftShift(DenseTensor<float> tensor, int value, DenseTensor<float> result)
         {
             throw new NotSupportedException();
         }
-        public void LessThan(Tensor<float> left, Tensor<float> right, Tensor<bool> result)
+        public void LessThan(DenseTensor<float> left, DenseTensor<float> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4078,16 +5940,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4098,10 +5960,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThanOrEqual(Tensor<float> left, Tensor<float> right, Tensor<bool> result)
+        public void LessThanOrEqual(DenseTensor<float> left, DenseTensor<float> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4113,16 +5975,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4133,10 +5995,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<float> left, Tensor<float> right, Tensor<float> result)
+        public void Modulo(DenseTensor<float> left, DenseTensor<float> right, DenseTensor<float> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4148,16 +6010,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4168,10 +6030,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<float> tensor, float scalar, Tensor<float> result)
+        public void Modulo(DenseTensor<float> tensor, float scalar, DenseTensor<float> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4183,12 +6045,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4199,10 +6061,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<float> left, Tensor<float> right, Tensor<float> result)
+        public void Multiply(DenseTensor<float> left, DenseTensor<float> right, DenseTensor<float> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4214,16 +6076,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4234,10 +6096,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<float> tensor, float scalar, Tensor<float> result)
+        public void Multiply(DenseTensor<float> tensor, float scalar, DenseTensor<float> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4249,12 +6111,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4265,10 +6127,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void NotEquals(Tensor<float> left, Tensor<float> right, Tensor<bool> result)
+        public void NotEquals(DenseTensor<float> left, DenseTensor<float> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4280,16 +6142,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4300,22 +6162,22 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<float> left, Tensor<float> right, Tensor<float> result)
+        public void Or(DenseTensor<float> left, DenseTensor<float> right, DenseTensor<float> result)
         {
             throw new NotSupportedException();
         }
-        public void Or(Tensor<float> tensor, float scalar, Tensor<float> result)
+        public void Or(DenseTensor<float> tensor, float scalar, DenseTensor<float> result)
         {
             throw new NotSupportedException();
         }
-        public void RightShift(Tensor<float> tensor, int value, Tensor<float> result)
+        public void RightShift(DenseTensor<float> tensor, int value, DenseTensor<float> result)
         {
             throw new NotSupportedException();
         }
-        public void Subtract(Tensor<float> left, Tensor<float> right, Tensor<float> result)
+        public void Subtract(DenseTensor<float> left, DenseTensor<float> right, DenseTensor<float> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4327,16 +6189,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4347,10 +6209,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<float> tensor, float scalar, Tensor<float> result)
+        public void Subtract(DenseTensor<float> tensor, float scalar, DenseTensor<float> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4362,12 +6224,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4378,10 +6240,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryMinus(Tensor<float> tensor, Tensor<float> result)
+        public void UnaryMinus(DenseTensor<float> tensor, DenseTensor<float> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4393,12 +6255,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4409,10 +6271,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryPlus(Tensor<float> tensor, Tensor<float> result)
+        public void UnaryPlus(DenseTensor<float> tensor, DenseTensor<float> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4424,12 +6286,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4440,11 +6302,11 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<float> left, Tensor<float> right, Tensor<float> result)
+        public void Xor(DenseTensor<float> left, DenseTensor<float> right, DenseTensor<float> result)
         {
             throw new NotSupportedException();
         }
-        public void Xor(Tensor<float> tensor, float scalar, Tensor<float> result)
+        public void Xor(DenseTensor<float> tensor, float scalar, DenseTensor<float> result)
         {
             throw new NotSupportedException();
         }
@@ -4452,11 +6314,382 @@ namespace System.Numerics
     internal class IntArithmetic : ITensorArithmetic<int>
     {
         public int One => 1;
+        public int Zero => 0;
 
         public void Add(Tensor<int> left, Tensor<int> right, Tensor<int> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(left[indices] + right[indices]);
+            }
+            
+        }
+        public void Add(Tensor<int> tensor, int scalar, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(tensor[indices] + scalar);
+            }
+            
+        }
+        public void And(Tensor<int> left, Tensor<int> right, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(left[indices] & right[indices]);
+            }
+            
+        }
+        public void And(Tensor<int> tensor, int scalar, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(tensor[indices] & scalar);
+            }
+            
+        }
+        public void Contract(Tensor<int> left, Tensor<int> right, int[] leftAxes, int[] rightAxes, Tensor<int> result)
+        {
+            var leftIndices = new int[left.Rank];
+            var rightIndices = new int[right.Rank];
+            var resultIndices = new int[result.Rank];
+
+            var summingDimensions = new int[leftAxes.Length];
+            for(int i = 0; i < leftAxes.Length; i++)
+            {
+                summingDimensions[i] = left.dimensions[leftAxes[i]];
+            }
+
+            var summingStrides = ArrayUtilities.GetStrides(summingDimensions);
+            int summingLength = (int)ArrayUtilities.GetProduct(summingDimensions);
+
+            var resultStrides = result.strides;
+
+            // translates from result index to left non-summing dimensions' index portion
+            // since left non-summing dimensions are given precedence in result, the end is zero-padded
+            int[] leftNonSummingStrides = new int[result.Rank];
+
+            // translates from summing index to left summing dimensions' index portion
+            int[] leftSummingStrides = new int[leftAxes.Length];
+            ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
+
+            // translates from result index to right non-summing dimensions' index portion
+            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
+            int[] rightNonSummingStrides = new int[result.Rank];
+            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+
+            // translates from summing index to right summing dimensions' index portion
+            int[] rightSummingStrides = new int[rightAxes.Length];
+            ArrayUtilities.SplitStrides(right.strides, rightAxes, rightNonSummingStrides, rightNonSummingStridesOffset, rightSummingStrides, 0);
+
+            for (int resultIndex = 0; resultIndex < result.Length; resultIndex++)
+            {
+                int sum = (int)0;
+                
+                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+
+                for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
+                {
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+
+                    int leftIndex = leftIndexNonSumming + leftIndexSumming;
+                    int rightIndex = rightIndexNonSumming + rightIndexSumming;
+
+                    // todo, make this more efficient
+                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+
+                    sum += (int)(left[leftIndices] * right[rightIndices]);
+                }
+                
+                result[resultIndices] = sum;
+            }
+        }
+        public void Decrement(Tensor<int> tensor, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]--;
+            }
+            
+        }
+        public void Divide(Tensor<int> left, Tensor<int> right, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(left[indices] / right[indices]);
+            }
+            
+        }
+        public void Divide(Tensor<int> tensor, int scalar, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(tensor[indices] / scalar);
+            }
+            
+        }
+        public void Equals(Tensor<int> left, Tensor<int> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] == right[indices];
+            }
+            
+        }
+        public void GreaterThan(Tensor<int> left, Tensor<int> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] > right[indices];
+            }
+            
+        }
+        public void GreaterThanOrEqual(Tensor<int> left, Tensor<int> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] >= right[indices];
+            }
+            
+        }
+        public void Increment(Tensor<int> tensor, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]++;
+            }
+            
+        }
+        public void LeftShift(Tensor<int> tensor, int value, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(tensor[indices] << value);
+            }
+            
+        }
+        public void LessThan(Tensor<int> left, Tensor<int> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] < right[indices];
+            }
+            
+        }
+        public void LessThanOrEqual(Tensor<int> left, Tensor<int> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] <= right[indices];
+            }
+            
+        }
+        public void Modulo(Tensor<int> left, Tensor<int> right, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(left[indices] % right[indices]);
+            }
+            
+        }
+        public void Modulo(Tensor<int> tensor, int scalar, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(tensor[indices] % scalar);
+            }
+            
+        }
+        public void Multiply(Tensor<int> left, Tensor<int> right, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(left[indices] * right[indices]);
+            }
+            
+        }
+        public void Multiply(Tensor<int> tensor, int scalar, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(tensor[indices] * scalar);
+            }
+            
+        }
+        public void NotEquals(Tensor<int> left, Tensor<int> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] != right[indices];
+            }
+            
+        }
+        public void Or(Tensor<int> left, Tensor<int> right, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(left[indices] | right[indices]);
+            }
+            
+        }
+        public void Or(Tensor<int> tensor, int scalar, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(tensor[indices] | scalar);
+            }
+            
+        }
+        public void RightShift(Tensor<int> tensor, int value, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(tensor[indices] >> value);
+            }
+            
+        }
+        public void Subtract(Tensor<int> left, Tensor<int> right, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(left[indices] - right[indices]);
+            }
+            
+        }
+        public void Subtract(Tensor<int> tensor, int scalar, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(tensor[indices] - scalar);
+            }
+            
+        }
+        public void UnaryMinus(Tensor<int> tensor, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)-tensor[indices];
+            }
+            
+        }
+        public void UnaryPlus(Tensor<int> tensor, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)+tensor[indices];
+            }
+            
+        }
+        public void Xor(Tensor<int> left, Tensor<int> right, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(left[indices] ^ right[indices]);
+            }
+            
+        }
+        public void Xor(Tensor<int> tensor, int scalar, Tensor<int> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (int)(tensor[indices] ^ scalar);
+            }
+            
+        }
+
+        public void Add(DenseTensor<int> left, DenseTensor<int> right, DenseTensor<int> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4468,16 +6701,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4488,10 +6721,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Add(Tensor<int> tensor, int scalar, Tensor<int> result)
+        public void Add(DenseTensor<int> tensor, int scalar, DenseTensor<int> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4503,12 +6736,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4519,10 +6752,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<int> left, Tensor<int> right, Tensor<int> result)
+        public void And(DenseTensor<int> left, DenseTensor<int> right, DenseTensor<int> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4534,16 +6767,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4554,10 +6787,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<int> tensor, int scalar, Tensor<int> result)
+        public void And(DenseTensor<int> tensor, int scalar, DenseTensor<int> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4569,12 +6802,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4585,7 +6818,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Contract(Tensor<int> left, Tensor<int> right, int[] leftAxes, int[] rightAxes, Tensor<int> result)
+        public void Contract(DenseTensor<int> left, DenseTensor<int> right, int[] leftAxes, int[] rightAxes, DenseTensor<int> result)
         {
             var summingDimensions = new int[leftAxes.Length];
             for(int i = 0; i < leftAxes.Length; i++)
@@ -4636,7 +6869,7 @@ namespace System.Numerics
                 result.Buffer[resultIndex] = sum;
             }
         }
-        public void Decrement(Tensor<int> tensor, Tensor<int> result)
+        public void Decrement(DenseTensor<int> tensor, DenseTensor<int> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -4644,10 +6877,10 @@ namespace System.Numerics
                 result.Buffer[i]--;
             }
         }
-        public void Divide(Tensor<int> left, Tensor<int> right, Tensor<int> result)
+        public void Divide(DenseTensor<int> left, DenseTensor<int> right, DenseTensor<int> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4659,16 +6892,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4679,10 +6912,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Divide(Tensor<int> tensor, int scalar, Tensor<int> result)
+        public void Divide(DenseTensor<int> tensor, int scalar, DenseTensor<int> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4694,12 +6927,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4710,10 +6943,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Equals(Tensor<int> left, Tensor<int> right, Tensor<bool> result)
+        public void Equals(DenseTensor<int> left, DenseTensor<int> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4725,16 +6958,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4745,10 +6978,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThan(Tensor<int> left, Tensor<int> right, Tensor<bool> result)
+        public void GreaterThan(DenseTensor<int> left, DenseTensor<int> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4760,16 +6993,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4780,10 +7013,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThanOrEqual(Tensor<int> left, Tensor<int> right, Tensor<bool> result)
+        public void GreaterThanOrEqual(DenseTensor<int> left, DenseTensor<int> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4795,16 +7028,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4815,7 +7048,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Increment(Tensor<int> tensor, Tensor<int> result)
+        public void Increment(DenseTensor<int> tensor, DenseTensor<int> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -4823,10 +7056,10 @@ namespace System.Numerics
                 result.Buffer[i]++;
             }
         }
-        public void LeftShift(Tensor<int> tensor, int value, Tensor<int> result)
+        public void LeftShift(DenseTensor<int> tensor, int value, DenseTensor<int> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4838,12 +7071,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4854,10 +7087,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThan(Tensor<int> left, Tensor<int> right, Tensor<bool> result)
+        public void LessThan(DenseTensor<int> left, DenseTensor<int> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4869,16 +7102,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4889,10 +7122,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThanOrEqual(Tensor<int> left, Tensor<int> right, Tensor<bool> result)
+        public void LessThanOrEqual(DenseTensor<int> left, DenseTensor<int> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4904,16 +7137,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4924,10 +7157,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<int> left, Tensor<int> right, Tensor<int> result)
+        public void Modulo(DenseTensor<int> left, DenseTensor<int> right, DenseTensor<int> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4939,16 +7172,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4959,10 +7192,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<int> tensor, int scalar, Tensor<int> result)
+        public void Modulo(DenseTensor<int> tensor, int scalar, DenseTensor<int> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -4974,12 +7207,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -4990,10 +7223,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<int> left, Tensor<int> right, Tensor<int> result)
+        public void Multiply(DenseTensor<int> left, DenseTensor<int> right, DenseTensor<int> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5005,16 +7238,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5025,10 +7258,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<int> tensor, int scalar, Tensor<int> result)
+        public void Multiply(DenseTensor<int> tensor, int scalar, DenseTensor<int> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5040,12 +7273,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5056,10 +7289,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void NotEquals(Tensor<int> left, Tensor<int> right, Tensor<bool> result)
+        public void NotEquals(DenseTensor<int> left, DenseTensor<int> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5071,16 +7304,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5091,10 +7324,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<int> left, Tensor<int> right, Tensor<int> result)
+        public void Or(DenseTensor<int> left, DenseTensor<int> right, DenseTensor<int> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5106,16 +7339,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5126,10 +7359,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<int> tensor, int scalar, Tensor<int> result)
+        public void Or(DenseTensor<int> tensor, int scalar, DenseTensor<int> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5141,12 +7374,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5157,10 +7390,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void RightShift(Tensor<int> tensor, int value, Tensor<int> result)
+        public void RightShift(DenseTensor<int> tensor, int value, DenseTensor<int> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5172,12 +7405,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5188,10 +7421,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<int> left, Tensor<int> right, Tensor<int> result)
+        public void Subtract(DenseTensor<int> left, DenseTensor<int> right, DenseTensor<int> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5203,16 +7436,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5223,10 +7456,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<int> tensor, int scalar, Tensor<int> result)
+        public void Subtract(DenseTensor<int> tensor, int scalar, DenseTensor<int> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5238,12 +7471,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5254,10 +7487,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryMinus(Tensor<int> tensor, Tensor<int> result)
+        public void UnaryMinus(DenseTensor<int> tensor, DenseTensor<int> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5269,12 +7502,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5285,10 +7518,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryPlus(Tensor<int> tensor, Tensor<int> result)
+        public void UnaryPlus(DenseTensor<int> tensor, DenseTensor<int> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5300,12 +7533,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5316,10 +7549,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<int> left, Tensor<int> right, Tensor<int> result)
+        public void Xor(DenseTensor<int> left, DenseTensor<int> right, DenseTensor<int> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5331,16 +7564,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5351,10 +7584,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<int> tensor, int scalar, Tensor<int> result)
+        public void Xor(DenseTensor<int> tensor, int scalar, DenseTensor<int> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5366,12 +7599,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5386,11 +7619,382 @@ namespace System.Numerics
     internal class LongArithmetic : ITensorArithmetic<long>
     {
         public long One => 1;
+        public long Zero => 0;
 
         public void Add(Tensor<long> left, Tensor<long> right, Tensor<long> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(left[indices] + right[indices]);
+            }
+            
+        }
+        public void Add(Tensor<long> tensor, long scalar, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(tensor[indices] + scalar);
+            }
+            
+        }
+        public void And(Tensor<long> left, Tensor<long> right, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(left[indices] & right[indices]);
+            }
+            
+        }
+        public void And(Tensor<long> tensor, long scalar, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(tensor[indices] & scalar);
+            }
+            
+        }
+        public void Contract(Tensor<long> left, Tensor<long> right, int[] leftAxes, int[] rightAxes, Tensor<long> result)
+        {
+            var leftIndices = new int[left.Rank];
+            var rightIndices = new int[right.Rank];
+            var resultIndices = new int[result.Rank];
+
+            var summingDimensions = new int[leftAxes.Length];
+            for(int i = 0; i < leftAxes.Length; i++)
+            {
+                summingDimensions[i] = left.dimensions[leftAxes[i]];
+            }
+
+            var summingStrides = ArrayUtilities.GetStrides(summingDimensions);
+            int summingLength = (int)ArrayUtilities.GetProduct(summingDimensions);
+
+            var resultStrides = result.strides;
+
+            // translates from result index to left non-summing dimensions' index portion
+            // since left non-summing dimensions are given precedence in result, the end is zero-padded
+            int[] leftNonSummingStrides = new int[result.Rank];
+
+            // translates from summing index to left summing dimensions' index portion
+            int[] leftSummingStrides = new int[leftAxes.Length];
+            ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
+
+            // translates from result index to right non-summing dimensions' index portion
+            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
+            int[] rightNonSummingStrides = new int[result.Rank];
+            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+
+            // translates from summing index to right summing dimensions' index portion
+            int[] rightSummingStrides = new int[rightAxes.Length];
+            ArrayUtilities.SplitStrides(right.strides, rightAxes, rightNonSummingStrides, rightNonSummingStridesOffset, rightSummingStrides, 0);
+
+            for (int resultIndex = 0; resultIndex < result.Length; resultIndex++)
+            {
+                long sum = (long)0;
+                
+                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+
+                for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
+                {
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+
+                    int leftIndex = leftIndexNonSumming + leftIndexSumming;
+                    int rightIndex = rightIndexNonSumming + rightIndexSumming;
+
+                    // todo, make this more efficient
+                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+
+                    sum += (long)(left[leftIndices] * right[rightIndices]);
+                }
+                
+                result[resultIndices] = sum;
+            }
+        }
+        public void Decrement(Tensor<long> tensor, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]--;
+            }
+            
+        }
+        public void Divide(Tensor<long> left, Tensor<long> right, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(left[indices] / right[indices]);
+            }
+            
+        }
+        public void Divide(Tensor<long> tensor, long scalar, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(tensor[indices] / scalar);
+            }
+            
+        }
+        public void Equals(Tensor<long> left, Tensor<long> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] == right[indices];
+            }
+            
+        }
+        public void GreaterThan(Tensor<long> left, Tensor<long> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] > right[indices];
+            }
+            
+        }
+        public void GreaterThanOrEqual(Tensor<long> left, Tensor<long> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] >= right[indices];
+            }
+            
+        }
+        public void Increment(Tensor<long> tensor, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]++;
+            }
+            
+        }
+        public void LeftShift(Tensor<long> tensor, int value, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(tensor[indices] << value);
+            }
+            
+        }
+        public void LessThan(Tensor<long> left, Tensor<long> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] < right[indices];
+            }
+            
+        }
+        public void LessThanOrEqual(Tensor<long> left, Tensor<long> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] <= right[indices];
+            }
+            
+        }
+        public void Modulo(Tensor<long> left, Tensor<long> right, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(left[indices] % right[indices]);
+            }
+            
+        }
+        public void Modulo(Tensor<long> tensor, long scalar, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(tensor[indices] % scalar);
+            }
+            
+        }
+        public void Multiply(Tensor<long> left, Tensor<long> right, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(left[indices] * right[indices]);
+            }
+            
+        }
+        public void Multiply(Tensor<long> tensor, long scalar, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(tensor[indices] * scalar);
+            }
+            
+        }
+        public void NotEquals(Tensor<long> left, Tensor<long> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] != right[indices];
+            }
+            
+        }
+        public void Or(Tensor<long> left, Tensor<long> right, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(left[indices] | right[indices]);
+            }
+            
+        }
+        public void Or(Tensor<long> tensor, long scalar, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(tensor[indices] | scalar);
+            }
+            
+        }
+        public void RightShift(Tensor<long> tensor, int value, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(tensor[indices] >> value);
+            }
+            
+        }
+        public void Subtract(Tensor<long> left, Tensor<long> right, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(left[indices] - right[indices]);
+            }
+            
+        }
+        public void Subtract(Tensor<long> tensor, long scalar, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(tensor[indices] - scalar);
+            }
+            
+        }
+        public void UnaryMinus(Tensor<long> tensor, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)-tensor[indices];
+            }
+            
+        }
+        public void UnaryPlus(Tensor<long> tensor, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)+tensor[indices];
+            }
+            
+        }
+        public void Xor(Tensor<long> left, Tensor<long> right, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(left[indices] ^ right[indices]);
+            }
+            
+        }
+        public void Xor(Tensor<long> tensor, long scalar, Tensor<long> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (long)(tensor[indices] ^ scalar);
+            }
+            
+        }
+
+        public void Add(DenseTensor<long> left, DenseTensor<long> right, DenseTensor<long> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5402,16 +8006,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5422,10 +8026,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Add(Tensor<long> tensor, long scalar, Tensor<long> result)
+        public void Add(DenseTensor<long> tensor, long scalar, DenseTensor<long> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5437,12 +8041,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5453,10 +8057,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<long> left, Tensor<long> right, Tensor<long> result)
+        public void And(DenseTensor<long> left, DenseTensor<long> right, DenseTensor<long> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5468,16 +8072,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5488,10 +8092,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<long> tensor, long scalar, Tensor<long> result)
+        public void And(DenseTensor<long> tensor, long scalar, DenseTensor<long> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5503,12 +8107,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5519,7 +8123,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Contract(Tensor<long> left, Tensor<long> right, int[] leftAxes, int[] rightAxes, Tensor<long> result)
+        public void Contract(DenseTensor<long> left, DenseTensor<long> right, int[] leftAxes, int[] rightAxes, DenseTensor<long> result)
         {
             var summingDimensions = new int[leftAxes.Length];
             for(int i = 0; i < leftAxes.Length; i++)
@@ -5570,7 +8174,7 @@ namespace System.Numerics
                 result.Buffer[resultIndex] = sum;
             }
         }
-        public void Decrement(Tensor<long> tensor, Tensor<long> result)
+        public void Decrement(DenseTensor<long> tensor, DenseTensor<long> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -5578,10 +8182,10 @@ namespace System.Numerics
                 result.Buffer[i]--;
             }
         }
-        public void Divide(Tensor<long> left, Tensor<long> right, Tensor<long> result)
+        public void Divide(DenseTensor<long> left, DenseTensor<long> right, DenseTensor<long> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5593,16 +8197,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5613,10 +8217,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Divide(Tensor<long> tensor, long scalar, Tensor<long> result)
+        public void Divide(DenseTensor<long> tensor, long scalar, DenseTensor<long> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5628,12 +8232,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5644,10 +8248,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Equals(Tensor<long> left, Tensor<long> right, Tensor<bool> result)
+        public void Equals(DenseTensor<long> left, DenseTensor<long> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5659,16 +8263,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5679,10 +8283,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThan(Tensor<long> left, Tensor<long> right, Tensor<bool> result)
+        public void GreaterThan(DenseTensor<long> left, DenseTensor<long> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5694,16 +8298,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5714,10 +8318,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThanOrEqual(Tensor<long> left, Tensor<long> right, Tensor<bool> result)
+        public void GreaterThanOrEqual(DenseTensor<long> left, DenseTensor<long> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5729,16 +8333,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5749,7 +8353,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Increment(Tensor<long> tensor, Tensor<long> result)
+        public void Increment(DenseTensor<long> tensor, DenseTensor<long> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -5757,10 +8361,10 @@ namespace System.Numerics
                 result.Buffer[i]++;
             }
         }
-        public void LeftShift(Tensor<long> tensor, int value, Tensor<long> result)
+        public void LeftShift(DenseTensor<long> tensor, int value, DenseTensor<long> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5772,12 +8376,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5788,10 +8392,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThan(Tensor<long> left, Tensor<long> right, Tensor<bool> result)
+        public void LessThan(DenseTensor<long> left, DenseTensor<long> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5803,16 +8407,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5823,10 +8427,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThanOrEqual(Tensor<long> left, Tensor<long> right, Tensor<bool> result)
+        public void LessThanOrEqual(DenseTensor<long> left, DenseTensor<long> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5838,16 +8442,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5858,10 +8462,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<long> left, Tensor<long> right, Tensor<long> result)
+        public void Modulo(DenseTensor<long> left, DenseTensor<long> right, DenseTensor<long> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5873,16 +8477,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5893,10 +8497,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<long> tensor, long scalar, Tensor<long> result)
+        public void Modulo(DenseTensor<long> tensor, long scalar, DenseTensor<long> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5908,12 +8512,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5924,10 +8528,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<long> left, Tensor<long> right, Tensor<long> result)
+        public void Multiply(DenseTensor<long> left, DenseTensor<long> right, DenseTensor<long> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5939,16 +8543,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5959,10 +8563,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<long> tensor, long scalar, Tensor<long> result)
+        public void Multiply(DenseTensor<long> tensor, long scalar, DenseTensor<long> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -5974,12 +8578,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -5990,10 +8594,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void NotEquals(Tensor<long> left, Tensor<long> right, Tensor<bool> result)
+        public void NotEquals(DenseTensor<long> left, DenseTensor<long> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6005,16 +8609,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6025,10 +8629,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<long> left, Tensor<long> right, Tensor<long> result)
+        public void Or(DenseTensor<long> left, DenseTensor<long> right, DenseTensor<long> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6040,16 +8644,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6060,10 +8664,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<long> tensor, long scalar, Tensor<long> result)
+        public void Or(DenseTensor<long> tensor, long scalar, DenseTensor<long> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6075,12 +8679,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6091,10 +8695,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void RightShift(Tensor<long> tensor, int value, Tensor<long> result)
+        public void RightShift(DenseTensor<long> tensor, int value, DenseTensor<long> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6106,12 +8710,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6122,10 +8726,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<long> left, Tensor<long> right, Tensor<long> result)
+        public void Subtract(DenseTensor<long> left, DenseTensor<long> right, DenseTensor<long> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6137,16 +8741,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6157,10 +8761,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<long> tensor, long scalar, Tensor<long> result)
+        public void Subtract(DenseTensor<long> tensor, long scalar, DenseTensor<long> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6172,12 +8776,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6188,10 +8792,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryMinus(Tensor<long> tensor, Tensor<long> result)
+        public void UnaryMinus(DenseTensor<long> tensor, DenseTensor<long> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6203,12 +8807,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6219,10 +8823,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryPlus(Tensor<long> tensor, Tensor<long> result)
+        public void UnaryPlus(DenseTensor<long> tensor, DenseTensor<long> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6234,12 +8838,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6250,10 +8854,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<long> left, Tensor<long> right, Tensor<long> result)
+        public void Xor(DenseTensor<long> left, DenseTensor<long> right, DenseTensor<long> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6265,16 +8869,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6285,10 +8889,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<long> tensor, long scalar, Tensor<long> result)
+        public void Xor(DenseTensor<long> tensor, long scalar, DenseTensor<long> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6300,12 +8904,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6320,11 +8924,382 @@ namespace System.Numerics
     internal class SByteArithmetic : ITensorArithmetic<sbyte>
     {
         public sbyte One => 1;
+        public sbyte Zero => 0;
 
         public void Add(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(left[indices] + right[indices]);
+            }
+            
+        }
+        public void Add(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(tensor[indices] + scalar);
+            }
+            
+        }
+        public void And(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(left[indices] & right[indices]);
+            }
+            
+        }
+        public void And(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(tensor[indices] & scalar);
+            }
+            
+        }
+        public void Contract(Tensor<sbyte> left, Tensor<sbyte> right, int[] leftAxes, int[] rightAxes, Tensor<sbyte> result)
+        {
+            var leftIndices = new int[left.Rank];
+            var rightIndices = new int[right.Rank];
+            var resultIndices = new int[result.Rank];
+
+            var summingDimensions = new int[leftAxes.Length];
+            for(int i = 0; i < leftAxes.Length; i++)
+            {
+                summingDimensions[i] = left.dimensions[leftAxes[i]];
+            }
+
+            var summingStrides = ArrayUtilities.GetStrides(summingDimensions);
+            int summingLength = (int)ArrayUtilities.GetProduct(summingDimensions);
+
+            var resultStrides = result.strides;
+
+            // translates from result index to left non-summing dimensions' index portion
+            // since left non-summing dimensions are given precedence in result, the end is zero-padded
+            int[] leftNonSummingStrides = new int[result.Rank];
+
+            // translates from summing index to left summing dimensions' index portion
+            int[] leftSummingStrides = new int[leftAxes.Length];
+            ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
+
+            // translates from result index to right non-summing dimensions' index portion
+            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
+            int[] rightNonSummingStrides = new int[result.Rank];
+            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+
+            // translates from summing index to right summing dimensions' index portion
+            int[] rightSummingStrides = new int[rightAxes.Length];
+            ArrayUtilities.SplitStrides(right.strides, rightAxes, rightNonSummingStrides, rightNonSummingStridesOffset, rightSummingStrides, 0);
+
+            for (int resultIndex = 0; resultIndex < result.Length; resultIndex++)
+            {
+                sbyte sum = (sbyte)0;
+                
+                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+
+                for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
+                {
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+
+                    int leftIndex = leftIndexNonSumming + leftIndexSumming;
+                    int rightIndex = rightIndexNonSumming + rightIndexSumming;
+
+                    // todo, make this more efficient
+                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+
+                    sum += (sbyte)(left[leftIndices] * right[rightIndices]);
+                }
+                
+                result[resultIndices] = sum;
+            }
+        }
+        public void Decrement(Tensor<sbyte> tensor, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]--;
+            }
+            
+        }
+        public void Divide(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(left[indices] / right[indices]);
+            }
+            
+        }
+        public void Divide(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(tensor[indices] / scalar);
+            }
+            
+        }
+        public void Equals(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] == right[indices];
+            }
+            
+        }
+        public void GreaterThan(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] > right[indices];
+            }
+            
+        }
+        public void GreaterThanOrEqual(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] >= right[indices];
+            }
+            
+        }
+        public void Increment(Tensor<sbyte> tensor, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]++;
+            }
+            
+        }
+        public void LeftShift(Tensor<sbyte> tensor, int value, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(tensor[indices] << value);
+            }
+            
+        }
+        public void LessThan(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] < right[indices];
+            }
+            
+        }
+        public void LessThanOrEqual(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] <= right[indices];
+            }
+            
+        }
+        public void Modulo(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(left[indices] % right[indices]);
+            }
+            
+        }
+        public void Modulo(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(tensor[indices] % scalar);
+            }
+            
+        }
+        public void Multiply(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(left[indices] * right[indices]);
+            }
+            
+        }
+        public void Multiply(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(tensor[indices] * scalar);
+            }
+            
+        }
+        public void NotEquals(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] != right[indices];
+            }
+            
+        }
+        public void Or(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(left[indices] | right[indices]);
+            }
+            
+        }
+        public void Or(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(tensor[indices] | scalar);
+            }
+            
+        }
+        public void RightShift(Tensor<sbyte> tensor, int value, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(tensor[indices] >> value);
+            }
+            
+        }
+        public void Subtract(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(left[indices] - right[indices]);
+            }
+            
+        }
+        public void Subtract(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(tensor[indices] - scalar);
+            }
+            
+        }
+        public void UnaryMinus(Tensor<sbyte> tensor, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)-tensor[indices];
+            }
+            
+        }
+        public void UnaryPlus(Tensor<sbyte> tensor, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)+tensor[indices];
+            }
+            
+        }
+        public void Xor(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(left[indices] ^ right[indices]);
+            }
+            
+        }
+        public void Xor(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (sbyte)(tensor[indices] ^ scalar);
+            }
+            
+        }
+
+        public void Add(DenseTensor<sbyte> left, DenseTensor<sbyte> right, DenseTensor<sbyte> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6336,16 +9311,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6356,10 +9331,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Add(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        public void Add(DenseTensor<sbyte> tensor, sbyte scalar, DenseTensor<sbyte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6371,12 +9346,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6387,10 +9362,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
+        public void And(DenseTensor<sbyte> left, DenseTensor<sbyte> right, DenseTensor<sbyte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6402,16 +9377,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6422,10 +9397,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        public void And(DenseTensor<sbyte> tensor, sbyte scalar, DenseTensor<sbyte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6437,12 +9412,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6453,7 +9428,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Contract(Tensor<sbyte> left, Tensor<sbyte> right, int[] leftAxes, int[] rightAxes, Tensor<sbyte> result)
+        public void Contract(DenseTensor<sbyte> left, DenseTensor<sbyte> right, int[] leftAxes, int[] rightAxes, DenseTensor<sbyte> result)
         {
             var summingDimensions = new int[leftAxes.Length];
             for(int i = 0; i < leftAxes.Length; i++)
@@ -6504,7 +9479,7 @@ namespace System.Numerics
                 result.Buffer[resultIndex] = sum;
             }
         }
-        public void Decrement(Tensor<sbyte> tensor, Tensor<sbyte> result)
+        public void Decrement(DenseTensor<sbyte> tensor, DenseTensor<sbyte> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -6512,10 +9487,10 @@ namespace System.Numerics
                 result.Buffer[i]--;
             }
         }
-        public void Divide(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
+        public void Divide(DenseTensor<sbyte> left, DenseTensor<sbyte> right, DenseTensor<sbyte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6527,16 +9502,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6547,10 +9522,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Divide(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        public void Divide(DenseTensor<sbyte> tensor, sbyte scalar, DenseTensor<sbyte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6562,12 +9537,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6578,10 +9553,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Equals(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<bool> result)
+        public void Equals(DenseTensor<sbyte> left, DenseTensor<sbyte> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6593,16 +9568,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6613,10 +9588,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThan(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<bool> result)
+        public void GreaterThan(DenseTensor<sbyte> left, DenseTensor<sbyte> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6628,16 +9603,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6648,10 +9623,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThanOrEqual(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<bool> result)
+        public void GreaterThanOrEqual(DenseTensor<sbyte> left, DenseTensor<sbyte> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6663,16 +9638,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6683,7 +9658,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Increment(Tensor<sbyte> tensor, Tensor<sbyte> result)
+        public void Increment(DenseTensor<sbyte> tensor, DenseTensor<sbyte> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -6691,10 +9666,10 @@ namespace System.Numerics
                 result.Buffer[i]++;
             }
         }
-        public void LeftShift(Tensor<sbyte> tensor, int value, Tensor<sbyte> result)
+        public void LeftShift(DenseTensor<sbyte> tensor, int value, DenseTensor<sbyte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6706,12 +9681,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6722,10 +9697,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThan(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<bool> result)
+        public void LessThan(DenseTensor<sbyte> left, DenseTensor<sbyte> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6737,16 +9712,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6757,10 +9732,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThanOrEqual(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<bool> result)
+        public void LessThanOrEqual(DenseTensor<sbyte> left, DenseTensor<sbyte> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6772,16 +9747,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6792,10 +9767,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
+        public void Modulo(DenseTensor<sbyte> left, DenseTensor<sbyte> right, DenseTensor<sbyte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6807,16 +9782,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6827,10 +9802,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        public void Modulo(DenseTensor<sbyte> tensor, sbyte scalar, DenseTensor<sbyte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6842,12 +9817,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6858,10 +9833,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
+        public void Multiply(DenseTensor<sbyte> left, DenseTensor<sbyte> right, DenseTensor<sbyte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6873,16 +9848,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6893,10 +9868,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        public void Multiply(DenseTensor<sbyte> tensor, sbyte scalar, DenseTensor<sbyte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6908,12 +9883,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6924,10 +9899,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void NotEquals(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<bool> result)
+        public void NotEquals(DenseTensor<sbyte> left, DenseTensor<sbyte> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6939,16 +9914,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6959,10 +9934,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
+        public void Or(DenseTensor<sbyte> left, DenseTensor<sbyte> right, DenseTensor<sbyte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -6974,16 +9949,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -6994,10 +9969,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        public void Or(DenseTensor<sbyte> tensor, sbyte scalar, DenseTensor<sbyte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7009,12 +9984,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7025,10 +10000,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void RightShift(Tensor<sbyte> tensor, int value, Tensor<sbyte> result)
+        public void RightShift(DenseTensor<sbyte> tensor, int value, DenseTensor<sbyte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7040,12 +10015,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7056,10 +10031,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
+        public void Subtract(DenseTensor<sbyte> left, DenseTensor<sbyte> right, DenseTensor<sbyte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7071,16 +10046,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7091,10 +10066,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        public void Subtract(DenseTensor<sbyte> tensor, sbyte scalar, DenseTensor<sbyte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7106,12 +10081,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7122,10 +10097,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryMinus(Tensor<sbyte> tensor, Tensor<sbyte> result)
+        public void UnaryMinus(DenseTensor<sbyte> tensor, DenseTensor<sbyte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7137,12 +10112,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7153,10 +10128,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryPlus(Tensor<sbyte> tensor, Tensor<sbyte> result)
+        public void UnaryPlus(DenseTensor<sbyte> tensor, DenseTensor<sbyte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7168,12 +10143,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7184,10 +10159,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<sbyte> left, Tensor<sbyte> right, Tensor<sbyte> result)
+        public void Xor(DenseTensor<sbyte> left, DenseTensor<sbyte> right, DenseTensor<sbyte> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7199,16 +10174,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7219,10 +10194,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<sbyte> tensor, sbyte scalar, Tensor<sbyte> result)
+        public void Xor(DenseTensor<sbyte> tensor, sbyte scalar, DenseTensor<sbyte> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7234,12 +10209,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7254,11 +10229,382 @@ namespace System.Numerics
     internal class ShortArithmetic : ITensorArithmetic<short>
     {
         public short One => 1;
+        public short Zero => 0;
 
         public void Add(Tensor<short> left, Tensor<short> right, Tensor<short> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(left[indices] + right[indices]);
+            }
+            
+        }
+        public void Add(Tensor<short> tensor, short scalar, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(tensor[indices] + scalar);
+            }
+            
+        }
+        public void And(Tensor<short> left, Tensor<short> right, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(left[indices] & right[indices]);
+            }
+            
+        }
+        public void And(Tensor<short> tensor, short scalar, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(tensor[indices] & scalar);
+            }
+            
+        }
+        public void Contract(Tensor<short> left, Tensor<short> right, int[] leftAxes, int[] rightAxes, Tensor<short> result)
+        {
+            var leftIndices = new int[left.Rank];
+            var rightIndices = new int[right.Rank];
+            var resultIndices = new int[result.Rank];
+
+            var summingDimensions = new int[leftAxes.Length];
+            for(int i = 0; i < leftAxes.Length; i++)
+            {
+                summingDimensions[i] = left.dimensions[leftAxes[i]];
+            }
+
+            var summingStrides = ArrayUtilities.GetStrides(summingDimensions);
+            int summingLength = (int)ArrayUtilities.GetProduct(summingDimensions);
+
+            var resultStrides = result.strides;
+
+            // translates from result index to left non-summing dimensions' index portion
+            // since left non-summing dimensions are given precedence in result, the end is zero-padded
+            int[] leftNonSummingStrides = new int[result.Rank];
+
+            // translates from summing index to left summing dimensions' index portion
+            int[] leftSummingStrides = new int[leftAxes.Length];
+            ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
+
+            // translates from result index to right non-summing dimensions' index portion
+            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
+            int[] rightNonSummingStrides = new int[result.Rank];
+            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+
+            // translates from summing index to right summing dimensions' index portion
+            int[] rightSummingStrides = new int[rightAxes.Length];
+            ArrayUtilities.SplitStrides(right.strides, rightAxes, rightNonSummingStrides, rightNonSummingStridesOffset, rightSummingStrides, 0);
+
+            for (int resultIndex = 0; resultIndex < result.Length; resultIndex++)
+            {
+                short sum = (short)0;
+                
+                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+
+                for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
+                {
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+
+                    int leftIndex = leftIndexNonSumming + leftIndexSumming;
+                    int rightIndex = rightIndexNonSumming + rightIndexSumming;
+
+                    // todo, make this more efficient
+                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+
+                    sum += (short)(left[leftIndices] * right[rightIndices]);
+                }
+                
+                result[resultIndices] = sum;
+            }
+        }
+        public void Decrement(Tensor<short> tensor, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]--;
+            }
+            
+        }
+        public void Divide(Tensor<short> left, Tensor<short> right, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(left[indices] / right[indices]);
+            }
+            
+        }
+        public void Divide(Tensor<short> tensor, short scalar, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(tensor[indices] / scalar);
+            }
+            
+        }
+        public void Equals(Tensor<short> left, Tensor<short> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] == right[indices];
+            }
+            
+        }
+        public void GreaterThan(Tensor<short> left, Tensor<short> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] > right[indices];
+            }
+            
+        }
+        public void GreaterThanOrEqual(Tensor<short> left, Tensor<short> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] >= right[indices];
+            }
+            
+        }
+        public void Increment(Tensor<short> tensor, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]++;
+            }
+            
+        }
+        public void LeftShift(Tensor<short> tensor, int value, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(tensor[indices] << value);
+            }
+            
+        }
+        public void LessThan(Tensor<short> left, Tensor<short> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] < right[indices];
+            }
+            
+        }
+        public void LessThanOrEqual(Tensor<short> left, Tensor<short> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] <= right[indices];
+            }
+            
+        }
+        public void Modulo(Tensor<short> left, Tensor<short> right, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(left[indices] % right[indices]);
+            }
+            
+        }
+        public void Modulo(Tensor<short> tensor, short scalar, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(tensor[indices] % scalar);
+            }
+            
+        }
+        public void Multiply(Tensor<short> left, Tensor<short> right, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(left[indices] * right[indices]);
+            }
+            
+        }
+        public void Multiply(Tensor<short> tensor, short scalar, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(tensor[indices] * scalar);
+            }
+            
+        }
+        public void NotEquals(Tensor<short> left, Tensor<short> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] != right[indices];
+            }
+            
+        }
+        public void Or(Tensor<short> left, Tensor<short> right, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(left[indices] | right[indices]);
+            }
+            
+        }
+        public void Or(Tensor<short> tensor, short scalar, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(tensor[indices] | scalar);
+            }
+            
+        }
+        public void RightShift(Tensor<short> tensor, int value, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(tensor[indices] >> value);
+            }
+            
+        }
+        public void Subtract(Tensor<short> left, Tensor<short> right, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(left[indices] - right[indices]);
+            }
+            
+        }
+        public void Subtract(Tensor<short> tensor, short scalar, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(tensor[indices] - scalar);
+            }
+            
+        }
+        public void UnaryMinus(Tensor<short> tensor, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)-tensor[indices];
+            }
+            
+        }
+        public void UnaryPlus(Tensor<short> tensor, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)+tensor[indices];
+            }
+            
+        }
+        public void Xor(Tensor<short> left, Tensor<short> right, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(left[indices] ^ right[indices]);
+            }
+            
+        }
+        public void Xor(Tensor<short> tensor, short scalar, Tensor<short> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (short)(tensor[indices] ^ scalar);
+            }
+            
+        }
+
+        public void Add(DenseTensor<short> left, DenseTensor<short> right, DenseTensor<short> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7270,16 +10616,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7290,10 +10636,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Add(Tensor<short> tensor, short scalar, Tensor<short> result)
+        public void Add(DenseTensor<short> tensor, short scalar, DenseTensor<short> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7305,12 +10651,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7321,10 +10667,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<short> left, Tensor<short> right, Tensor<short> result)
+        public void And(DenseTensor<short> left, DenseTensor<short> right, DenseTensor<short> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7336,16 +10682,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7356,10 +10702,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<short> tensor, short scalar, Tensor<short> result)
+        public void And(DenseTensor<short> tensor, short scalar, DenseTensor<short> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7371,12 +10717,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7387,7 +10733,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Contract(Tensor<short> left, Tensor<short> right, int[] leftAxes, int[] rightAxes, Tensor<short> result)
+        public void Contract(DenseTensor<short> left, DenseTensor<short> right, int[] leftAxes, int[] rightAxes, DenseTensor<short> result)
         {
             var summingDimensions = new int[leftAxes.Length];
             for(int i = 0; i < leftAxes.Length; i++)
@@ -7438,7 +10784,7 @@ namespace System.Numerics
                 result.Buffer[resultIndex] = sum;
             }
         }
-        public void Decrement(Tensor<short> tensor, Tensor<short> result)
+        public void Decrement(DenseTensor<short> tensor, DenseTensor<short> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -7446,10 +10792,10 @@ namespace System.Numerics
                 result.Buffer[i]--;
             }
         }
-        public void Divide(Tensor<short> left, Tensor<short> right, Tensor<short> result)
+        public void Divide(DenseTensor<short> left, DenseTensor<short> right, DenseTensor<short> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7461,16 +10807,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7481,10 +10827,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Divide(Tensor<short> tensor, short scalar, Tensor<short> result)
+        public void Divide(DenseTensor<short> tensor, short scalar, DenseTensor<short> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7496,12 +10842,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7512,10 +10858,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Equals(Tensor<short> left, Tensor<short> right, Tensor<bool> result)
+        public void Equals(DenseTensor<short> left, DenseTensor<short> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7527,16 +10873,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7547,10 +10893,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThan(Tensor<short> left, Tensor<short> right, Tensor<bool> result)
+        public void GreaterThan(DenseTensor<short> left, DenseTensor<short> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7562,16 +10908,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7582,10 +10928,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThanOrEqual(Tensor<short> left, Tensor<short> right, Tensor<bool> result)
+        public void GreaterThanOrEqual(DenseTensor<short> left, DenseTensor<short> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7597,16 +10943,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7617,7 +10963,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Increment(Tensor<short> tensor, Tensor<short> result)
+        public void Increment(DenseTensor<short> tensor, DenseTensor<short> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -7625,10 +10971,10 @@ namespace System.Numerics
                 result.Buffer[i]++;
             }
         }
-        public void LeftShift(Tensor<short> tensor, int value, Tensor<short> result)
+        public void LeftShift(DenseTensor<short> tensor, int value, DenseTensor<short> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7640,12 +10986,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7656,10 +11002,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThan(Tensor<short> left, Tensor<short> right, Tensor<bool> result)
+        public void LessThan(DenseTensor<short> left, DenseTensor<short> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7671,16 +11017,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7691,10 +11037,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThanOrEqual(Tensor<short> left, Tensor<short> right, Tensor<bool> result)
+        public void LessThanOrEqual(DenseTensor<short> left, DenseTensor<short> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7706,16 +11052,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7726,10 +11072,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<short> left, Tensor<short> right, Tensor<short> result)
+        public void Modulo(DenseTensor<short> left, DenseTensor<short> right, DenseTensor<short> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7741,16 +11087,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7761,10 +11107,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<short> tensor, short scalar, Tensor<short> result)
+        public void Modulo(DenseTensor<short> tensor, short scalar, DenseTensor<short> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7776,12 +11122,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7792,10 +11138,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<short> left, Tensor<short> right, Tensor<short> result)
+        public void Multiply(DenseTensor<short> left, DenseTensor<short> right, DenseTensor<short> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7807,16 +11153,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7827,10 +11173,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<short> tensor, short scalar, Tensor<short> result)
+        public void Multiply(DenseTensor<short> tensor, short scalar, DenseTensor<short> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7842,12 +11188,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7858,10 +11204,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void NotEquals(Tensor<short> left, Tensor<short> right, Tensor<bool> result)
+        public void NotEquals(DenseTensor<short> left, DenseTensor<short> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7873,16 +11219,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7893,10 +11239,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<short> left, Tensor<short> right, Tensor<short> result)
+        public void Or(DenseTensor<short> left, DenseTensor<short> right, DenseTensor<short> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7908,16 +11254,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7928,10 +11274,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<short> tensor, short scalar, Tensor<short> result)
+        public void Or(DenseTensor<short> tensor, short scalar, DenseTensor<short> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7943,12 +11289,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7959,10 +11305,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void RightShift(Tensor<short> tensor, int value, Tensor<short> result)
+        public void RightShift(DenseTensor<short> tensor, int value, DenseTensor<short> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -7974,12 +11320,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -7990,10 +11336,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<short> left, Tensor<short> right, Tensor<short> result)
+        public void Subtract(DenseTensor<short> left, DenseTensor<short> right, DenseTensor<short> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8005,16 +11351,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8025,10 +11371,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<short> tensor, short scalar, Tensor<short> result)
+        public void Subtract(DenseTensor<short> tensor, short scalar, DenseTensor<short> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8040,12 +11386,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8056,10 +11402,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryMinus(Tensor<short> tensor, Tensor<short> result)
+        public void UnaryMinus(DenseTensor<short> tensor, DenseTensor<short> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8071,12 +11417,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8087,10 +11433,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryPlus(Tensor<short> tensor, Tensor<short> result)
+        public void UnaryPlus(DenseTensor<short> tensor, DenseTensor<short> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8102,12 +11448,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8118,10 +11464,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<short> left, Tensor<short> right, Tensor<short> result)
+        public void Xor(DenseTensor<short> left, DenseTensor<short> right, DenseTensor<short> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8133,16 +11479,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8153,10 +11499,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<short> tensor, short scalar, Tensor<short> result)
+        public void Xor(DenseTensor<short> tensor, short scalar, DenseTensor<short> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8168,12 +11514,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8188,11 +11534,375 @@ namespace System.Numerics
     internal class UIntArithmetic : ITensorArithmetic<uint>
     {
         public uint One => 1;
+        public uint Zero => 0;
 
         public void Add(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(left[indices] + right[indices]);
+            }
+            
+        }
+        public void Add(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(tensor[indices] + scalar);
+            }
+            
+        }
+        public void And(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(left[indices] & right[indices]);
+            }
+            
+        }
+        public void And(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(tensor[indices] & scalar);
+            }
+            
+        }
+        public void Contract(Tensor<uint> left, Tensor<uint> right, int[] leftAxes, int[] rightAxes, Tensor<uint> result)
+        {
+            var leftIndices = new int[left.Rank];
+            var rightIndices = new int[right.Rank];
+            var resultIndices = new int[result.Rank];
+
+            var summingDimensions = new int[leftAxes.Length];
+            for(int i = 0; i < leftAxes.Length; i++)
+            {
+                summingDimensions[i] = left.dimensions[leftAxes[i]];
+            }
+
+            var summingStrides = ArrayUtilities.GetStrides(summingDimensions);
+            int summingLength = (int)ArrayUtilities.GetProduct(summingDimensions);
+
+            var resultStrides = result.strides;
+
+            // translates from result index to left non-summing dimensions' index portion
+            // since left non-summing dimensions are given precedence in result, the end is zero-padded
+            int[] leftNonSummingStrides = new int[result.Rank];
+
+            // translates from summing index to left summing dimensions' index portion
+            int[] leftSummingStrides = new int[leftAxes.Length];
+            ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
+
+            // translates from result index to right non-summing dimensions' index portion
+            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
+            int[] rightNonSummingStrides = new int[result.Rank];
+            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+
+            // translates from summing index to right summing dimensions' index portion
+            int[] rightSummingStrides = new int[rightAxes.Length];
+            ArrayUtilities.SplitStrides(right.strides, rightAxes, rightNonSummingStrides, rightNonSummingStridesOffset, rightSummingStrides, 0);
+
+            for (int resultIndex = 0; resultIndex < result.Length; resultIndex++)
+            {
+                uint sum = (uint)0;
+                
+                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+
+                for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
+                {
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+
+                    int leftIndex = leftIndexNonSumming + leftIndexSumming;
+                    int rightIndex = rightIndexNonSumming + rightIndexSumming;
+
+                    // todo, make this more efficient
+                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+
+                    sum += (uint)(left[leftIndices] * right[rightIndices]);
+                }
+                
+                result[resultIndices] = sum;
+            }
+        }
+        public void Decrement(Tensor<uint> tensor, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]--;
+            }
+            
+        }
+        public void Divide(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(left[indices] / right[indices]);
+            }
+            
+        }
+        public void Divide(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(tensor[indices] / scalar);
+            }
+            
+        }
+        public void Equals(Tensor<uint> left, Tensor<uint> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] == right[indices];
+            }
+            
+        }
+        public void GreaterThan(Tensor<uint> left, Tensor<uint> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] > right[indices];
+            }
+            
+        }
+        public void GreaterThanOrEqual(Tensor<uint> left, Tensor<uint> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] >= right[indices];
+            }
+            
+        }
+        public void Increment(Tensor<uint> tensor, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]++;
+            }
+            
+        }
+        public void LeftShift(Tensor<uint> tensor, int value, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(tensor[indices] << value);
+            }
+            
+        }
+        public void LessThan(Tensor<uint> left, Tensor<uint> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] < right[indices];
+            }
+            
+        }
+        public void LessThanOrEqual(Tensor<uint> left, Tensor<uint> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] <= right[indices];
+            }
+            
+        }
+        public void Modulo(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(left[indices] % right[indices]);
+            }
+            
+        }
+        public void Modulo(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(tensor[indices] % scalar);
+            }
+            
+        }
+        public void Multiply(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(left[indices] * right[indices]);
+            }
+            
+        }
+        public void Multiply(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(tensor[indices] * scalar);
+            }
+            
+        }
+        public void NotEquals(Tensor<uint> left, Tensor<uint> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] != right[indices];
+            }
+            
+        }
+        public void Or(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(left[indices] | right[indices]);
+            }
+            
+        }
+        public void Or(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(tensor[indices] | scalar);
+            }
+            
+        }
+        public void RightShift(Tensor<uint> tensor, int value, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(tensor[indices] >> value);
+            }
+            
+        }
+        public void Subtract(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(left[indices] - right[indices]);
+            }
+            
+        }
+        public void Subtract(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(tensor[indices] - scalar);
+            }
+            
+        }
+        public void UnaryMinus(Tensor<uint> tensor, Tensor<uint> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void UnaryPlus(Tensor<uint> tensor, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)+tensor[indices];
+            }
+            
+        }
+        public void Xor(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(left[indices] ^ right[indices]);
+            }
+            
+        }
+        public void Xor(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (uint)(tensor[indices] ^ scalar);
+            }
+            
+        }
+
+        public void Add(DenseTensor<uint> left, DenseTensor<uint> right, DenseTensor<uint> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8204,16 +11914,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8224,10 +11934,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Add(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        public void Add(DenseTensor<uint> tensor, uint scalar, DenseTensor<uint> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8239,12 +11949,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8255,10 +11965,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
+        public void And(DenseTensor<uint> left, DenseTensor<uint> right, DenseTensor<uint> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8270,16 +11980,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8290,10 +12000,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        public void And(DenseTensor<uint> tensor, uint scalar, DenseTensor<uint> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8305,12 +12015,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8321,7 +12031,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Contract(Tensor<uint> left, Tensor<uint> right, int[] leftAxes, int[] rightAxes, Tensor<uint> result)
+        public void Contract(DenseTensor<uint> left, DenseTensor<uint> right, int[] leftAxes, int[] rightAxes, DenseTensor<uint> result)
         {
             var summingDimensions = new int[leftAxes.Length];
             for(int i = 0; i < leftAxes.Length; i++)
@@ -8372,7 +12082,7 @@ namespace System.Numerics
                 result.Buffer[resultIndex] = sum;
             }
         }
-        public void Decrement(Tensor<uint> tensor, Tensor<uint> result)
+        public void Decrement(DenseTensor<uint> tensor, DenseTensor<uint> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -8380,10 +12090,10 @@ namespace System.Numerics
                 result.Buffer[i]--;
             }
         }
-        public void Divide(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
+        public void Divide(DenseTensor<uint> left, DenseTensor<uint> right, DenseTensor<uint> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8395,16 +12105,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8415,10 +12125,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Divide(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        public void Divide(DenseTensor<uint> tensor, uint scalar, DenseTensor<uint> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8430,12 +12140,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8446,10 +12156,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Equals(Tensor<uint> left, Tensor<uint> right, Tensor<bool> result)
+        public void Equals(DenseTensor<uint> left, DenseTensor<uint> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8461,16 +12171,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8481,10 +12191,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThan(Tensor<uint> left, Tensor<uint> right, Tensor<bool> result)
+        public void GreaterThan(DenseTensor<uint> left, DenseTensor<uint> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8496,16 +12206,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8516,10 +12226,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThanOrEqual(Tensor<uint> left, Tensor<uint> right, Tensor<bool> result)
+        public void GreaterThanOrEqual(DenseTensor<uint> left, DenseTensor<uint> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8531,16 +12241,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8551,7 +12261,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Increment(Tensor<uint> tensor, Tensor<uint> result)
+        public void Increment(DenseTensor<uint> tensor, DenseTensor<uint> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -8559,10 +12269,10 @@ namespace System.Numerics
                 result.Buffer[i]++;
             }
         }
-        public void LeftShift(Tensor<uint> tensor, int value, Tensor<uint> result)
+        public void LeftShift(DenseTensor<uint> tensor, int value, DenseTensor<uint> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8574,12 +12284,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8590,10 +12300,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThan(Tensor<uint> left, Tensor<uint> right, Tensor<bool> result)
+        public void LessThan(DenseTensor<uint> left, DenseTensor<uint> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8605,16 +12315,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8625,10 +12335,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThanOrEqual(Tensor<uint> left, Tensor<uint> right, Tensor<bool> result)
+        public void LessThanOrEqual(DenseTensor<uint> left, DenseTensor<uint> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8640,16 +12350,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8660,10 +12370,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
+        public void Modulo(DenseTensor<uint> left, DenseTensor<uint> right, DenseTensor<uint> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8675,16 +12385,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8695,10 +12405,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        public void Modulo(DenseTensor<uint> tensor, uint scalar, DenseTensor<uint> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8710,12 +12420,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8726,10 +12436,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
+        public void Multiply(DenseTensor<uint> left, DenseTensor<uint> right, DenseTensor<uint> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8741,16 +12451,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8761,10 +12471,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        public void Multiply(DenseTensor<uint> tensor, uint scalar, DenseTensor<uint> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8776,12 +12486,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8792,10 +12502,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void NotEquals(Tensor<uint> left, Tensor<uint> right, Tensor<bool> result)
+        public void NotEquals(DenseTensor<uint> left, DenseTensor<uint> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8807,16 +12517,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8827,10 +12537,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
+        public void Or(DenseTensor<uint> left, DenseTensor<uint> right, DenseTensor<uint> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8842,16 +12552,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8862,10 +12572,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        public void Or(DenseTensor<uint> tensor, uint scalar, DenseTensor<uint> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8877,12 +12587,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8893,10 +12603,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void RightShift(Tensor<uint> tensor, int value, Tensor<uint> result)
+        public void RightShift(DenseTensor<uint> tensor, int value, DenseTensor<uint> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8908,12 +12618,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8924,10 +12634,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
+        public void Subtract(DenseTensor<uint> left, DenseTensor<uint> right, DenseTensor<uint> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8939,16 +12649,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8959,10 +12669,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        public void Subtract(DenseTensor<uint> tensor, uint scalar, DenseTensor<uint> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -8974,12 +12684,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -8990,14 +12700,14 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryMinus(Tensor<uint> tensor, Tensor<uint> result)
+        public void UnaryMinus(DenseTensor<uint> tensor, DenseTensor<uint> result)
         {
             throw new NotSupportedException();
         }
-        public void UnaryPlus(Tensor<uint> tensor, Tensor<uint> result)
+        public void UnaryPlus(DenseTensor<uint> tensor, DenseTensor<uint> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9009,12 +12719,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9025,10 +12735,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<uint> left, Tensor<uint> right, Tensor<uint> result)
+        public void Xor(DenseTensor<uint> left, DenseTensor<uint> right, DenseTensor<uint> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9040,16 +12750,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9060,10 +12770,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<uint> tensor, uint scalar, Tensor<uint> result)
+        public void Xor(DenseTensor<uint> tensor, uint scalar, DenseTensor<uint> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9075,12 +12785,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9095,11 +12805,375 @@ namespace System.Numerics
     internal class ULongArithmetic : ITensorArithmetic<ulong>
     {
         public ulong One => 1;
+        public ulong Zero => 0;
 
         public void Add(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(left[indices] + right[indices]);
+            }
+            
+        }
+        public void Add(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(tensor[indices] + scalar);
+            }
+            
+        }
+        public void And(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(left[indices] & right[indices]);
+            }
+            
+        }
+        public void And(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(tensor[indices] & scalar);
+            }
+            
+        }
+        public void Contract(Tensor<ulong> left, Tensor<ulong> right, int[] leftAxes, int[] rightAxes, Tensor<ulong> result)
+        {
+            var leftIndices = new int[left.Rank];
+            var rightIndices = new int[right.Rank];
+            var resultIndices = new int[result.Rank];
+
+            var summingDimensions = new int[leftAxes.Length];
+            for(int i = 0; i < leftAxes.Length; i++)
+            {
+                summingDimensions[i] = left.dimensions[leftAxes[i]];
+            }
+
+            var summingStrides = ArrayUtilities.GetStrides(summingDimensions);
+            int summingLength = (int)ArrayUtilities.GetProduct(summingDimensions);
+
+            var resultStrides = result.strides;
+
+            // translates from result index to left non-summing dimensions' index portion
+            // since left non-summing dimensions are given precedence in result, the end is zero-padded
+            int[] leftNonSummingStrides = new int[result.Rank];
+
+            // translates from summing index to left summing dimensions' index portion
+            int[] leftSummingStrides = new int[leftAxes.Length];
+            ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
+
+            // translates from result index to right non-summing dimensions' index portion
+            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
+            int[] rightNonSummingStrides = new int[result.Rank];
+            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+
+            // translates from summing index to right summing dimensions' index portion
+            int[] rightSummingStrides = new int[rightAxes.Length];
+            ArrayUtilities.SplitStrides(right.strides, rightAxes, rightNonSummingStrides, rightNonSummingStridesOffset, rightSummingStrides, 0);
+
+            for (int resultIndex = 0; resultIndex < result.Length; resultIndex++)
+            {
+                ulong sum = (ulong)0;
+                
+                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+
+                for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
+                {
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+
+                    int leftIndex = leftIndexNonSumming + leftIndexSumming;
+                    int rightIndex = rightIndexNonSumming + rightIndexSumming;
+
+                    // todo, make this more efficient
+                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+
+                    sum += (ulong)(left[leftIndices] * right[rightIndices]);
+                }
+                
+                result[resultIndices] = sum;
+            }
+        }
+        public void Decrement(Tensor<ulong> tensor, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]--;
+            }
+            
+        }
+        public void Divide(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(left[indices] / right[indices]);
+            }
+            
+        }
+        public void Divide(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(tensor[indices] / scalar);
+            }
+            
+        }
+        public void Equals(Tensor<ulong> left, Tensor<ulong> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] == right[indices];
+            }
+            
+        }
+        public void GreaterThan(Tensor<ulong> left, Tensor<ulong> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] > right[indices];
+            }
+            
+        }
+        public void GreaterThanOrEqual(Tensor<ulong> left, Tensor<ulong> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] >= right[indices];
+            }
+            
+        }
+        public void Increment(Tensor<ulong> tensor, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]++;
+            }
+            
+        }
+        public void LeftShift(Tensor<ulong> tensor, int value, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(tensor[indices] << value);
+            }
+            
+        }
+        public void LessThan(Tensor<ulong> left, Tensor<ulong> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] < right[indices];
+            }
+            
+        }
+        public void LessThanOrEqual(Tensor<ulong> left, Tensor<ulong> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] <= right[indices];
+            }
+            
+        }
+        public void Modulo(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(left[indices] % right[indices]);
+            }
+            
+        }
+        public void Modulo(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(tensor[indices] % scalar);
+            }
+            
+        }
+        public void Multiply(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(left[indices] * right[indices]);
+            }
+            
+        }
+        public void Multiply(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(tensor[indices] * scalar);
+            }
+            
+        }
+        public void NotEquals(Tensor<ulong> left, Tensor<ulong> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] != right[indices];
+            }
+            
+        }
+        public void Or(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(left[indices] | right[indices]);
+            }
+            
+        }
+        public void Or(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(tensor[indices] | scalar);
+            }
+            
+        }
+        public void RightShift(Tensor<ulong> tensor, int value, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(tensor[indices] >> value);
+            }
+            
+        }
+        public void Subtract(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(left[indices] - right[indices]);
+            }
+            
+        }
+        public void Subtract(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(tensor[indices] - scalar);
+            }
+            
+        }
+        public void UnaryMinus(Tensor<ulong> tensor, Tensor<ulong> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void UnaryPlus(Tensor<ulong> tensor, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)+tensor[indices];
+            }
+            
+        }
+        public void Xor(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(left[indices] ^ right[indices]);
+            }
+            
+        }
+        public void Xor(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ulong)(tensor[indices] ^ scalar);
+            }
+            
+        }
+
+        public void Add(DenseTensor<ulong> left, DenseTensor<ulong> right, DenseTensor<ulong> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9111,16 +13185,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9131,10 +13205,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Add(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        public void Add(DenseTensor<ulong> tensor, ulong scalar, DenseTensor<ulong> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9146,12 +13220,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9162,10 +13236,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
+        public void And(DenseTensor<ulong> left, DenseTensor<ulong> right, DenseTensor<ulong> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9177,16 +13251,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9197,10 +13271,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        public void And(DenseTensor<ulong> tensor, ulong scalar, DenseTensor<ulong> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9212,12 +13286,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9228,7 +13302,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Contract(Tensor<ulong> left, Tensor<ulong> right, int[] leftAxes, int[] rightAxes, Tensor<ulong> result)
+        public void Contract(DenseTensor<ulong> left, DenseTensor<ulong> right, int[] leftAxes, int[] rightAxes, DenseTensor<ulong> result)
         {
             var summingDimensions = new int[leftAxes.Length];
             for(int i = 0; i < leftAxes.Length; i++)
@@ -9279,7 +13353,7 @@ namespace System.Numerics
                 result.Buffer[resultIndex] = sum;
             }
         }
-        public void Decrement(Tensor<ulong> tensor, Tensor<ulong> result)
+        public void Decrement(DenseTensor<ulong> tensor, DenseTensor<ulong> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -9287,10 +13361,10 @@ namespace System.Numerics
                 result.Buffer[i]--;
             }
         }
-        public void Divide(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
+        public void Divide(DenseTensor<ulong> left, DenseTensor<ulong> right, DenseTensor<ulong> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9302,16 +13376,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9322,10 +13396,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Divide(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        public void Divide(DenseTensor<ulong> tensor, ulong scalar, DenseTensor<ulong> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9337,12 +13411,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9353,10 +13427,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Equals(Tensor<ulong> left, Tensor<ulong> right, Tensor<bool> result)
+        public void Equals(DenseTensor<ulong> left, DenseTensor<ulong> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9368,16 +13442,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9388,10 +13462,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThan(Tensor<ulong> left, Tensor<ulong> right, Tensor<bool> result)
+        public void GreaterThan(DenseTensor<ulong> left, DenseTensor<ulong> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9403,16 +13477,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9423,10 +13497,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThanOrEqual(Tensor<ulong> left, Tensor<ulong> right, Tensor<bool> result)
+        public void GreaterThanOrEqual(DenseTensor<ulong> left, DenseTensor<ulong> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9438,16 +13512,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9458,7 +13532,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Increment(Tensor<ulong> tensor, Tensor<ulong> result)
+        public void Increment(DenseTensor<ulong> tensor, DenseTensor<ulong> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -9466,10 +13540,10 @@ namespace System.Numerics
                 result.Buffer[i]++;
             }
         }
-        public void LeftShift(Tensor<ulong> tensor, int value, Tensor<ulong> result)
+        public void LeftShift(DenseTensor<ulong> tensor, int value, DenseTensor<ulong> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9481,12 +13555,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9497,10 +13571,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThan(Tensor<ulong> left, Tensor<ulong> right, Tensor<bool> result)
+        public void LessThan(DenseTensor<ulong> left, DenseTensor<ulong> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9512,16 +13586,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9532,10 +13606,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThanOrEqual(Tensor<ulong> left, Tensor<ulong> right, Tensor<bool> result)
+        public void LessThanOrEqual(DenseTensor<ulong> left, DenseTensor<ulong> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9547,16 +13621,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9567,10 +13641,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
+        public void Modulo(DenseTensor<ulong> left, DenseTensor<ulong> right, DenseTensor<ulong> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9582,16 +13656,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9602,10 +13676,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        public void Modulo(DenseTensor<ulong> tensor, ulong scalar, DenseTensor<ulong> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9617,12 +13691,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9633,10 +13707,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
+        public void Multiply(DenseTensor<ulong> left, DenseTensor<ulong> right, DenseTensor<ulong> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9648,16 +13722,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9668,10 +13742,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        public void Multiply(DenseTensor<ulong> tensor, ulong scalar, DenseTensor<ulong> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9683,12 +13757,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9699,10 +13773,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void NotEquals(Tensor<ulong> left, Tensor<ulong> right, Tensor<bool> result)
+        public void NotEquals(DenseTensor<ulong> left, DenseTensor<ulong> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9714,16 +13788,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9734,10 +13808,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
+        public void Or(DenseTensor<ulong> left, DenseTensor<ulong> right, DenseTensor<ulong> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9749,16 +13823,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9769,10 +13843,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        public void Or(DenseTensor<ulong> tensor, ulong scalar, DenseTensor<ulong> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9784,12 +13858,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9800,10 +13874,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void RightShift(Tensor<ulong> tensor, int value, Tensor<ulong> result)
+        public void RightShift(DenseTensor<ulong> tensor, int value, DenseTensor<ulong> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9815,12 +13889,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9831,10 +13905,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
+        public void Subtract(DenseTensor<ulong> left, DenseTensor<ulong> right, DenseTensor<ulong> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9846,16 +13920,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9866,10 +13940,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        public void Subtract(DenseTensor<ulong> tensor, ulong scalar, DenseTensor<ulong> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9881,12 +13955,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9897,14 +13971,14 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryMinus(Tensor<ulong> tensor, Tensor<ulong> result)
+        public void UnaryMinus(DenseTensor<ulong> tensor, DenseTensor<ulong> result)
         {
             throw new NotSupportedException();
         }
-        public void UnaryPlus(Tensor<ulong> tensor, Tensor<ulong> result)
+        public void UnaryPlus(DenseTensor<ulong> tensor, DenseTensor<ulong> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9916,12 +13990,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9932,10 +14006,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<ulong> left, Tensor<ulong> right, Tensor<ulong> result)
+        public void Xor(DenseTensor<ulong> left, DenseTensor<ulong> right, DenseTensor<ulong> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9947,16 +14021,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -9967,10 +14041,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<ulong> tensor, ulong scalar, Tensor<ulong> result)
+        public void Xor(DenseTensor<ulong> tensor, ulong scalar, DenseTensor<ulong> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -9982,12 +14056,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10002,11 +14076,375 @@ namespace System.Numerics
     internal class UShortArithmetic : ITensorArithmetic<ushort>
     {
         public ushort One => 1;
+        public ushort Zero => 0;
 
         public void Add(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(left[indices] + right[indices]);
+            }
+            
+        }
+        public void Add(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(tensor[indices] + scalar);
+            }
+            
+        }
+        public void And(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(left[indices] & right[indices]);
+            }
+            
+        }
+        public void And(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(tensor[indices] & scalar);
+            }
+            
+        }
+        public void Contract(Tensor<ushort> left, Tensor<ushort> right, int[] leftAxes, int[] rightAxes, Tensor<ushort> result)
+        {
+            var leftIndices = new int[left.Rank];
+            var rightIndices = new int[right.Rank];
+            var resultIndices = new int[result.Rank];
+
+            var summingDimensions = new int[leftAxes.Length];
+            for(int i = 0; i < leftAxes.Length; i++)
+            {
+                summingDimensions[i] = left.dimensions[leftAxes[i]];
+            }
+
+            var summingStrides = ArrayUtilities.GetStrides(summingDimensions);
+            int summingLength = (int)ArrayUtilities.GetProduct(summingDimensions);
+
+            var resultStrides = result.strides;
+
+            // translates from result index to left non-summing dimensions' index portion
+            // since left non-summing dimensions are given precedence in result, the end is zero-padded
+            int[] leftNonSummingStrides = new int[result.Rank];
+
+            // translates from summing index to left summing dimensions' index portion
+            int[] leftSummingStrides = new int[leftAxes.Length];
+            ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
+
+            // translates from result index to right non-summing dimensions' index portion
+            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
+            int[] rightNonSummingStrides = new int[result.Rank];
+            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+
+            // translates from summing index to right summing dimensions' index portion
+            int[] rightSummingStrides = new int[rightAxes.Length];
+            ArrayUtilities.SplitStrides(right.strides, rightAxes, rightNonSummingStrides, rightNonSummingStridesOffset, rightSummingStrides, 0);
+
+            for (int resultIndex = 0; resultIndex < result.Length; resultIndex++)
+            {
+                ushort sum = (ushort)0;
+                
+                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+
+                for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
+                {
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+
+                    int leftIndex = leftIndexNonSumming + leftIndexSumming;
+                    int rightIndex = rightIndexNonSumming + rightIndexSumming;
+
+                    // todo, make this more efficient
+                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+
+                    sum += (ushort)(left[leftIndices] * right[rightIndices]);
+                }
+                
+                result[resultIndices] = sum;
+            }
+        }
+        public void Decrement(Tensor<ushort> tensor, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]--;
+            }
+            
+        }
+        public void Divide(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(left[indices] / right[indices]);
+            }
+            
+        }
+        public void Divide(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(tensor[indices] / scalar);
+            }
+            
+        }
+        public void Equals(Tensor<ushort> left, Tensor<ushort> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] == right[indices];
+            }
+            
+        }
+        public void GreaterThan(Tensor<ushort> left, Tensor<ushort> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] > right[indices];
+            }
+            
+        }
+        public void GreaterThanOrEqual(Tensor<ushort> left, Tensor<ushort> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] >= right[indices];
+            }
+            
+        }
+        public void Increment(Tensor<ushort> tensor, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices]++;
+            }
+            
+        }
+        public void LeftShift(Tensor<ushort> tensor, int value, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(tensor[indices] << value);
+            }
+            
+        }
+        public void LessThan(Tensor<ushort> left, Tensor<ushort> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] < right[indices];
+            }
+            
+        }
+        public void LessThanOrEqual(Tensor<ushort> left, Tensor<ushort> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] <= right[indices];
+            }
+            
+        }
+        public void Modulo(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(left[indices] % right[indices]);
+            }
+            
+        }
+        public void Modulo(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(tensor[indices] % scalar);
+            }
+            
+        }
+        public void Multiply(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(left[indices] * right[indices]);
+            }
+            
+        }
+        public void Multiply(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(tensor[indices] * scalar);
+            }
+            
+        }
+        public void NotEquals(Tensor<ushort> left, Tensor<ushort> right, Tensor<bool> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = left[indices] != right[indices];
+            }
+            
+        }
+        public void Or(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(left[indices] | right[indices]);
+            }
+            
+        }
+        public void Or(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(tensor[indices] | scalar);
+            }
+            
+        }
+        public void RightShift(Tensor<ushort> tensor, int value, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(tensor[indices] >> value);
+            }
+            
+        }
+        public void Subtract(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(left[indices] - right[indices]);
+            }
+            
+        }
+        public void Subtract(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(tensor[indices] - scalar);
+            }
+            
+        }
+        public void UnaryMinus(Tensor<ushort> tensor, Tensor<ushort> result)
+        {
+            throw new NotSupportedException();
+        }
+        public void UnaryPlus(Tensor<ushort> tensor, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)+tensor[indices];
+            }
+            
+        }
+        public void Xor(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(left[indices] ^ right[indices]);
+            }
+            
+        }
+        public void Xor(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        {
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < result.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                result[indices] = (ushort)(tensor[indices] ^ scalar);
+            }
+            
+        }
+
+        public void Add(DenseTensor<ushort> left, DenseTensor<ushort> right, DenseTensor<ushort> result)
+        {
+
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10018,16 +14456,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10038,10 +14476,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Add(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        public void Add(DenseTensor<ushort> tensor, ushort scalar, DenseTensor<ushort> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10053,12 +14491,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10069,10 +14507,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
+        public void And(DenseTensor<ushort> left, DenseTensor<ushort> right, DenseTensor<ushort> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10084,16 +14522,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10104,10 +14542,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void And(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        public void And(DenseTensor<ushort> tensor, ushort scalar, DenseTensor<ushort> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10119,12 +14557,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10135,7 +14573,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Contract(Tensor<ushort> left, Tensor<ushort> right, int[] leftAxes, int[] rightAxes, Tensor<ushort> result)
+        public void Contract(DenseTensor<ushort> left, DenseTensor<ushort> right, int[] leftAxes, int[] rightAxes, DenseTensor<ushort> result)
         {
             var summingDimensions = new int[leftAxes.Length];
             for(int i = 0; i < leftAxes.Length; i++)
@@ -10186,7 +14624,7 @@ namespace System.Numerics
                 result.Buffer[resultIndex] = sum;
             }
         }
-        public void Decrement(Tensor<ushort> tensor, Tensor<ushort> result)
+        public void Decrement(DenseTensor<ushort> tensor, DenseTensor<ushort> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -10194,10 +14632,10 @@ namespace System.Numerics
                 result.Buffer[i]--;
             }
         }
-        public void Divide(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
+        public void Divide(DenseTensor<ushort> left, DenseTensor<ushort> right, DenseTensor<ushort> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10209,16 +14647,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10229,10 +14667,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Divide(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        public void Divide(DenseTensor<ushort> tensor, ushort scalar, DenseTensor<ushort> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10244,12 +14682,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10260,10 +14698,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Equals(Tensor<ushort> left, Tensor<ushort> right, Tensor<bool> result)
+        public void Equals(DenseTensor<ushort> left, DenseTensor<ushort> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10275,16 +14713,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10295,10 +14733,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThan(Tensor<ushort> left, Tensor<ushort> right, Tensor<bool> result)
+        public void GreaterThan(DenseTensor<ushort> left, DenseTensor<ushort> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10310,16 +14748,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10330,10 +14768,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void GreaterThanOrEqual(Tensor<ushort> left, Tensor<ushort> right, Tensor<bool> result)
+        public void GreaterThanOrEqual(DenseTensor<ushort> left, DenseTensor<ushort> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10345,16 +14783,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10365,7 +14803,7 @@ namespace System.Numerics
                 }
             }
         }
-        public void Increment(Tensor<ushort> tensor, Tensor<ushort> result)
+        public void Increment(DenseTensor<ushort> tensor, DenseTensor<ushort> result)
         {
 
             for(int i = 0; i < result.Length; i++)
@@ -10373,10 +14811,10 @@ namespace System.Numerics
                 result.Buffer[i]++;
             }
         }
-        public void LeftShift(Tensor<ushort> tensor, int value, Tensor<ushort> result)
+        public void LeftShift(DenseTensor<ushort> tensor, int value, DenseTensor<ushort> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10388,12 +14826,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10404,10 +14842,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThan(Tensor<ushort> left, Tensor<ushort> right, Tensor<bool> result)
+        public void LessThan(DenseTensor<ushort> left, DenseTensor<ushort> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10419,16 +14857,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10439,10 +14877,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void LessThanOrEqual(Tensor<ushort> left, Tensor<ushort> right, Tensor<bool> result)
+        public void LessThanOrEqual(DenseTensor<ushort> left, DenseTensor<ushort> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10454,16 +14892,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10474,10 +14912,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
+        public void Modulo(DenseTensor<ushort> left, DenseTensor<ushort> right, DenseTensor<ushort> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10489,16 +14927,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10509,10 +14947,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Modulo(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        public void Modulo(DenseTensor<ushort> tensor, ushort scalar, DenseTensor<ushort> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10524,12 +14962,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10540,10 +14978,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
+        public void Multiply(DenseTensor<ushort> left, DenseTensor<ushort> right, DenseTensor<ushort> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10555,16 +14993,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10575,10 +15013,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Multiply(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        public void Multiply(DenseTensor<ushort> tensor, ushort scalar, DenseTensor<ushort> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10590,12 +15028,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10606,10 +15044,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void NotEquals(Tensor<ushort> left, Tensor<ushort> right, Tensor<bool> result)
+        public void NotEquals(DenseTensor<ushort> left, DenseTensor<ushort> right, DenseTensor<bool> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10621,16 +15059,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10641,10 +15079,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
+        public void Or(DenseTensor<ushort> left, DenseTensor<ushort> right, DenseTensor<ushort> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10656,16 +15094,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10676,10 +15114,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Or(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        public void Or(DenseTensor<ushort> tensor, ushort scalar, DenseTensor<ushort> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10691,12 +15129,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10707,10 +15145,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void RightShift(Tensor<ushort> tensor, int value, Tensor<ushort> result)
+        public void RightShift(DenseTensor<ushort> tensor, int value, DenseTensor<ushort> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10722,12 +15160,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10738,10 +15176,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
+        public void Subtract(DenseTensor<ushort> left, DenseTensor<ushort> right, DenseTensor<ushort> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10753,16 +15191,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10773,10 +15211,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Subtract(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        public void Subtract(DenseTensor<ushort> tensor, ushort scalar, DenseTensor<ushort> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10788,12 +15226,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10804,14 +15242,14 @@ namespace System.Numerics
                 }
             }
         }
-        public void UnaryMinus(Tensor<ushort> tensor, Tensor<ushort> result)
+        public void UnaryMinus(DenseTensor<ushort> tensor, DenseTensor<ushort> result)
         {
             throw new NotSupportedException();
         }
-        public void UnaryPlus(Tensor<ushort> tensor, Tensor<ushort> result)
+        public void UnaryPlus(DenseTensor<ushort> tensor, DenseTensor<ushort> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10823,12 +15261,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10839,10 +15277,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<ushort> left, Tensor<ushort> right, Tensor<ushort> result)
+        public void Xor(DenseTensor<ushort> left, DenseTensor<ushort> right, DenseTensor<ushort> result)
         {
 
-            if  ((result.IsRowMajor == left.IsRowMajor) && (result.IsRowMajor == right.IsRowMajor))
+            if  ((result.IsReversedStride == left.IsReversedStride) && (result.IsReversedStride == right.IsReversedStride))
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10854,16 +15292,16 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(left.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(left.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                ref int op2Index = ref RefUtilities.Ternary(right.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(right.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
-                                      left.IsRowMajor ? left.strides : 
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
+                                      !left.IsReversedStride ? left.strides : 
                                       right.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
-                                         left.IsColumnMajor ? left.strides : 
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
+                                         left.IsReversedStride ? left.strides : 
                                          right.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {
@@ -10874,10 +15312,10 @@ namespace System.Numerics
                 }
             }
         }
-        public void Xor(Tensor<ushort> tensor, ushort scalar, Tensor<ushort> result)
+        public void Xor(DenseTensor<ushort> tensor, ushort scalar, DenseTensor<ushort> result)
         {
 
-            if  (result.IsRowMajor == tensor.IsRowMajor)
+            if  (result.IsReversedStride == tensor.IsReversedStride)
             {
                 for(int i = 0; i < result.Length; i++)
                 {
@@ -10889,12 +15327,12 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(result.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(tensor.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(result.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(tensor.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
-                var rowMajorStrides = result.IsRowMajor ? result.strides :
+                var rowMajorStrides = !result.IsReversedStride ? result.strides :
                                       tensor.strides;
-                var columnMajorStrides = result.IsColumnMajor ? result.strides :
+                var columnMajorStrides = result.IsReversedStride ? result.strides :
                                          tensor.strides;
                 for(;rowMajorIndex < result.Length; rowMajorIndex++)
                 {

--- a/src/System.Numerics.Tensors/System/Numerics/TensorArithmetic.tt
+++ b/src/System.Numerics.Tensors/System/Numerics/TensorArithmetic.tt
@@ -54,7 +54,7 @@ namespace System.Numerics
             Span<int> indices = new Span<int>(new int[result.Rank]);
             for(int i = 0; i < <#= method.ResultName #>.Length; i++)
             {
-                ArrayUtilities.GetIndices(result.strides, i, indices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, i, indices);
                 <#=method.GetElementOperation(type.TypeName, "[indices]")#>;
             }
             
@@ -83,9 +83,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -95,22 +95,22 @@ namespace System.Numerics
             {
                 <#=type.TypeName#> sum = (<#=type.TypeName#>)0;
                 
-                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+                ArrayUtilities.GetIndices(result.strides, result.IsReversedStride, resultIndex, resultIndices);
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;
 
                     // todo, make this more efficient
-                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
-                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+                    ArrayUtilities.GetIndices(left.strides, left.IsReversedStride, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, right.IsReversedStride, rightIndex, rightIndices);
 
                     sum += (<#=type.TypeName#>)(left[leftIndices] * right[rightIndices]);
                 }
@@ -146,27 +146,27 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(<#= method.ResultName #>.IsReveresedStride, ref colMajorIndex,  ref rowMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(<#= method.Op1Name #>.IsReveresedStride , ref colMajorIndex, ref rowMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(<#= method.ResultName #>.IsReversedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(<#= method.Op1Name #>.IsReversedStride , ref colMajorIndex, ref rowMajorIndex);
                 
 <# if ((method.MethodType == MethodType.Binary) || (method.MethodType == MethodType.Comparison)) {#>
-                ref int op2Index = ref RefUtilities.Ternary(<#= method.Op2Name #>.IsReveresedStride, ref colMajorIndex, ref rowMajorIndex );
+                ref int op2Index = ref RefUtilities.Ternary(<#= method.Op2Name #>.IsReversedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = !<#= method.ResultName #>.IsReveresedStride ? <#= method.ResultName #>.strides :
-                                      !<#= method.Op1Name #>.IsReveresedStride ? <#= method.Op1Name #>.strides : 
+                var rowMajorStrides = !<#= method.ResultName #>.IsReversedStride ? <#= method.ResultName #>.strides :
+                                      !<#= method.Op1Name #>.IsReversedStride ? <#= method.Op1Name #>.strides : 
                                       <#= method.Op2Name #>.strides;
-                var columnMajorStrides = <#= method.ResultName #>.IsReveresedStride ? <#= method.ResultName #>.strides :
-                                         <#= method.Op1Name #>.IsReveresedStride ? <#= method.Op1Name #>.strides : 
+                var columnMajorStrides = <#= method.ResultName #>.IsReversedStride ? <#= method.ResultName #>.strides :
+                                         <#= method.Op1Name #>.IsReversedStride ? <#= method.Op1Name #>.strides : 
                                          <#= method.Op2Name #>.strides;
 <# } else {#>
-                var rowMajorStrides = !<#= method.ResultName #>.IsReveresedStride ? <#= method.ResultName #>.strides :
+                var rowMajorStrides = !<#= method.ResultName #>.IsReversedStride ? <#= method.ResultName #>.strides :
                                       <#= method.Op1Name #>.strides;
-                var columnMajorStrides = <#= method.ResultName #>.IsReveresedStride ? <#= method.ResultName #>.strides :
+                var columnMajorStrides = <#= method.ResultName #>.IsReversedStride ? <#= method.ResultName #>.strides :
                                          <#= method.Op1Name #>.strides;
 <# } #>
                 for(;rowMajorIndex < <#= method.ResultName #>.Length; rowMajorIndex++)
                 {
-                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, columnMajorStrides);
+                    colMajorIndex = ArrayUtilities.TransformIndexByStrides(rowMajorIndex, rowMajorStrides, false, columnMajorStrides);
                     
                     <#=method.GetElementOperation(type.TypeName, ".Buffer[resultIndex]", ".Buffer[op1Index]", ".Buffer[op2Index]")#>;
 
@@ -194,9 +194,9 @@ namespace System.Numerics
             ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
 
             // translates from result index to right non-summing dimensions' index portion
-            // since right non-summing dimensions are given not precedence in result, the begingin is zero-padded to account for dimensions that come from left.
             int[] rightNonSummingStrides = new int[result.Rank];
-            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+            //  right non-summing dimensions appear after left non-summing dimensions.
+            int rightNonSummingStridesOffset = (left.Rank - leftAxes.Length);
 
             // translates from summing index to right summing dimensions' index portion
             int[] rightSummingStrides = new int[rightAxes.Length];
@@ -206,13 +206,13 @@ namespace System.Numerics
             {
                 <#=type.TypeName#> sum = (<#=type.TypeName#>)0;
 
-                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
-                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, result.IsReversedStride, rightNonSummingStrides);
 
                 for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
                 {
-                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
-                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, false, rightSummingStrides);
 
                     int leftIndex = leftIndexNonSumming + leftIndexSumming;
                     int rightIndex = rightIndexNonSumming + rightIndexSumming;

--- a/src/System.Numerics.Tensors/System/Numerics/TensorArithmetic.tt
+++ b/src/System.Numerics.Tensors/System/Numerics/TensorArithmetic.tt
@@ -13,8 +13,9 @@ namespace System.Numerics
     internal interface ITensorArithmetic<T>
     {
         T One { get; }
+        T Zero { get; }
 <# foreach (MethodConfiguration method in methodConfiguration) { #>
-        <#= method.GetResultMethodSignature("T")#>;
+        <#= method.GetResultMethodSignature("Tensor", "T")#>;
 <# } #>
     }
 
@@ -41,9 +42,87 @@ namespace System.Numerics
     internal class <#=type.ClassPrefix#>Arithmetic : ITensorArithmetic<<#=type.TypeName#>>
     {
         public <#=type.TypeName#> One => <#=type.OneLiteral#>;
+        public <#=type.TypeName#> Zero => <#=type.ZeroLiteral#>;
 
 <# foreach (MethodConfiguration method in methodConfiguration) { #>
-        public <#= method.GetResultMethodSignature(type.TypeName)#>
+        public <#= method.GetResultMethodSignature("Tensor", type.TypeName)#>
+        {
+<# if ((method.IsNumeric && !type.SupportsNumeric) ||  (method.IsBitwise && !type.SupportsBitwise) || (type.UnsupportedMethods.Contains(method.MethodName))) { #>
+            throw new NotSupportedException();
+<# } else if (method.Operator != null) { #>
+
+            Span<int> indices = new Span<int>(new int[result.Rank]);
+            for(int i = 0; i < <#= method.ResultName #>.Length; i++)
+            {
+                ArrayUtilities.GetIndices(result.strides, i, indices);
+                <#=method.GetElementOperation(type.TypeName, "[indices]")#>;
+            }
+            
+<# } else if (method.MethodName == "Contract") {#>
+            var leftIndices = new int[left.Rank];
+            var rightIndices = new int[right.Rank];
+            var resultIndices = new int[result.Rank];
+
+            var summingDimensions = new int[leftAxes.Length];
+            for(int i = 0; i < leftAxes.Length; i++)
+            {
+                summingDimensions[i] = left.dimensions[leftAxes[i]];
+            }
+
+            var summingStrides = ArrayUtilities.GetStrides(summingDimensions);
+            int summingLength = (int)ArrayUtilities.GetProduct(summingDimensions);
+
+            var resultStrides = result.strides;
+
+            // translates from result index to left non-summing dimensions' index portion
+            // since left non-summing dimensions are given precedence in result, the end is zero-padded
+            int[] leftNonSummingStrides = new int[result.Rank];
+
+            // translates from summing index to left summing dimensions' index portion
+            int[] leftSummingStrides = new int[leftAxes.Length];
+            ArrayUtilities.SplitStrides(left.strides, leftAxes, leftNonSummingStrides, 0, leftSummingStrides, 0);
+
+            // translates from result index to right non-summing dimensions' index portion
+            // since right non-summing dimensions are given not precedence in result, the begining is zero-padded to account for dimensions that come from left.
+            int[] rightNonSummingStrides = new int[result.Rank];
+            int rightNonSummingStridesOffset = result.Rank - (left.Rank - leftAxes.Length);
+
+            // translates from summing index to right summing dimensions' index portion
+            int[] rightSummingStrides = new int[rightAxes.Length];
+            ArrayUtilities.SplitStrides(right.strides, rightAxes, rightNonSummingStrides, rightNonSummingStridesOffset, rightSummingStrides, 0);
+
+            for (int resultIndex = 0; resultIndex < result.Length; resultIndex++)
+            {
+                <#=type.TypeName#> sum = (<#=type.TypeName#>)0;
+                
+                ArrayUtilities.GetIndices(result.strides, resultIndex, resultIndices);
+
+                int leftIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, leftNonSummingStrides);
+                int rightIndexNonSumming = ArrayUtilities.TransformIndexByStrides(resultIndex, resultStrides, rightNonSummingStrides);
+
+                for (int summingIndex = 0; summingIndex < summingLength; summingIndex++)
+                {
+                    int leftIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, leftSummingStrides);
+                    int rightIndexSumming = ArrayUtilities.TransformIndexByStrides(summingIndex, summingStrides, rightSummingStrides);
+
+                    int leftIndex = leftIndexNonSumming + leftIndexSumming;
+                    int rightIndex = rightIndexNonSumming + rightIndexSumming;
+
+                    // todo, make this more efficient
+                    ArrayUtilities.GetIndices(left.strides, leftIndex, leftIndices);
+                    ArrayUtilities.GetIndices(right.strides, rightIndex, rightIndices);
+
+                    sum += (<#=type.TypeName#>)(left[leftIndices] * right[rightIndices]);
+                }
+                
+                result[resultIndices] = sum;
+            }
+<# } #>
+        }
+<# } #>
+
+<# foreach (MethodConfiguration method in methodConfiguration) { #>
+        public <#= method.GetResultMethodSignature("DenseTensor", type.TypeName)#>
         {
 <# if ((method.IsNumeric && !type.SupportsNumeric) ||  (method.IsBitwise && !type.SupportsBitwise) || (type.UnsupportedMethods.Contains(method.MethodName))) { #>
             throw new NotSupportedException();
@@ -67,22 +146,22 @@ namespace System.Numerics
                 int rowMajorIndex = 0;
                 int colMajorIndex = 0;
                 
-                ref int resultIndex = ref RefUtilities.Ternary(<#= method.ResultName #>.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
-                ref int op1Index = ref RefUtilities.Ternary(<#= method.Op1Name #>.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int resultIndex = ref RefUtilities.Ternary(<#= method.ResultName #>.IsReveresedStride, ref colMajorIndex,  ref rowMajorIndex);
+                ref int op1Index = ref RefUtilities.Ternary(<#= method.Op1Name #>.IsReveresedStride , ref colMajorIndex, ref rowMajorIndex);
                 
 <# if ((method.MethodType == MethodType.Binary) || (method.MethodType == MethodType.Comparison)) {#>
-                ref int op2Index = ref RefUtilities.Ternary(<#= method.Op2Name #>.IsRowMajor, ref rowMajorIndex , ref colMajorIndex);
+                ref int op2Index = ref RefUtilities.Ternary(<#= method.Op2Name #>.IsReveresedStride, ref colMajorIndex, ref rowMajorIndex );
 
-                var rowMajorStrides = <#= method.ResultName #>.IsRowMajor ? <#= method.ResultName #>.strides :
-                                      <#= method.Op1Name #>.IsRowMajor ? <#= method.Op1Name #>.strides : 
+                var rowMajorStrides = !<#= method.ResultName #>.IsReveresedStride ? <#= method.ResultName #>.strides :
+                                      !<#= method.Op1Name #>.IsReveresedStride ? <#= method.Op1Name #>.strides : 
                                       <#= method.Op2Name #>.strides;
-                var columnMajorStrides = <#= method.ResultName #>.IsColumnMajor ? <#= method.ResultName #>.strides :
-                                         <#= method.Op1Name #>.IsColumnMajor ? <#= method.Op1Name #>.strides : 
+                var columnMajorStrides = <#= method.ResultName #>.IsReveresedStride ? <#= method.ResultName #>.strides :
+                                         <#= method.Op1Name #>.IsReveresedStride ? <#= method.Op1Name #>.strides : 
                                          <#= method.Op2Name #>.strides;
 <# } else {#>
-                var rowMajorStrides = <#= method.ResultName #>.IsRowMajor ? <#= method.ResultName #>.strides :
+                var rowMajorStrides = !<#= method.ResultName #>.IsReveresedStride ? <#= method.ResultName #>.strides :
                                       <#= method.Op1Name #>.strides;
-                var columnMajorStrides = <#= method.ResultName #>.IsColumnMajor ? <#= method.ResultName #>.strides :
+                var columnMajorStrides = <#= method.ResultName #>.IsReveresedStride ? <#= method.ResultName #>.strides :
                                          <#= method.Op1Name #>.strides;
 <# } #>
                 for(;rowMajorIndex < <#= method.ResultName #>.Length; rowMajorIndex++)

--- a/src/System.Numerics.Tensors/System/Numerics/TensorTemplate.ttinclude
+++ b/src/System.Numerics.Tensors/System/Numerics/TensorTemplate.ttinclude
@@ -228,10 +228,10 @@
                 case MethodType.Unary:
                 case MethodType.BinaryScalar:
                 case MethodType.BinaryInt:
-                    return $"({ResultName}.IsReveresedStride == {Op1Name}.IsReveresedStride)";
+                    return $"({ResultName}.IsReversedStride == {Op1Name}.IsReversedStride)";
                 case MethodType.Binary:
                 case MethodType.Comparison:
-                    return $"(({ResultName}.IsReveresedStride == {Op1Name}.IsReveresedStride) && ({ResultName}.IsReveresedStride == {Op2Name}.IsReveresedStride))";
+                    return $"(({ResultName}.IsReversedStride == {Op1Name}.IsReversedStride) && ({ResultName}.IsReversedStride == {Op2Name}.IsReversedStride))";
                 case MethodType.UnaryInPlace:
                 default:
                     throw new ArgumentException();
@@ -279,7 +279,7 @@
                 case MethodType.Comparison:
                     return $"{Op1Name}.CloneEmpty<bool>()";
                 case MethodType.Contraction:
-                    return $"new DenseTensor<{typeName}>(dimensions:resultDimensions)";
+                    return $"{Op1Name}.CloneEmpty(resultDimensions)";
                 default:
                     throw new ArgumentException();
             }

--- a/src/System.Numerics.Tensors/System/Numerics/TensorTemplate.ttinclude
+++ b/src/System.Numerics.Tensors/System/Numerics/TensorTemplate.ttinclude
@@ -4,11 +4,12 @@
 <#+
     public class TypeConfiguration
     {
-        public TypeConfiguration(string typeName, string classPrefix = null, string oneLiteral = "1", bool supportsNumeric = true, bool supportsBitwise = true, IEnumerable<string> unsupportedMethods = null)
+        public TypeConfiguration(string typeName, string classPrefix = null, string oneLiteral = "1", string zeroLiteral = "0", bool supportsNumeric = true, bool supportsBitwise = true, IEnumerable<string> unsupportedMethods = null)
         {
             TypeName = typeName;
             ClassPrefix = classPrefix ?? char.ToUpper(typeName[0]) + typeName.Substring(1);
             OneLiteral = oneLiteral;
+            ZeroLiteral = zeroLiteral;
             SupportsNumeric = supportsNumeric;
             SupportsBitwise = supportsBitwise;
             UnsupportedMethods = new HashSet<string>(unsupportedMethods ?? Enumerable.Empty<string>());
@@ -17,6 +18,7 @@
         public string TypeName { get; }
         public string ClassPrefix { get; }
         public string OneLiteral { get; }
+        public string ZeroLiteral { get; }
         
         public bool SupportsNumeric { get; }
         public bool SupportsBitwise { get; }
@@ -31,9 +33,9 @@
 
     public TypeConfiguration[] typeConfiguration = new []
     {
-        new TypeConfiguration("bool", oneLiteral:"true", supportsNumeric: false, unsupportedMethods: new[] {"LeftShift", "RightShift"}),
+        new TypeConfiguration("bool", oneLiteral:"true", zeroLiteral:"false", supportsNumeric: false, unsupportedMethods: new[] {"LeftShift", "RightShift"}),
         new TypeConfiguration("byte"),
-        new TypeConfiguration("char", oneLiteral:"(char)1"),
+        new TypeConfiguration("char", oneLiteral:"(char)1", zeroLiteral:"(char)0"),
         new TypeConfiguration("decimal", supportsBitwise: false),
         new TypeConfiguration("double", oneLiteral:"1.0", supportsBitwise: false),
         new TypeConfiguration("float", oneLiteral:"1.0f", supportsBitwise: false),
@@ -117,46 +119,46 @@
         public MethodType MethodType { get; }
         public string Operator { get; }
         
-        public string GetGenericMethodSignature(string typeName)
+        public string GetGenericMethodSignature(string tensorType, string genericType)
         {
-            var resultType = GetResultType(typeName);
-            var arguments = GetMethodArguments(typeName);
+            var resultType = GetResultType(tensorType, genericType);
+            var arguments = GetMethodArguments(tensorType, genericType);
 
-            return $"{resultType} {MethodName}<{typeName}>({arguments})";
+            return $"{resultType} {MethodName}<{genericType}>({arguments})";
         }
         
-        public string GetGenericResultMethodSignature(string typeName)
+        public string GetGenericResultMethodSignature(string tensorType, string genericType)
         {
-            var resultType = GetResultType(typeName);
-            var arguments = GetMethodArguments(typeName);
+            var resultType = GetResultType(tensorType, genericType);
+            var arguments = GetMethodArguments(tensorType, genericType);
 
-            return $"void {MethodName}<{typeName}>({arguments}, {resultType} {ResultName})";
+            return $"void {MethodName}<{genericType}>({arguments}, {resultType} {ResultName})";
         }
 
-        public string GetResultMethodSignature(string typeName)
+        public string GetResultMethodSignature(string tensorType, string genericType)
         {
-            var resultType = GetResultType(typeName);
-            var arguments = GetMethodArguments(typeName);
+            var resultType = GetResultType(tensorType, genericType);
+            var arguments = GetMethodArguments(tensorType, genericType);
 
             return $"void {MethodName}({arguments}, {resultType} {ResultName})";
         }
 
-        public string GetMethodArguments(string typeName)
+        public string GetMethodArguments(string tensorType, string genericType)
         {
             switch (MethodType)
             {
                 case MethodType.Unary:
                 case MethodType.UnaryInPlace:
-                    return $"Tensor<{typeName}> {Op1Name}";
+                    return $"{tensorType}<{genericType}> {Op1Name}";
                 case MethodType.BinaryScalar:
-                    return $"Tensor<{typeName}> {Op1Name}, {typeName} {Op2Name}";
+                    return $"{tensorType}<{genericType}> {Op1Name}, {genericType} {Op2Name}";
                 case MethodType.BinaryInt:
-                    return $"Tensor<{typeName}> {Op1Name}, int {Op2Name}";
+                    return $"{tensorType}<{genericType}> {Op1Name}, int {Op2Name}";
                 case MethodType.Binary:
                 case MethodType.Comparison:
-                    return $"Tensor<{typeName}> {Op1Name}, Tensor<{typeName}> {Op2Name}";
+                    return $"{tensorType}<{genericType}> {Op1Name}, {tensorType}<{genericType}> {Op2Name}";
                 case MethodType.Contraction:
-                    return $"Tensor<{typeName}> {Op1Name}, Tensor<{typeName}> {Op2Name}, int[] leftAxes, int[] rightAxes";
+                    return $"{tensorType}<{genericType}> {Op1Name}, {tensorType}<{genericType}> {Op2Name}, int[] leftAxes, int[] rightAxes";
                 default:
                     throw new ArgumentException();
             }
@@ -168,12 +170,12 @@
             {
                 case MethodType.Unary:
                 case MethodType.UnaryInPlace:
-                    return "{Op1Name}";
+                    return $"{Op1Name}";
                 case MethodType.BinaryScalar:
                 case MethodType.BinaryInt:
                 case MethodType.Binary:
                 case MethodType.Comparison:
-                    return "{Op1Name}, {Op2Name}";
+                    return $"{Op1Name}, {Op2Name}";
                 case MethodType.Contraction:
                     return "left, right, leftAxes, rightAxes";
                 default:
@@ -201,7 +203,7 @@
             }
         }
 
-        public string GetResultType(string typeName)
+        public string GetResultType(string tensorType, string typeName)
         {
             switch (MethodType)
             {
@@ -211,9 +213,9 @@
                 case MethodType.BinaryInt:
                 case MethodType.Binary:
                 case MethodType.Contraction:
-                    return $"Tensor<{typeName}>";
+                    return $"{tensorType}<{typeName}>";
                 case MethodType.Comparison:
-                    return $"Tensor<bool>";
+                    return $"{tensorType}<bool>";
                 default:
                     throw new ArgumentException();
             }
@@ -226,10 +228,10 @@
                 case MethodType.Unary:
                 case MethodType.BinaryScalar:
                 case MethodType.BinaryInt:
-                    return $"({ResultName}.IsRowMajor == {Op1Name}.IsRowMajor)";
+                    return $"({ResultName}.IsReveresedStride == {Op1Name}.IsReveresedStride)";
                 case MethodType.Binary:
                 case MethodType.Comparison:
-                    return $"(({ResultName}.IsRowMajor == {Op1Name}.IsRowMajor) && ({ResultName}.IsRowMajor == {Op2Name}.IsRowMajor))";
+                    return $"(({ResultName}.IsReveresedStride == {Op1Name}.IsReveresedStride) && ({ResultName}.IsReveresedStride == {Op2Name}.IsReveresedStride))";
                 case MethodType.UnaryInPlace:
                 default:
                     throw new ArgumentException();
@@ -277,7 +279,7 @@
                 case MethodType.Comparison:
                     return $"{Op1Name}.CloneEmpty<bool>()";
                 case MethodType.Contraction:
-                    return $"new Tensor<{typeName}>(resultDimensions)";
+                    return $"new DenseTensor<{typeName}>(dimensions:resultDimensions)";
                 default:
                     throw new ArgumentException();
             }

--- a/tests/System.Numerics.Tensors.Tests/TensorTests.cs
+++ b/tests/System.Numerics.Tensors.Tests/TensorTests.cs
@@ -1715,19 +1715,22 @@ namespace tests
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, true)]
-        public void MatrixMultiply(bool leftColumnMajor, bool rightColumnMajor)
+        [InlineData(false, false, TensorType.Dense)]
+        [InlineData(false, true, TensorType.Dense)]
+        [InlineData(true, true, TensorType.Dense)]
+        [InlineData(false, false, TensorType.Sparse)]
+        [InlineData(false, true, TensorType.Sparse)]
+        [InlineData(true, true, TensorType.Sparse)]
+        public void MatrixMultiply(bool leftColumnMajor, bool rightColumnMajor, TensorType tensorType)
         {
-            var left = new DenseTensor<int>(
+            var left = CreateTensor<int>(tensorType,
                 new[,]
                 {
                     {0, 1, 2},
                     {3, 4, 5}
                 }, leftColumnMajor);
 
-            var right = new DenseTensor<int>(
+            var right = CreateTensor<int>(tensorType,
                 new[,]
                 {
                     {0, 1, 2, 3, 4},
@@ -1735,7 +1738,7 @@ namespace tests
                     {10, 11, 12, 13, 14}
                 }, rightColumnMajor);
 
-            var expected = new DenseTensor<int>(
+            var expected = CreateTensor<int>(tensorType,
                 new[,]
                 {
                     {0*0 + 1*5 + 2*10, 0*1 + 1*6 + 2*11, 0*2 + 1*7 + 2*12, 0*3 + 1*8 + 2*13, 0*4 + 1*9 + 2*14},
@@ -1745,6 +1748,27 @@ namespace tests
             var actual = left.MatrixMultiply(right);
             Assert.Equal(true, StructuralComparisons.StructuralEqualityComparer.Equals(actual, expected));
         }
+
+
+        public enum TensorType
+        {
+            Dense,
+            Sparse
+        }
+        
+        private static Tensor<T> CreateTensor<T>(TensorType tensorType, Array array, bool reverseStride = false)
+        {
+            switch(tensorType)
+            {
+                case TensorType.Dense:
+                    return new DenseTensor<T>(array, reverseStride);
+                case TensorType.Sparse:
+                    return new SparseTensor<T>(array, reverseStride);
+            }
+            return null;
+        }
+
+
 
         [Theory]
         [InlineData(false, false)]


### PR DESCRIPTION
This is a large refactoring of the tensors library to support different layouts.

Right now this library is still a work-in-progress, but this moves us closer to the feature set we want to have in the prototype.

The old tensor type became DenseTensor and I've created a basic SparseTensor which uses the dictionary-of-keys (DOK) storage that's convenient for building out a sparse tensor.