### PR TITLE
Changing Base64 APIs to follow same pattern as text encoders

### DIFF
--- a/src/System.Azure.Experimental/System/Azure/CosmosDbAuthorizationHeader.cs
+++ b/src/System.Azure.Experimental/System/Azure/CosmosDbAuthorizationHeader.cs
@@ -133,7 +133,7 @@ namespace System.Azure.Authentication
 
             hash.Append(buffer.Slice(front.Length, totalWritten));
             hash.GetHash(buffer.Slice(front.Length, hash.OutputSize));
-            if (!Base64.EncodeInPlace(buffer.Slice(front.Length), hash.OutputSize, out written))
+            if (Base64.BytesToUtf8InPlace(buffer.Slice(front.Length), hash.OutputSize, out written) != OperationStatus.Done)
             {
                 throw new NotImplementedException("need to resize buffer");
             }

--- a/src/System.Azure.Experimental/System/Azure/Key.cs
+++ b/src/System.Azure.Experimental/System/Azure/Key.cs
@@ -23,7 +23,7 @@ namespace System.Azure.Authentication
             }
 
             var keyBytes = new byte[64];
-            var result = Base64.Decode(buffer.Slice(0, written), keyBytes, out consumed, out written);
+            var result = Base64.Utf8ToBytes(buffer.Slice(0, written), keyBytes, out consumed, out written);
             if (result != OperationStatus.Done || written != 64)
             {
                 throw new NotImplementedException("need to resize buffer");

--- a/src/System.Azure.Experimental/System/Azure/StorageAccessSignature.cs
+++ b/src/System.Azure.Experimental/System/Azure/StorageAccessSignature.cs
@@ -65,7 +65,7 @@ namespace System.Azure.Authentication
             hash.Append(formatted);
             hash.GetHash(output.Slice(0, hash.OutputSize));
 
-            if (!Base64.EncodeInPlace(output, hash.OutputSize, out written))
+            if (Base64.BytesToUtf8InPlace(output, hash.OutputSize, out written) != OperationStatus.Done)
             {
                 bytesWritten = 0;
                 return false;

--- a/src/System.Binary.Base64/System/Binary/Base64.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64.cs
@@ -6,7 +6,23 @@ namespace System.Binary.Base64
 {
     public static partial class Base64
     {
-        public static readonly BufferEncoder Encoder = new ToBase64();
-        public static readonly BufferDecoder Decoder = new FromBase64();
+        public static readonly BufferEncoder BytesToUtf8Encoder = new ToBase64Utf8();
+        public static readonly BufferDecoder Utf8ToBytesDecoder = new FromBase64Utf8();
+
+        public static OperationStatus BytesToUtf8(ReadOnlySpan<byte> bytes, Span<byte> utf8, out int consumed, out int written)
+            =>Encode(bytes, utf8, out consumed, out written);
+
+        public static int BytesToUtf8Length(int bytesLength) => ComputeEncodedUtf8Length(bytesLength);
+
+        public static OperationStatus BytesToUtf8InPlace(Span<byte> buffer, int bytesLength, out int written)
+            => EncodeInPlace(buffer, bytesLength, out written) ? OperationStatus.Done : OperationStatus.DestinationTooSmall;
+
+        public static OperationStatus Utf8ToBytes(ReadOnlySpan<byte> utf8, Span<byte> bytes, out int consumed, out int written)
+            => Decode(utf8, bytes, out consumed, out written);
+
+        public static OperationStatus Utf8ToBytesInPlace(Span<byte> buffer, out int consumed, out int written)
+            => DecodeInPlace(buffer, out consumed, out written);
+
+        public static int Utf8ToBytesLength(ReadOnlySpan<byte> utf8) => ComputeDecodedUtf8Length(utf8);
     }
 }

--- a/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 namespace System.Binary.Base64
@@ -28,8 +29,9 @@ namespace System.Binary.Base64
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         };
 
+        [Obsolete("Use Base64.Utf8ToBytesLength")]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ComputeDecodedLength(ReadOnlySpan<byte> source)
+        public static int ComputeDecodedUtf8Length(ReadOnlySpan<byte> source)
         {
             int srcLength = source.Length;
 
@@ -84,6 +86,8 @@ namespace System.Binary.Base64
             Unsafe.Add(ref destBytes, 2) = (byte)i0;
         }
 
+        [Obsolete("Use Base64.Utf8ToBytes")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static OperationStatus Decode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
         {
             ref byte srcBytes = ref source.DangerousGetPinnableReference();
@@ -191,6 +195,8 @@ namespace System.Binary.Base64
         /// </summary>
         /// <param name="buffer"></param>
         /// <returns>Number of bytes written to the buffer.</returns>
+        [Obsolete("Use Base64.Utf8ToBytesInPlace")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static OperationStatus DecodeInPlace(Span<byte> buffer, out int bytesConsumed, out int bytesWritten)
         {
             ref byte bufferBytes = ref buffer.DangerousGetPinnableReference();
@@ -282,10 +288,15 @@ namespace System.Binary.Base64
             return OperationStatus.InvalidData;
         }
 
-        sealed class FromBase64 : BufferDecoder
+        sealed class FromBase64Utf8 : BufferDecoder
         {
             public override OperationStatus Decode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
                 => Base64.Decode(source, destination, out bytesConsumed, out bytesWritten);
+
+            public override OperationStatus DecodeInPlace(Span<byte> buffer, int inputLength, out int written)
+                => Base64.DecodeInPlace(buffer.Slice(0, inputLength), out var consumed, out written);
+
+            public override bool IsDecodeInPlaceSupported => true;
         }
     }
 }

--- a/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
 namespace System.Binary.Base64
@@ -23,7 +24,8 @@ namespace System.Binary.Base64
         const byte s_encodingPad = (byte)'=';              // '=', for padding
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ComputeEncodedLength(int sourceLength)
+        [Obsolete("Use Base64.BytesToUtf8Length")]
+        public static int ComputeEncodedUtf8Length(int sourceLength)
         {
             Diagnostics.Debug.Assert(sourceLength >= 0);
             return ((sourceLength + 2) / 3) << 2;
@@ -103,6 +105,8 @@ namespace System.Binary.Base64
         /// <param name="source"></param>
         /// <param name="destination"></param>
         /// <returns>Number of bytes written to the destination.</returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [Obsolete("Use Base64.BytesToUtf8InPlace")]
         public static OperationStatus Encode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
         {
             ref byte srcBytes = ref source.DangerousGetPinnableReference();
@@ -157,9 +161,11 @@ namespace System.Binary.Base64
         /// <param name="buffer">Buffer containing source bytes and empty space for the encoded bytes</param>
         /// <param name="sourceLength">Number of bytes to encode.</param>
         /// <returns>Number of bytes written to the buffer.</returns>
+        [Obsolete("Use Base64.BytesToUtf8InPlace")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static bool EncodeInPlace(Span<byte> buffer, int sourceLength, out int bytesWritten)
         {
-            var encodedLength = ComputeEncodedLength(sourceLength);
+            var encodedLength = ComputeEncodedUtf8Length(sourceLength);
             if (buffer.Length < encodedLength) goto FalseExit;
 
             var leftover = sourceLength - sourceLength / 3 * 3; // how many bytes after packs of 3
@@ -192,10 +198,15 @@ namespace System.Binary.Base64
             return false;
         }
 
-        sealed class ToBase64 : BufferEncoder
+        sealed class ToBase64Utf8 : BufferEncoder
         {
             public override OperationStatus Encode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
                 => Base64.Encode(source, destination, out bytesConsumed, out bytesWritten);
+
+            public override OperationStatus EncodeInPlace(Span<byte> buffer, int inputLength, out int written)
+                => Base64.EncodeInPlace(buffer, inputLength, out written)?OperationStatus.Done:OperationStatus.DestinationTooSmall;
+
+            public override bool IsEncodeInPlaceSupported => true;
         }
     }
 }

--- a/src/System.Buffers.Primitives/System/Buffers/BufferDecoder.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/BufferDecoder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+
 namespace System.Buffers
 {
     public abstract class BufferDecoder : IBufferOperation
@@ -10,12 +12,29 @@ namespace System.Buffers
 
         public virtual OperationStatus DecodeInPlace(Span<byte> buffer, int inputLength, out int written)
         {
-            written = 0;
-            return OperationStatus.NotSupported;
+            throw new NotSupportedException();
         }
+
+        public virtual bool IsDecodeInPlaceSupported { get; } = false;
 
         OperationStatus IBufferOperation.Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written) =>
             Decode(input, output, out consumed, out written);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj)
+        {
+            return base.Equals(obj);
+        }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString()
+        {
+            return base.ToString();
+        }
     }
 }
 

