### PR TITLE
Updating toolset compiler.

### DIFF
--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RuntimeFrameworkVersion>2.1.0-preview2-25610-02</RuntimeFrameworkVersion>
     <CoreFxVersion>4.3.0</CoreFxVersion>
-    <RoslynVersion>2.6.0-rdonly-ref-62106-01</RoslynVersion>
+    <RoslynVersion>2.6.0-rdonly-ref-62111-06</RoslynVersion>
     <SystemMemoryVersion>4.5.0-preview2-25610-02</SystemMemoryVersion>
     <SystemCompilerServicesUnsafeVersion>4.5.0-preview2-25610-02</SystemCompilerServicesUnsafeVersion>
     <SystemNumericsVectorsVersion>4.5.0-preview2-25610-02</SystemNumericsVectorsVersion>


### PR DESCRIPTION
- minor bug fixes
- recent merge from Roslyn master   
- should be running on 2.0 

The corresponding VSIX is:  
https://dotnet.myget.org/F/roslyn/vsix/0b48e25b-9903-4d8b-ad39-d4cca196e3c7-2.6.0.6211106.vsix