--- a/src/System.Buffers.Primitives/System/Buffers/BufferEncoder.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/BufferEncoder.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+
 namespace System.Buffers
 {
     public abstract class BufferEncoder : IBufferOperation
@@ -10,12 +12,29 @@ namespace System.Buffers
 
         public virtual OperationStatus EncodeInPlace(Span<byte> buffer, int inputLength, out int written)
         {
-            written = 0;
-            return OperationStatus.NotSupported;
+            throw new NotSupportedException();
         }
+
+        public virtual bool IsEncodeInPlaceSupported { get; } = false;
 
         OperationStatus IBufferOperation.Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written) =>
             Encode(input, output, out consumed, out written);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj)
+        {
+            return base.Equals(obj);
+        }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString()
+        {
+            return base.ToString();
+        }
     }
 }
 

--- a/src/System.Buffers.Primitives/System/Buffers/Transformation.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Transformation.cs
@@ -15,6 +15,5 @@ namespace System.Buffers
         DestinationTooSmall,
         NeedMoreSourceData,
         InvalidData, // TODO: how do we communicate details of the error
-        NotSupported,
     }
 }

--- a/tests/System.Binary.Base64.Tests/Base64TestHelper.cs
+++ b/tests/System.Binary.Base64.Tests/Base64TestHelper.cs
@@ -104,9 +104,9 @@ namespace System.Binary.Base64.Tests
         {
             bytesConsumed = 0;
             bytesWritten = 0;
-            if (Base64.Decoder.Decode(source1, destination, out int consumed1, out int written1) == OperationStatus.Done)
+            if (Base64.Utf8ToBytes(source1, destination, out int consumed1, out int written1) == OperationStatus.Done)
             {
-                Base64.Decoder.Decode(source2, destination.Slice(written1), out int consumed2, out int written2);
+                Base64.Utf8ToBytes(source2, destination.Slice(written1), out int consumed2, out int written2);
                 bytesConsumed = consumed2;
                 bytesWritten = written2;
             }
@@ -119,7 +119,7 @@ namespace System.Binary.Base64.Tests
             bytesConsumed = 0;
             bytesWritten = 0;
             int afterMergeSlice = 0;
-            if (Base64.Decoder.Decode(source1, destination, out int consumed1, out int written1) != OperationStatus.Done)
+            if (Base64.Utf8ToBytes(source1, destination, out int consumed1, out int written1) != OperationStatus.Done)
             {
                 int leftOverBytes = source1.Length - consumed1;
                 if (leftOverBytes < 4)
@@ -131,7 +131,7 @@ namespace System.Binary.Base64.Tests
                     source2.Slice(0, amountToCopy).CopyTo(stackSpan.Slice(leftOverBytes));
                     amountOfData += amountToCopy;
 
-                    Base64.Decoder.Decode(stackSpan.Slice(0, amountOfData), destination.Slice(written1), out int consumed2, out int written2);
+                    Base64.Utf8ToBytes(stackSpan.Slice(0, amountOfData), destination.Slice(written1), out int consumed2, out int written2);
                     bytesConsumed = consumed2;
                     bytesWritten = written2;
 
@@ -144,7 +144,7 @@ namespace System.Binary.Base64.Tests
             {
                 return;
             }
-            Base64.Decoder.Decode(source2.Slice(afterMergeSlice), destination.Slice(bytesWritten), out int consumed3, out int written3);
+            Base64.Utf8ToBytes(source2.Slice(afterMergeSlice), destination.Slice(bytesWritten), out int consumed3, out int written3);
             bytesConsumed += consumed3;
             bytesWritten += written3;
         }

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -20,8 +20,8 @@ namespace System.Binary.Base64.Tests
             for (int value = 0; value < 256; value++)
             {
                 Span<byte> sourceBytes = bytes.AsSpan().Slice(0, value + 1);
-                Span<byte> encodedBytes = new byte[Base64.ComputeEncodedLength(sourceBytes.Length)];
-                Assert.Equal(OperationStatus.Done, Base64.Encoder.Encode(sourceBytes, encodedBytes, out int consumed, out int encodedBytesCount));
+                Span<byte> encodedBytes = new byte[Base64.BytesToUtf8Length(sourceBytes.Length)];
+                Assert.Equal(OperationStatus.Done, Base64.BytesToUtf8(sourceBytes, encodedBytes, out int consumed, out int encodedBytesCount));
                 Assert.Equal(encodedBytes.Length, encodedBytesCount);
 
                 string encodedText = Text.Encoding.ASCII.GetString(encodedBytes.ToArray());
@@ -30,8 +30,8 @@ namespace System.Binary.Base64.Tests
 
                 if (encodedBytes.Length % 4 == 0)
                 {
-                    Span<byte> decodedBytes = new byte[Base64.ComputeDecodedLength(encodedBytes)];
-                    Assert.Equal(OperationStatus.Done, Base64.Decoder.Decode(encodedBytes, decodedBytes, out consumed, out int decodedByteCount));
+                    Span<byte> decodedBytes = new byte[Base64.Utf8ToBytesLength(encodedBytes)];
+                    Assert.Equal(OperationStatus.Done, Base64.Utf8ToBytes(encodedBytes, decodedBytes, out consumed, out int decodedByteCount));
                     Assert.Equal(sourceBytes.Length, decodedByteCount);
                     Assert.True(sourceBytes.SequenceEqual(decodedBytes));
                 }
@@ -48,8 +48,8 @@ namespace System.Binary.Base64.Tests
                 Span<byte> source = new byte[numBytes];
                 Base64TestHelper.InitalizeBytes(source, numBytes);
 
-                Span<byte> encodedBytes = new byte[Base64.ComputeEncodedLength(source.Length)];
-                Assert.Equal(OperationStatus.Done, Base64.Encoder.Encode(source, encodedBytes, out int consumed, out int encodedBytesCount));
+                Span<byte> encodedBytes = new byte[Base64.BytesToUtf8Length(source.Length)];
+                Assert.Equal(OperationStatus.Done, Base64.BytesToUtf8(source, encodedBytes, out int consumed, out int encodedBytesCount));
                 Assert.Equal(encodedBytes.Length, encodedBytesCount);
 
                 string encodedText = Text.Encoding.ASCII.GetString(encodedBytes.ToArray());
@@ -65,16 +65,16 @@ namespace System.Binary.Base64.Tests
             Base64TestHelper.InitalizeBytes(source);
 
             int outputSize = 320;
-            int requiredSize = Base64.ComputeEncodedLength(source.Length);
+            int requiredSize = Base64.BytesToUtf8Length(source.Length);
 
             Span<byte> encodedBytes = new byte[outputSize];
             Assert.Equal(OperationStatus.DestinationTooSmall,
-                Base64.Encoder.Encode(source, encodedBytes, out int consumed, out int written));
+                Base64.BytesToUtf8(source, encodedBytes, out int consumed, out int written));
             Assert.Equal(encodedBytes.Length, written);
             Assert.Equal(encodedBytes.Length / 4 * 3, consumed);
             encodedBytes = new byte[requiredSize - outputSize];
             Assert.Equal(OperationStatus.Done,
-                Base64.Encoder.Encode(source.Slice(consumed), encodedBytes, out consumed, out written));
+                Base64.BytesToUtf8(source.Slice(consumed), encodedBytes, out consumed, out written));
             Assert.Equal(encodedBytes.Length, written);
             Assert.Equal(encodedBytes.Length / 4 * 3, consumed);
 
@@ -97,9 +97,9 @@ namespace System.Binary.Base64.Tests
                 Span<byte> source = new byte[numBytes];
                 Base64TestHelper.InitalizeDecodableBytes(source, numBytes);
 
-                Span<byte> decodedBytes = new byte[Base64.ComputeDecodedLength(source)];
+                Span<byte> decodedBytes = new byte[Base64.Utf8ToBytesLength(source)];
                 Assert.Equal(OperationStatus.Done, 
-                    Base64.Decoder.Decode(source, decodedBytes, out int consumed, out int decodedByteCount));
+                    Base64.Utf8ToBytes(source, decodedBytes, out int consumed, out int decodedByteCount));
                 Assert.Equal(decodedBytes.Length, decodedByteCount);
 
                 string expectedStr = Text.Encoding.ASCII.GetString(source.ToArray());
@@ -116,7 +116,7 @@ namespace System.Binary.Base64.Tests
             for (int j = 0; j < 8; j++)
             {
                 Span<byte> source = new byte[] { 50, 50, 50, 50, 80, 80, 80, 80 };
-                Span<byte> decodedBytes = new byte[Base64.ComputeDecodedLength(source)];
+                Span<byte> decodedBytes = new byte[Base64.Utf8ToBytesLength(source)];
 
                 for (int i = 0; i < invalidBytes.Length; i++)
                 {
@@ -126,7 +126,7 @@ namespace System.Binary.Base64.Tests
                     source[j] = (byte)invalidBytes[i];
 
                     Assert.Equal(OperationStatus.InvalidData,
-                        Base64.Decoder.Decode(source, decodedBytes, out int consumed, out int decodedByteCount));
+                        Base64.Utf8ToBytes(source, decodedBytes, out int consumed, out int decodedByteCount));
                 }
             }
         }
@@ -138,24 +138,24 @@ namespace System.Binary.Base64.Tests
             for (int j = 0; j < 7; j++)
             {
                 Span<byte> source = new byte[] { 50, 50, 50, 50, 80, 80, 80, 80 };
-                Span<byte> decodedBytes = new byte[Base64.ComputeDecodedLength(source)];
+                Span<byte> decodedBytes = new byte[Base64.Utf8ToBytesLength(source)];
                 source[j] = Base64TestHelper.s_encodingPad;
                 Assert.Equal(OperationStatus.InvalidData,
-                    Base64.Decoder.Decode(source, decodedBytes, out int consumed, out int decodedByteCount));
+                    Base64.Utf8ToBytes(source, decodedBytes, out int consumed, out int decodedByteCount));
             }
 
             {
                 Span<byte> source = new byte[] { 50, 50, 50, 50, 80, 80, 80, 80 };
-                Span<byte> decodedBytes = new byte[Base64.ComputeDecodedLength(source)];
+                Span<byte> decodedBytes = new byte[Base64.Utf8ToBytesLength(source)];
                 source[6] = Base64TestHelper.s_encodingPad;
                 source[7] = Base64TestHelper.s_encodingPad;
                 Assert.Equal(OperationStatus.Done,
-                    Base64.Decoder.Decode(source, decodedBytes, out int consumed, out int decodedByteCount));
+                    Base64.Utf8ToBytes(source, decodedBytes, out int consumed, out int decodedByteCount));
 
                 source = new byte[] { 50, 50, 50, 50, 80, 80, 80, 80 };
                 source[7] = Base64TestHelper.s_encodingPad;
                 Assert.Equal(OperationStatus.Done,
-                    Base64.Decoder.Decode(source, decodedBytes, out consumed, out decodedByteCount));
+                    Base64.Utf8ToBytes(source, decodedBytes, out consumed, out decodedByteCount));
             }
         }
 
@@ -166,16 +166,16 @@ namespace System.Binary.Base64.Tests
             Base64TestHelper.InitalizeDecodableBytes(source);
 
             int outputSize = 240;
-            int requiredSize = Base64.ComputeDecodedLength(source);
+            int requiredSize = Base64.Utf8ToBytesLength(source);
 
             Span<byte> decodedBytes = new byte[outputSize];
             Assert.Equal(OperationStatus.DestinationTooSmall, 
-                Base64.Decoder.Decode(source, decodedBytes, out int consumed, out int decodedByteCount));
+                Base64.Utf8ToBytes(source, decodedBytes, out int consumed, out int decodedByteCount));
             Assert.Equal(decodedBytes.Length, decodedByteCount);
             Assert.Equal(decodedBytes.Length / 3 * 4, consumed);
             decodedBytes = new byte[requiredSize - outputSize];
             Assert.Equal(OperationStatus.Done,
-                Base64.Decoder.Decode(source.Slice(consumed), decodedBytes, out consumed, out decodedByteCount));
+                Base64.Utf8ToBytes(source.Slice(consumed), decodedBytes, out consumed, out decodedByteCount));
             Assert.Equal(decodedBytes.Length, decodedByteCount);
             Assert.Equal(decodedBytes.Length / 3 * 4, consumed);
 
@@ -192,17 +192,17 @@ namespace System.Binary.Base64.Tests
             int[] expected = { 0, 4, 4, 4, 8, 8, 8, 2147483640, 2147483640, 2147483640, 2147483644, 2147483644, 2147483644 };
             for (int i = 0; i < input.Length; i++)
             {
-                Assert.Equal(expected[i], Base64.ComputeEncodedLength(input[i]));
+                Assert.Equal(expected[i], Base64.BytesToUtf8Length(input[i]));
             }
 
-            Assert.True(Base64.ComputeEncodedLength(1610612734) < 0);   // integer overflow
+            Assert.True(Base64.BytesToUtf8Length(1610612734) < 0);   // integer overflow
         }
 
         [Fact]
         public void ComputeDecodedLength()
         {
             Span<byte> sourceEmpty = Span<byte>.Empty;
-            Assert.Equal(0, Base64.ComputeDecodedLength(sourceEmpty));
+            Assert.Equal(0, Base64.Utf8ToBytesLength(sourceEmpty));
 
             int[] input = { 4, 8, 12, 16, 20 };
             int[] expected = { 3, 6, 9, 12, 15 };
@@ -211,11 +211,11 @@ namespace System.Binary.Base64.Tests
             {
                 int sourceLength = input[i];
                 Span<byte> source = new byte[sourceLength];
-                Assert.Equal(expected[i], Base64.ComputeDecodedLength(source));
+                Assert.Equal(expected[i], Base64.Utf8ToBytesLength(source));
                 source[sourceLength - 1] = Base64TestHelper.s_encodingPad;                          // single character padding
-                Assert.Equal(expected[i] - 1, Base64.ComputeDecodedLength(source));
+                Assert.Equal(expected[i] - 1, Base64.Utf8ToBytesLength(source));
                 source[sourceLength - 2] = Base64TestHelper.s_encodingPad;                          // two characters padding
-                Assert.Equal(expected[i] - 2, Base64.ComputeDecodedLength(source));
+                Assert.Equal(expected[i] - 2, Base64.Utf8ToBytesLength(source));
             }
 
             // int.MaxValue - (int.MaxValue % 4) => 2147483644, largest multiple of 4 less than int.MaxValue
@@ -225,11 +225,11 @@ namespace System.Binary.Base64.Tests
                 int sourceLength = 2000000000;
                 int expectedLength = 1500000000;
                 Span<byte> source = new byte[sourceLength];
-                Assert.Equal(expectedLength, Base64.ComputeDecodedLength(source));
+                Assert.Equal(expectedLength, Base64.Utf8ToBytesLength(source));
                 source[sourceLength - 1] = Base64TestHelper.s_encodingPad;                          // single character padding
-                Assert.Equal(expectedLength - 1, Base64.ComputeDecodedLength(source));
+                Assert.Equal(expectedLength - 1, Base64.Utf8ToBytesLength(source));
                 source[sourceLength - 2] = Base64TestHelper.s_encodingPad;                          // two characters padding
-                Assert.Equal(expectedLength - 2, Base64.ComputeDecodedLength(source));
+                Assert.Equal(expectedLength - 2, Base64.Utf8ToBytesLength(source));
             }
             catch (OutOfMemoryException)
             {
@@ -243,13 +243,13 @@ namespace System.Binary.Base64.Tests
             {
                 int sourceLength = lengthsNotMultipleOfFour[i];
                 Span<byte> source = new byte[sourceLength];
-                Assert.Equal(expectedOutput[i], Base64.ComputeDecodedLength(source));
+                Assert.Equal(expectedOutput[i], Base64.Utf8ToBytesLength(source));
                 source[sourceLength - 1] = Base64TestHelper.s_encodingPad;
-                Assert.Equal(expectedOutput[i], Base64.ComputeDecodedLength(source));
+                Assert.Equal(expectedOutput[i], Base64.Utf8ToBytesLength(source));
                 if (sourceLength > 1)
                 {
                     source[sourceLength - 2] = Base64TestHelper.s_encodingPad;
-                    Assert.Equal(expectedOutput[i], Base64.ComputeDecodedLength(source));
+                    Assert.Equal(expectedOutput[i], Base64.Utf8ToBytesLength(source));
                 }
             }
         }
@@ -267,16 +267,16 @@ namespace System.Binary.Base64.Tests
             for (int value = 0; value < 256; value++)
             {
                 var sourceBytes = testBytes.AsSpan().Slice(0, value + 1);
-                var buffer = new byte[Base64.ComputeEncodedLength(sourceBytes.Length)];
+                var buffer = new byte[Base64.BytesToUtf8Length(sourceBytes.Length)];
                 var bufferSlice = buffer.AsSpan();
 
-                Base64.Encoder.Encode(sourceBytes, bufferSlice, out int consumed, out int written);
+                Base64.BytesToUtf8(sourceBytes, bufferSlice, out int consumed, out int written);
 
                 var encodedText = Text.Encoding.ASCII.GetString(bufferSlice.ToArray());
                 var expectedText = Convert.ToBase64String(testBytes, 0, value + 1);
                 Assert.Equal(expectedText, encodedText);
 
-                Assert.Equal(OperationStatus.Done, Base64.DecodeInPlace(bufferSlice, out int bytesConsumed, out int bytesWritten));
+                Assert.Equal(OperationStatus.Done, Base64.Utf8ToBytesInPlace(bufferSlice, out int bytesConsumed, out int bytesWritten));
                 Assert.Equal(sourceBytes.Length, bytesWritten);
                 Assert.Equal(bufferSlice.Length, bytesConsumed);
 
@@ -292,9 +292,9 @@ namespace System.Binary.Base64.Tests
         {
             Span<byte> inputSpan = new byte[1000];
             Base64TestHelper.InitalizeDecodableBytes(inputSpan);
-            int requiredLength = Base64.ComputeDecodedLength(inputSpan);
+            int requiredLength = Base64.Utf8ToBytesLength(inputSpan);
             Span<byte> expected = new byte[requiredLength];
-            Assert.Equal(OperationStatus.Done, Base64.Decoder.Decode(inputSpan, expected, out int bytesConsumed, out int bytesWritten));
+            Assert.Equal(OperationStatus.Done, Base64.Utf8ToBytes(inputSpan, expected, out int bytesConsumed, out int bytesWritten));
 
             byte[][] input = new byte[10][];
 
@@ -310,7 +310,7 @@ namespace System.Binary.Base64.Tests
             Assert.Equal(1000, sum);
 
             var output = new TestOutput();
-            Base64.Decoder.Pipe(ReadOnlyBytes.Create(input), output);
+            Base64.Utf8ToBytesDecoder.Pipe(ReadOnlyBytes.Create(input), output);
 
             Assert.True(expected.SequenceEqual(output.GetBuffer.Slice(0, requiredLength)));
         }
@@ -338,8 +338,8 @@ namespace System.Binary.Base64.Tests
                 var copy = testBytes.Clone();
                 var expectedText = Convert.ToBase64String(testBytes, 0, numberOfBytesToTest);
 
-                Assert.True(Base64.EncodeInPlace(testBytes, numberOfBytesToTest, out int bytesWritten));
-                Assert.Equal(Base64.ComputeEncodedLength(numberOfBytesToTest), bytesWritten);
+                Assert.Equal(OperationStatus.Done, Base64.BytesToUtf8InPlace(testBytes, numberOfBytesToTest, out int bytesWritten));
+                Assert.Equal(Base64.BytesToUtf8Length(numberOfBytesToTest), bytesWritten);
 
                 var encodedText = Text.Encoding.ASCII.GetString(testBytes, 0, bytesWritten);
 

--- a/tests/System.Binary.Base64.Tests/PerformanceTests.cs
+++ b/tests/System.Binary.Base64.Tests/PerformanceTests.cs
@@ -20,12 +20,12 @@ namespace System.Binary.Base64.Tests
         {
             Span<byte> source = new byte[numberOfBytes];
             Base64TestHelper.InitalizeBytes(source);
-            Span<byte> destination = new byte[Base64.ComputeEncodedLength(numberOfBytes)];
+            Span<byte> destination = new byte[Base64.BytesToUtf8Length(numberOfBytes)];
 
             foreach (var iteration in Benchmark.Iterations) {
                 using (iteration.StartMeasurement()) {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                        Base64.Encoder.Encode(source, destination, out int consumed, out int written);
+                        Base64.BytesToUtf8(source, destination, out int consumed, out int written);
                 }
             }
         }
@@ -39,7 +39,7 @@ namespace System.Binary.Base64.Tests
         {
             var source = new byte[numberOfBytes];
             Base64TestHelper.InitalizeBytes(source.AsSpan());
-            var destination = new char[Base64.ComputeEncodedLength(numberOfBytes)];
+            var destination = new char[Base64.BytesToUtf8Length(numberOfBytes)];
 
             foreach (var iteration in Benchmark.Iterations) {
                 using (iteration.StartMeasurement()) {
@@ -58,13 +58,13 @@ namespace System.Binary.Base64.Tests
         {
             Span<byte> source = new byte[numberOfBytes];
             Base64TestHelper.InitalizeBytes(source);
-            Span<byte> encoded = new byte[Base64.ComputeEncodedLength(numberOfBytes)];
-            Base64.Encoder.Encode(source, encoded, out int consumed, out int written);
+            Span<byte> encoded = new byte[Base64.BytesToUtf8Length(numberOfBytes)];
+            Base64.BytesToUtf8(source, encoded, out int consumed, out int written);
 
             foreach (var iteration in Benchmark.Iterations) {
                 using (iteration.StartMeasurement()) {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                        Base64.Decoder.Decode(encoded, source, out int bytesConsumed, out int bytesWritten);
+                        Base64.Utf8ToBytes(encoded, source, out int bytesConsumed, out int bytesWritten);
                 }
             }
         }
@@ -97,7 +97,7 @@ namespace System.Binary.Base64.Tests
         {
             Span<byte> source = new byte[numberOfBytes];
             Base64TestHelper.InitalizeBytes(source);
-            int length = Base64.ComputeEncodedLength(numberOfBytes);
+            int length = Base64.BytesToUtf8Length(numberOfBytes);
 
             foreach (var iteration in Benchmark.Iterations)
             {
@@ -106,8 +106,8 @@ namespace System.Binary.Base64.Tests
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
                         Span<byte> encodedSpan = new byte[length];
-                        Base64.Encoder.Encode(source, encodedSpan, out int consumed, out int written);
-                        Base64.DecodeInPlace(encodedSpan, out int bytesConsumed, out int bytesWritten);
+                        Base64.BytesToUtf8(source, encodedSpan, out int consumed, out int written);
+                        Base64.Utf8ToBytesInPlace(encodedSpan, out int bytesConsumed, out int bytesWritten);
                     }
                 }
             }
@@ -124,7 +124,7 @@ namespace System.Binary.Base64.Tests
             Span<byte> source = new byte[inputBufferSize];
             Base64TestHelper.InitalizeDecodableBytes(source);
             Span<byte> expected = new byte[inputBufferSize];
-            Base64.Decoder.Decode(source, expected, out int expectedConsumed, out int expectedWritten);
+            Base64.Utf8ToBytes(source, expected, out int expectedConsumed, out int expectedWritten);
 
             Base64TestHelper.SplitSourceIntoSpans(source, false, out ReadOnlySpan<byte> source1, out ReadOnlySpan<byte> source2);
 
@@ -189,7 +189,7 @@ namespace System.Binary.Base64.Tests
             Span<byte> source = new byte[inputBufferSize];
             Base64TestHelper.InitalizeDecodableBytes(source);
             Span<byte> expected = new byte[inputBufferSize];
-            Base64.Decoder.Decode(source, expected, out int expectedConsumed, out int expectedWritten);
+            Base64.Utf8ToBytes(source, expected, out int expectedConsumed, out int expectedWritten);
 
             Base64TestHelper.SplitSourceIntoSpans(source, true, out ReadOnlySpan<byte> source1, out ReadOnlySpan<byte> source2);
 


### PR DESCRIPTION
The new APIs are as follows:

```c#
    public static class Base64 {
        public static readonly BufferDecoder Utf8ToBytesDecoder;
        public static readonly BufferEncoder BytesToUtf8Encoder;

        public static OperationStatus BytesToUtf8(ReadOnlySpan<byte> bytes, Span<byte> utf8, out int consumed, out int written);
        public static OperationStatus BytesToUtf8InPlace(Span<byte> buffer, int bytesLength, out int written);
        public static int BytesToUtf8Length(int bytesLength);

        public static OperationStatus Utf8ToBytes(ReadOnlySpan<byte> utf8, Span<byte> bytes, out int consumed, out int written);
        public static OperationStatus Utf8ToBytesInPlace(Span<byte> buffer, out int consumed, out int written);
        public static int Utf8ToBytesLength(ReadOnlySpan<byte> utf8);
    }
```

@ahsonkhan, @shiftylogic, @terrajobst, @joshfree 