### PR TITLE
Removed multiple Utf8 classes

### DIFF
--- a/samples/LibuvWithNonAllocatingFormatters/Program.cs
+++ b/samples/LibuvWithNonAllocatingFormatters/Program.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Buffers;
+using System.Buffers.Text;
 using System.Linq;
 using System.Net.Libuv;
 using System.Text;

--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/HttpServer.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/HttpServer.cs
@@ -11,6 +11,7 @@ using System.Text.Http;
 using System.Threading.Tasks;
 using System.Text;
 using System.Threading;
+using System.Buffers.Text;
 
 namespace Microsoft.Net.Http
 {

--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/Log.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/Log.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
 using System.Collections.Sequences;
 using System.Text;
 using System.Text.Http;

--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/RoutingTable.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/RoutingTable.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Buffers.Text;
 using System.Text;
 using System.Text.Http;
 using System.Text.Utf8;

--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/TcpConnectionFormatter.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/TcpConnectionFormatter.cs
@@ -5,6 +5,7 @@
 using Microsoft.Net.Sockets;
 using System;
 using System.Buffers;
+using System.Buffers.Text;
 using System.Text;
 using System.Text.Formatting;
 using System.Text.Http;
@@ -95,7 +96,7 @@ namespace Microsoft.Net.Http
         }
         int WriteChunkPrefix(Span<byte> chunkPrefixBuffer, int chunkLength)
         {
-            if (!System.Text.Formatters.Utf8.TryFormat(chunkLength, chunkPrefixBuffer, out var written, 'X'))
+            if (!Formatters.Utf8.TryFormat(chunkLength, chunkPrefixBuffer, out var written, 'X'))
             {
                 throw new Exception("cannot format chunk length");
             }

--- a/samples/QotdService/Program.cs
+++ b/samples/QotdService/Program.cs
@@ -4,6 +4,8 @@
 
 using System.Net.Libuv;
 using System.Text.Utf8;
+using System.Buffers.Text;
+using System.Buffers;
 
 namespace QotdService
 {

--- a/samples/System.IO.Pipelines.Samples/Framing/Codec.cs
+++ b/samples/System.IO.Pipelines.Samples/Framing/Codec.cs
@@ -8,6 +8,7 @@ using System.Text.Formatting;
 using System.Threading.Tasks;
 using System.IO.Pipelines.Networking.Libuv;
 using System.IO.Pipelines.Text.Primitives;
+using System.Buffers.Text;
 
 namespace System.IO.Pipelines.Samples.Framing
 {

--- a/samples/System.IO.Pipelines.Samples/HttpClient/PipelineHttpClientHandler.cs
+++ b/samples/System.IO.Pipelines.Samples/HttpClient/PipelineHttpClientHandler.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using System.IO.Pipelines.Text.Primitives;
 using System.Text;
 using System.Text.Formatting;
+using System.Buffers.Text;
 
 namespace System.IO.Pipelines.Samples
 {

--- a/samples/System.IO.Pipelines.Samples/HttpServer/HttpConnection.cs
+++ b/samples/System.IO.Pipelines.Samples/HttpServer/HttpConnection.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
 using System.Text.Formatting;
+using System.Buffers.Text;
 
 namespace System.IO.Pipelines.Samples.Http
 {

--- a/samples/System.IO.Pipelines.Samples/HttpServer/ResponseHeaderDictionary.cs
+++ b/samples/System.IO.Pipelines.Samples/HttpServer/ResponseHeaderDictionary.cs
@@ -9,6 +9,7 @@ using System.Text.Formatting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Server.Kestrel.Internal.Http;
 using Microsoft.Extensions.Primitives;
+using System.Buffers.Text;
 
 namespace System.IO.Pipelines.Samples.Http
 {

--- a/samples/System.IO.Pipelines.Samples/SampleBase/RawHttpClientSampleBase.cs
+++ b/samples/System.IO.Pipelines.Samples/SampleBase/RawHttpClientSampleBase.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Text;
 using System.Text.Formatting;
+using System.Buffers.Text;
 
 namespace System.IO.Pipelines.Samples
 {

--- a/samples/System.IO.Pipelines.Samples/SampleBase/RawHttpServerSampleBase.cs
+++ b/samples/System.IO.Pipelines.Samples/SampleBase/RawHttpServerSampleBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers.Text;
 using System.Net;
 using System.Text;
 using System.Text.Formatting;

--- a/src/System.Azure.Experimental/System/Azure/CosmosDbAuthorizationHeader.cs
+++ b/src/System.Azure.Experimental/System/Azure/CosmosDbAuthorizationHeader.cs
@@ -4,8 +4,8 @@
 using System.Binary.Base64;
 using System.Buffers;
 using System.Buffers.Cryptography;
+using System.Buffers.Text;
 using System.Text;
-using System.Text.Encoders;
 using System.Text.Encodings.Web.Utf8;
 
 namespace System.Azure.Authentication
@@ -41,7 +41,7 @@ namespace System.Azure.Authentication
             totalWritten += s_type.Length;
             var bufferSlice = buffer.Slice(totalWritten);
 
-            if (Utf16.ToUtf8(keyType.AsReadOnlySpan().AsBytes(), bufferSlice, out consumed, out written) != OperationStatus.Done)
+            if (Encodings.Utf16.ToUtf8(keyType.AsReadOnlySpan().AsBytes(), bufferSlice, out consumed, out written) != OperationStatus.Done)
             {
                 throw new NotImplementedException("need to resize buffer");
             }
@@ -53,7 +53,7 @@ namespace System.Azure.Authentication
 
             bufferSlice = buffer.Slice(totalWritten);
 
-            if (Utf16.ToUtf8(tokenVersion.AsReadOnlySpan().AsBytes(), bufferSlice, out consumed, out written) != OperationStatus.Done)
+            if (Encodings.Utf16.ToUtf8(tokenVersion.AsReadOnlySpan().AsBytes(), bufferSlice, out consumed, out written) != OperationStatus.Done)
             {
                 throw new NotImplementedException("need to resize buffer");
             }
@@ -85,11 +85,11 @@ namespace System.Azure.Authentication
             }
             else
             {
-                if (Utf16.ToUtf8(verb.AsReadOnlySpan().AsBytes(), payload, out consumed, out written) != OperationStatus.Done)
+                if (Encodings.Utf16.ToUtf8(verb.AsReadOnlySpan().AsBytes(), payload, out consumed, out written) != OperationStatus.Done)
                 {
                     throw new NotImplementedException("need to resize buffer");
                 }
-                if (Ascii.ToLowerInPlace(payload.Slice(0, written), out written) != OperationStatus.Done)
+                if (Encodings.Ascii.ToLowerInPlace(payload.Slice(0, written), out written) != OperationStatus.Done)
                 {
                     throw new NotImplementedException("need to resize buffer");
                 }
@@ -100,19 +100,11 @@ namespace System.Azure.Authentication
 
             bufferSlice = payload.Slice(totalWritten);
 
-            if (Utf16.ToUtf8(resourceType.AsReadOnlySpan().AsBytes(), bufferSlice, out consumed, out written) != OperationStatus.Done)
+            if (Encodings.Utf16.ToUtf8(resourceType.AsReadOnlySpan().AsBytes(), bufferSlice, out consumed, out written) != OperationStatus.Done)
             {
                 throw new NotImplementedException("need to resize buffer");
             }
-            if (Ascii.ToLowerInPlace(bufferSlice.Slice(0, written), out written) != OperationStatus.Done)
-            {
-                throw new NotImplementedException("need to resize buffer");
-            }
-            bufferSlice[written] = (byte)'\n';
-            totalWritten += written + 1;
-            bufferSlice = payload.Slice(totalWritten);
-
-            if (Utf16.ToUtf8(resourceId.AsReadOnlySpan().AsBytes(), bufferSlice, out consumed, out written) != OperationStatus.Done)
+            if (Encodings.Ascii.ToLowerInPlace(bufferSlice.Slice(0, written), out written) != OperationStatus.Done)
             {
                 throw new NotImplementedException("need to resize buffer");
             }
@@ -120,7 +112,15 @@ namespace System.Azure.Authentication
             totalWritten += written + 1;
             bufferSlice = payload.Slice(totalWritten);
 
-            if (!Text.Formatters.Utf8.TryFormat(utc, bufferSlice, out written, 'l'))
+            if (Encodings.Utf16.ToUtf8(resourceId.AsReadOnlySpan().AsBytes(), bufferSlice, out consumed, out written) != OperationStatus.Done)
+            {
+                throw new NotImplementedException("need to resize buffer");
+            }
+            bufferSlice[written] = (byte)'\n';
+            totalWritten += written + 1;
+            bufferSlice = payload.Slice(totalWritten);
+
+            if (!Formatters.Utf8.TryFormat(utc, bufferSlice, out written, 'l'))
             {
                 throw new NotImplementedException("need to resize buffer");
             }

--- a/src/System.Azure.Experimental/System/Azure/Key.cs
+++ b/src/System.Azure.Experimental/System/Azure/Key.cs
@@ -3,10 +3,6 @@
 
 using System.Binary.Base64;
 using System.Buffers;
-using System.Buffers.Cryptography;
-using System.Text;
-using System.Text.Encoders;
-using System.Text.Encodings.Web.Utf8;
 
 namespace System.Azure.Authentication
 {
@@ -17,7 +13,7 @@ namespace System.Azure.Authentication
             var buffer = size < 128 ? stackalloc byte[size] : (Span<byte>)new byte[size];
 
             int written, consumed;
-            if (Utf16.ToUtf8(key.AsReadOnlySpan().AsBytes(), buffer, out consumed, out written) != OperationStatus.Done)
+            if (Encodings.Utf16.ToUtf8(key.AsReadOnlySpan().AsBytes(), buffer, out consumed, out written) != OperationStatus.Done)
             {
                 throw new NotImplementedException("need to resize buffer");
             }

--- a/src/System.Azure.Experimental/System/Azure/StorageAccessSignature.cs
+++ b/src/System.Azure.Experimental/System/Azure/StorageAccessSignature.cs
@@ -5,8 +5,6 @@ using System.Binary.Base64;
 using System.Buffers;
 using System.Buffers.Cryptography;
 using System.Text;
-using System.Text.Encoders;
-using System.Text.Encodings.Web.Utf8;
 
 namespace System.Azure.Authentication
 {
@@ -29,7 +27,7 @@ namespace System.Azure.Authentication
             }
             else
             {
-                if (Utf16.ToUtf8(verb.AsReadOnlySpan().AsBytes(), output, out consumed, out written) != OperationStatus.Done)
+                if (Encodings.Utf16.ToUtf8(verb.AsReadOnlySpan().AsBytes(), output, out consumed, out written) != OperationStatus.Done)
                 {
                     bytesWritten = 0;
                     return false;
@@ -44,7 +42,7 @@ namespace System.Azure.Authentication
             bytesWritten += s_emptyHeaders.Length;
 
             free = output.Slice(bytesWritten);
-            if (!Text.Formatters.Utf8.TryFormat(utc, free, out written, 'R'))
+            if (!Formatters.Utf8.TryFormat(utc, free, out written, 'R'))
             {
                 bytesWritten = 0;
                 return false;
@@ -53,7 +51,7 @@ namespace System.Azure.Authentication
             bytesWritten += written + 1;
             free = output.Slice(bytesWritten);
 
-            if (Utf16.ToUtf8(canonicalizedResource.AsReadOnlySpan().AsBytes(), free, out consumed, out written) != OperationStatus.Done)
+            if (Encodings.Utf16.ToUtf8(canonicalizedResource.AsReadOnlySpan().AsBytes(), free, out consumed, out written) != OperationStatus.Done)
             {
                 bytesWritten = 0;
                 return false;

--- a/src/System.Buffers.Experimental/System/Buffers/BytesReader.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BytesReader.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -280,13 +281,13 @@ namespace System.Buffers
 
         #region Parsing Methods
         // TODO: how to we chose the lengths of the temp buffers?
-        // TODO: these methods call the slow overloads of PrimitiveParser.TryParseXXX. Do we need fast path?
+        // TODO: these methods call the slow overloads of Parsers.Custom.TryParseXXX. Do we need fast path?
         // TODO: these methods hardcode the format. Do we need this to be something that can be specified?
         public bool TryParseBoolean(out bool value)
         {
             int consumed;
             var unread = Unread;
-            if (PrimitiveParser.TryParseBoolean(unread, out value, out consumed, _symbolTable))
+            if (Parsers.Custom.TryParseBoolean(unread, out value, out consumed, _symbolTable))
             {
                 if (unread.Length > consumed)
                 {
@@ -298,7 +299,7 @@ namespace System.Buffers
             Span<byte> tempSpan = stackalloc byte[15];
             var copied = CopyTo(tempSpan);
 
-            if (PrimitiveParser.TryParseBoolean(tempSpan.Slice(0, copied), out value, out consumed, _symbolTable))
+            if (Parsers.Custom.TryParseBoolean(tempSpan.Slice(0, copied), out value, out consumed, _symbolTable))
             {
                 Advance(consumed);
                 return true;
@@ -311,7 +312,7 @@ namespace System.Buffers
         {
             int consumed;
             var unread = Unread;
-            if (PrimitiveParser.TryParseUInt64(unread, out value, out consumed, default, _symbolTable))
+            if (Parsers.Custom.TryParseUInt64(unread, out value, out consumed, default, _symbolTable))
             {
                 if (unread.Length > consumed)
                 {
@@ -323,7 +324,7 @@ namespace System.Buffers
             Span<byte> tempSpan = stackalloc byte[32];
             var copied = CopyTo(tempSpan);
 
-            if (PrimitiveParser.TryParseUInt64(tempSpan.Slice(0, copied), out value, out consumed, 'G', _symbolTable))
+            if (Parsers.Custom.TryParseUInt64(tempSpan.Slice(0, copied), out value, out consumed, 'G', _symbolTable))
             {
                 Advance(consumed);
                 return true;

--- a/src/System.Buffers.Experimental/System/Buffers/Utf8BufferReader.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Utf8BufferReader.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 using System.IO;
 using System.Text;
-using System.Text.Encoders;
 using System.Threading.Tasks;
 
 namespace System.Buffers.Adapters {
@@ -26,7 +25,7 @@ namespace System.Buffers.Adapters {
             unsafe
             {
                 var destination = new Span<char>(&result, 1).AsBytes();
-                if (Utf8.ToUtf16(utf8Unread, destination, out int consumed, out int written) == OperationStatus.InvalidData)
+                if (Encodings.Utf8.ToUtf16(utf8Unread, destination, out int consumed, out int written) == OperationStatus.InvalidData)
                 {
                     throw new Exception("invalid UTF8 byte at " + _index.ToString());
                 }
@@ -43,7 +42,7 @@ namespace System.Buffers.Adapters {
             unsafe
             {
                 var destination = new Span<char>(&result, 1).AsBytes();
-                if (Utf8.ToUtf16(utf8Unread, destination, out int consumed, out int written) == OperationStatus.InvalidData)
+                if (Encodings.Utf8.ToUtf16(utf8Unread, destination, out int consumed, out int written) == OperationStatus.InvalidData)
                 {
                     throw new Exception("invalid UTF8 byte at " + _index.ToString());
                 }
@@ -55,7 +54,7 @@ namespace System.Buffers.Adapters {
         {
             var utf8Unread = _buffer.Span.Slice(_index);
             var utf16Buffer = buffer.AsSpan().Slice(index, count);
-            if(Utf8.ToUtf16(utf8Unread, utf16Buffer.AsBytes(), out int bytesConsumed, out int bytesWritten)== OperationStatus.InvalidData)
+            if(Encodings.Utf8.ToUtf16(utf8Unread, utf16Buffer.AsBytes(), out int bytesConsumed, out int bytesWritten)== OperationStatus.InvalidData)
             {
                 throw new Exception("invalid UTF8 byte at " + _index.ToString());
             }
@@ -88,7 +87,7 @@ namespace System.Buffers.Adapters {
         // TODO: this should be moved to System.Text.Primitives. Probably to Utf8 class
         static string Utf8ToString(ReadOnlySpan<byte> utf8)
         {
-            var result = Utf8.ToUtf16Length(utf8, out int bytesNeeded);
+            var result = Encodings.Utf8.ToUtf16Length(utf8, out int bytesNeeded);
             if (result == OperationStatus.InvalidData || result == OperationStatus.NeedMoreSourceData)
             {
                 throw new Exception("invalid UTF8 byte");
@@ -99,7 +98,7 @@ namespace System.Buffers.Adapters {
                 fixed (char* pStr = str)
                 {
                     var strSpan = new Span<char>(pStr, str.Length);
-                    if (Utf8.ToUtf16(utf8, strSpan.AsBytes(), out int consumed, out int written) != OperationStatus.Done)
+                    if (Encodings.Utf8.ToUtf16(utf8, strSpan.AsBytes(), out int consumed, out int written) != OperationStatus.Done)
                     {
                         throw new Exception();
                     }

--- a/src/System.IO.Pipelines.Text.Primitives/PipelineTextOutput.cs
+++ b/src/System.IO.Pipelines.Text.Primitives/PipelineTextOutput.cs
@@ -3,7 +3,7 @@
 
 using System.Threading.Tasks;
 using System.Text.Formatting;
-using System.Text;
+using System.Buffers.Text;
 
 namespace System.IO.Pipelines.Text.Primitives
 {

--- a/src/System.IO.Pipelines.Text.Primitives/PipelineWriterExtensions.cs
+++ b/src/System.IO.Pipelines.Text.Primitives/PipelineWriterExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
 using System.Text;
 
 namespace System.IO.Pipelines.Text.Primitives

--- a/src/System.IO.Pipelines.Text.Primitives/ReadableBufferExtensions.cs
+++ b/src/System.IO.Pipelines.Text.Primitives/ReadableBufferExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Parsing;
@@ -105,7 +106,7 @@ namespace System.IO.Pipelines.Text.Primitives
                 fixed (byte* source = &buffer.First.Span.DangerousGetPinnableReference())
                 {
                     // We are able to cast because IsSingleSpan and span size is int
-                    if (!PrimitiveParser.InvariantUtf8.TryParseUInt64(source, (int) len, out value))
+                    if (!Parsers.Utf8.TryParseUInt64(source, (int) len, out value))
                     {
                         ThrowInvalidOperation();
                     }
@@ -118,7 +119,7 @@ namespace System.IO.Pipelines.Text.Primitives
                 var data = stackalloc byte[length];
                 buffer.CopyTo(new Span<byte>(data, length));
                 addr = data;
-                if (!PrimitiveParser.InvariantUtf8.TryParseUInt64(addr, length, out value))
+                if (!Parsers.Utf8.TryParseUInt64(addr, length, out value))
                 {
                     throw new InvalidOperationException();
                 }
@@ -127,7 +128,7 @@ namespace System.IO.Pipelines.Text.Primitives
             {
                 // Heap allocated copy to parse into array (should be rare)
                 var arr = buffer.ToArray();
-                if (!PrimitiveParser.InvariantUtf8.TryParseUInt64(arr, out value))
+                if (!Parsers.Utf8.TryParseUInt64(arr, out value))
                 {
                     throw new InvalidOperationException();
                 }

--- a/src/System.Text.Formatting.Globalization/System/Text/Formatting/FormattingDataProvider.cs
+++ b/src/System.Text.Formatting.Globalization/System/Text/Formatting/FormattingDataProvider.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
+using System.Buffers.Text;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
@@ -43,7 +45,7 @@ namespace System.Text.Formatting
             resourceStream.Read(index, 0, indexSize);
 
             byte[] idBytes = new byte[maxIdLength];
-            var status = Encoders.Utf16.ToUtf8(localeId.AsReadOnlySpan().AsBytes(), idBytes, out int consumed, out int idByteCount);
+            var status = Encodings.Utf16.ToUtf8(localeId.AsReadOnlySpan().AsBytes(), idBytes, out int consumed, out int idByteCount);
             if (status != System.Buffers.OperationStatus.Done)
                 throw new Exception("bad locale id");
 

--- a/src/System.Text.Formatting/System/Text/Formatting/CompositeFormat.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/CompositeFormat.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Diagnostics;
 
 namespace System.Text.Formatting

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/ArrayFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/ArrayFormatter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Collections.Sequences;
 
 namespace System.Text.Formatting

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/OutputFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/OutputFormatter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Buffers.Text;
 
 namespace System.Text.Formatting
 {

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/SequenceFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/SequenceFormatter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Collections.Sequences;
 
 namespace System.Text.Formatting

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/StreamFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/StreamFormatter.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Buffers;
+using System.Buffers.Text;
 
 namespace System.Text.Formatting
 {

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/StringFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/StringFormatter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Collections.Sequences;
 
 namespace System.Text.Formatting

--- a/src/System.Text.Formatting/System/Text/Formatting/IOutputExtensions.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/IOutputExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Text.Utf8;
 
 namespace System.Text.Formatting

--- a/src/System.Text.Formatting/System/Text/Formatting/ITextOutput.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/ITextOutput.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Buffers.Text;
 
 namespace System.Text.Formatting
 {

--- a/src/System.Text.Formatting/System/Text/Formatting/ITextOutputExtensions.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/ITextOutputExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
 using System.Text.Utf8;
 
 namespace System.Text.Formatting

--- a/src/System.Text.Formatting/System/Text/Parsing/SequenceParser.cs
+++ b/src/System.Text.Formatting/System/Text/Parsing/SequenceParser.cs
@@ -23,7 +23,7 @@ namespace System.Text.Parsing
             }
 
             // Attempt to parse the first segment. If it works (and it should in most cases), then return success.
-            bool parsed = PrimitiveParser.InvariantUtf8.TryParseUInt64(first.Span, out value, out consumed);
+            bool parsed = Parsers.Utf8.TryParseUInt64(first.Span, out value, out consumed);
             if (parsed && consumed < first.Length) {
                 return true;
             }
@@ -66,7 +66,7 @@ namespace System.Text.Parsing
                 var combinedStackSpan = destination.Slice(0, StackBufferSize - free.Length);
 
                 // if the stack allocated buffer parsed succesfully (and for uint it should always do), then return success. 
-                if (PrimitiveParser.InvariantUtf8.TryParseUInt64(combinedStackSpan, out value, out consumed))
+                if (Parsers.Utf8.TryParseUInt64(combinedStackSpan, out value, out consumed))
                 {
                     if (consumed < combinedStackSpan.Length || combinedStackSpan.Length < StackBufferSize)
                     {
@@ -78,7 +78,7 @@ namespace System.Text.Parsing
             // for invariant culture, we should never reach this point, as invariant uint text is never longer than 127 bytes. 
             // I left this code here, as we will need it for custom cultures and possibly when we shrink the stack allocated buffer.
             var combinedSpan = bufferSequence.ToSpan();
-            if (!PrimitiveParser.InvariantUtf8.TryParseUInt64(combinedSpan, out value, out consumed)) {
+            if (!Parsers.Utf8.TryParseUInt64(combinedSpan, out value, out consumed)) {
                 return false;
             }
             return true;
@@ -97,7 +97,7 @@ namespace System.Text.Parsing
             }
 
             // Attempt to parse the first segment. If it works (and it should in most cases), then return success.
-            bool parsed = PrimitiveParser.InvariantUtf8.TryParseUInt32(first.Span, out value, out consumed);
+            bool parsed = Parsers.Utf8.TryParseUInt32(first.Span, out value, out consumed);
             if (parsed && consumed < first.Length) {
                 return true;
             }
@@ -137,7 +137,7 @@ namespace System.Text.Parsing
                 var combinedStackSpan = destination.Slice(0, StackBufferSize - free.Length);
 
                 // if the stack allocated buffer parsed succesfully (and for uint it should always do), then return success. 
-                if (PrimitiveParser.InvariantUtf8.TryParseUInt32(combinedStackSpan, out value, out consumed)) {
+                if (Parsers.Utf8.TryParseUInt32(combinedStackSpan, out value, out consumed)) {
                     if(consumed < combinedStackSpan.Length || combinedStackSpan.Length < StackBufferSize) {
                         return true;
                     }
@@ -147,7 +147,7 @@ namespace System.Text.Parsing
             // for invariant culture, we should never reach this point, as invariant uint text is never longer than 127 bytes. 
             // I left this code here, as we will need it for custom cultures and possibly when we shrink the stack allocated buffer.
             var combinedSpan = bufferSequence.ToSpan();
-            if (!PrimitiveParser.InvariantUtf8.TryParseUInt32(combinedSpan, out value, out consumed)) {
+            if (!Parsers.Utf8.TryParseUInt32(combinedSpan, out value, out consumed)) {
                 return false;
             }
             return true;

--- a/src/System.Text.Http.Parser/HttpUtilities.cs
+++ b/src/System.Text.Http.Parser/HttpUtilities.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Binary;
+using System.Buffers;
 
 namespace System.Text.Http.Parser.Internal
 {
@@ -72,7 +73,7 @@ namespace System.Text.Http.Parser.Internal
             Debug.Assert(str.Length == 8, "String must be exactly 8 (ASCII) characters long.");
 
             Span<byte> span = stackalloc byte[8];
-            Encoders.Utf16.ToUtf8(str.AsReadOnlySpan().AsBytes(), span, out int consumed, out int written);
+            Encodings.Utf16.ToUtf8(str.AsReadOnlySpan().AsBytes(), span, out int consumed, out int written);
             return span.Read<ulong>();
         }
 
@@ -81,7 +82,7 @@ namespace System.Text.Http.Parser.Internal
             Debug.Assert(str.Length == 4, "String must be exactly 4 (ASCII) characters long.");
 
             Span<byte> span = stackalloc byte[4];
-            Encoders.Utf16.ToUtf8(str.AsReadOnlySpan().AsBytes(), span, out int consumed, out int written);
+            Encodings.Utf16.ToUtf8(str.AsReadOnlySpan().AsBytes(), span, out int consumed, out int written);
             return span.Read<uint>();
         }
 

--- a/src/System.Text.Http/System/Text/Http/HttpRequest.cs
+++ b/src/System.Text.Http/System/Text/Http/HttpRequest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Collections.Sequences;
 using System.Text.Formatting;
 using System.Text.Utf8;

--- a/src/System.Text.Http/System/Text/Http/IFormatterHttpExtensions.cs
+++ b/src/System.Text.Http/System/Text/Http/IFormatterHttpExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
 using System.Text.Formatting;
 using System.Text.Utf8;
 

--- a/src/System.Text.Http/System/Text/Http/Obsolete/HttpHeaderBuffer.cs
+++ b/src/System.Text.Http/System/Text/Http/Obsolete/HttpHeaderBuffer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
+
 namespace System.Text.Http.SingleSegment
 {
     public ref struct HttpHeaderBuffer

--- a/src/System.Text.Json.Dynamic/System/Text/Json/JsonDynamicObject.cs
+++ b/src/System.Text.Json.Dynamic/System/Text/Json/JsonDynamicObject.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Text.Utf8;
@@ -96,7 +98,7 @@ namespace System.Text.Json
             {
                 throw new InvalidOperationException();
             }
-            return PrimitiveParser.InvariantUtf8.TryParseUInt32(jsonValue.Value.Bytes, out value);
+            return Parsers.Utf8.TryParseUInt32(jsonValue.Value.Bytes, out value);
         }
 
         public bool TryGetString(Utf8String property, out Utf8String value)

--- a/src/System.Text.Json/System/Text/Json/JsonParseObject.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonParseObject.cs
@@ -225,7 +225,7 @@ namespace System.Text.Json
             var slice = json._values.Slice(record.Location);
 
             bool result;
-            if(!PrimitiveParser.InvariantUtf8.TryParseBoolean(slice, out result)){
+            if(!Parsers.Utf8.TryParseBoolean(slice, out result)){
                 throw new InvalidCastException();
             }
             return result;
@@ -241,7 +241,7 @@ namespace System.Text.Json
             var slice = json._values.Slice(record.Location);
 
             int result;
-            if (!PrimitiveParser.InvariantUtf8.TryParseInt32(slice, out result)) {
+            if (!Parsers.Utf8.TryParseInt32(slice, out result)) {
                 throw new InvalidCastException();
             }
             return result;

--- a/src/System.Text.Json/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonReader.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
 using System.Runtime.CompilerServices;
 
 namespace System.Text.Json

--- a/src/System.Text.Json/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonWriter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
+using System.Buffers.Text;
 using System.Runtime.CompilerServices;
 using System.Text.Formatting;
 
@@ -427,7 +429,7 @@ namespace System.Text.Json
 
                 while (true)
                 {
-                    var status = Encoders.Utf16.ToUtf8(source, destination, out int consumed, out int written);
+                    var status = Encodings.Utf16.ToUtf8(source, destination, out int consumed, out int written);
                     if (status == Buffers.OperationStatus.Done)
                     {
                         _output.Advance(written);

--- a/src/System.Text.Primitives/System/Text/Encoders/Ascii/Ascii_casing.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Ascii/Ascii_casing.cs
@@ -4,69 +4,72 @@
 
 using System.Buffers;
 
-namespace System.Text.Encoders
+namespace System.Buffers
 {
-    public static partial class Ascii
+    public static partial class Encodings
     {
-        static readonly byte[] s_toLower = new byte[128];
-        static readonly byte[] s_toUpper = new byte[128];
-
-        static Ascii()
+        public static partial class Ascii
         {
-            for (int i = 0; i < s_toLower.Length; i++)
-            {
-                s_toLower[i] = (byte)char.ToLowerInvariant(((char)i));
-                s_toUpper[i] = (byte)char.ToUpperInvariant(((char)i));
-            }
-        }
+            static readonly byte[] s_toLower = new byte[128];
+            static readonly byte[] s_toUpper = new byte[128];
 
-        public static OperationStatus ToLowerInPlace(Span<byte> ascii, out int bytesChanged)
-        {
-            for (bytesChanged = 0; bytesChanged < ascii.Length; bytesChanged++)
+            static Ascii()
             {
-                byte next = ascii[bytesChanged];
-                if (next > 127)
+                for (int i = 0; i < s_toLower.Length; i++)
                 {
-                    return OperationStatus.InvalidData;
+                    s_toLower[i] = (byte)char.ToLowerInvariant(((char)i));
+                    s_toUpper[i] = (byte)char.ToUpperInvariant(((char)i));
                 }
-                ascii[bytesChanged] = s_toLower[next];
             }
-            return OperationStatus.Done;
-        }
 
-        public static OperationStatus ToLower(ReadOnlySpan<byte> input, Span<byte> output, out int processedBytes)
-        {
-            int min = input.Length < output.Length ? input.Length : output.Length;
-            for (processedBytes = 0; processedBytes < min; processedBytes++)
+            public static OperationStatus ToLowerInPlace(Span<byte> ascii, out int bytesChanged)
             {
-                byte next = input[processedBytes];
-                if (next > 127) return OperationStatus.InvalidData;
-                output[processedBytes] = s_toLower[next];
+                for (bytesChanged = 0; bytesChanged < ascii.Length; bytesChanged++)
+                {
+                    byte next = ascii[bytesChanged];
+                    if (next > 127)
+                    {
+                        return OperationStatus.InvalidData;
+                    }
+                    ascii[bytesChanged] = s_toLower[next];
+                }
+                return OperationStatus.Done;
             }
-            return OperationStatus.Done;
-        }
 
-        public static OperationStatus ToUpperInPlace(Span<byte> ascii, out int bytesChanged)
-        {
-            for (bytesChanged = 0; bytesChanged < ascii.Length; bytesChanged++)
+            public static OperationStatus ToLower(ReadOnlySpan<byte> input, Span<byte> output, out int processedBytes)
             {
-                byte next = ascii[bytesChanged];
-                if (next > 127) return OperationStatus.InvalidData;
-                ascii[bytesChanged] = s_toUpper[next];
+                int min = input.Length < output.Length ? input.Length : output.Length;
+                for (processedBytes = 0; processedBytes < min; processedBytes++)
+                {
+                    byte next = input[processedBytes];
+                    if (next > 127) return OperationStatus.InvalidData;
+                    output[processedBytes] = s_toLower[next];
+                }
+                return OperationStatus.Done;
             }
-            return OperationStatus.Done;
-        }
 
-        public static OperationStatus ToUpper(ReadOnlySpan<byte> input, Span<byte> output, out int processedBytes)
-        {
-            int min = input.Length < output.Length ? input.Length : output.Length;
-            for (processedBytes = 0; processedBytes < min; processedBytes++)
+            public static OperationStatus ToUpperInPlace(Span<byte> ascii, out int bytesChanged)
             {
-                byte next = input[processedBytes];
-                if (next > 127) return OperationStatus.InvalidData;
-                output[processedBytes] = s_toUpper[next];
+                for (bytesChanged = 0; bytesChanged < ascii.Length; bytesChanged++)
+                {
+                    byte next = ascii[bytesChanged];
+                    if (next > 127) return OperationStatus.InvalidData;
+                    ascii[bytesChanged] = s_toUpper[next];
+                }
+                return OperationStatus.Done;
             }
-            return OperationStatus.Done;
+
+            public static OperationStatus ToUpper(ReadOnlySpan<byte> input, Span<byte> output, out int processedBytes)
+            {
+                int min = input.Length < output.Length ? input.Length : output.Length;
+                for (processedBytes = 0; processedBytes < min; processedBytes++)
+                {
+                    byte next = input[processedBytes];
+                    if (next > 127) return OperationStatus.InvalidData;
+                    output[processedBytes] = s_toUpper[next];
+                }
+                return OperationStatus.Done;
+            }
         }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Encoders/Ascii/Ascii_encoding.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Ascii/Ascii_encoding.cs
@@ -4,125 +4,138 @@
 
 using System.Runtime.CompilerServices;
 
-namespace System.Text.Encoders
+namespace System.Buffers
 {
-    public static partial class Ascii
+    public static partial class Encodings
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string ToUtf16String(ReadOnlySpan<byte> bytes)
+        public static partial class Ascii
         {
-            var len = bytes.Length;
-            if (len == 0) {
-                return string.Empty;
-            }
-
-            var result = new string('\0', len);
-
-            unsafe
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string ToUtf16String(ReadOnlySpan<byte> bytes)
             {
-                fixed (char* destination = result)
-                fixed (byte* source = &bytes.DangerousGetPinnableReference()) {
-                    if (!TryGetAsciiString(source, destination, len)) {
-                        ThrowArgumentException();
+                var len = bytes.Length;
+                if (len == 0)
+                {
+                    return string.Empty;
+                }
+
+                var result = new string('\0', len);
+
+                unsafe
+                {
+                    fixed (char* destination = result)
+                    fixed (byte* source = &bytes.DangerousGetPinnableReference())
+                    {
+                        if (!TryGetAsciiString(source, destination, len))
+                        {
+                            ThrowArgumentException();
+                        }
                     }
                 }
+
+                return result;
             }
 
-            return result;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string ToUtf16String(Span<byte> bytes)
-        {
-            var len = bytes.Length;
-            if (len == 0) {
-                return string.Empty;
-            }
-
-            var result = new string('\0', len);
-
-            unsafe
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static string ToUtf16String(Span<byte> bytes)
             {
-                fixed (char* destination = result)
-                fixed (byte* source = &bytes.DangerousGetPinnableReference()) {
-                    if (!TryGetAsciiString(source, destination, len)) {
-                        ThrowArgumentException();
+                var len = bytes.Length;
+                if (len == 0)
+                {
+                    return string.Empty;
+                }
+
+                var result = new string('\0', len);
+
+                unsafe
+                {
+                    fixed (char* destination = result)
+                    fixed (byte* source = &bytes.DangerousGetPinnableReference())
+                    {
+                        if (!TryGetAsciiString(source, destination, len))
+                        {
+                            ThrowArgumentException();
+                        }
                     }
                 }
+
+                return result;
             }
 
-            return result;
+            static void ThrowArgumentException()
+            {
+                throw new ArgumentException();
+            }
+
+            static unsafe bool TryGetAsciiString(byte* input, char* output, int count)
+            {
+                var i = 0;
+
+                int isValid = 0;
+                while (i < count - 11)
+                {
+                    isValid = isValid | *input | *(input + 1) | *(input + 2) |
+                        *(input + 3) | *(input + 4) | *(input + 5) | *(input + 6) |
+                        *(input + 7) | *(input + 8) | *(input + 9) | *(input + 10) |
+                        *(input + 11);
+
+                    i += 12;
+                    *(output) = (char)*(input);
+                    *(output + 1) = (char)*(input + 1);
+                    *(output + 2) = (char)*(input + 2);
+                    *(output + 3) = (char)*(input + 3);
+                    *(output + 4) = (char)*(input + 4);
+                    *(output + 5) = (char)*(input + 5);
+                    *(output + 6) = (char)*(input + 6);
+                    *(output + 7) = (char)*(input + 7);
+                    *(output + 8) = (char)*(input + 8);
+                    *(output + 9) = (char)*(input + 9);
+                    *(output + 10) = (char)*(input + 10);
+                    *(output + 11) = (char)*(input + 11);
+                    output += 12;
+                    input += 12;
+                }
+                if (i < count - 5)
+                {
+                    isValid = isValid | *input | *(input + 1) | *(input + 2) |
+                        *(input + 3) | *(input + 4) | *(input + 5);
+
+                    i += 6;
+                    *(output) = (char)*(input);
+                    *(output + 1) = (char)*(input + 1);
+                    *(output + 2) = (char)*(input + 2);
+                    *(output + 3) = (char)*(input + 3);
+                    *(output + 4) = (char)*(input + 4);
+                    *(output + 5) = (char)*(input + 5);
+                    output += 6;
+                    input += 6;
+                }
+                if (i < count - 3)
+                {
+                    isValid = isValid | *input | *(input + 1) | *(input + 2) |
+                        *(input + 3);
+
+                    i += 4;
+                    *(output) = (char)*(input);
+                    *(output + 1) = (char)*(input + 1);
+                    *(output + 2) = (char)*(input + 2);
+                    *(output + 3) = (char)*(input + 3);
+                    output += 4;
+                    input += 4;
+                }
+
+                while (i < count)
+                {
+                    isValid = isValid | *input;
+
+                    i++;
+                    *output = (char)*input;
+                    output++;
+                    input++;
+                }
+
+                return isValid <= 127;
+            }
         }
-
-        static void ThrowArgumentException()
-        {
-            throw new ArgumentException();
-        }
-
-        static unsafe bool TryGetAsciiString(byte* input, char* output, int count)
-        {
-            var i = 0;
-
-            int isValid = 0;
-            while (i < count - 11) {
-                isValid = isValid | *input | *(input + 1) | *(input + 2) |
-                    *(input + 3) | *(input + 4) | *(input + 5) | *(input + 6) |
-                    *(input + 7) | *(input + 8) | *(input + 9) | *(input + 10) |
-                    *(input + 11);
-
-                i += 12;
-                *(output) = (char)*(input);
-                *(output + 1) = (char)*(input + 1);
-                *(output + 2) = (char)*(input + 2);
-                *(output + 3) = (char)*(input + 3);
-                *(output + 4) = (char)*(input + 4);
-                *(output + 5) = (char)*(input + 5);
-                *(output + 6) = (char)*(input + 6);
-                *(output + 7) = (char)*(input + 7);
-                *(output + 8) = (char)*(input + 8);
-                *(output + 9) = (char)*(input + 9);
-                *(output + 10) = (char)*(input + 10);
-                *(output + 11) = (char)*(input + 11);
-                output += 12;
-                input += 12;
-            }
-            if (i < count - 5) {
-                isValid = isValid | *input | *(input + 1) | *(input + 2) |
-                    *(input + 3) | *(input + 4) | *(input + 5);
-
-                i += 6;
-                *(output) = (char)*(input);
-                *(output + 1) = (char)*(input + 1);
-                *(output + 2) = (char)*(input + 2);
-                *(output + 3) = (char)*(input + 3);
-                *(output + 4) = (char)*(input + 4);
-                *(output + 5) = (char)*(input + 5);
-                output += 6;
-                input += 6;
-            }
-            if (i < count - 3) {
-                isValid = isValid | *input | *(input + 1) | *(input + 2) |
-                    *(input + 3);
-
-                i += 4;
-                *(output) = (char)*(input);
-                *(output + 1) = (char)*(input + 1);
-                *(output + 2) = (char)*(input + 2);
-                *(output + 3) = (char)*(input + 3);
-                output += 4;
-                input += 4;
-            }
-
-            while (i < count) {
-                isValid = isValid | *input;
-
-                i++;
-                *output = (char)*input;
-                output++;
-                input++;
-            }
-
-            return isValid <= 127;
-        }     
     }
 }

--- a/src/System.Text.Primitives/System/Text/Encoders/EncodingHelper.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/EncodingHelper.cs
@@ -3,7 +3,7 @@
 
 using System.Runtime.CompilerServices;
 
-namespace System.Text.Encoders
+namespace System.Buffers
 {
     internal static class EncodingHelper
     {

--- a/src/System.Text.Primitives/System/Text/Encoders/Utf16.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Utf16.cs
@@ -1,185 +1,186 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-namespace System.Text.Encoders
+namespace System.Buffers
 {
-    public static class Utf16
+    public static partial class Encodings
     {
-        #region UTF-8 Conversions
-
-        /// <summary>
-        /// Calculates the byte count needed to encode the UTF-16 bytes from the specified UTF-8 sequence.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
-        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
-        public static OperationStatus FromUtf8Length(ReadOnlySpan<byte> source, out int bytesNeeded)
-            => Utf8.ToUtf16Length(source, out bytesNeeded);
-
-        /// <summary>
-        /// Converts a span containing a sequence of UTF-8 bytes into UTF-16 bytes.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
-        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
-        /// the <paramref name="destination"/>.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
-        /// <param name="destination">A span to write the UTF-16 bytes into.</param>
-        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
-        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
-        public static OperationStatus FromUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-            => Utf8.ToUtf16(source, destination, out bytesConsumed, out bytesWritten);
-
-        /// <summary>
-        /// Calculates the byte count needed to encode the UTF-8 bytes from the specified UTF-16 sequence.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
-        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
-        public static OperationStatus ToUtf8Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+        public static class Utf16
         {
-            bytesNeeded = 0;
+            #region UTF-8 Conversions
 
-            // try? because Convert.ConvertToUtf32 can throw
-            // if the high/low surrogates aren't valid; no point
-            // running all the tests twice per code-point
-            try
+            /// <summary>
+            /// Calculates the byte count needed to encode the UTF-16 bytes from the specified UTF-8 sequence.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
+            /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
+            public static OperationStatus FromUtf8Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+                => Utf8.ToUtf16Length(source, out bytesNeeded);
+
+            /// <summary>
+            /// Converts a span containing a sequence of UTF-8 bytes into UTF-16 bytes.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            ///
+            /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+            /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+            /// the <paramref name="destination"/>.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
+            /// <param name="destination">A span to write the UTF-16 bytes into.</param>
+            /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+            /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
+            public static OperationStatus FromUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+                => Utf8.ToUtf16(source, destination, out bytesConsumed, out bytesWritten);
+
+            /// <summary>
+            /// Calculates the byte count needed to encode the UTF-8 bytes from the specified UTF-16 sequence.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
+            /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
+            public static OperationStatus ToUtf8Length(ReadOnlySpan<byte> source, out int bytesNeeded)
             {
-                ref char utf16 = ref Unsafe.As<byte, char>(ref source.DangerousGetPinnableReference());
-                int utf16Length = source.Length >> 1; // byte => char count
+                bytesNeeded = 0;
 
-                for (int i = 0; i < utf16Length; i++)
+                // try? because Convert.ConvertToUtf32 can throw
+                // if the high/low surrogates aren't valid; no point
+                // running all the tests twice per code-point
+                try
                 {
-                    var ch = Unsafe.Add(ref utf16, i);
+                    ref char utf16 = ref Unsafe.As<byte, char>(ref source.DangerousGetPinnableReference());
+                    int utf16Length = source.Length >> 1; // byte => char count
 
-                    if ((ushort)ch <= 0x7f) // Fast path for ASCII
-                        bytesNeeded++;
-                    else if (!char.IsSurrogate(ch))
-                        bytesNeeded += EncodingHelper.GetUtf8EncodedBytes((uint)ch);
-                    else
+                    for (int i = 0; i < utf16Length; i++)
                     {
-                        if (++i >= utf16Length)
-                            return OperationStatus.NeedMoreSourceData;
+                        var ch = Unsafe.Add(ref utf16, i);
 
-                        uint codePoint = (uint)char.ConvertToUtf32(ch, Unsafe.Add(ref utf16, i));
-                        bytesNeeded += EncodingHelper.GetUtf8EncodedBytes(codePoint);
-                    }
-                }
-
-                if ((utf16Length << 1) != source.Length)
-                    return OperationStatus.NeedMoreSourceData;
-
-                return OperationStatus.Done;
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-                return OperationStatus.InvalidData;
-            }
-        }
-
-        /// <summary>
-        /// Converts a span containing a sequence of UTF-16 bytes into UTF-8 bytes.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
-        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
-        /// the <paramref name="destination"/>.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
-        /// <param name="destination">A span to write the UTF-8 bytes into.</param>
-        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
-        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
-        public unsafe static OperationStatus ToUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-        {
-            //
-            //
-            // KEEP THIS IMPLEMENTATION IN SYNC WITH https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
-            //
-            //
-            fixed (byte* chars = &source.DangerousGetPinnableReference())
-            fixed (byte* bytes = &destination.DangerousGetPinnableReference())
-            {
-                char* pSrc = (char*)chars;
-                byte* pTarget = bytes;
-
-                char* pEnd = (char*)(chars + source.Length);
-                byte* pAllocatedBufferEnd = pTarget + destination.Length;
-
-                // assume that JIT will enregister pSrc, pTarget and ch
-
-                // Entering the fast encoding loop incurs some overhead that does not get amortized for small
-                // number of characters, and the slow encoding loop typically ends up running for the last few
-                // characters anyway since the fast encoding loop needs 5 characters on input at least.
-                // Thus don't use the fast decoding loop at all if we don't have enough characters. The threashold
-                // was choosen based on performance testing.
-                // Note that if we don't have enough bytes, pStop will prevent us from entering the fast loop.
-                while (pEnd - pSrc > 13)
-                {
-                    // we need at least 1 byte per character, but Convert might allow us to convert
-                    // only part of the input, so try as much as we can.  Reduce charCount if necessary
-                    int available = Math.Min(EncodingHelper.PtrDiff(pEnd, pSrc), EncodingHelper.PtrDiff(pAllocatedBufferEnd, pTarget));
-
-                    // FASTLOOP:
-                    // - optimistic range checks
-                    // - fallbacks to the slow loop for all special cases, exception throwing, etc.
-
-                    // To compute the upper bound, assume that all characters are ASCII characters at this point,
-                    //  the boundary will be decreased for every non-ASCII character we encounter
-                    // Also, we need 5 chars reserve for the unrolled ansi decoding loop and for decoding of surrogates
-                    // If there aren't enough bytes for the output, then pStop will be <= pSrc and will bypass the loop.
-                    char* pStop = pSrc + available - 5;
-                    if (pSrc >= pStop)
-                        break;
-
-                    do
-                    {
-                        int ch = *pSrc;
-                        pSrc++;
-
-                        if (ch > 0x7F)
+                        if ((ushort)ch <= 0x7f) // Fast path for ASCII
+                            bytesNeeded++;
+                        else if (!char.IsSurrogate(ch))
+                            bytesNeeded += EncodingHelper.GetUtf8EncodedBytes((uint)ch);
+                        else
                         {
-                            goto LongCode;
+                            if (++i >= utf16Length)
+                                return OperationStatus.NeedMoreSourceData;
+
+                            uint codePoint = (uint)char.ConvertToUtf32(ch, Unsafe.Add(ref utf16, i));
+                            bytesNeeded += EncodingHelper.GetUtf8EncodedBytes(codePoint);
                         }
-                        *pTarget = (byte)ch;
-                        pTarget++;
+                    }
 
-                        // get pSrc aligned
-                        if ((unchecked((int)pSrc) & 0x2) != 0)
+                    if ((utf16Length << 1) != source.Length)
+                        return OperationStatus.NeedMoreSourceData;
+
+                    return OperationStatus.Done;
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    return OperationStatus.InvalidData;
+                }
+            }
+
+            /// <summary>
+            /// Converts a span containing a sequence of UTF-16 bytes into UTF-8 bytes.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            ///
+            /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+            /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+            /// the <paramref name="destination"/>.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
+            /// <param name="destination">A span to write the UTF-8 bytes into.</param>
+            /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+            /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
+            public unsafe static OperationStatus ToUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+            {
+                //
+                //
+                // KEEP THIS IMPLEMENTATION IN SYNC WITH https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
+                //
+                //
+                fixed (byte* chars = &source.DangerousGetPinnableReference())
+                fixed (byte* bytes = &destination.DangerousGetPinnableReference())
+                {
+                    char* pSrc = (char*)chars;
+                    byte* pTarget = bytes;
+
+                    char* pEnd = (char*)(chars + source.Length);
+                    byte* pAllocatedBufferEnd = pTarget + destination.Length;
+
+                    // assume that JIT will enregister pSrc, pTarget and ch
+
+                    // Entering the fast encoding loop incurs some overhead that does not get amortized for small
+                    // number of characters, and the slow encoding loop typically ends up running for the last few
+                    // characters anyway since the fast encoding loop needs 5 characters on input at least.
+                    // Thus don't use the fast decoding loop at all if we don't have enough characters. The threashold
+                    // was choosen based on performance testing.
+                    // Note that if we don't have enough bytes, pStop will prevent us from entering the fast loop.
+                    while (pEnd - pSrc > 13)
+                    {
+                        // we need at least 1 byte per character, but Convert might allow us to convert
+                        // only part of the input, so try as much as we can.  Reduce charCount if necessary
+                        int available = Math.Min(EncodingHelper.PtrDiff(pEnd, pSrc), EncodingHelper.PtrDiff(pAllocatedBufferEnd, pTarget));
+
+                        // FASTLOOP:
+                        // - optimistic range checks
+                        // - fallbacks to the slow loop for all special cases, exception throwing, etc.
+
+                        // To compute the upper bound, assume that all characters are ASCII characters at this point,
+                        //  the boundary will be decreased for every non-ASCII character we encounter
+                        // Also, we need 5 chars reserve for the unrolled ansi decoding loop and for decoding of surrogates
+                        // If there aren't enough bytes for the output, then pStop will be <= pSrc and will bypass the loop.
+                        char* pStop = pSrc + available - 5;
+                        if (pSrc >= pStop)
+                            break;
+
+                        do
                         {
-                            ch = *pSrc;
+                            int ch = *pSrc;
                             pSrc++;
+
                             if (ch > 0x7F)
                             {
                                 goto LongCode;
                             }
                             *pTarget = (byte)ch;
                             pTarget++;
-                        }
 
-                        // Run 4 characters at a time!
-                        while (pSrc < pStop)
-                        {
-                            ch = *(int*)pSrc;
-                            int chc = *(int*)(pSrc + 2);
-                            if (((ch | chc) & unchecked((int)0xFF80FF80)) != 0)
+                            // get pSrc aligned
+                            if ((unchecked((int)pSrc) & 0x2) != 0)
                             {
-                                goto LongCodeWithMask;
+                                ch = *pSrc;
+                                pSrc++;
+                                if (ch > 0x7F)
+                                {
+                                    goto LongCode;
+                                }
+                                *pTarget = (byte)ch;
+                                pTarget++;
                             }
 
-                            // Unfortunately, this is endianess sensitive
+                            // Run 4 characters at a time!
+                            while (pSrc < pStop)
+                            {
+                                ch = *(int*)pSrc;
+                                int chc = *(int*)(pSrc + 2);
+                                if (((ch | chc) & unchecked((int)0xFF80FF80)) != 0)
+                                {
+                                    goto LongCodeWithMask;
+                                }
+
+                                // Unfortunately, this is endianess sensitive
 #if BIGENDIAN
                             *pTarget = (byte)(ch >> 16);
                             *(pTarget + 1) = (byte)ch;
@@ -188,39 +189,128 @@ namespace System.Text.Encoders
                             *(pTarget + 3) = (byte)chc;
                             pTarget += 4;
 #else // BIGENDIAN
-                            *pTarget = (byte)ch;
-                            *(pTarget + 1) = (byte)(ch >> 16);
-                            pSrc += 4;
-                            *(pTarget + 2) = (byte)chc;
-                            *(pTarget + 3) = (byte)(chc >> 16);
-                            pTarget += 4;
+                                *pTarget = (byte)ch;
+                                *(pTarget + 1) = (byte)(ch >> 16);
+                                pSrc += 4;
+                                *(pTarget + 2) = (byte)chc;
+                                *(pTarget + 3) = (byte)(chc >> 16);
+                                pTarget += 4;
 #endif // BIGENDIAN
-                        }
-                        continue;
+                            }
+                            continue;
 
-                    LongCodeWithMask:
+                            LongCodeWithMask:
 #if BIGENDIAN
                         // be careful about the sign extension
                         ch = (int)(((uint)ch) >> 16);
 #else // BIGENDIAN
-                        ch = (char)ch;
+                            ch = (char)ch;
 #endif // BIGENDIAN
+                            pSrc++;
+
+                            if (ch > 0x7F)
+                            {
+                                goto LongCode;
+                            }
+                            *pTarget = (byte)ch;
+                            pTarget++;
+                            continue;
+
+                            LongCode:
+                            // use separate helper variables for slow and fast loop so that the jit optimizations
+                            // won't get confused about the variable lifetimes
+                            int chd;
+                            if (ch <= 0x7FF)
+                            {
+                                // 2 byte encoding
+                                chd = unchecked((sbyte)0xC0) | (ch >> 6);
+                            }
+                            else
+                            {
+                                // if (!IsLowSurrogate(ch) && !IsHighSurrogate(ch))
+                                if (!EncodingHelper.InRange(ch, EncodingHelper.HighSurrogateStart, EncodingHelper.LowSurrogateEnd))
+                                {
+                                    // 3 byte encoding
+                                    chd = unchecked((sbyte)0xE0) | (ch >> 12);
+                                }
+                                else
+                                {
+                                    // 4 byte encoding - high surrogate + low surrogate
+                                    // if (!IsHighSurrogate(ch))
+                                    if (ch > EncodingHelper.HighSurrogateEnd)
+                                    {
+                                        // low without high -> bad
+                                        goto InvalidData;
+                                    }
+
+                                    chd = *pSrc;
+
+                                    // if (!IsLowSurrogate(chd)) {
+                                    if (!EncodingHelper.InRange(chd, EncodingHelper.LowSurrogateStart, EncodingHelper.LowSurrogateEnd))
+                                    {
+                                        // high not followed by low -> bad
+                                        goto InvalidData;
+                                    }
+
+                                    pSrc++;
+
+                                    ch = chd + (ch << 10) +
+                                        (0x10000
+                                        - EncodingHelper.LowSurrogateStart
+                                        - (EncodingHelper.HighSurrogateStart << 10));
+
+                                    *pTarget = (byte)(unchecked((sbyte)0xF0) | (ch >> 18));
+                                    // pStop - this byte is compensated by the second surrogate character
+                                    // 2 input chars require 4 output bytes.  2 have been anticipated already
+                                    // and 2 more will be accounted for by the 2 pStop-- calls below.
+                                    pTarget++;
+
+                                    chd = unchecked((sbyte)0x80) | (ch >> 12) & 0x3F;
+                                }
+                                *pTarget = (byte)chd;
+                                pStop--;                    // 3 byte sequence for 1 char, so need pStop-- and the one below too.
+                                pTarget++;
+
+                                chd = unchecked((sbyte)0x80) | (ch >> 6) & 0x3F;
+                            }
+                            *pTarget = (byte)chd;
+                            pStop--;                        // 2 byte sequence for 1 char so need pStop--.
+
+                            *(pTarget + 1) = (byte)(unchecked((sbyte)0x80) | ch & 0x3F);
+                            // pStop - this byte is already included
+
+                            pTarget += 2;
+                        }
+                        while (pSrc < pStop);
+
+                        Debug.Assert(pTarget <= pAllocatedBufferEnd, "[UTF8Encoding.GetBytes]pTarget <= pAllocatedBufferEnd");
+                    }
+
+                    while (pSrc < pEnd)
+                    {
+                        // SLOWLOOP: does all range checks, handles all special cases, but it is slow
+
+                        // read next char. The JIT optimization seems to be getting confused when
+                        // compiling "ch = *pSrc++;", so rather use "ch = *pSrc; pSrc++;" instead
+                        int ch = *pSrc;
                         pSrc++;
 
-                        if (ch > 0x7F)
+                        if (ch <= 0x7F)
                         {
-                            goto LongCode;
-                        }
-                        *pTarget = (byte)ch;
-                        pTarget++;
-                        continue;
+                            if (pAllocatedBufferEnd - pTarget <= 0)
+                                goto DestinationFull;
 
-                    LongCode:
-                        // use separate helper variables for slow and fast loop so that the jit optimizations
-                        // won't get confused about the variable lifetimes
+                            *pTarget = (byte)ch;
+                            pTarget++;
+                            continue;
+                        }
+
                         int chd;
                         if (ch <= 0x7FF)
                         {
+                            if (pAllocatedBufferEnd - pTarget <= 1)
+                                goto DestinationFull;
+
                             // 2 byte encoding
                             chd = unchecked((sbyte)0xC0) | (ch >> 6);
                         }
@@ -229,11 +319,17 @@ namespace System.Text.Encoders
                             // if (!IsLowSurrogate(ch) && !IsHighSurrogate(ch))
                             if (!EncodingHelper.InRange(ch, EncodingHelper.HighSurrogateStart, EncodingHelper.LowSurrogateEnd))
                             {
+                                if (pAllocatedBufferEnd - pTarget <= 2)
+                                    goto DestinationFull;
+
                                 // 3 byte encoding
                                 chd = unchecked((sbyte)0xE0) | (ch >> 12);
                             }
                             else
                             {
+                                if (pAllocatedBufferEnd - pTarget <= 3)
+                                    goto DestinationFull;
+
                                 // 4 byte encoding - high surrogate + low surrogate
                                 // if (!IsHighSurrogate(ch))
                                 if (ch > EncodingHelper.HighSurrogateEnd)
@@ -241,6 +337,9 @@ namespace System.Text.Encoders
                                     // low without high -> bad
                                     goto InvalidData;
                                 }
+
+                                if (pSrc >= pEnd)
+                                    goto NeedMoreData;
 
                                 chd = *pSrc;
 
@@ -259,271 +358,174 @@ namespace System.Text.Encoders
                                     - (EncodingHelper.HighSurrogateStart << 10));
 
                                 *pTarget = (byte)(unchecked((sbyte)0xF0) | (ch >> 18));
-                                // pStop - this byte is compensated by the second surrogate character
-                                // 2 input chars require 4 output bytes.  2 have been anticipated already
-                                // and 2 more will be accounted for by the 2 pStop-- calls below.
                                 pTarget++;
 
                                 chd = unchecked((sbyte)0x80) | (ch >> 12) & 0x3F;
                             }
                             *pTarget = (byte)chd;
-                            pStop--;                    // 3 byte sequence for 1 char, so need pStop-- and the one below too.
                             pTarget++;
 
                             chd = unchecked((sbyte)0x80) | (ch >> 6) & 0x3F;
                         }
-                        *pTarget = (byte)chd;
-                        pStop--;                        // 2 byte sequence for 1 char so need pStop--.
 
+                        *pTarget = (byte)chd;
                         *(pTarget + 1) = (byte)(unchecked((sbyte)0x80) | ch & 0x3F);
-                        // pStop - this byte is already included
 
                         pTarget += 2;
                     }
-                    while (pSrc < pStop);
 
-                    Debug.Assert(pTarget <= pAllocatedBufferEnd, "[UTF8Encoding.GetBytes]pTarget <= pAllocatedBufferEnd");
-                }
+                    bytesConsumed = (int)((byte*)pSrc - chars);
+                    bytesWritten = (int)(pTarget - bytes);
+                    return OperationStatus.Done;
 
-                while (pSrc < pEnd)
-                {
-                    // SLOWLOOP: does all range checks, handles all special cases, but it is slow
+                    InvalidData:
+                    bytesConsumed = (int)((byte*)(pSrc - 1) - chars);
+                    bytesWritten = (int)(pTarget - bytes);
+                    return OperationStatus.InvalidData;
 
-                    // read next char. The JIT optimization seems to be getting confused when
-                    // compiling "ch = *pSrc++;", so rather use "ch = *pSrc; pSrc++;" instead
-                    int ch = *pSrc;
-                    pSrc++;
-
-                    if (ch <= 0x7F)
-                    {
-                        if (pAllocatedBufferEnd - pTarget <= 0)
-                            goto DestinationFull;
-
-                        *pTarget = (byte)ch;
-                        pTarget++;
-                        continue;
-                    }
-
-                    int chd;
-                    if (ch <= 0x7FF)
-                    {
-                        if (pAllocatedBufferEnd - pTarget <= 1)
-                            goto DestinationFull;
-
-                        // 2 byte encoding
-                        chd = unchecked((sbyte)0xC0) | (ch >> 6);
-                    }
-                    else
-                    {
-                        // if (!IsLowSurrogate(ch) && !IsHighSurrogate(ch))
-                        if (!EncodingHelper.InRange(ch, EncodingHelper.HighSurrogateStart, EncodingHelper.LowSurrogateEnd))
-                        {
-                            if (pAllocatedBufferEnd - pTarget <= 2)
-                                goto DestinationFull;
-
-                            // 3 byte encoding
-                            chd = unchecked((sbyte)0xE0) | (ch >> 12);
-                        }
-                        else
-                        {
-                            if (pAllocatedBufferEnd - pTarget <= 3)
-                                goto DestinationFull;
-
-                            // 4 byte encoding - high surrogate + low surrogate
-                            // if (!IsHighSurrogate(ch))
-                            if (ch > EncodingHelper.HighSurrogateEnd)
-                            {
-                                // low without high -> bad
-                                goto InvalidData;
-                            }
-
-                            if (pSrc >= pEnd)
-                                goto NeedMoreData;
-
-                            chd = *pSrc;
-
-                            // if (!IsLowSurrogate(chd)) {
-                            if (!EncodingHelper.InRange(chd, EncodingHelper.LowSurrogateStart, EncodingHelper.LowSurrogateEnd))
-                            {
-                                // high not followed by low -> bad
-                                goto InvalidData;
-                            }
-
-                            pSrc++;
-
-                            ch = chd + (ch << 10) +
-                                (0x10000
-                                - EncodingHelper.LowSurrogateStart
-                                - (EncodingHelper.HighSurrogateStart << 10));
-
-                            *pTarget = (byte)(unchecked((sbyte)0xF0) | (ch >> 18));
-                            pTarget++;
-
-                            chd = unchecked((sbyte)0x80) | (ch >> 12) & 0x3F;
-                        }
-                        *pTarget = (byte)chd;
-                        pTarget++;
-
-                        chd = unchecked((sbyte)0x80) | (ch >> 6) & 0x3F;
-                    }
-
-                    *pTarget = (byte)chd;
-                    *(pTarget + 1) = (byte)(unchecked((sbyte)0x80) | ch & 0x3F);
-
-                    pTarget += 2;
-                }
-
-                bytesConsumed = (int)((byte*)pSrc - chars);
-                bytesWritten = (int)(pTarget - bytes);
-                return OperationStatus.Done;
-
-            InvalidData:
-                bytesConsumed = (int)((byte*)(pSrc - 1) - chars);
-                bytesWritten = (int)(pTarget - bytes);
-                return OperationStatus.InvalidData;
-
-            DestinationFull:
-                bytesConsumed = (int)((byte*)(pSrc - 1) - chars);
-                bytesWritten = (int)(pTarget - bytes);
-                return OperationStatus.DestinationTooSmall;
-
-            NeedMoreData:
-                bytesConsumed = (int)((byte*)(pSrc - 1) - chars);
-                bytesWritten = (int)(pTarget - bytes);
-                return OperationStatus.NeedMoreSourceData;
-            }
-        }
-
-        #endregion UTF-8 Conversions
-
-        #region UTF-32 Conversions
-
-        /// <summary>
-        /// Calculates the byte count needed to encode the UTF-16 bytes from the specified UTF-32 sequence.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
-        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
-        public static OperationStatus FromUtf32Length(ReadOnlySpan<byte> source, out int bytesNeeded)
-            => Utf32.ToUtf16Length(source, out bytesNeeded);
-
-        /// <summary>
-        /// Converts a span containing a sequence of UTF-32 bytes into UTF-16 bytes.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
-        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
-        /// the <paramref name="destination"/>.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
-        /// <param name="destination">A span to write the UTF-16 bytes into.</param>
-        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
-        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
-        public static OperationStatus FromUtf32(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-            => Utf32.ToUtf16(source, destination, out bytesConsumed, out bytesWritten);
-
-        /// <summary>
-        /// Calculates the byte count needed to encode the UTF-32 bytes from the specified UTF-16 sequence.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
-        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
-        public static OperationStatus ToUtf32Length(ReadOnlySpan<byte> source, out int bytesNeeded)
-        {
-            bytesNeeded = 0;
-
-            ref byte src = ref source.DangerousGetPinnableReference();
-            int srcLength = source.Length;
-            int srcIndex = 0;
-
-            while (srcLength - srcIndex >= sizeof(char))
-            {
-                uint codePoint = Unsafe.As<byte, char>(ref Unsafe.Add(ref src, srcIndex));
-                if (EncodingHelper.IsSurrogate(codePoint))
-                {
-                    if (!EncodingHelper.IsHighSurrogate(codePoint))
-                        return OperationStatus.InvalidData;
-
-                    if (srcLength - srcIndex < sizeof(char) * 2)
-                        return OperationStatus.NeedMoreSourceData;
-
-                    uint lowSurrogate = Unsafe.As<byte, char>(ref Unsafe.Add(ref src, srcIndex + 2));
-                    if (!EncodingHelper.IsLowSurrogate(lowSurrogate))
-                        return OperationStatus.InvalidData;
-
-                    srcIndex += 2;
-                }
-
-                srcIndex += 2;
-                bytesNeeded += 4;
-            }
-
-            return srcIndex < srcLength ? OperationStatus.NeedMoreSourceData : OperationStatus.Done;
-        }
-
-        /// <summary>
-        /// Converts a span containing a sequence of UTF-16 bytes into UTF-32 bytes.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
-        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
-        /// the <paramref name="destination"/>.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
-        /// <param name="destination">A span to write the UTF-32 bytes into.</param>
-        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
-        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
-        public static OperationStatus ToUtf32(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-        {
-            bytesConsumed = 0;
-            bytesWritten = 0;
-
-            ref byte src = ref source.DangerousGetPinnableReference();
-            int srcLength = source.Length;
-
-            ref byte dst = ref destination.DangerousGetPinnableReference();
-            int dstLength = destination.Length;
-
-            while (srcLength - bytesConsumed >= sizeof(char))
-            {
-                if (dstLength - bytesWritten < sizeof(uint))
+                    DestinationFull:
+                    bytesConsumed = (int)((byte*)(pSrc - 1) - chars);
+                    bytesWritten = (int)(pTarget - bytes);
                     return OperationStatus.DestinationTooSmall;
 
-                uint codePoint = Unsafe.As<byte, char>(ref Unsafe.Add(ref src, bytesConsumed));
-                if (EncodingHelper.IsSurrogate(codePoint))
-                {
-                    if (!EncodingHelper.IsHighSurrogate(codePoint))
-                        return OperationStatus.InvalidData;
-
-                    if (srcLength - bytesConsumed < sizeof(char) * 2)
-                        return OperationStatus.NeedMoreSourceData;
-
-                    uint lowSurrogate = Unsafe.As<byte, char>(ref Unsafe.Add(ref src, bytesConsumed + 2));
-                    if (!EncodingHelper.IsLowSurrogate(lowSurrogate))
-                        return OperationStatus.InvalidData;
-
-                    codePoint -= EncodingHelper.HighSurrogateStart;
-                    lowSurrogate -= EncodingHelper.LowSurrogateStart;
-                    codePoint = ((codePoint << 10) | lowSurrogate) + 0x010000u;
-                    bytesConsumed += 2;
+                    NeedMoreData:
+                    bytesConsumed = (int)((byte*)(pSrc - 1) - chars);
+                    bytesWritten = (int)(pTarget - bytes);
+                    return OperationStatus.NeedMoreSourceData;
                 }
-
-                Unsafe.As<byte, uint>(ref Unsafe.Add(ref dst, bytesWritten)) = codePoint;
-                bytesConsumed += 2;
-                bytesWritten += 4;
             }
 
-            return bytesConsumed < srcLength ? OperationStatus.NeedMoreSourceData : OperationStatus.Done;
-        }
+            #endregion UTF-8 Conversions
 
-        #endregion UTF-32 Conversions
+            #region UTF-32 Conversions
+
+            /// <summary>
+            /// Calculates the byte count needed to encode the UTF-16 bytes from the specified UTF-32 sequence.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+            /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
+            public static OperationStatus FromUtf32Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+                => Utf32.ToUtf16Length(source, out bytesNeeded);
+
+            /// <summary>
+            /// Converts a span containing a sequence of UTF-32 bytes into UTF-16 bytes.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            ///
+            /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+            /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+            /// the <paramref name="destination"/>.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+            /// <param name="destination">A span to write the UTF-16 bytes into.</param>
+            /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+            /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
+            public static OperationStatus FromUtf32(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+                => Utf32.ToUtf16(source, destination, out bytesConsumed, out bytesWritten);
+
+            /// <summary>
+            /// Calculates the byte count needed to encode the UTF-32 bytes from the specified UTF-16 sequence.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
+            /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
+            public static OperationStatus ToUtf32Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+            {
+                bytesNeeded = 0;
+
+                ref byte src = ref source.DangerousGetPinnableReference();
+                int srcLength = source.Length;
+                int srcIndex = 0;
+
+                while (srcLength - srcIndex >= sizeof(char))
+                {
+                    uint codePoint = Unsafe.As<byte, char>(ref Unsafe.Add(ref src, srcIndex));
+                    if (EncodingHelper.IsSurrogate(codePoint))
+                    {
+                        if (!EncodingHelper.IsHighSurrogate(codePoint))
+                            return OperationStatus.InvalidData;
+
+                        if (srcLength - srcIndex < sizeof(char) * 2)
+                            return OperationStatus.NeedMoreSourceData;
+
+                        uint lowSurrogate = Unsafe.As<byte, char>(ref Unsafe.Add(ref src, srcIndex + 2));
+                        if (!EncodingHelper.IsLowSurrogate(lowSurrogate))
+                            return OperationStatus.InvalidData;
+
+                        srcIndex += 2;
+                    }
+
+                    srcIndex += 2;
+                    bytesNeeded += 4;
+                }
+
+                return srcIndex < srcLength ? OperationStatus.NeedMoreSourceData : OperationStatus.Done;
+            }
+
+            /// <summary>
+            /// Converts a span containing a sequence of UTF-16 bytes into UTF-32 bytes.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            ///
+            /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+            /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+            /// the <paramref name="destination"/>.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
+            /// <param name="destination">A span to write the UTF-32 bytes into.</param>
+            /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+            /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
+            public static OperationStatus ToUtf32(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+            {
+                bytesConsumed = 0;
+                bytesWritten = 0;
+
+                ref byte src = ref source.DangerousGetPinnableReference();
+                int srcLength = source.Length;
+
+                ref byte dst = ref destination.DangerousGetPinnableReference();
+                int dstLength = destination.Length;
+
+                while (srcLength - bytesConsumed >= sizeof(char))
+                {
+                    if (dstLength - bytesWritten < sizeof(uint))
+                        return OperationStatus.DestinationTooSmall;
+
+                    uint codePoint = Unsafe.As<byte, char>(ref Unsafe.Add(ref src, bytesConsumed));
+                    if (EncodingHelper.IsSurrogate(codePoint))
+                    {
+                        if (!EncodingHelper.IsHighSurrogate(codePoint))
+                            return OperationStatus.InvalidData;
+
+                        if (srcLength - bytesConsumed < sizeof(char) * 2)
+                            return OperationStatus.NeedMoreSourceData;
+
+                        uint lowSurrogate = Unsafe.As<byte, char>(ref Unsafe.Add(ref src, bytesConsumed + 2));
+                        if (!EncodingHelper.IsLowSurrogate(lowSurrogate))
+                            return OperationStatus.InvalidData;
+
+                        codePoint -= EncodingHelper.HighSurrogateStart;
+                        lowSurrogate -= EncodingHelper.LowSurrogateStart;
+                        codePoint = ((codePoint << 10) | lowSurrogate) + 0x010000u;
+                        bytesConsumed += 2;
+                    }
+
+                    Unsafe.As<byte, uint>(ref Unsafe.Add(ref dst, bytesWritten)) = codePoint;
+                    bytesConsumed += 2;
+                    bytesWritten += 4;
+                }
+
+                return bytesConsumed < srcLength ? OperationStatus.NeedMoreSourceData : OperationStatus.Done;
+            }
+
+            #endregion UTF-32 Conversions
+        }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Encoders/Utf32.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Utf32.cs
@@ -4,255 +4,258 @@
 using System.Buffers;
 using System.Runtime.CompilerServices;
 
-namespace System.Text.Encoders
+namespace System.Buffers
 {
-    public static class Utf32
+    public static partial class Encodings
     {
-        #region UTF-8 Conversions
-
-        /// <summary>
-        /// Calculates the byte count needed to encode the UTF-32 bytes from the specified UTF-8 sequence.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
-        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
-        public static OperationStatus FromUtf8Length(ReadOnlySpan<byte> source, out int bytesNeeded)
-            => Utf8.ToUtf32Length(source, out bytesNeeded);
-
-        /// <summary>
-        /// Converts a span containing a sequence of UTF-8 bytes into UTF-32 bytes.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
-        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
-        /// the <paramref name="destination"/>.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
-        /// <param name="destination">A span to write the UTF-32 bytes into.</param>
-        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
-        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
-        public static OperationStatus FromUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-            => Utf8.ToUtf32(source, destination, out bytesConsumed, out bytesWritten);
-
-        /// <summary>
-        /// Calculates the byte count needed to encode the UTF-8 bytes from the specified UTF-32 sequence.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
-        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
-        public static OperationStatus ToUtf8Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+        public static class Utf32
         {
-            bytesNeeded = 0;
+            #region UTF-8 Conversions
 
-            ref uint utf32 = ref Unsafe.As<byte, uint>(ref source.DangerousGetPinnableReference());
-            int utf32Length = source.Length >> 2; // byte => uint count
+            /// <summary>
+            /// Calculates the byte count needed to encode the UTF-32 bytes from the specified UTF-8 sequence.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
+            /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
+            public static OperationStatus FromUtf8Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+                => Utf8.ToUtf32Length(source, out bytesNeeded);
 
-            for (int i = 0; i < utf32Length; i++)
+            /// <summary>
+            /// Converts a span containing a sequence of UTF-8 bytes into UTF-32 bytes.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            ///
+            /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+            /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+            /// the <paramref name="destination"/>.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
+            /// <param name="destination">A span to write the UTF-32 bytes into.</param>
+            /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+            /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
+            public static OperationStatus FromUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+                => Utf8.ToUtf32(source, destination, out bytesConsumed, out bytesWritten);
+
+            /// <summary>
+            /// Calculates the byte count needed to encode the UTF-8 bytes from the specified UTF-32 sequence.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+            /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
+            public static OperationStatus ToUtf8Length(ReadOnlySpan<byte> source, out int bytesNeeded)
             {
-                uint codePoint = Unsafe.Add(ref utf32, i);
-                if (!EncodingHelper.IsSupportedCodePoint(codePoint))
-                    return OperationStatus.InvalidData;
+                bytesNeeded = 0;
 
-                bytesNeeded += EncodingHelper.GetUtf8EncodedBytes(codePoint);
-            }
+                ref uint utf32 = ref Unsafe.As<byte, uint>(ref source.DangerousGetPinnableReference());
+                int utf32Length = source.Length >> 2; // byte => uint count
 
-            if (utf32Length << 2 != source.Length)
-                return OperationStatus.NeedMoreSourceData;
-
-            return OperationStatus.Done;
-        }
-
-        /// <summary>
-        /// Converts a span containing a sequence of UTF-32 bytes into UTF-8 bytes.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
-        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
-        /// the <paramref name="destination"/>.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
-        /// <param name="destination">A span to write the UTF-8 bytes into.</param>
-        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
-        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
-        public static OperationStatus ToUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-        {
-            bytesConsumed = 0;
-            bytesWritten = 0;
-
-            ref byte src = ref source.DangerousGetPinnableReference();
-            int srcLength = source.Length;
-
-            ref byte dst = ref destination.DangerousGetPinnableReference();
-            int dstLength = destination.Length;
-
-            while (srcLength - bytesConsumed >= sizeof(uint))
-            {
-                uint codePoint = Unsafe.As<byte, uint>(ref Unsafe.Add(ref src, bytesConsumed));
-                if (!EncodingHelper.IsSupportedCodePoint(codePoint))
-                    return OperationStatus.InvalidData;
-
-                int bytesNeeded = EncodingHelper.GetUtf8EncodedBytes(codePoint);
-                if (dstLength - bytesWritten < bytesNeeded)
-                    return OperationStatus.DestinationTooSmall;
-
-                switch (bytesNeeded)
+                for (int i = 0; i < utf32Length; i++)
                 {
-                    case 1:
-                        Unsafe.Add(ref dst, bytesWritten) = (byte)(EncodingHelper.b0111_1111U & codePoint);
-                        break;
-
-                    case 2:
-                        Unsafe.Add(ref dst, bytesWritten) = (byte)(((codePoint >> 6) & EncodingHelper.b0001_1111U) | EncodingHelper.b1100_0000U);
-                        Unsafe.Add(ref dst, bytesWritten + 1) = (byte)((codePoint & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
-                        break;
-
-                    case 3:
-                        Unsafe.Add(ref dst, bytesWritten) = (byte)(((codePoint >> 12) & EncodingHelper.b0000_1111U) | EncodingHelper.b1110_0000U);
-                        Unsafe.Add(ref dst, bytesWritten + 1) = (byte)(((codePoint >> 6) & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
-                        Unsafe.Add(ref dst, bytesWritten + 2) = (byte)((codePoint & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
-                        break;
-
-                    case 4:
-                        Unsafe.Add(ref dst, bytesWritten) = (byte)(((codePoint >> 18) & EncodingHelper.b0000_0111U) | EncodingHelper.b1111_0000U);
-                        Unsafe.Add(ref dst, bytesWritten + 1) = (byte)(((codePoint >> 12) & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
-                        Unsafe.Add(ref dst, bytesWritten + 2) = (byte)(((codePoint >> 6) & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
-                        Unsafe.Add(ref dst, bytesWritten + 3) = (byte)((codePoint & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
-                        break;
-
-                    default:
+                    uint codePoint = Unsafe.Add(ref utf32, i);
+                    if (!EncodingHelper.IsSupportedCodePoint(codePoint))
                         return OperationStatus.InvalidData;
+
+                    bytesNeeded += EncodingHelper.GetUtf8EncodedBytes(codePoint);
                 }
 
-                bytesConsumed += 4;
-                bytesWritten += bytesNeeded;
+                if (utf32Length << 2 != source.Length)
+                    return OperationStatus.NeedMoreSourceData;
+
+                return OperationStatus.Done;
             }
 
-            return bytesConsumed < srcLength ? OperationStatus.NeedMoreSourceData : OperationStatus.Done;
-        }
-
-        #endregion UTF-8 Conversions
-
-        #region UTF-16 Conversions
-
-        /// <summary>
-        /// Calculates the byte count needed to encode the UTF-32 bytes from the specified UTF-16 sequence.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
-        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
-        public static OperationStatus FromUtf16Length(ReadOnlySpan<byte> source, out int bytesNeeded)
-            => Utf16.ToUtf32Length(source, out bytesNeeded);
-
-        /// <summary>
-        /// Converts a span containing a sequence of UTF-16 bytes into UTF-32 bytes.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
-        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
-        /// the <paramref name="destination"/>.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
-        /// <param name="destination">A span to write the UTF-32 bytes into.</param>
-        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
-        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
-        public static OperationStatus FromUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-            => Utf16.ToUtf32(source, destination, out bytesConsumed, out bytesWritten);
-
-        /// <summary>
-        /// Calculates the byte count needed to encode the UTF-16 bytes from the specified UTF-32 sequence.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
-        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
-        public static OperationStatus ToUtf16Length(ReadOnlySpan<byte> source, out int bytesNeeded)
-        {
-            int index = 0;
-            int length = source.Length;
-            ref byte src = ref source.DangerousGetPinnableReference();
-
-            bytesNeeded = 0;
-
-            while (length - index >= 4)
+            /// <summary>
+            /// Converts a span containing a sequence of UTF-32 bytes into UTF-8 bytes.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            ///
+            /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+            /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+            /// the <paramref name="destination"/>.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+            /// <param name="destination">A span to write the UTF-8 bytes into.</param>
+            /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+            /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
+            public static OperationStatus ToUtf8(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
             {
-                ref uint codePoint = ref Unsafe.As<byte, uint>(ref Unsafe.Add(ref src, index));
+                bytesConsumed = 0;
+                bytesWritten = 0;
 
-                if (!EncodingHelper.IsSupportedCodePoint(codePoint))
-                    return OperationStatus.InvalidData;
+                ref byte src = ref source.DangerousGetPinnableReference();
+                int srcLength = source.Length;
 
-                bytesNeeded += EncodingHelper.IsBmp(codePoint) ? 2 : 4;
-                index += 4;
-            }
+                ref byte dst = ref destination.DangerousGetPinnableReference();
+                int dstLength = destination.Length;
 
-            return index < length ? OperationStatus.NeedMoreSourceData : OperationStatus.Done;
-        }
-
-        /// <summary>
-        /// Converts a span containing a sequence of UTF-32 bytes into UTF-16 bytes.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
-        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
-        /// the <paramref name="destination"/>.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
-        /// <param name="destination">A span to write the UTF-16 bytes into.</param>
-        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
-        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
-        public static OperationStatus ToUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-        {
-            ref byte src = ref source.DangerousGetPinnableReference();
-            ref byte dst = ref destination.DangerousGetPinnableReference();
-            int srcLength = source.Length;
-            int dstLength = destination.Length;
-
-            bytesConsumed = 0;
-            bytesWritten = 0;
-
-            while (srcLength - bytesConsumed >= sizeof(uint))
-            {
-                ref uint codePoint = ref Unsafe.As<byte, uint>(ref Unsafe.Add(ref src, bytesConsumed));
-
-                if (!EncodingHelper.IsSupportedCodePoint(codePoint))
-                    return OperationStatus.InvalidData;
-
-                int written = EncodingHelper.IsBmp(codePoint) ? 2 : 4;
-                if (dstLength - bytesWritten < written)
-                    return OperationStatus.DestinationTooSmall;
-
-                unchecked
+                while (srcLength - bytesConsumed >= sizeof(uint))
                 {
-                    if (written == 2)
-                        Unsafe.As<byte, char>(ref Unsafe.Add(ref dst, bytesWritten)) = (char)codePoint;
-                    else
+                    uint codePoint = Unsafe.As<byte, uint>(ref Unsafe.Add(ref src, bytesConsumed));
+                    if (!EncodingHelper.IsSupportedCodePoint(codePoint))
+                        return OperationStatus.InvalidData;
+
+                    int bytesNeeded = EncodingHelper.GetUtf8EncodedBytes(codePoint);
+                    if (dstLength - bytesWritten < bytesNeeded)
+                        return OperationStatus.DestinationTooSmall;
+
+                    switch (bytesNeeded)
                     {
-                        Unsafe.As<byte, char>(ref Unsafe.Add(ref dst, bytesWritten)) = (char)(((codePoint - 0x010000u) >> 10) + EncodingHelper.HighSurrogateStart);
-                        Unsafe.As<byte, char>(ref Unsafe.Add(ref dst, bytesWritten + 2)) = (char)((codePoint & 0x3FF) + EncodingHelper.LowSurrogateStart);
+                        case 1:
+                            Unsafe.Add(ref dst, bytesWritten) = (byte)(EncodingHelper.b0111_1111U & codePoint);
+                            break;
+
+                        case 2:
+                            Unsafe.Add(ref dst, bytesWritten) = (byte)(((codePoint >> 6) & EncodingHelper.b0001_1111U) | EncodingHelper.b1100_0000U);
+                            Unsafe.Add(ref dst, bytesWritten + 1) = (byte)((codePoint & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
+                            break;
+
+                        case 3:
+                            Unsafe.Add(ref dst, bytesWritten) = (byte)(((codePoint >> 12) & EncodingHelper.b0000_1111U) | EncodingHelper.b1110_0000U);
+                            Unsafe.Add(ref dst, bytesWritten + 1) = (byte)(((codePoint >> 6) & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
+                            Unsafe.Add(ref dst, bytesWritten + 2) = (byte)((codePoint & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
+                            break;
+
+                        case 4:
+                            Unsafe.Add(ref dst, bytesWritten) = (byte)(((codePoint >> 18) & EncodingHelper.b0000_0111U) | EncodingHelper.b1111_0000U);
+                            Unsafe.Add(ref dst, bytesWritten + 1) = (byte)(((codePoint >> 12) & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
+                            Unsafe.Add(ref dst, bytesWritten + 2) = (byte)(((codePoint >> 6) & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
+                            Unsafe.Add(ref dst, bytesWritten + 3) = (byte)((codePoint & EncodingHelper.b0011_1111U) | EncodingHelper.b1000_0000U);
+                            break;
+
+                        default:
+                            return OperationStatus.InvalidData;
                     }
+
+                    bytesConsumed += 4;
+                    bytesWritten += bytesNeeded;
                 }
 
-                bytesWritten += written;
-                bytesConsumed += 4;
+                return bytesConsumed < srcLength ? OperationStatus.NeedMoreSourceData : OperationStatus.Done;
             }
 
-            return bytesConsumed < srcLength ? OperationStatus.NeedMoreSourceData : OperationStatus.Done;
-        }
+            #endregion UTF-8 Conversions
 
-        #endregion UTF-16 Conversions
+            #region UTF-16 Conversions
+
+            /// <summary>
+            /// Calculates the byte count needed to encode the UTF-32 bytes from the specified UTF-16 sequence.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
+            /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
+            public static OperationStatus FromUtf16Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+                => Utf16.ToUtf32Length(source, out bytesNeeded);
+
+            /// <summary>
+            /// Converts a span containing a sequence of UTF-16 bytes into UTF-32 bytes.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            ///
+            /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+            /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+            /// the <paramref name="destination"/>.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
+            /// <param name="destination">A span to write the UTF-32 bytes into.</param>
+            /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+            /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
+            public static OperationStatus FromUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+                => Utf16.ToUtf32(source, destination, out bytesConsumed, out bytesWritten);
+
+            /// <summary>
+            /// Calculates the byte count needed to encode the UTF-16 bytes from the specified UTF-32 sequence.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+            /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
+            public static OperationStatus ToUtf16Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+            {
+                int index = 0;
+                int length = source.Length;
+                ref byte src = ref source.DangerousGetPinnableReference();
+
+                bytesNeeded = 0;
+
+                while (length - index >= 4)
+                {
+                    ref uint codePoint = ref Unsafe.As<byte, uint>(ref Unsafe.Add(ref src, index));
+
+                    if (!EncodingHelper.IsSupportedCodePoint(codePoint))
+                        return OperationStatus.InvalidData;
+
+                    bytesNeeded += EncodingHelper.IsBmp(codePoint) ? 2 : 4;
+                    index += 4;
+                }
+
+                return index < length ? OperationStatus.NeedMoreSourceData : OperationStatus.Done;
+            }
+
+            /// <summary>
+            /// Converts a span containing a sequence of UTF-32 bytes into UTF-16 bytes.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            ///
+            /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+            /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+            /// the <paramref name="destination"/>.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+            /// <param name="destination">A span to write the UTF-16 bytes into.</param>
+            /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+            /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
+            public static OperationStatus ToUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+            {
+                ref byte src = ref source.DangerousGetPinnableReference();
+                ref byte dst = ref destination.DangerousGetPinnableReference();
+                int srcLength = source.Length;
+                int dstLength = destination.Length;
+
+                bytesConsumed = 0;
+                bytesWritten = 0;
+
+                while (srcLength - bytesConsumed >= sizeof(uint))
+                {
+                    ref uint codePoint = ref Unsafe.As<byte, uint>(ref Unsafe.Add(ref src, bytesConsumed));
+
+                    if (!EncodingHelper.IsSupportedCodePoint(codePoint))
+                        return OperationStatus.InvalidData;
+
+                    int written = EncodingHelper.IsBmp(codePoint) ? 2 : 4;
+                    if (dstLength - bytesWritten < written)
+                        return OperationStatus.DestinationTooSmall;
+
+                    unchecked
+                    {
+                        if (written == 2)
+                            Unsafe.As<byte, char>(ref Unsafe.Add(ref dst, bytesWritten)) = (char)codePoint;
+                        else
+                        {
+                            Unsafe.As<byte, char>(ref Unsafe.Add(ref dst, bytesWritten)) = (char)(((codePoint - 0x010000u) >> 10) + EncodingHelper.HighSurrogateStart);
+                            Unsafe.As<byte, char>(ref Unsafe.Add(ref dst, bytesWritten + 2)) = (char)((codePoint & 0x3FF) + EncodingHelper.LowSurrogateStart);
+                        }
+                    }
+
+                    bytesWritten += written;
+                    bytesConsumed += 4;
+                }
+
+                return bytesConsumed < srcLength ? OperationStatus.NeedMoreSourceData : OperationStatus.Done;
+            }
+
+            #endregion UTF-16 Conversions
+        }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Encoders/Utf8.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Utf8.cs
@@ -5,100 +5,91 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-namespace System.Text.Encoders
+namespace System.Buffers
 {
-    public static class Utf8
+    public static partial class Encodings
     {
-        #region UTF-16 Conversions
-
-        /// <summary>
-        /// Calculates the byte count needed to encode the UTF-8 bytes from the specified UTF-16 sequence.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
-        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
-        public static OperationStatus FromUtf16Length(ReadOnlySpan<byte> source, out int bytesNeeded)
-            => Utf16.ToUtf8Length(source, out bytesNeeded);
-
-        /// <summary>
-        /// Converts a span containing a sequence of UTF-16 bytes into UTF-8 bytes.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
-        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
-        /// the <paramref name="destination"/>.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
-        /// <param name="destination">A span to write the UTF-8 bytes into.</param>
-        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
-        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
-        public static OperationStatus FromUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-            => Utf16.ToUtf8(source, destination, out bytesConsumed, out bytesWritten);
-
-        /// <summary>
-        /// Calculates the byte count needed to encode the UTF-16 bytes from the specified UTF-8 sequence.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
-        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
-        public unsafe static OperationStatus ToUtf16Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+        public static class Utf8
         {
-            fixed (byte* pUtf8 = &source.DangerousGetPinnableReference())
+            #region UTF-16 Conversions
+
+            /// <summary>
+            /// Calculates the byte count needed to encode the UTF-8 bytes from the specified UTF-16 sequence.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
+            /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
+            public static OperationStatus FromUtf16Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+                => Utf16.ToUtf8Length(source, out bytesNeeded);
+
+            /// <summary>
+            /// Converts a span containing a sequence of UTF-16 bytes into UTF-8 bytes.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            ///
+            /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+            /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+            /// the <paramref name="destination"/>.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-16 bytes.</param>
+            /// <param name="destination">A span to write the UTF-8 bytes into.</param>
+            /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+            /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
+            public static OperationStatus FromUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+                => Utf16.ToUtf8(source, destination, out bytesConsumed, out bytesWritten);
+
+            /// <summary>
+            /// Calculates the byte count needed to encode the UTF-16 bytes from the specified UTF-8 sequence.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
+            /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
+            public unsafe static OperationStatus ToUtf16Length(ReadOnlySpan<byte> source, out int bytesNeeded)
             {
-                byte* pSrc = pUtf8;
-                byte* pSrcEnd = pSrc + source.Length;
-
-                bytesNeeded = 0;
-
-                int ch = 0;
-                while (pSrc < pSrcEnd)
+                fixed (byte* pUtf8 = &source.DangerousGetPinnableReference())
                 {
-                    int availableBytes = EncodingHelper.PtrDiff(pSrcEnd, pSrc);
+                    byte* pSrc = pUtf8;
+                    byte* pSrcEnd = pSrc + source.Length;
 
-                    // don't fall into the fast decoding loop if we don't have enough bytes
-                    if (availableBytes <= 13)
+                    bytesNeeded = 0;
+
+                    int ch = 0;
+                    while (pSrc < pSrcEnd)
                     {
-                        // try to get over the remainder of the ascii characters fast though
-                        byte* pLocalEnd = pSrc + availableBytes;
-                        while (pSrc < pLocalEnd)
+                        int availableBytes = EncodingHelper.PtrDiff(pSrcEnd, pSrc);
+
+                        // don't fall into the fast decoding loop if we don't have enough bytes
+                        if (availableBytes <= 13)
                         {
-                            ch = *pSrc;
-                            pSrc++;
+                            // try to get over the remainder of the ascii characters fast though
+                            byte* pLocalEnd = pSrc + availableBytes;
+                            while (pSrc < pLocalEnd)
+                            {
+                                ch = *pSrc;
+                                pSrc++;
 
-                            if (ch > 0x7F)
-                                goto LongCodeSlow;
+                                if (ch > 0x7F)
+                                    goto LongCodeSlow;
 
-                            bytesNeeded++;
+                                bytesNeeded++;
+                            }
+
+                            // we are done
+                            break;
                         }
 
-                        // we are done
-                        break;
-                    }
+                        // To compute the upper bound, assume that all characters are ASCII characters at this point,
+                        //  the boundary will be decreased for every non-ASCII character we encounter
+                        // Also, we need 7 chars reserve for the unrolled ansi decoding loop and for decoding of multibyte sequences
+                        byte* pStop = pSrc + availableBytes - 7;
 
-                    // To compute the upper bound, assume that all characters are ASCII characters at this point,
-                    //  the boundary will be decreased for every non-ASCII character we encounter
-                    // Also, we need 7 chars reserve for the unrolled ansi decoding loop and for decoding of multibyte sequences
-                    byte* pStop = pSrc + availableBytes - 7;
-
-                    // Fast loop
-                    while (pSrc < pStop)
-                    {
-                        ch = *pSrc;
-                        pSrc++;
-
-                        if (ch > 0x7F)
-                            goto LongCode;
-
-                        bytesNeeded++;
-
-                        // 2-byte align
-                        if ((unchecked((int)pSrc) & 0x1) != 0)
+                        // Fast loop
+                        while (pSrc < pStop)
                         {
                             ch = *pSrc;
                             pSrc++;
@@ -107,30 +98,41 @@ namespace System.Text.Encoders
                                 goto LongCode;
 
                             bytesNeeded++;
-                        }
 
-                        // 4-byte align
-                        if ((unchecked((int)pSrc) & 0x2) != 0)
-                        {
-                            ch = *(ushort*)pSrc;
-                            if ((ch & 0x8080) != 0)
-                                goto LongCodeWithMask16;
-                            pSrc += 2;
-                            bytesNeeded += 2;
-                        }
+                            // 2-byte align
+                            if ((unchecked((int)pSrc) & 0x1) != 0)
+                            {
+                                ch = *pSrc;
+                                pSrc++;
 
-                        // Run 8 characters at a time!
-                        while (pSrc < pStop)
-                        {
-                            ch = *(int*)pSrc;
-                            int chb = *(int*)(pSrc + 4);
-                            if (((ch | chb) & unchecked((int)0x80808080)) != 0)
-                                goto LongCodeWithMask32;
-                            pSrc += 8;
-                            bytesNeeded += 8;
-                        }
+                                if (ch > 0x7F)
+                                    goto LongCode;
 
-                        break;
+                                bytesNeeded++;
+                            }
+
+                            // 4-byte align
+                            if ((unchecked((int)pSrc) & 0x2) != 0)
+                            {
+                                ch = *(ushort*)pSrc;
+                                if ((ch & 0x8080) != 0)
+                                    goto LongCodeWithMask16;
+                                pSrc += 2;
+                                bytesNeeded += 2;
+                            }
+
+                            // Run 8 characters at a time!
+                            while (pSrc < pStop)
+                            {
+                                ch = *(int*)pSrc;
+                                int chb = *(int*)(pSrc + 4);
+                                if (((ch | chb) & unchecked((int)0x80808080)) != 0)
+                                    goto LongCodeWithMask32;
+                                pSrc += 8;
+                                bytesNeeded += 8;
+                            }
+
+                            break;
 
 #if BIGENDIAN
                     LongCodeWithMask32:
@@ -139,54 +141,155 @@ namespace System.Text.Encoders
                     LongCodeWithMask16:
                         ch = (int)(((uint)ch) >> 8);
 #else // BIGENDIAN
-                    LongCodeWithMask32:
-                    LongCodeWithMask16:
-                        ch &= 0xFF;
+                            LongCodeWithMask32:
+                            LongCodeWithMask16:
+                            ch &= 0xFF;
 #endif // BIGENDIAN
-                        pSrc++;
-                        if (ch <= 0x7F)
-                        {
+                            pSrc++;
+                            if (ch <= 0x7F)
+                            {
+                                bytesNeeded++;
+                                continue;
+                            }
+
+                            LongCode:
+                            int chc = *pSrc;
+                            pSrc++;
+
+                            // Bit 6 should be 0, and trailing byte should be 10vvvvvv
+                            if ((ch & 0x40) == 0 || (chc & unchecked((sbyte)0xC0)) != 0x80)
+                                goto InvalidData;
+
+                            chc &= 0x3F;
+
+                            if ((ch & 0x20) != 0)
+                            {
+                                // Handle 3 or 4 byte encoding.
+
+                                // Fold the first 2 bytes together
+                                chc |= (ch & 0x0F) << 6;
+
+                                if ((ch & 0x10) != 0)
+                                {
+                                    // 4 byte - surrogate pair
+                                    ch = *pSrc;
+
+                                    // Bit 4 should be zero + the surrogate should be in the range 0x000000 - 0x10FFFF
+                                    // and the trailing byte should be 10vvvvvv
+                                    if (!EncodingHelper.InRange(chc >> 4, 0x01, 0x10) || (ch & unchecked((sbyte)0xC0)) != 0x80)
+                                        goto InvalidData;
+
+                                    // Merge 3rd byte then read the last byte
+                                    chc = (chc << 6) | (ch & 0x3F);
+                                    ch = *(pSrc + 1);
+
+                                    // The last trailing byte still holds the form 10vvvvvv
+                                    if ((ch & unchecked((sbyte)0xC0)) != 0x80)
+                                        goto InvalidData;
+
+                                    pSrc += 2;
+                                    ch = (chc << 6) | (ch & 0x3F);
+
+                                    bytesNeeded++;
+
+                                    ch = (ch & 0x3FF) + unchecked((short)(EncodingHelper.LowSurrogateStart));
+                                }
+                                else
+                                {
+                                    // 3 byte encoding
+                                    ch = *pSrc;
+
+                                    // Check for non-shortest form of 3 byte sequence
+                                    // No surrogates
+                                    // Trailing byte must be in the form 10vvvvvv
+                                    if ((chc & (0x1F << 5)) == 0 ||
+                                        (chc & (0xF800 >> 6)) == (0xD800 >> 6) ||
+                                        (ch & unchecked((sbyte)0xC0)) != 0x80)
+                                        goto InvalidData;
+
+                                    pSrc++;
+                                    ch = (chc << 6) | (ch & 0x3F);
+                                }
+
+                                // extra byte, we're already planning 2 chars for 2 of these bytes,
+                                // but the big loop is testing the target against pStop, so we need
+                                // to subtract 2 more or we risk overrunning the input.  Subtract
+                                // one here and one below.
+                                pStop--;
+                            }
+                            else
+                            {
+                                // 2 byte encoding
+                                ch &= 0x1F;
+
+                                // Check for non-shortest form
+                                if (ch <= 1)
+                                    goto InvalidData;
+
+                                ch = (ch << 6) | chc;
+                            }
+
                             bytesNeeded++;
-                            continue;
+
+                            // extra byte, we're only expecting 1 char for each of these 2 bytes,
+                            // but the loop is testing the target (not source) against pStop.
+                            // subtract an extra count from pStop so that we don't overrun the input.
+                            pStop--;
                         }
 
-                    LongCode:
-                        int chc = *pSrc;
+                        continue;
+
+                        LongCodeSlow:
+                        if (pSrc >= pSrcEnd)
+                        {
+                            // This is a special case where hit the end of the buffer but are in the middle
+                            // of decoding a long code. The error exit thinks we have read 2 extra bytes already,
+                            // so we add +1 to pSrc to get the count correct for the bytes consumed value.
+                            pSrc++;
+                            goto NeedMoreData;
+                        }
+
+                        int chd = *pSrc;
                         pSrc++;
 
                         // Bit 6 should be 0, and trailing byte should be 10vvvvvv
-                        if ((ch & 0x40) == 0 || (chc & unchecked((sbyte)0xC0)) != 0x80)
+                        if ((ch & 0x40) == 0 || (chd & unchecked((sbyte)0xC0)) != 0x80)
                             goto InvalidData;
 
-                        chc &= 0x3F;
+                        chd &= 0x3F;
 
                         if ((ch & 0x20) != 0)
                         {
                             // Handle 3 or 4 byte encoding.
 
                             // Fold the first 2 bytes together
-                            chc |= (ch & 0x0F) << 6;
+                            chd |= (ch & 0x0F) << 6;
 
                             if ((ch & 0x10) != 0)
                             {
                                 // 4 byte - surrogate pair
+                                // We need 2 more bytes
+                                if (pSrc >= pSrcEnd - 1)
+                                    goto NeedMoreData;
+
                                 ch = *pSrc;
 
                                 // Bit 4 should be zero + the surrogate should be in the range 0x000000 - 0x10FFFF
                                 // and the trailing byte should be 10vvvvvv
-                                if (!EncodingHelper.InRange(chc >> 4, 0x01, 0x10) || (ch & unchecked((sbyte)0xC0)) != 0x80)
+                                if (!EncodingHelper.InRange(chd >> 4, 0x01, 0x10) || (ch & unchecked((sbyte)0xC0)) != 0x80)
                                     goto InvalidData;
 
                                 // Merge 3rd byte then read the last byte
-                                chc = (chc << 6) | (ch & 0x3F);
+                                chd = (chd << 6) | (ch & 0x3F);
                                 ch = *(pSrc + 1);
 
                                 // The last trailing byte still holds the form 10vvvvvv
+                                // We only know for sure we have room for one more char, but we need an extra now.
                                 if ((ch & unchecked((sbyte)0xC0)) != 0x80)
                                     goto InvalidData;
 
                                 pSrc += 2;
-                                ch = (chc << 6) | (ch & 0x3F);
+                                ch = (chd << 6) | (ch & 0x3F);
 
                                 bytesNeeded++;
 
@@ -195,25 +298,22 @@ namespace System.Text.Encoders
                             else
                             {
                                 // 3 byte encoding
+                                if (pSrc >= pSrcEnd)
+                                    goto NeedMoreData;
+
                                 ch = *pSrc;
 
                                 // Check for non-shortest form of 3 byte sequence
                                 // No surrogates
                                 // Trailing byte must be in the form 10vvvvvv
-                                if ((chc & (0x1F << 5)) == 0 ||
-                                    (chc & (0xF800 >> 6)) == (0xD800 >> 6) ||
+                                if ((chd & (0x1F << 5)) == 0 ||
+                                    (chd & (0xF800 >> 6)) == (0xD800 >> 6) ||
                                     (ch & unchecked((sbyte)0xC0)) != 0x80)
                                     goto InvalidData;
 
                                 pSrc++;
-                                ch = (chc << 6) | (ch & 0x3F);
+                                ch = (chd << 6) | (ch & 0x3F);
                             }
-
-                            // extra byte, we're already planning 2 chars for 2 of these bytes,
-                            // but the big loop is testing the target against pStop, so we need
-                            // to subtract 2 more or we risk overrunning the input.  Subtract
-                            // one here and one below.
-                            pStop--;
                         }
                         else
                         {
@@ -224,198 +324,88 @@ namespace System.Text.Encoders
                             if (ch <= 1)
                                 goto InvalidData;
 
-                            ch = (ch << 6) | chc;
+                            ch = (ch << 6) | chd;
                         }
 
                         bytesNeeded++;
-
-                        // extra byte, we're only expecting 1 char for each of these 2 bytes,
-                        // but the loop is testing the target (not source) against pStop.
-                        // subtract an extra count from pStop so that we don't overrun the input.
-                        pStop--;
                     }
 
-                    continue;
+                    bytesNeeded <<= 1;  // Count we have is chars, double for bytes.
+                    return EncodingHelper.PtrDiff(pSrcEnd, pSrc) == 0 ? OperationStatus.Done : OperationStatus.DestinationTooSmall;
 
-                LongCodeSlow:
-                    if (pSrc >= pSrcEnd)
-                    {
-                        // This is a special case where hit the end of the buffer but are in the middle
-                        // of decoding a long code. The error exit thinks we have read 2 extra bytes already,
-                        // so we add +1 to pSrc to get the count correct for the bytes consumed value.
-                        pSrc++;
-                        goto NeedMoreData;
-                    }
+                    NeedMoreData:
+                    bytesNeeded <<= 1;  // Count we have is chars, double for bytes.
+                    return OperationStatus.NeedMoreSourceData;
 
-                    int chd = *pSrc;
-                    pSrc++;
-
-                    // Bit 6 should be 0, and trailing byte should be 10vvvvvv
-                    if ((ch & 0x40) == 0 || (chd & unchecked((sbyte)0xC0)) != 0x80)
-                        goto InvalidData;
-
-                    chd &= 0x3F;
-
-                    if ((ch & 0x20) != 0)
-                    {
-                        // Handle 3 or 4 byte encoding.
-
-                        // Fold the first 2 bytes together
-                        chd |= (ch & 0x0F) << 6;
-
-                        if ((ch & 0x10) != 0)
-                        {
-                            // 4 byte - surrogate pair
-                            // We need 2 more bytes
-                            if (pSrc >= pSrcEnd - 1)
-                                goto NeedMoreData;
-
-                            ch = *pSrc;
-
-                            // Bit 4 should be zero + the surrogate should be in the range 0x000000 - 0x10FFFF
-                            // and the trailing byte should be 10vvvvvv
-                            if (!EncodingHelper.InRange(chd >> 4, 0x01, 0x10) || (ch & unchecked((sbyte)0xC0)) != 0x80)
-                                goto InvalidData;
-
-                            // Merge 3rd byte then read the last byte
-                            chd = (chd << 6) | (ch & 0x3F);
-                            ch = *(pSrc + 1);
-
-                            // The last trailing byte still holds the form 10vvvvvv
-                            // We only know for sure we have room for one more char, but we need an extra now.
-                            if ((ch & unchecked((sbyte)0xC0)) != 0x80)
-                                goto InvalidData;
-
-                            pSrc += 2;
-                            ch = (chd << 6) | (ch & 0x3F);
-
-                            bytesNeeded++;
-
-                            ch = (ch & 0x3FF) + unchecked((short)(EncodingHelper.LowSurrogateStart));
-                        }
-                        else
-                        {
-                            // 3 byte encoding
-                            if (pSrc >= pSrcEnd)
-                                goto NeedMoreData;
-
-                            ch = *pSrc;
-
-                            // Check for non-shortest form of 3 byte sequence
-                            // No surrogates
-                            // Trailing byte must be in the form 10vvvvvv
-                            if ((chd & (0x1F << 5)) == 0 ||
-                                (chd & (0xF800 >> 6)) == (0xD800 >> 6) ||
-                                (ch & unchecked((sbyte)0xC0)) != 0x80)
-                                goto InvalidData;
-
-                            pSrc++;
-                            ch = (chd << 6) | (ch & 0x3F);
-                        }
-                    }
-                    else
-                    {
-                        // 2 byte encoding
-                        ch &= 0x1F;
-
-                        // Check for non-shortest form
-                        if (ch <= 1)
-                            goto InvalidData;
-
-                        ch = (ch << 6) | chd;
-                    }
-
-                    bytesNeeded++;
+                    InvalidData:
+                    bytesNeeded <<= 1;  // Count we have is chars, double for bytes.
+                    return OperationStatus.InvalidData;
                 }
-
-                bytesNeeded <<= 1;  // Count we have is chars, double for bytes.
-                return EncodingHelper.PtrDiff(pSrcEnd, pSrc) == 0 ? OperationStatus.Done : OperationStatus.DestinationTooSmall;
-
-            NeedMoreData:
-                bytesNeeded <<= 1;  // Count we have is chars, double for bytes.
-                return OperationStatus.NeedMoreSourceData;
-
-            InvalidData:
-                bytesNeeded <<= 1;  // Count we have is chars, double for bytes.
-                return OperationStatus.InvalidData;
             }
-        }
 
-        /// <summary>
-        /// Converts a span containing a sequence of UTF-8 bytes into UTF-16 bytes.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
-        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
-        /// the <paramref name="destination"/>.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
-        /// <param name="destination">A span to write the UTF-16 bytes into.</param>
-        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
-        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
-        public unsafe static OperationStatus ToUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-        {
-            fixed (byte* pUtf8 = &source.DangerousGetPinnableReference())
-            fixed (byte* pUtf16 = &destination.DangerousGetPinnableReference())
+            /// <summary>
+            /// Converts a span containing a sequence of UTF-8 bytes into UTF-16 bytes.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            ///
+            /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+            /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+            /// the <paramref name="destination"/>.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
+            /// <param name="destination">A span to write the UTF-16 bytes into.</param>
+            /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+            /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
+            public unsafe static OperationStatus ToUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
             {
-                byte* pSrc = pUtf8;
-                byte* pSrcEnd = pSrc + source.Length;
-                char* pDst = (char*)pUtf16;
-                char* pDstEnd = pDst + (destination.Length >> 1);   // Conversion from bytes to chars - div by sizeof(char)
-
-                int ch = 0;
-                while (pSrc < pSrcEnd && pDst < pDstEnd)
+                fixed (byte* pUtf8 = &source.DangerousGetPinnableReference())
+                fixed (byte* pUtf16 = &destination.DangerousGetPinnableReference())
                 {
-                    // we may need as many as 1 character per byte, so reduce the byte count if necessary.
-                    // If availableChars is too small, pStop will be before pTarget and we won't do fast loop.
-                    int availableChars = EncodingHelper.PtrDiff(pDstEnd, pDst);
-                    int availableBytes = EncodingHelper.PtrDiff(pSrcEnd, pSrc);
+                    byte* pSrc = pUtf8;
+                    byte* pSrcEnd = pSrc + source.Length;
+                    char* pDst = (char*)pUtf16;
+                    char* pDstEnd = pDst + (destination.Length >> 1);   // Conversion from bytes to chars - div by sizeof(char)
 
-                    if (availableChars < availableBytes)
-                        availableBytes = availableChars;
-
-                    // don't fall into the fast decoding loop if we don't have enough bytes
-                    if (availableBytes <= 13)
+                    int ch = 0;
+                    while (pSrc < pSrcEnd && pDst < pDstEnd)
                     {
-                        // try to get over the remainder of the ascii characters fast though
-                        byte* pLocalEnd = pSrc + availableBytes;
-                        while (pSrc < pLocalEnd)
+                        // we may need as many as 1 character per byte, so reduce the byte count if necessary.
+                        // If availableChars is too small, pStop will be before pTarget and we won't do fast loop.
+                        int availableChars = EncodingHelper.PtrDiff(pDstEnd, pDst);
+                        int availableBytes = EncodingHelper.PtrDiff(pSrcEnd, pSrc);
+
+                        if (availableChars < availableBytes)
+                            availableBytes = availableChars;
+
+                        // don't fall into the fast decoding loop if we don't have enough bytes
+                        if (availableBytes <= 13)
                         {
-                            ch = *pSrc;
-                            pSrc++;
+                            // try to get over the remainder of the ascii characters fast though
+                            byte* pLocalEnd = pSrc + availableBytes;
+                            while (pSrc < pLocalEnd)
+                            {
+                                ch = *pSrc;
+                                pSrc++;
 
-                            if (ch > 0x7F)
-                                goto LongCodeSlow;
+                                if (ch > 0x7F)
+                                    goto LongCodeSlow;
 
-                            *pDst = (char)ch;
-                            pDst++;
+                                *pDst = (char)ch;
+                                pDst++;
+                            }
+
+                            // we are done
+                            break;
                         }
 
-                        // we are done
-                        break;
-                    }
+                        // To compute the upper bound, assume that all characters are ASCII characters at this point,
+                        //  the boundary will be decreased for every non-ASCII character we encounter
+                        // Also, we need 7 chars reserve for the unrolled ansi decoding loop and for decoding of multibyte sequences
+                        char* pStop = pDst + availableBytes - 7;
 
-                    // To compute the upper bound, assume that all characters are ASCII characters at this point,
-                    //  the boundary will be decreased for every non-ASCII character we encounter
-                    // Also, we need 7 chars reserve for the unrolled ansi decoding loop and for decoding of multibyte sequences
-                    char* pStop = pDst + availableBytes - 7;
-
-                    // Fast loop
-                    while (pDst < pStop)
-                    {
-                        ch = *pSrc;
-                        pSrc++;
-
-                        if (ch > 0x7F)
-                            goto LongCode;
-
-                        *pDst = (char)ch;
-                        pDst++;
-
-                        // 2-byte align
-                        if ((unchecked((int)pSrc) & 0x1) != 0)
+                        // Fast loop
+                        while (pDst < pStop)
                         {
                             ch = *pSrc;
                             pSrc++;
@@ -425,38 +415,50 @@ namespace System.Text.Encoders
 
                             *pDst = (char)ch;
                             pDst++;
-                        }
 
-                        // 4-byte align
-                        if ((unchecked((int)pSrc) & 0x2) != 0)
-                        {
-                            ch = *(ushort*)pSrc;
-                            if ((ch & 0x8080) != 0)
-                                goto LongCodeWithMask16;
+                            // 2-byte align
+                            if ((unchecked((int)pSrc) & 0x1) != 0)
+                            {
+                                ch = *pSrc;
+                                pSrc++;
 
-                            // Unfortunately, endianness sensitive
+                                if (ch > 0x7F)
+                                    goto LongCode;
+
+                                *pDst = (char)ch;
+                                pDst++;
+                            }
+
+                            // 4-byte align
+                            if ((unchecked((int)pSrc) & 0x2) != 0)
+                            {
+                                ch = *(ushort*)pSrc;
+                                if ((ch & 0x8080) != 0)
+                                    goto LongCodeWithMask16;
+
+                                // Unfortunately, endianness sensitive
 #if BIGENDIAN
                             *pDst = (char)((ch >> 8) & 0x7F);
                             pSrc += 2;
                             *(pDst + 1) = (char)(ch & 0x7F);
                             pDst += 2;
 #else // BIGENDIAN
-                            *pDst = (char)(ch & 0x7F);
-                            pSrc += 2;
-                            *(pDst + 1) = (char)((ch >> 8) & 0x7F);
-                            pDst += 2;
+                                *pDst = (char)(ch & 0x7F);
+                                pSrc += 2;
+                                *(pDst + 1) = (char)((ch >> 8) & 0x7F);
+                                pDst += 2;
 #endif // BIGENDIAN
-                        }
+                            }
 
-                        // Run 8 characters at a time!
-                        while (pDst < pStop)
-                        {
-                            ch = *(int*)pSrc;
-                            int chb = *(int*)(pSrc + 4);
-                            if (((ch | chb) & unchecked((int)0x80808080)) != 0)
-                                goto LongCodeWithMask32;
+                            // Run 8 characters at a time!
+                            while (pDst < pStop)
+                            {
+                                ch = *(int*)pSrc;
+                                int chb = *(int*)(pSrc + 4);
+                                if (((ch | chb) & unchecked((int)0x80808080)) != 0)
+                                    goto LongCodeWithMask32;
 
-                            // Unfortunately, endianness sensitive
+                                // Unfortunately, endianness sensitive
 #if BIGENDIAN
                             *pDst = (char)((ch >> 24) & 0x7F);
                             *(pDst+1) = (char)((ch >> 16) & 0x7F);
@@ -469,20 +471,20 @@ namespace System.Text.Encoders
                             *(pDst+7) = (char)(chb & 0x7F);
                             pDst += 8;
 #else // BIGENDIAN
-                            *pDst = (char)(ch & 0x7F);
-                            *(pDst + 1) = (char)((ch >> 8) & 0x7F);
-                            *(pDst + 2) = (char)((ch >> 16) & 0x7F);
-                            *(pDst + 3) = (char)((ch >> 24) & 0x7F);
-                            pSrc += 8;
-                            *(pDst + 4) = (char)(chb & 0x7F);
-                            *(pDst + 5) = (char)((chb >> 8) & 0x7F);
-                            *(pDst + 6) = (char)((chb >> 16) & 0x7F);
-                            *(pDst + 7) = (char)((chb >> 24) & 0x7F);
-                            pDst += 8;
+                                *pDst = (char)(ch & 0x7F);
+                                *(pDst + 1) = (char)((ch >> 8) & 0x7F);
+                                *(pDst + 2) = (char)((ch >> 16) & 0x7F);
+                                *(pDst + 3) = (char)((ch >> 24) & 0x7F);
+                                pSrc += 8;
+                                *(pDst + 4) = (char)(chb & 0x7F);
+                                *(pDst + 5) = (char)((chb >> 8) & 0x7F);
+                                *(pDst + 6) = (char)((chb >> 16) & 0x7F);
+                                *(pDst + 7) = (char)((chb >> 24) & 0x7F);
+                                pDst += 8;
 #endif // BIGENDIAN
-                        }
+                            }
 
-                        break;
+                            break;
 
 #if BIGENDIAN
                     LongCodeWithMask32:
@@ -491,55 +493,161 @@ namespace System.Text.Encoders
                     LongCodeWithMask16:
                         ch = (int)(((uint)ch) >> 8);
 #else // BIGENDIAN
-                    LongCodeWithMask32:
-                    LongCodeWithMask16:
-                        ch &= 0xFF;
+                            LongCodeWithMask32:
+                            LongCodeWithMask16:
+                            ch &= 0xFF;
 #endif // BIGENDIAN
-                        pSrc++;
-                        if (ch <= 0x7F)
-                        {
+                            pSrc++;
+                            if (ch <= 0x7F)
+                            {
+                                *pDst = (char)ch;
+                                pDst++;
+                                continue;
+                            }
+
+                            LongCode:
+                            int chc = *pSrc;
+                            pSrc++;
+
+                            // Bit 6 should be 0, and trailing byte should be 10vvvvvv
+                            if ((ch & 0x40) == 0 || (chc & unchecked((sbyte)0xC0)) != 0x80)
+                                goto InvalidData;
+
+                            chc &= 0x3F;
+
+                            if ((ch & 0x20) != 0)
+                            {
+                                // Handle 3 or 4 byte encoding.
+
+                                // Fold the first 2 bytes together
+                                chc |= (ch & 0x0F) << 6;
+
+                                if ((ch & 0x10) != 0)
+                                {
+                                    // 4 byte - surrogate pair
+                                    ch = *pSrc;
+
+                                    // Bit 4 should be zero + the surrogate should be in the range 0x000000 - 0x10FFFF
+                                    // and the trailing byte should be 10vvvvvv
+                                    if (!EncodingHelper.InRange(chc >> 4, 0x01, 0x10) || (ch & unchecked((sbyte)0xC0)) != 0x80)
+                                        goto InvalidData;
+
+                                    // Merge 3rd byte then read the last byte
+                                    chc = (chc << 6) | (ch & 0x3F);
+                                    ch = *(pSrc + 1);
+
+                                    // The last trailing byte still holds the form 10vvvvvv
+                                    if ((ch & unchecked((sbyte)0xC0)) != 0x80)
+                                        goto InvalidData;
+
+                                    pSrc += 2;
+                                    ch = (chc << 6) | (ch & 0x3F);
+
+                                    *pDst = (char)(((ch >> 10) & 0x7FF) + unchecked((short)(EncodingHelper.HighSurrogateStart - (0x10000 >> 10))));
+                                    pDst++;
+
+                                    ch = (ch & 0x3FF) + unchecked((short)(EncodingHelper.LowSurrogateStart));
+                                }
+                                else
+                                {
+                                    // 3 byte encoding
+                                    ch = *pSrc;
+
+                                    // Check for non-shortest form of 3 byte sequence
+                                    // No surrogates
+                                    // Trailing byte must be in the form 10vvvvvv
+                                    if ((chc & (0x1F << 5)) == 0 ||
+                                        (chc & (0xF800 >> 6)) == (0xD800 >> 6) ||
+                                        (ch & unchecked((sbyte)0xC0)) != 0x80)
+                                        goto InvalidData;
+
+                                    pSrc++;
+                                    ch = (chc << 6) | (ch & 0x3F);
+                                }
+
+                                // extra byte, we're already planning 2 chars for 2 of these bytes,
+                                // but the big loop is testing the target against pStop, so we need
+                                // to subtract 2 more or we risk overrunning the input.  Subtract
+                                // one here and one below.
+                                pStop--;
+                            }
+                            else
+                            {
+                                // 2 byte encoding
+                                ch &= 0x1F;
+
+                                // Check for non-shortest form
+                                if (ch <= 1)
+                                    goto InvalidData;
+
+                                ch = (ch << 6) | chc;
+                            }
+
                             *pDst = (char)ch;
                             pDst++;
-                            continue;
+
+                            // extra byte, we're only expecting 1 char for each of these 2 bytes,
+                            // but the loop is testing the target (not source) against pStop.
+                            // subtract an extra count from pStop so that we don't overrun the input.
+                            pStop--;
                         }
 
-                    LongCode:
-                        int chc = *pSrc;
+                        continue;
+
+                        LongCodeSlow:
+                        if (pSrc >= pSrcEnd)
+                        {
+                            // This is a special case where hit the end of the buffer but are in the middle
+                            // of decoding a long code. The error exit thinks we have read 2 extra bytes already,
+                            // so we add +1 to pSrc to get the count correct for the bytes consumed value.
+                            pSrc++;
+                            goto NeedMoreData;
+                        }
+
+                        int chd = *pSrc;
                         pSrc++;
 
                         // Bit 6 should be 0, and trailing byte should be 10vvvvvv
-                        if ((ch & 0x40) == 0 || (chc & unchecked((sbyte)0xC0)) != 0x80)
+                        if ((ch & 0x40) == 0 || (chd & unchecked((sbyte)0xC0)) != 0x80)
                             goto InvalidData;
 
-                        chc &= 0x3F;
+                        chd &= 0x3F;
 
                         if ((ch & 0x20) != 0)
                         {
                             // Handle 3 or 4 byte encoding.
 
                             // Fold the first 2 bytes together
-                            chc |= (ch & 0x0F) << 6;
+                            chd |= (ch & 0x0F) << 6;
 
                             if ((ch & 0x10) != 0)
                             {
                                 // 4 byte - surrogate pair
+                                // We need 2 more bytes
+                                if (pSrc >= pSrcEnd - 1)
+                                    goto NeedMoreData;
+
                                 ch = *pSrc;
 
                                 // Bit 4 should be zero + the surrogate should be in the range 0x000000 - 0x10FFFF
                                 // and the trailing byte should be 10vvvvvv
-                                if (!EncodingHelper.InRange(chc >> 4, 0x01, 0x10) || (ch & unchecked((sbyte)0xC0)) != 0x80)
+                                if (!EncodingHelper.InRange(chd >> 4, 0x01, 0x10) || (ch & unchecked((sbyte)0xC0)) != 0x80)
                                     goto InvalidData;
 
                                 // Merge 3rd byte then read the last byte
-                                chc = (chc << 6) | (ch & 0x3F);
+                                chd = (chd << 6) | (ch & 0x3F);
                                 ch = *(pSrc + 1);
 
                                 // The last trailing byte still holds the form 10vvvvvv
+                                // We only know for sure we have room for one more char, but we need an extra now.
                                 if ((ch & unchecked((sbyte)0xC0)) != 0x80)
                                     goto InvalidData;
 
+                                if (EncodingHelper.PtrDiff(pDstEnd, pDst) < 2)
+                                    goto DestinationFull;
+
                                 pSrc += 2;
-                                ch = (chc << 6) | (ch & 0x3F);
+                                ch = (chd << 6) | (ch & 0x3F);
 
                                 *pDst = (char)(((ch >> 10) & 0x7FF) + unchecked((short)(EncodingHelper.HighSurrogateStart - (0x10000 >> 10))));
                                 pDst++;
@@ -549,25 +657,22 @@ namespace System.Text.Encoders
                             else
                             {
                                 // 3 byte encoding
+                                if (pSrc >= pSrcEnd)
+                                    goto NeedMoreData;
+
                                 ch = *pSrc;
 
                                 // Check for non-shortest form of 3 byte sequence
                                 // No surrogates
                                 // Trailing byte must be in the form 10vvvvvv
-                                if ((chc & (0x1F << 5)) == 0 ||
-                                    (chc & (0xF800 >> 6)) == (0xD800 >> 6) ||
+                                if ((chd & (0x1F << 5)) == 0 ||
+                                    (chd & (0xF800 >> 6)) == (0xD800 >> 6) ||
                                     (ch & unchecked((sbyte)0xC0)) != 0x80)
                                     goto InvalidData;
 
                                 pSrc++;
-                                ch = (chc << 6) | (ch & 0x3F);
+                                ch = (chd << 6) | (ch & 0x3F);
                             }
-
-                            // extra byte, we're already planning 2 chars for 2 of these bytes,
-                            // but the big loop is testing the target against pStop, so we need
-                            // to subtract 2 more or we risk overrunning the input.  Subtract
-                            // one here and one below.
-                            pStop--;
                         }
                         else
                         {
@@ -578,261 +683,159 @@ namespace System.Text.Encoders
                             if (ch <= 1)
                                 goto InvalidData;
 
-                            ch = (ch << 6) | chc;
+                            ch = (ch << 6) | chd;
                         }
 
                         *pDst = (char)ch;
                         pDst++;
-
-                        // extra byte, we're only expecting 1 char for each of these 2 bytes,
-                        // but the loop is testing the target (not source) against pStop.
-                        // subtract an extra count from pStop so that we don't overrun the input.
-                        pStop--;
                     }
 
-                    continue;
+                    DestinationFull:
+                    bytesConsumed = EncodingHelper.PtrDiff(pSrc, pUtf8);
+                    bytesWritten = EncodingHelper.PtrDiff((byte*)pDst, pUtf16);
+                    return EncodingHelper.PtrDiff(pSrcEnd, pSrc) == 0 ? OperationStatus.Done : OperationStatus.DestinationTooSmall;
 
-                LongCodeSlow:
-                    if (pSrc >= pSrcEnd)
-                    {
-                        // This is a special case where hit the end of the buffer but are in the middle
-                        // of decoding a long code. The error exit thinks we have read 2 extra bytes already,
-                        // so we add +1 to pSrc to get the count correct for the bytes consumed value.
-                        pSrc++;
-                        goto NeedMoreData;
-                    }
+                    NeedMoreData:
+                    bytesConsumed = EncodingHelper.PtrDiff(pSrc - 2, pUtf8);
+                    bytesWritten = EncodingHelper.PtrDiff((byte*)pDst, pUtf16);
+                    return OperationStatus.NeedMoreSourceData;
 
-                    int chd = *pSrc;
-                    pSrc++;
+                    InvalidData:
+                    bytesConsumed = EncodingHelper.PtrDiff(pSrc - 2, pUtf8);
+                    bytesWritten = EncodingHelper.PtrDiff((byte*)pDst, pUtf16);
+                    return OperationStatus.InvalidData;
+                }
+            }
 
-                    // Bit 6 should be 0, and trailing byte should be 10vvvvvv
-                    if ((ch & 0x40) == 0 || (chd & unchecked((sbyte)0xC0)) != 0x80)
+            #endregion UTF-16 Conversions
+
+            #region UTF-32 Conversions
+
+            /// <summary>
+            /// Calculates the byte count needed to encode the UTF-8 bytes from the specified UTF-32 sequence.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+            /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
+            public static OperationStatus FromUtf32Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+                => Utf32.ToUtf8Length(source, out bytesNeeded);
+
+            /// <summary>
+            /// Converts a span containing a sequence of UTF-32 bytes into UTF-8 bytes.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            ///
+            /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+            /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+            /// the <paramref name="destination"/>.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
+            /// <param name="destination">A span to write the UTF-8 bytes into.</param>
+            /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+            /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
+            public static OperationStatus FromUtf32(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+                => Utf32.ToUtf8(source, destination, out bytesConsumed, out bytesWritten);
+
+            /// <summary>
+            /// Calculates the byte count needed to encode the UTF-32 bytes from the specified UTF-8 sequence.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
+            /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
+            public static OperationStatus ToUtf32Length(ReadOnlySpan<byte> source, out int bytesNeeded)
+            {
+                bytesNeeded = 0;
+
+                int index = 0;
+                int length = source.Length;
+                ref byte src = ref source.DangerousGetPinnableReference();
+
+                while (index < length)
+                {
+                    int count = EncodingHelper.GetUtf8DecodedBytes(Unsafe.Add(ref src, index));
+                    if (count == 0)
                         goto InvalidData;
+                    if (length - index < count)
+                        goto NeedMoreData;
 
-                    chd &= 0x3F;
+                    bytesNeeded += count;
+                }
 
-                    if ((ch & 0x20) != 0)
+                return index < length ? OperationStatus.DestinationTooSmall : OperationStatus.Done;
+
+                InvalidData:
+                return OperationStatus.InvalidData;
+
+                NeedMoreData:
+                return OperationStatus.NeedMoreSourceData;
+            }
+
+            /// <summary>
+            /// Converts a span containing a sequence of UTF-8 bytes into UTF-32 bytes.
+            ///
+            /// This method will consume as many of the input bytes as possible.
+            ///
+            /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
+            /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
+            /// the <paramref name="destination"/>.
+            /// </summary>
+            /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
+            /// <param name="destination">A span to write the UTF-32 bytes into.</param>
+            /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
+            /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
+            /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
+            public static OperationStatus ToUtf32(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+            {
+                bytesConsumed = 0;
+                bytesWritten = 0;
+
+                int srcLength = source.Length;
+                int dstLength = destination.Length;
+                ref byte src = ref source.DangerousGetPinnableReference();
+                ref byte dst = ref destination.DangerousGetPinnableReference();
+
+                while (bytesConsumed < srcLength && bytesWritten < dstLength)
+                {
+                    uint codePoint = Unsafe.Add(ref src, bytesConsumed);
+
+                    int byteCount = EncodingHelper.GetUtf8DecodedBytes((byte)codePoint);
+                    if (byteCount == 0)
+                        goto InvalidData;
+                    if (srcLength - bytesConsumed < byteCount)
+                        goto NeedMoreData;
+
+                    if (byteCount > 1)
+                        codePoint &= (byte)(0x7F >> byteCount);
+
+                    for (var i = 1; i < byteCount; i++)
                     {
-                        // Handle 3 or 4 byte encoding.
-
-                        // Fold the first 2 bytes together
-                        chd |= (ch & 0x0F) << 6;
-
-                        if ((ch & 0x10) != 0)
-                        {
-                            // 4 byte - surrogate pair
-                            // We need 2 more bytes
-                            if (pSrc >= pSrcEnd - 1)
-                                goto NeedMoreData;
-
-                            ch = *pSrc;
-
-                            // Bit 4 should be zero + the surrogate should be in the range 0x000000 - 0x10FFFF
-                            // and the trailing byte should be 10vvvvvv
-                            if (!EncodingHelper.InRange(chd >> 4, 0x01, 0x10) || (ch & unchecked((sbyte)0xC0)) != 0x80)
-                                goto InvalidData;
-
-                            // Merge 3rd byte then read the last byte
-                            chd = (chd << 6) | (ch & 0x3F);
-                            ch = *(pSrc + 1);
-
-                            // The last trailing byte still holds the form 10vvvvvv
-                            // We only know for sure we have room for one more char, but we need an extra now.
-                            if ((ch & unchecked((sbyte)0xC0)) != 0x80)
-                                goto InvalidData;
-
-                            if (EncodingHelper.PtrDiff(pDstEnd, pDst) < 2)
-                                goto DestinationFull;
-
-                            pSrc += 2;
-                            ch = (chd << 6) | (ch & 0x3F);
-
-                            *pDst = (char)(((ch >> 10) & 0x7FF) + unchecked((short)(EncodingHelper.HighSurrogateStart - (0x10000 >> 10))));
-                            pDst++;
-
-                            ch = (ch & 0x3FF) + unchecked((short)(EncodingHelper.LowSurrogateStart));
-                        }
-                        else
-                        {
-                            // 3 byte encoding
-                            if (pSrc >= pSrcEnd)
-                                goto NeedMoreData;
-
-                            ch = *pSrc;
-
-                            // Check for non-shortest form of 3 byte sequence
-                            // No surrogates
-                            // Trailing byte must be in the form 10vvvvvv
-                            if ((chd & (0x1F << 5)) == 0 ||
-                                (chd & (0xF800 >> 6)) == (0xD800 >> 6) ||
-                                (ch & unchecked((sbyte)0xC0)) != 0x80)
-                                goto InvalidData;
-
-                            pSrc++;
-                            ch = (chd << 6) | (ch & 0x3F);
-                        }
-                    }
-                    else
-                    {
-                        // 2 byte encoding
-                        ch &= 0x1F;
-
-                        // Check for non-shortest form
-                        if (ch <= 1)
+                        ref byte next = ref Unsafe.Add(ref src, bytesConsumed + i);
+                        if ((next & EncodingHelper.b1100_0000U) != EncodingHelper.b1000_0000U)
                             goto InvalidData;
 
-                        ch = (ch << 6) | chd;
+                        codePoint = (codePoint << 6) | (uint)(EncodingHelper.b0011_1111U & next);
                     }
 
-                    *pDst = (char)ch;
-                    pDst++;
+                    Unsafe.As<byte, uint>(ref Unsafe.Add(ref dst, bytesWritten)) = codePoint;
+                    bytesWritten += 4;
+                    bytesConsumed += byteCount;
                 }
 
-            DestinationFull:
-                bytesConsumed = EncodingHelper.PtrDiff(pSrc, pUtf8);
-                bytesWritten = EncodingHelper.PtrDiff((byte*)pDst, pUtf16);
-                return EncodingHelper.PtrDiff(pSrcEnd, pSrc) == 0 ? OperationStatus.Done : OperationStatus.DestinationTooSmall;
+                return bytesConsumed < srcLength ? OperationStatus.DestinationTooSmall : OperationStatus.Done;
 
-            NeedMoreData:
-                bytesConsumed = EncodingHelper.PtrDiff(pSrc - 2, pUtf8);
-                bytesWritten = EncodingHelper.PtrDiff((byte*)pDst, pUtf16);
-                return OperationStatus.NeedMoreSourceData;
-
-            InvalidData:
-                bytesConsumed = EncodingHelper.PtrDiff(pSrc - 2, pUtf8);
-                bytesWritten = EncodingHelper.PtrDiff((byte*)pDst, pUtf16);
+                InvalidData:
                 return OperationStatus.InvalidData;
-            }
-        }
 
-        #endregion UTF-16 Conversions
-
-        #region UTF-32 Conversions
-
-        /// <summary>
-        /// Calculates the byte count needed to encode the UTF-8 bytes from the specified UTF-32 sequence.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
-        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
-        public static OperationStatus FromUtf32Length(ReadOnlySpan<byte> source, out int bytesNeeded)
-            => Utf32.ToUtf8Length(source, out bytesNeeded);
-
-        /// <summary>
-        /// Converts a span containing a sequence of UTF-32 bytes into UTF-8 bytes.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
-        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
-        /// the <paramref name="destination"/>.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-32 bytes.</param>
-        /// <param name="destination">A span to write the UTF-8 bytes into.</param>
-        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
-        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
-        public static OperationStatus FromUtf32(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-            => Utf32.ToUtf8(source, destination, out bytesConsumed, out bytesWritten);
-
-        /// <summary>
-        /// Calculates the byte count needed to encode the UTF-32 bytes from the specified UTF-8 sequence.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
-        /// <param name="bytesNeeded">On exit, contains the number of bytes required for encoding from the <paramref name="source"/>.</param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the expected state of the conversion.</returns>
-        public static OperationStatus ToUtf32Length(ReadOnlySpan<byte> source, out int bytesNeeded)
-        {
-            bytesNeeded = 0;
-
-            int index = 0;
-            int length = source.Length;
-            ref byte src = ref source.DangerousGetPinnableReference();
-
-            while (index < length)
-            {
-                int count = EncodingHelper.GetUtf8DecodedBytes(Unsafe.Add(ref src, index));
-                if (count == 0)
-                    goto InvalidData;
-                if (length - index < count)
-                    goto NeedMoreData;
-
-                bytesNeeded += count;
+                NeedMoreData:
+                return OperationStatus.NeedMoreSourceData;
             }
 
-            return index < length ? OperationStatus.DestinationTooSmall : OperationStatus.Done;
-
-        InvalidData:
-            return OperationStatus.InvalidData;
-
-        NeedMoreData:
-            return OperationStatus.NeedMoreSourceData;
+            #endregion UTF-32 Conversions
         }
-
-        /// <summary>
-        /// Converts a span containing a sequence of UTF-8 bytes into UTF-32 bytes.
-        ///
-        /// This method will consume as many of the input bytes as possible.
-        ///
-        /// On successful exit, the entire input was consumed and encoded successfully. In this case, <paramref name="bytesConsumed"/> will be
-        /// equal to the length of the <paramref name="source"/> and <paramref name="bytesWritten"/> will equal the total number of bytes written to
-        /// the <paramref name="destination"/>.
-        /// </summary>
-        /// <param name="source">A span containing a sequence of UTF-8 bytes.</param>
-        /// <param name="destination">A span to write the UTF-32 bytes into.</param>
-        /// <param name="bytesConsumed">On exit, contains the number of bytes that were consumed from the <paramref name="source"/>.</param>
-        /// <param name="bytesWritten">On exit, contains the number of bytes written to <paramref name="destination"/></param>
-        /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
-        public static OperationStatus ToUtf32(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-        {
-            bytesConsumed = 0;
-            bytesWritten = 0;
-
-            int srcLength = source.Length;
-            int dstLength = destination.Length;
-            ref byte src = ref source.DangerousGetPinnableReference();
-            ref byte dst = ref destination.DangerousGetPinnableReference();
-
-            while (bytesConsumed < srcLength && bytesWritten < dstLength)
-            {
-                uint codePoint = Unsafe.Add(ref src, bytesConsumed);
-
-                int byteCount = EncodingHelper.GetUtf8DecodedBytes((byte)codePoint);
-                if (byteCount == 0)
-                    goto InvalidData;
-                if (srcLength - bytesConsumed < byteCount)
-                    goto NeedMoreData;
-
-                if (byteCount > 1)
-                    codePoint &= (byte)(0x7F >> byteCount);
-
-                for (var i = 1; i < byteCount; i++)
-                {
-                    ref byte next = ref Unsafe.Add(ref src, bytesConsumed + i);
-                    if ((next & EncodingHelper.b1100_0000U) != EncodingHelper.b1000_0000U)
-                        goto InvalidData;
-
-                    codePoint = (codePoint << 6) | (uint)(EncodingHelper.b0011_1111U & next);
-                }
-
-                Unsafe.As<byte, uint>(ref Unsafe.Add(ref dst, bytesWritten)) = codePoint;
-                bytesWritten += 4;
-                bytesConsumed += byteCount;
-            }
-
-            return bytesConsumed < srcLength ? OperationStatus.DestinationTooSmall : OperationStatus.Done;
-
-        InvalidData:
-            return OperationStatus.InvalidData;
-
-        NeedMoreData:
-            return OperationStatus.NeedMoreSourceData;
-        }
-
-        #endregion UTF-32 Conversions
     }
 }

--- a/src/System.Text.Primitives/System/Text/Extensions.Float.cs
+++ b/src/System.Text.Primitives/System/Text/Extensions.Float.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text
+namespace System.Buffers.Text
 {
     public static partial class Extensions
     {

--- a/src/System.Text.Primitives/System/Text/Extensions.Guid.cs
+++ b/src/System.Text.Primitives/System/Text/Extensions.Guid.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text
+using System.Buffers;
+
+namespace System.Buffers.Text
 {
     public static partial class Extensions
     {

--- a/src/System.Text.Primitives/System/Text/Extensions.Integer.cs
+++ b/src/System.Text.Primitives/System/Text/Extensions.Integer.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text
+using System.Buffers;
+
+namespace System.Buffers.Text
 {
     /// <summary>
     /// Pseudo-implementations of IBufferFormattable interface for primitive types

--- a/src/System.Text.Primitives/System/Text/Extensions.Time.cs
+++ b/src/System.Text.Primitives/System/Text/Extensions.Time.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text
+using System.Buffers;
+
+namespace System.Buffers.Text
 {
     public static partial class Extensions
     {

--- a/src/System.Text.Primitives/System/Text/Formatters/Custom.Float.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Custom.Float.cs
@@ -1,85 +1,90 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
 using System.Diagnostics;
+using System.Text;
 
-namespace System.Text.Formatters
+namespace System.Buffers
 {
-    public static partial class Custom
+    public static partial class Formatters
     {
-        private static bool TryFormatNumber(double value, bool isSingle, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
+        public static partial class Custom
         {
-            Precondition.Require(format.Symbol == 'G' || format.Symbol == 'E' || format.Symbol == 'F');
-
-            symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
-
-            bytesWritten = 0;
-            int written;
-
-            if (Double.IsNaN(value))
+            private static bool TryFormatNumber(double value, bool isSingle, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
             {
-                return symbolTable.TryEncode(SymbolTable.Symbol.NaN, buffer, out bytesWritten);
-            }
+                Precondition.Require(format.Symbol == 'G' || format.Symbol == 'E' || format.Symbol == 'F');
 
-            if (Double.IsInfinity(value))
-            {
-                if (Double.IsNegativeInfinity(value))
+                symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
+
+                bytesWritten = 0;
+                int written;
+
+                if (Double.IsNaN(value))
                 {
-                    if (!symbolTable.TryEncode(SymbolTable.Symbol.MinusSign, buffer, out written))
+                    return symbolTable.TryEncode(SymbolTable.Symbol.NaN, buffer, out bytesWritten);
+                }
+
+                if (Double.IsInfinity(value))
+                {
+                    if (Double.IsNegativeInfinity(value))
+                    {
+                        if (!symbolTable.TryEncode(SymbolTable.Symbol.MinusSign, buffer, out written))
+                        {
+                            bytesWritten = 0;
+                            return false;
+                        }
+                        bytesWritten += written;
+                    }
+                    if (!symbolTable.TryEncode(SymbolTable.Symbol.InfinitySign, buffer.Slice(bytesWritten), out written))
                     {
                         bytesWritten = 0;
                         return false;
                     }
                     bytesWritten += written;
-                }
-                if (!symbolTable.TryEncode(SymbolTable.Symbol.InfinitySign, buffer.Slice(bytesWritten), out written))
-                {
-                    bytesWritten = 0;
-                    return false;
-                }
-                bytesWritten += written;
-                return true;
-            }
-
-            // TODO: the lines below need to be replaced with properly implemented algorithm
-            // the problem is the algorithm is complex, so I am commiting a stub for now
-            var hack = value.ToString(format.Symbol.ToString());
-            var utf16Bytes = hack.AsReadOnlySpan().AsBytes();
-            if (symbolTable == SymbolTable.InvariantUtf8)
-            {
-                var status = Encoders.Utf16.ToUtf8(utf16Bytes, buffer, out int consumed, out bytesWritten);
-                return status == Buffers.OperationStatus.Done;
-            }
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-            {
-                bytesWritten = utf16Bytes.Length;
-                if (utf16Bytes.TryCopyTo(buffer))
                     return true;
+                }
 
-                bytesWritten = 0;
-                return false;
-            }
-            else
-            {
-                // TODO: This is currently pretty expensive. Can this be done more efficiently?
-                //       Note: removing the hack might solve this problem a very different way.
-                var status = Encoders.Utf16.ToUtf8Length(utf16Bytes, out int needed);
-                if (status != Buffers.OperationStatus.Done)
+                // TODO: the lines below need to be replaced with properly implemented algorithm
+                // the problem is the algorithm is complex, so I am commiting a stub for now
+                var hack = value.ToString(format.Symbol.ToString());
+                var utf16Bytes = hack.AsReadOnlySpan().AsBytes();
+                if (symbolTable == SymbolTable.InvariantUtf8)
                 {
+                    var status = Encodings.Utf16.ToUtf8(utf16Bytes, buffer, out int consumed, out bytesWritten);
+                    return status == OperationStatus.Done;
+                }
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                {
+                    bytesWritten = utf16Bytes.Length;
+                    if (utf16Bytes.TryCopyTo(buffer))
+                        return true;
+
                     bytesWritten = 0;
                     return false;
                 }
-
-                Span<byte> temp = stackalloc byte[needed];
-
-                status = Encoders.Utf16.ToUtf8(utf16Bytes, temp, out int consumed, out written);
-                if (status != Buffers.OperationStatus.Done)
+                else
                 {
-                    bytesWritten = 0;
-                    return false;
-                }
+                    // TODO: This is currently pretty expensive. Can this be done more efficiently?
+                    //       Note: removing the hack might solve this problem a very different way.
+                    var status = Encodings.Utf16.ToUtf8Length(utf16Bytes, out int needed);
+                    if (status != OperationStatus.Done)
+                    {
+                        bytesWritten = 0;
+                        return false;
+                    }
 
-                return symbolTable.TryEncode(temp, buffer, out consumed, out bytesWritten);
+                    Span<byte> temp = stackalloc byte[needed];
+
+                    status = Encodings.Utf16.ToUtf8(utf16Bytes, temp, out int consumed, out written);
+                    if (status != OperationStatus.Done)
+                    {
+                        bytesWritten = 0;
+                        return false;
+                    }
+
+                    return symbolTable.TryEncode(temp, buffer, out consumed, out bytesWritten);
+                }
             }
         }
     }

--- a/src/System.Text.Primitives/System/Text/Formatters/Custom.Integer.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Custom.Integer.cs
@@ -1,485 +1,358 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
 using System.Diagnostics;
+using System.Text;
 
-namespace System.Text.Formatters
+namespace System.Buffers
 {
-    public static partial class Custom
+    public static partial class Formatters
     {
-        private static bool TryFormatInt64(long value, ulong mask, Span<byte> buffer, out int bytesWritten, ParsedFormat format, SymbolTable symbolTable)
+        public static partial class Custom
         {
-            if (value >= 0)
+            private static bool TryFormatInt64(long value, ulong mask, Span<byte> buffer, out int bytesWritten, ParsedFormat format, SymbolTable symbolTable)
             {
-                return TryFormatUInt64(unchecked((ulong)value), buffer, out bytesWritten, format, symbolTable);
-            }
-            else if (format.Symbol == 'x' || format.Symbol == 'X')
-            {
-                return TryFormatUInt64(unchecked((ulong)value) & mask, buffer, out bytesWritten, format, symbolTable);
-            }
-            else
-            {
-                int minusSignBytes = 0;
-                if (!symbolTable.TryEncode(SymbolTable.Symbol.MinusSign, buffer, out minusSignBytes))
+                if (value >= 0)
                 {
-                    bytesWritten = 0;
-                    return false;
+                    return TryFormatUInt64(unchecked((ulong)value), buffer, out bytesWritten, format, symbolTable);
                 }
-
-                int digitBytes = 0;
-                if (!TryFormatUInt64(unchecked((ulong)-value), buffer.Slice(minusSignBytes), out digitBytes, format, symbolTable))
+                else if (format.Symbol == 'x' || format.Symbol == 'X')
                 {
-                    bytesWritten = 0;
-                    return false;
-                }
-                bytesWritten = digitBytes + minusSignBytes;
-                return true;
-            }
-        }
-
-        private static bool TryFormatUInt64(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format, SymbolTable symbolTable)
-        {
-            switch (format.Symbol)
-            {
-                case 'x':
-                case 'X':
-                    if (symbolTable == SymbolTable.InvariantUtf8)
-                        return TryFormatHexadecimalInvariantCultureUtf8(value, buffer, out bytesWritten, format);
-                    else if (symbolTable == SymbolTable.InvariantUtf16)
-                        return TryFormatHexadecimalInvariantCultureUtf16(value, buffer, out bytesWritten, format);
-                    else
-                        throw new NotSupportedException();
-
-                case 'd':
-                case 'D':
-                case 'g':
-                case 'G':
-                    if (symbolTable == SymbolTable.InvariantUtf8)
-                        return TryFormatDecimalInvariantCultureUtf8(value, buffer, out bytesWritten, format);
-                    else if (symbolTable == SymbolTable.InvariantUtf16)
-                        return TryFormatDecimalInvariantCultureUtf16(value, buffer, out bytesWritten, format);
-                    else
-                        return TryFormatDecimal(value, buffer, out bytesWritten, format, symbolTable);
-
-                case 'n':
-                case 'N':
-                    return TryFormatDecimal(value, buffer, out bytesWritten, format, symbolTable);
-
-                default:
-                    throw new FormatException();
-            }
-        }
-
-        private static bool TryFormatDecimalInvariantCultureUtf16(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
-        {
-            char symbol = char.ToUpperInvariant(format.Symbol);
-            Precondition.Require(symbol == 'D' || symbol == 'G');
-
-            // Count digits
-            var valueToCountDigits = value;
-            var digitsCount = 1;
-            while (valueToCountDigits >= 10UL)
-            {
-                valueToCountDigits = valueToCountDigits / 10UL;
-                digitsCount++;
-            }
-
-            var index = 0;
-            var bytesCount = digitsCount * 2;
-
-            // If format is D and precision is greater than digits count, append leading zeros
-            if ((symbol == 'D') && format.HasPrecision)
-            {
-                var leadingZerosCount = format.Precision - digitsCount;
-                if (leadingZerosCount > 0)
-                {
-                    bytesCount += leadingZerosCount * 2;
-                }
-
-                if (bytesCount > buffer.Length)
-                {
-                    bytesWritten = 0;
-                    return false;
-                }
-
-                while (leadingZerosCount-- > 0)
-                {
-                    buffer[index++] = (byte)'0';
-                    buffer[index++] = 0;
-                }
-            }
-            else if (bytesCount > buffer.Length)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            index = bytesCount;
-            while (digitsCount-- > 0)
-            {
-                ulong digit = value % 10UL;
-                value /= 10UL;
-                buffer[--index] = 0;
-                buffer[--index] = (byte)(digit + (ulong)'0');
-            }
-
-            bytesWritten = bytesCount;
-            return true;
-        }
-
-        private static bool TryFormatDecimalInvariantCultureUtf8(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
-        {
-            char symbol = char.ToUpperInvariant(format.Symbol);
-            Precondition.Require(symbol == 'D' || symbol == 'G');
-
-            // Count digits
-            var valueToCountDigits = value;
-            var digitsCount = 1;
-            while (valueToCountDigits >= 10UL)
-            {
-                valueToCountDigits = valueToCountDigits / 10UL;
-                digitsCount++;
-            }
-
-            var index = 0;
-            var bytesCount = digitsCount;
-
-            // If format is D and precision is greater than digits count, append leading zeros
-            if ((symbol == 'D') && format.HasPrecision)
-            {
-                var leadingZerosCount = format.Precision - digitsCount;
-                if (leadingZerosCount > 0)
-                {
-                    bytesCount += leadingZerosCount;
-                }
-
-                if (bytesCount > buffer.Length)
-                {
-                    bytesWritten = 0;
-                    return false;
-                }
-
-                while (leadingZerosCount-- > 0)
-                {
-                    buffer[index++] = (byte)'0';
-                }
-            }
-            else if (bytesCount > buffer.Length)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            index = bytesCount;
-            while (digitsCount-- > 0)
-            {
-                ulong digit = value % 10UL;
-                value /= 10UL;
-                buffer[--index] = (byte)(digit + (ulong)'0');
-            }
-
-            bytesWritten = bytesCount;
-            return true;
-        }
-
-        private static bool TryFormatHexadecimalInvariantCultureUtf16(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
-        {
-            Precondition.Require(format.Symbol == 'X' || format.Symbol == 'x');
-
-            byte firstDigitOffset = (byte)'0';
-            byte firstHexCharOffset = format.Symbol == 'x' ? (byte)'a' : (byte)'A';
-            firstHexCharOffset -= 10;
-
-            // Count amount of hex digits
-            var hexDigitsCount = 1;
-            ulong valueToCount = value;
-            if (valueToCount > 0xFFFFFFFF)
-            {
-                hexDigitsCount += 8;
-                valueToCount >>= 0x20;
-            }
-            if (valueToCount > 0xFFFF)
-            {
-                hexDigitsCount += 4;
-                valueToCount >>= 0x10;
-            }
-            if (valueToCount > 0xFF)
-            {
-                hexDigitsCount += 2;
-                valueToCount >>= 0x8;
-            }
-            if (valueToCount > 0xF)
-            {
-                hexDigitsCount++;
-            }
-
-            var bytesCount = hexDigitsCount * 2;
-
-            // Count leading zeros
-            var leadingZerosCount = format.HasPrecision ? format.Precision - hexDigitsCount : 0;
-            bytesCount += leadingZerosCount > 0 ? leadingZerosCount * 2 : 0;
-
-            if (bytesCount > buffer.Length)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            var index = bytesCount;
-            while (hexDigitsCount-- > 0)
-            {
-                byte digit = (byte)(value & 0xF);
-                value >>= 0x4;
-                digit += digit < 10 ? firstDigitOffset : firstHexCharOffset;
-
-                buffer[--index] = 0;
-                buffer[--index] = digit;
-            }
-
-            // Write leading zeros if any
-            while (leadingZerosCount-- > 0)
-            {
-                buffer[--index] = 0;
-                buffer[--index] = firstDigitOffset;
-            }
-
-            bytesWritten = bytesCount;
-            return true;
-        }
-
-        private static bool TryFormatHexadecimalInvariantCultureUtf8(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
-        {
-            Precondition.Require(format.Symbol == 'X' || format.Symbol == 'x');
-
-            byte firstDigitOffset = (byte)'0';
-            byte firstHexCharOffset = format.Symbol == 'X' ? (byte)'A' : (byte)'a';
-            firstHexCharOffset -= 10;
-
-            // Count amount of hex digits
-            var hexDigitsCount = 1;
-            ulong valueToCount = value;
-            if (valueToCount > 0xFFFFFFFF)
-            {
-                hexDigitsCount += 8;
-                valueToCount >>= 0x20;
-            }
-            if (valueToCount > 0xFFFF)
-            {
-                hexDigitsCount += 4;
-                valueToCount >>= 0x10;
-            }
-            if (valueToCount > 0xFF)
-            {
-                hexDigitsCount += 2;
-                valueToCount >>= 0x8;
-            }
-            if (valueToCount > 0xF)
-            {
-                hexDigitsCount++;
-            }
-
-            var bytesCount = hexDigitsCount;
-
-            // Count leading zeros
-            var leadingZerosCount = format.HasPrecision ? format.Precision - hexDigitsCount : 0;
-            bytesCount += leadingZerosCount > 0 ? leadingZerosCount : 0;
-
-            if (bytesCount > buffer.Length)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            var index = bytesCount;
-            while (hexDigitsCount-- > 0)
-            {
-                byte digit = (byte)(value & 0xF);
-                value >>= 0x4;
-                digit += digit < 10 ? firstDigitOffset : firstHexCharOffset;
-                buffer[--index] = digit;
-            }
-
-            // Write leading zeros if any
-            while (leadingZerosCount-- > 0)
-            {
-                buffer[--index] = firstDigitOffset;
-            }
-
-            bytesWritten = bytesCount;
-            return true;
-        }
-
-        // TODO: this whole routine is too slow. It does div and mod twice, which are both costly (especially that some JITs cannot optimize it).
-        // It does it twice to avoid reversing the formatted buffer, which can be tricky given it should handle arbitrary cultures.
-        // One optimization I thought we could do is to do div/mod once and store digits in a temp buffer (but that would allocate). Modification to the idea would be to store the digits in a local struct
-        // Another idea possibly worth tying would be to special case cultures that have constant digit size, and go back to the format + reverse buffer approach.
-        private static bool TryFormatDecimal(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format, SymbolTable symbolTable)
-        {
-            char symbol = char.ToUpperInvariant(format.Symbol);
-            Precondition.Require(symbol == 'D' || format.Symbol == 'G' || format.Symbol == 'N');
-
-            // Reverse value on decimal basis, count digits and trailing zeros before the decimal separator
-            ulong reversedValueExceptFirst = 0;
-            var digitsCount = 1;
-            var trailingZerosCount = 0;
-
-            // We reverse the digits in numeric form because reversing encoded digits is hard and/or costly.
-            // If value contains 20 digits, its reversed value will not fit into ulong size.
-            // So reverse it till last digit (reversedValueExceptFirst will have all the digits except the first one).
-            while (value >= 10)
-            {
-                var digit = value % 10UL;
-                value = value / 10UL;
-
-                if (reversedValueExceptFirst == 0 && digit == 0)
-                {
-                    trailingZerosCount++;
+                    return TryFormatUInt64(unchecked((ulong)value) & mask, buffer, out bytesWritten, format, symbolTable);
                 }
                 else
                 {
-                    reversedValueExceptFirst = reversedValueExceptFirst * 10UL + digit;
+                    int minusSignBytes = 0;
+                    if (!symbolTable.TryEncode(SymbolTable.Symbol.MinusSign, buffer, out minusSignBytes))
+                    {
+                        bytesWritten = 0;
+                        return false;
+                    }
+
+                    int digitBytes = 0;
+                    if (!TryFormatUInt64(unchecked((ulong)-value), buffer.Slice(minusSignBytes), out digitBytes, format, symbolTable))
+                    {
+                        bytesWritten = 0;
+                        return false;
+                    }
+                    bytesWritten = digitBytes + minusSignBytes;
+                    return true;
+                }
+            }
+
+            private static bool TryFormatUInt64(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format, SymbolTable symbolTable)
+            {
+                switch (format.Symbol)
+                {
+                    case 'x':
+                    case 'X':
+                        if (symbolTable == SymbolTable.InvariantUtf8)
+                            return TryFormatHexadecimalInvariantCultureUtf8(value, buffer, out bytesWritten, format);
+                        else if (symbolTable == SymbolTable.InvariantUtf16)
+                            return TryFormatHexadecimalInvariantCultureUtf16(value, buffer, out bytesWritten, format);
+                        else
+                            throw new NotSupportedException();
+
+                    case 'd':
+                    case 'D':
+                    case 'g':
+                    case 'G':
+                        if (symbolTable == SymbolTable.InvariantUtf8)
+                            return TryFormatDecimalInvariantCultureUtf8(value, buffer, out bytesWritten, format);
+                        else if (symbolTable == SymbolTable.InvariantUtf16)
+                            return TryFormatDecimalInvariantCultureUtf16(value, buffer, out bytesWritten, format);
+                        else
+                            return TryFormatDecimal(value, buffer, out bytesWritten, format, symbolTable);
+
+                    case 'n':
+                    case 'N':
+                        return TryFormatDecimal(value, buffer, out bytesWritten, format, symbolTable);
+
+                    default:
+                        throw new FormatException();
+                }
+            }
+
+            private static bool TryFormatDecimalInvariantCultureUtf16(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
+            {
+                char symbol = char.ToUpperInvariant(format.Symbol);
+                Precondition.Require(symbol == 'D' || symbol == 'G');
+
+                // Count digits
+                var valueToCountDigits = value;
+                var digitsCount = 1;
+                while (valueToCountDigits >= 10UL)
+                {
+                    valueToCountDigits = valueToCountDigits / 10UL;
                     digitsCount++;
                 }
+
+                var index = 0;
+                var bytesCount = digitsCount * 2;
+
+                // If format is D and precision is greater than digits count, append leading zeros
+                if ((symbol == 'D') && format.HasPrecision)
+                {
+                    var leadingZerosCount = format.Precision - digitsCount;
+                    if (leadingZerosCount > 0)
+                    {
+                        bytesCount += leadingZerosCount * 2;
+                    }
+
+                    if (bytesCount > buffer.Length)
+                    {
+                        bytesWritten = 0;
+                        return false;
+                    }
+
+                    while (leadingZerosCount-- > 0)
+                    {
+                        buffer[index++] = (byte)'0';
+                        buffer[index++] = 0;
+                    }
+                }
+                else if (bytesCount > buffer.Length)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                index = bytesCount;
+                while (digitsCount-- > 0)
+                {
+                    ulong digit = value % 10UL;
+                    value /= 10UL;
+                    buffer[--index] = 0;
+                    buffer[--index] = (byte)(digit + (ulong)'0');
+                }
+
+                bytesWritten = bytesCount;
+                return true;
             }
 
-            bytesWritten = 0;
-            int digitBytes;
-            // If format is D and precision is greater than digitsCount + trailingZerosCount, append leading zeros
-            if (symbol == 'D' && format.HasPrecision)
+            private static bool TryFormatDecimalInvariantCultureUtf8(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
             {
-                var leadingZerosCount = format.Precision - digitsCount - trailingZerosCount;
+                char symbol = char.ToUpperInvariant(format.Symbol);
+                Precondition.Require(symbol == 'D' || symbol == 'G');
+
+                // Count digits
+                var valueToCountDigits = value;
+                var digitsCount = 1;
+                while (valueToCountDigits >= 10UL)
+                {
+                    valueToCountDigits = valueToCountDigits / 10UL;
+                    digitsCount++;
+                }
+
+                var index = 0;
+                var bytesCount = digitsCount;
+
+                // If format is D and precision is greater than digits count, append leading zeros
+                if ((symbol == 'D') && format.HasPrecision)
+                {
+                    var leadingZerosCount = format.Precision - digitsCount;
+                    if (leadingZerosCount > 0)
+                    {
+                        bytesCount += leadingZerosCount;
+                    }
+
+                    if (bytesCount > buffer.Length)
+                    {
+                        bytesWritten = 0;
+                        return false;
+                    }
+
+                    while (leadingZerosCount-- > 0)
+                    {
+                        buffer[index++] = (byte)'0';
+                    }
+                }
+                else if (bytesCount > buffer.Length)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                index = bytesCount;
+                while (digitsCount-- > 0)
+                {
+                    ulong digit = value % 10UL;
+                    value /= 10UL;
+                    buffer[--index] = (byte)(digit + (ulong)'0');
+                }
+
+                bytesWritten = bytesCount;
+                return true;
+            }
+
+            private static bool TryFormatHexadecimalInvariantCultureUtf16(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
+            {
+                Precondition.Require(format.Symbol == 'X' || format.Symbol == 'x');
+
+                byte firstDigitOffset = (byte)'0';
+                byte firstHexCharOffset = format.Symbol == 'x' ? (byte)'a' : (byte)'A';
+                firstHexCharOffset -= 10;
+
+                // Count amount of hex digits
+                var hexDigitsCount = 1;
+                ulong valueToCount = value;
+                if (valueToCount > 0xFFFFFFFF)
+                {
+                    hexDigitsCount += 8;
+                    valueToCount >>= 0x20;
+                }
+                if (valueToCount > 0xFFFF)
+                {
+                    hexDigitsCount += 4;
+                    valueToCount >>= 0x10;
+                }
+                if (valueToCount > 0xFF)
+                {
+                    hexDigitsCount += 2;
+                    valueToCount >>= 0x8;
+                }
+                if (valueToCount > 0xF)
+                {
+                    hexDigitsCount++;
+                }
+
+                var bytesCount = hexDigitsCount * 2;
+
+                // Count leading zeros
+                var leadingZerosCount = format.HasPrecision ? format.Precision - hexDigitsCount : 0;
+                bytesCount += leadingZerosCount > 0 ? leadingZerosCount * 2 : 0;
+
+                if (bytesCount > buffer.Length)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                var index = bytesCount;
+                while (hexDigitsCount-- > 0)
+                {
+                    byte digit = (byte)(value & 0xF);
+                    value >>= 0x4;
+                    digit += digit < 10 ? firstDigitOffset : firstHexCharOffset;
+
+                    buffer[--index] = 0;
+                    buffer[--index] = digit;
+                }
+
+                // Write leading zeros if any
                 while (leadingZerosCount-- > 0)
                 {
-                    if (!symbolTable.TryEncode(SymbolTable.Symbol.D0, buffer.Slice(bytesWritten), out digitBytes))
-                    {
-                        bytesWritten = 0;
-                        return false;
-                    }
-                    bytesWritten += digitBytes;
+                    buffer[--index] = 0;
+                    buffer[--index] = firstDigitOffset;
                 }
+
+                bytesWritten = bytesCount;
+                return true;
             }
 
-            // Append first digit
-            if (!symbolTable.TryEncode((SymbolTable.Symbol)value, buffer.Slice(bytesWritten), out digitBytes))
+            private static bool TryFormatHexadecimalInvariantCultureUtf8(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
             {
+                Precondition.Require(format.Symbol == 'X' || format.Symbol == 'x');
+
+                byte firstDigitOffset = (byte)'0';
+                byte firstHexCharOffset = format.Symbol == 'X' ? (byte)'A' : (byte)'a';
+                firstHexCharOffset -= 10;
+
+                // Count amount of hex digits
+                var hexDigitsCount = 1;
+                ulong valueToCount = value;
+                if (valueToCount > 0xFFFFFFFF)
+                {
+                    hexDigitsCount += 8;
+                    valueToCount >>= 0x20;
+                }
+                if (valueToCount > 0xFFFF)
+                {
+                    hexDigitsCount += 4;
+                    valueToCount >>= 0x10;
+                }
+                if (valueToCount > 0xFF)
+                {
+                    hexDigitsCount += 2;
+                    valueToCount >>= 0x8;
+                }
+                if (valueToCount > 0xF)
+                {
+                    hexDigitsCount++;
+                }
+
+                var bytesCount = hexDigitsCount;
+
+                // Count leading zeros
+                var leadingZerosCount = format.HasPrecision ? format.Precision - hexDigitsCount : 0;
+                bytesCount += leadingZerosCount > 0 ? leadingZerosCount : 0;
+
+                if (bytesCount > buffer.Length)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                var index = bytesCount;
+                while (hexDigitsCount-- > 0)
+                {
+                    byte digit = (byte)(value & 0xF);
+                    value >>= 0x4;
+                    digit += digit < 10 ? firstDigitOffset : firstHexCharOffset;
+                    buffer[--index] = digit;
+                }
+
+                // Write leading zeros if any
+                while (leadingZerosCount-- > 0)
+                {
+                    buffer[--index] = firstDigitOffset;
+                }
+
+                bytesWritten = bytesCount;
+                return true;
+            }
+
+            // TODO: this whole routine is too slow. It does div and mod twice, which are both costly (especially that some JITs cannot optimize it).
+            // It does it twice to avoid reversing the formatted buffer, which can be tricky given it should handle arbitrary cultures.
+            // One optimization I thought we could do is to do div/mod once and store digits in a temp buffer (but that would allocate). Modification to the idea would be to store the digits in a local struct
+            // Another idea possibly worth tying would be to special case cultures that have constant digit size, and go back to the format + reverse buffer approach.
+            private static bool TryFormatDecimal(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format, SymbolTable symbolTable)
+            {
+                char symbol = char.ToUpperInvariant(format.Symbol);
+                Precondition.Require(symbol == 'D' || format.Symbol == 'G' || format.Symbol == 'N');
+
+                // Reverse value on decimal basis, count digits and trailing zeros before the decimal separator
+                ulong reversedValueExceptFirst = 0;
+                var digitsCount = 1;
+                var trailingZerosCount = 0;
+
+                // We reverse the digits in numeric form because reversing encoded digits is hard and/or costly.
+                // If value contains 20 digits, its reversed value will not fit into ulong size.
+                // So reverse it till last digit (reversedValueExceptFirst will have all the digits except the first one).
+                while (value >= 10)
+                {
+                    var digit = value % 10UL;
+                    value = value / 10UL;
+
+                    if (reversedValueExceptFirst == 0 && digit == 0)
+                    {
+                        trailingZerosCount++;
+                    }
+                    else
+                    {
+                        reversedValueExceptFirst = reversedValueExceptFirst * 10UL + digit;
+                        digitsCount++;
+                    }
+                }
+
                 bytesWritten = 0;
-                return false;
-            }
-            bytesWritten += digitBytes;
-            digitsCount--;
-
-            if (symbol == 'N')
-            {
-                const int GroupSize = 3;
-
-                // Count amount of digits before first group separator. It will be reset to groupSize every time digitsLeftInGroup == zero
-                var digitsLeftInGroup = (digitsCount + trailingZerosCount) % GroupSize;
-                if (digitsLeftInGroup == 0)
+                int digitBytes;
+                // If format is D and precision is greater than digitsCount + trailingZerosCount, append leading zeros
+                if (symbol == 'D' && format.HasPrecision)
                 {
-                    if (digitsCount + trailingZerosCount > 0)
-                    {
-                        // There is a new group immediately after the first digit
-                        if (!symbolTable.TryEncode(SymbolTable.Symbol.GroupSeparator, buffer.Slice(bytesWritten), out digitBytes))
-                        {
-                            bytesWritten = 0;
-                            return false;
-                        }
-                        bytesWritten += digitBytes;
-                    }
-                    digitsLeftInGroup = GroupSize;
-                }
-
-                // Append digits
-                while (reversedValueExceptFirst > 0)
-                {
-                    if (digitsLeftInGroup == 0)
-                    {
-                        if (!symbolTable.TryEncode(SymbolTable.Symbol.GroupSeparator, buffer.Slice(bytesWritten), out digitBytes))
-                        {
-                            bytesWritten = 0;
-                            return false;
-                        }
-                        bytesWritten += digitBytes;
-                        digitsLeftInGroup = GroupSize;
-                    }
-
-                    var nextDigit = reversedValueExceptFirst % 10UL;
-                    reversedValueExceptFirst = reversedValueExceptFirst / 10UL;
-
-                    if (!symbolTable.TryEncode((SymbolTable.Symbol)nextDigit, buffer.Slice(bytesWritten), out digitBytes))
-                    {
-                        bytesWritten = 0;
-                        return false;
-                    }
-                    bytesWritten += digitBytes;
-                    digitsLeftInGroup--;
-                }
-
-                // Append trailing zeros if any
-                while (trailingZerosCount-- > 0)
-                {
-                    if (digitsLeftInGroup == 0)
-                    {
-                        if (!symbolTable.TryEncode(SymbolTable.Symbol.GroupSeparator, buffer.Slice(bytesWritten), out digitBytes))
-                        {
-                            bytesWritten = 0;
-                            return false;
-                        }
-                        bytesWritten += digitBytes;
-                        digitsLeftInGroup = GroupSize;
-                    }
-
-                    if (!symbolTable.TryEncode(SymbolTable.Symbol.D0, buffer.Slice(bytesWritten), out digitBytes))
-                    {
-                        bytesWritten = 0;
-                        return false;
-                    }
-                    bytesWritten += digitBytes;
-                    digitsLeftInGroup--;
-                }
-            }
-            else
-            {
-                while (reversedValueExceptFirst > 0)
-                {
-                    var bufferSlice = buffer.Slice(bytesWritten);
-                    var nextDigit = reversedValueExceptFirst % 10UL;
-                    reversedValueExceptFirst = reversedValueExceptFirst / 10UL;
-                    if (!symbolTable.TryEncode((SymbolTable.Symbol)nextDigit, bufferSlice, out digitBytes))
-                    {
-                        bytesWritten = 0;
-                        return false;
-                    }
-                    bytesWritten += digitBytes;
-                }
-
-                // Append trailing zeros if any
-                while (trailingZerosCount-- > 0)
-                {
-                    if (!symbolTable.TryEncode(SymbolTable.Symbol.D0, buffer.Slice(bytesWritten), out digitBytes))
-                    {
-                        bytesWritten = 0;
-                        return false;
-                    }
-                    bytesWritten += digitBytes;
-                }
-            }
-
-            // If format is N and precision is not defined or is greater than zero, append trailing zeros after decimal point
-            if (symbol == 'N')
-            {
-                int trailingZerosAfterDecimalCount = format.HasPrecision ? format.Precision : 2;
-
-                if (trailingZerosAfterDecimalCount > 0)
-                {
-                    if (!symbolTable.TryEncode(SymbolTable.Symbol.DecimalSeparator, buffer.Slice(bytesWritten), out digitBytes))
-                    {
-                        bytesWritten = 0;
-                        return false;
-                    }
-                    bytesWritten += digitBytes;
-
-                    while (trailingZerosAfterDecimalCount-- > 0)
+                    var leadingZerosCount = format.Precision - digitsCount - trailingZerosCount;
+                    while (leadingZerosCount-- > 0)
                     {
                         if (!symbolTable.TryEncode(SymbolTable.Symbol.D0, buffer.Slice(bytesWritten), out digitBytes))
                         {
@@ -489,9 +362,141 @@ namespace System.Text.Formatters
                         bytesWritten += digitBytes;
                     }
                 }
-            }
 
-            return true;
+                // Append first digit
+                if (!symbolTable.TryEncode((SymbolTable.Symbol)value, buffer.Slice(bytesWritten), out digitBytes))
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+                bytesWritten += digitBytes;
+                digitsCount--;
+
+                if (symbol == 'N')
+                {
+                    const int GroupSize = 3;
+
+                    // Count amount of digits before first group separator. It will be reset to groupSize every time digitsLeftInGroup == zero
+                    var digitsLeftInGroup = (digitsCount + trailingZerosCount) % GroupSize;
+                    if (digitsLeftInGroup == 0)
+                    {
+                        if (digitsCount + trailingZerosCount > 0)
+                        {
+                            // There is a new group immediately after the first digit
+                            if (!symbolTable.TryEncode(SymbolTable.Symbol.GroupSeparator, buffer.Slice(bytesWritten), out digitBytes))
+                            {
+                                bytesWritten = 0;
+                                return false;
+                            }
+                            bytesWritten += digitBytes;
+                        }
+                        digitsLeftInGroup = GroupSize;
+                    }
+
+                    // Append digits
+                    while (reversedValueExceptFirst > 0)
+                    {
+                        if (digitsLeftInGroup == 0)
+                        {
+                            if (!symbolTable.TryEncode(SymbolTable.Symbol.GroupSeparator, buffer.Slice(bytesWritten), out digitBytes))
+                            {
+                                bytesWritten = 0;
+                                return false;
+                            }
+                            bytesWritten += digitBytes;
+                            digitsLeftInGroup = GroupSize;
+                        }
+
+                        var nextDigit = reversedValueExceptFirst % 10UL;
+                        reversedValueExceptFirst = reversedValueExceptFirst / 10UL;
+
+                        if (!symbolTable.TryEncode((SymbolTable.Symbol)nextDigit, buffer.Slice(bytesWritten), out digitBytes))
+                        {
+                            bytesWritten = 0;
+                            return false;
+                        }
+                        bytesWritten += digitBytes;
+                        digitsLeftInGroup--;
+                    }
+
+                    // Append trailing zeros if any
+                    while (trailingZerosCount-- > 0)
+                    {
+                        if (digitsLeftInGroup == 0)
+                        {
+                            if (!symbolTable.TryEncode(SymbolTable.Symbol.GroupSeparator, buffer.Slice(bytesWritten), out digitBytes))
+                            {
+                                bytesWritten = 0;
+                                return false;
+                            }
+                            bytesWritten += digitBytes;
+                            digitsLeftInGroup = GroupSize;
+                        }
+
+                        if (!symbolTable.TryEncode(SymbolTable.Symbol.D0, buffer.Slice(bytesWritten), out digitBytes))
+                        {
+                            bytesWritten = 0;
+                            return false;
+                        }
+                        bytesWritten += digitBytes;
+                        digitsLeftInGroup--;
+                    }
+                }
+                else
+                {
+                    while (reversedValueExceptFirst > 0)
+                    {
+                        var bufferSlice = buffer.Slice(bytesWritten);
+                        var nextDigit = reversedValueExceptFirst % 10UL;
+                        reversedValueExceptFirst = reversedValueExceptFirst / 10UL;
+                        if (!symbolTable.TryEncode((SymbolTable.Symbol)nextDigit, bufferSlice, out digitBytes))
+                        {
+                            bytesWritten = 0;
+                            return false;
+                        }
+                        bytesWritten += digitBytes;
+                    }
+
+                    // Append trailing zeros if any
+                    while (trailingZerosCount-- > 0)
+                    {
+                        if (!symbolTable.TryEncode(SymbolTable.Symbol.D0, buffer.Slice(bytesWritten), out digitBytes))
+                        {
+                            bytesWritten = 0;
+                            return false;
+                        }
+                        bytesWritten += digitBytes;
+                    }
+                }
+
+                // If format is N and precision is not defined or is greater than zero, append trailing zeros after decimal point
+                if (symbol == 'N')
+                {
+                    int trailingZerosAfterDecimalCount = format.HasPrecision ? format.Precision : 2;
+
+                    if (trailingZerosAfterDecimalCount > 0)
+                    {
+                        if (!symbolTable.TryEncode(SymbolTable.Symbol.DecimalSeparator, buffer.Slice(bytesWritten), out digitBytes))
+                        {
+                            bytesWritten = 0;
+                            return false;
+                        }
+                        bytesWritten += digitBytes;
+
+                        while (trailingZerosAfterDecimalCount-- > 0)
+                        {
+                            if (!symbolTable.TryEncode(SymbolTable.Symbol.D0, buffer.Slice(bytesWritten), out digitBytes))
+                            {
+                                bytesWritten = 0;
+                                return false;
+                            }
+                            bytesWritten += digitBytes;
+                        }
+                    }
+                }
+
+                return true;
+            }
         }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Formatters/Custom.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Custom.cs
@@ -1,223 +1,227 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text.Formatters
+using System.Buffers.Text;
+
+namespace System.Buffers
 {
-    public static partial class Custom
-    {
-        #region Date / Time APIs
-
-        public static bool TryFormat(DateTimeOffset value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
+    public static partial class Formatters {
+        public static partial class Custom
         {
-            if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
-                return Utf8.TryFormat(value, buffer, out bytesWritten, format);
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-                return Utf16.TryFormat(value, buffer, out bytesWritten, format);
-            else
-                throw new NotSupportedException();
-        }
+            #region Date / Time APIs
 
-        public static bool TryFormat(DateTime value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
-                return Utf8.TryFormat(value, buffer, out bytesWritten, format);
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-                return Utf16.TryFormat(value, buffer, out bytesWritten, format);
-            else
-                throw new NotSupportedException();
-        }
-
-        public static bool TryFormat(TimeSpan value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
-                return Utf8.TryFormat(value, buffer, out bytesWritten, format);
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-                return Utf16.TryFormat(value, buffer, out bytesWritten, format);
-            else
-                throw new NotSupportedException();
-        }
-
-        #endregion Date / Time APIs
-
-        #region GUID APIs
-
-        public static bool TryFormat(Guid value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
-                return Utf8.TryFormat(value, buffer, out bytesWritten, format);
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-                return Utf16.TryFormat(value, buffer, out bytesWritten, format);
-            else
-                throw new NotSupportedException();
-        }
-
-        #endregion GUID APIs
-
-        #region Integer APIs
-
-        public static bool TryFormat(byte value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            if (format.IsDefault)
+            public static bool TryFormat(DateTimeOffset value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
             {
-                format = 'G';
-            }
-
-            if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
-                return Utf8.TryFormat(value, buffer, out bytesWritten, format);
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-                return Utf16.TryFormat(value, buffer, out bytesWritten, format);
-            else
-                return TryFormatUInt64(value, buffer, out bytesWritten, format, symbolTable);
-        }
-
-        public static bool TryFormat(sbyte value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
-            if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
-                return Utf8.TryFormat(value, buffer, out bytesWritten, format);
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-                return Utf16.TryFormat(value, buffer, out bytesWritten, format);
-            else
-                return TryFormatInt64(value, 0xff, buffer, out bytesWritten, format, symbolTable);
-        }
-
-        public static bool TryFormat(ushort value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
-            if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
-                return Utf8.TryFormat(value, buffer, out bytesWritten, format);
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-                return Utf16.TryFormat(value, buffer, out bytesWritten, format);
-            else
-                return TryFormatUInt64(value, buffer, out bytesWritten, format, symbolTable);
-        }
-
-        public static bool TryFormat(short value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
-            if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
-                return Utf8.TryFormat(value, buffer, out bytesWritten, format);
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-                return Utf16.TryFormat(value, buffer, out bytesWritten, format);
-            else
-                return TryFormatInt64(value, 0xffff, buffer, out bytesWritten, format, symbolTable);
-        }
-
-        public static bool TryFormat(uint value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
-            if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
-                return Utf8.TryFormat(value, buffer, out bytesWritten, format);
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-                return Utf16.TryFormat(value, buffer, out bytesWritten, format);
-            else
-                return TryFormatUInt64(value, buffer, out bytesWritten, format, symbolTable);
-        }
-
-        public static bool TryFormat(int value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
-            if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
-                return Utf8.TryFormat(value, buffer, out bytesWritten, format);
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-                return Utf16.TryFormat(value, buffer, out bytesWritten, format);
-            else
-                return TryFormatInt64(value, 0xffffffff, buffer, out bytesWritten, format, symbolTable);
-        }
-
-        public static bool TryFormat(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
-            if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
-                return Utf8.TryFormat(value, buffer, out bytesWritten, format);
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-                return Utf16.TryFormat(value, buffer, out bytesWritten, format);
-            else
-                return TryFormatUInt64(value, buffer, out bytesWritten, format, symbolTable);
-        }
-
-        public static bool TryFormat(long value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
-            if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
-                return Utf8.TryFormat(value, buffer, out bytesWritten, format);
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-                return Utf16.TryFormat(value, buffer, out bytesWritten, format);
-            else
-                return TryFormatInt64(value, 0xffffffffffffffff, buffer, out bytesWritten, format, symbolTable);
-        }
-
-        #endregion Integer APIs
-
-        #region Floating-point APIs
-
-        public static bool TryFormat(this double value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
-            symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
-
-            switch (format.Symbol)
-            {
-                case 'G':
-                    return Custom.TryFormatNumber(value, false, buffer, out bytesWritten, format, symbolTable);
-
-                default:
+                if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
+                    return Utf8.TryFormat(value, buffer, out bytesWritten, format);
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                    return Utf16.TryFormat(value, buffer, out bytesWritten, format);
+                else
                     throw new NotSupportedException();
             }
-        }
 
-        public static bool TryFormat(this float value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-
-            if (format.IsDefault)
+            public static bool TryFormat(DateTime value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
             {
-                format = 'G';
-            }
-
-            symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
-
-            switch (format.Symbol)
-            {
-                case 'G':
-                    return Custom.TryFormatNumber(value, true, buffer, out bytesWritten, format, symbolTable);
-
-                default:
+                if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
+                    return Utf8.TryFormat(value, buffer, out bytesWritten, format);
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                    return Utf16.TryFormat(value, buffer, out bytesWritten, format);
+                else
                     throw new NotSupportedException();
             }
-        }
 
-        #endregion Floating-point APIs
+            public static bool TryFormat(TimeSpan value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
+                    return Utf8.TryFormat(value, buffer, out bytesWritten, format);
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                    return Utf16.TryFormat(value, buffer, out bytesWritten, format);
+                else
+                    throw new NotSupportedException();
+            }
+
+            #endregion Date / Time APIs
+
+            #region GUID APIs
+
+            public static bool TryFormat(Guid value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
+                    return Utf8.TryFormat(value, buffer, out bytesWritten, format);
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                    return Utf16.TryFormat(value, buffer, out bytesWritten, format);
+                else
+                    throw new NotSupportedException();
+            }
+
+            #endregion GUID APIs
+
+            #region Integer APIs
+
+            public static bool TryFormat(byte value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                if (format.IsDefault)
+                {
+                    format = 'G';
+                }
+
+                if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
+                    return Utf8.TryFormat(value, buffer, out bytesWritten, format);
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                    return Utf16.TryFormat(value, buffer, out bytesWritten, format);
+                else
+                    return TryFormatUInt64(value, buffer, out bytesWritten, format, symbolTable);
+            }
+
+            public static bool TryFormat(sbyte value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                if (format.IsDefault)
+                {
+                    format = 'G';
+                }
+
+                if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
+                    return Utf8.TryFormat(value, buffer, out bytesWritten, format);
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                    return Utf16.TryFormat(value, buffer, out bytesWritten, format);
+                else
+                    return TryFormatInt64(value, 0xff, buffer, out bytesWritten, format, symbolTable);
+            }
+
+            public static bool TryFormat(ushort value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                if (format.IsDefault)
+                {
+                    format = 'G';
+                }
+
+                if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
+                    return Utf8.TryFormat(value, buffer, out bytesWritten, format);
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                    return Utf16.TryFormat(value, buffer, out bytesWritten, format);
+                else
+                    return TryFormatUInt64(value, buffer, out bytesWritten, format, symbolTable);
+            }
+
+            public static bool TryFormat(short value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                if (format.IsDefault)
+                {
+                    format = 'G';
+                }
+
+                if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
+                    return Utf8.TryFormat(value, buffer, out bytesWritten, format);
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                    return Utf16.TryFormat(value, buffer, out bytesWritten, format);
+                else
+                    return TryFormatInt64(value, 0xffff, buffer, out bytesWritten, format, symbolTable);
+            }
+
+            public static bool TryFormat(uint value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                if (format.IsDefault)
+                {
+                    format = 'G';
+                }
+
+                if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
+                    return Utf8.TryFormat(value, buffer, out bytesWritten, format);
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                    return Utf16.TryFormat(value, buffer, out bytesWritten, format);
+                else
+                    return TryFormatUInt64(value, buffer, out bytesWritten, format, symbolTable);
+            }
+
+            public static bool TryFormat(int value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                if (format.IsDefault)
+                {
+                    format = 'G';
+                }
+
+                if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
+                    return Utf8.TryFormat(value, buffer, out bytesWritten, format);
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                    return Utf16.TryFormat(value, buffer, out bytesWritten, format);
+                else
+                    return TryFormatInt64(value, 0xffffffff, buffer, out bytesWritten, format, symbolTable);
+            }
+
+            public static bool TryFormat(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                if (format.IsDefault)
+                {
+                    format = 'G';
+                }
+
+                if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
+                    return Utf8.TryFormat(value, buffer, out bytesWritten, format);
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                    return Utf16.TryFormat(value, buffer, out bytesWritten, format);
+                else
+                    return TryFormatUInt64(value, buffer, out bytesWritten, format, symbolTable);
+            }
+
+            public static bool TryFormat(long value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                if (format.IsDefault)
+                {
+                    format = 'G';
+                }
+
+                if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
+                    return Utf8.TryFormat(value, buffer, out bytesWritten, format);
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                    return Utf16.TryFormat(value, buffer, out bytesWritten, format);
+                else
+                    return TryFormatInt64(value, 0xffffffffffffffff, buffer, out bytesWritten, format, symbolTable);
+            }
+
+            #endregion Integer APIs
+
+            #region Floating-point APIs
+
+            public static bool TryFormat(double value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                if (format.IsDefault)
+                {
+                    format = 'G';
+                }
+
+                symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
+
+                switch (format.Symbol)
+                {
+                    case 'G':
+                        return Custom.TryFormatNumber(value, false, buffer, out bytesWritten, format, symbolTable);
+
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+
+            public static bool TryFormat(float value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+
+                if (format.IsDefault)
+                {
+                    format = 'G';
+                }
+
+                symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
+
+                switch (format.Symbol)
+                {
+                    case 'G':
+                        return Custom.TryFormatNumber(value, true, buffer, out bytesWritten, format, symbolTable);
+
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+
+            #endregion Floating-point APIs
+        }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Formatters/FormattingHelpers.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/FormattingHelpers.cs
@@ -4,7 +4,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-namespace System.Text.Formatters
+namespace System.Buffers
 {
     // All the helper methods in this class assume that the by-ref is valid and that there is
     // enough space to fit the items that will be written into the underlying memory. The calling

--- a/src/System.Text.Primitives/System/Text/Formatters/Utf16.Guid.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Utf16.Guid.cs
@@ -2,91 +2,95 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
+using System.Text;
 
-namespace System.Text.Formatters
+namespace System.Buffers
 {
-    public static partial class Utf16
+    public static partial class Formatters
     {
-        #region Constants
-
-        private const int GuidChars = 32;
-
-        private const char OpenBrace = '{';
-        private const char CloseBrace = '}';
-
-        private const char OpenParen = '(';
-        private const char CloseParen = ')';
-
-        private const char Dash = '-';
-
-        #endregion Constants
-
-        public static unsafe bool TryFormat(Guid value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+        public static partial class Utf16
         {
-            bool dash = format.Symbol != 'N';
-            bool bookEnds = (format.Symbol == 'B') || (format.Symbol == 'P');
+            #region Constants
 
-            bytesWritten = (GuidChars + (dash ? 4 : 0) + (bookEnds ? 2 : 0)) * sizeof(char);
-            if (buffer.Length < bytesWritten)
+            private const int GuidChars = 32;
+
+            private const char OpenBrace = '{';
+            private const char CloseBrace = '}';
+
+            private const char OpenParen = '(';
+            private const char CloseParen = ')';
+
+            private const char Dash = '-';
+
+            #endregion Constants
+
+            public static unsafe bool TryFormat(Guid value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
             {
-                bytesWritten = 0;
-                return false;
+                bool dash = format.Symbol != 'N';
+                bool bookEnds = (format.Symbol == 'B') || (format.Symbol == 'P');
+
+                bytesWritten = (GuidChars + (dash ? 4 : 0) + (bookEnds ? 2 : 0)) * sizeof(char);
+                if (buffer.Length < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                Span<char> dst = buffer.NonPortableCast<byte, char>();
+                ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
+                byte* bytes = (byte*)&value;
+                int idx = 0;
+
+                if (bookEnds && format.Symbol == 'B')
+                    Unsafe.Add(ref utf16Bytes, idx++) = OpenBrace;
+                else if (bookEnds && format.Symbol == (byte)'P')
+                    Unsafe.Add(ref utf16Bytes, idx++) = OpenParen;
+
+                FormattingHelpers.WriteHexByte(bytes[3], ref utf16Bytes, idx);
+                FormattingHelpers.WriteHexByte(bytes[2], ref utf16Bytes, idx + 2);
+                FormattingHelpers.WriteHexByte(bytes[1], ref utf16Bytes, idx + 4);
+                FormattingHelpers.WriteHexByte(bytes[0], ref utf16Bytes, idx + 6);
+                idx += 8;
+
+                if (dash)
+                    Unsafe.Add(ref utf16Bytes, idx++) = Dash;
+
+                FormattingHelpers.WriteHexByte(bytes[5], ref utf16Bytes, idx);
+                FormattingHelpers.WriteHexByte(bytes[4], ref utf16Bytes, idx + 2);
+                idx += 4;
+
+                if (dash)
+                    Unsafe.Add(ref utf16Bytes, idx++) = Dash;
+
+                FormattingHelpers.WriteHexByte(bytes[7], ref utf16Bytes, idx);
+                FormattingHelpers.WriteHexByte(bytes[6], ref utf16Bytes, idx + 2);
+                idx += 4;
+
+                if (dash)
+                    Unsafe.Add(ref utf16Bytes, idx++) = Dash;
+
+                FormattingHelpers.WriteHexByte(bytes[8], ref utf16Bytes, idx);
+                FormattingHelpers.WriteHexByte(bytes[9], ref utf16Bytes, idx + 2);
+                idx += 4;
+
+                if (dash)
+                    Unsafe.Add(ref utf16Bytes, idx++) = Dash;
+
+                FormattingHelpers.WriteHexByte(bytes[10], ref utf16Bytes, idx);
+                FormattingHelpers.WriteHexByte(bytes[11], ref utf16Bytes, idx + 2);
+                FormattingHelpers.WriteHexByte(bytes[12], ref utf16Bytes, idx + 4);
+                FormattingHelpers.WriteHexByte(bytes[13], ref utf16Bytes, idx + 6);
+                FormattingHelpers.WriteHexByte(bytes[14], ref utf16Bytes, idx + 8);
+                FormattingHelpers.WriteHexByte(bytes[15], ref utf16Bytes, idx + 10);
+                idx += 12;
+
+                if (bookEnds && format.Symbol == 'B')
+                    Unsafe.Add(ref utf16Bytes, idx++) = CloseBrace;
+                else if (bookEnds && format.Symbol == 'P')
+                    Unsafe.Add(ref utf16Bytes, idx++) = CloseParen;
+
+                return true;
             }
-
-            Span<char> dst = buffer.NonPortableCast<byte, char>();
-            ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
-            byte* bytes = (byte*)&value;
-            int idx = 0;
-
-            if (bookEnds && format.Symbol == 'B')
-                Unsafe.Add(ref utf16Bytes, idx++) = OpenBrace;
-            else if (bookEnds && format.Symbol == (byte)'P')
-                Unsafe.Add(ref utf16Bytes, idx++) = OpenParen;
-
-            FormattingHelpers.WriteHexByte(bytes[3], ref utf16Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[2], ref utf16Bytes, idx + 2);
-            FormattingHelpers.WriteHexByte(bytes[1], ref utf16Bytes, idx + 4);
-            FormattingHelpers.WriteHexByte(bytes[0], ref utf16Bytes, idx + 6);
-            idx += 8;
-
-            if (dash)
-                Unsafe.Add(ref utf16Bytes, idx++) = Dash;
-
-            FormattingHelpers.WriteHexByte(bytes[5], ref utf16Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[4], ref utf16Bytes, idx + 2);
-            idx += 4;
-
-            if (dash)
-                Unsafe.Add(ref utf16Bytes, idx++) = Dash;
-
-            FormattingHelpers.WriteHexByte(bytes[7], ref utf16Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[6], ref utf16Bytes, idx + 2);
-            idx += 4;
-
-            if (dash)
-                Unsafe.Add(ref utf16Bytes, idx++) = Dash;
-
-            FormattingHelpers.WriteHexByte(bytes[8], ref utf16Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[9], ref utf16Bytes, idx + 2);
-            idx += 4;
-
-            if (dash)
-                Unsafe.Add(ref utf16Bytes, idx++) = Dash;
-
-            FormattingHelpers.WriteHexByte(bytes[10], ref utf16Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[11], ref utf16Bytes, idx + 2);
-            FormattingHelpers.WriteHexByte(bytes[12], ref utf16Bytes, idx + 4);
-            FormattingHelpers.WriteHexByte(bytes[13], ref utf16Bytes, idx + 6);
-            FormattingHelpers.WriteHexByte(bytes[14], ref utf16Bytes, idx + 8);
-            FormattingHelpers.WriteHexByte(bytes[15], ref utf16Bytes, idx + 10);
-            idx += 12;
-
-            if (bookEnds && format.Symbol == 'B')
-                Unsafe.Add(ref utf16Bytes, idx++) = CloseBrace;
-            else if (bookEnds && format.Symbol == 'P')
-                Unsafe.Add(ref utf16Bytes, idx++) = CloseParen;
-
-            return true;
         }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Formatters/Utf16.Integer.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Utf16.Integer.cs
@@ -2,263 +2,267 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
+using System.Text;
 
-namespace System.Text.Formatters
+namespace System.Buffers
 {
-    public static partial class Utf16
+    public static partial class Formatters
     {
-        #region Constants
-
-        private const char Seperator = ',';
-
-        // Invariant formatting uses groups of 3 for each number group seperated by commas.
-        //   ex. 1,234,567,890
-        private const int GroupSize = 3;
-
-        #endregion Constants
-
-        private static bool TryFormatDecimalInt64(long value, byte precision, Span<byte> buffer, out int bytesWritten)
+        public static partial class Utf16
         {
-            int digitCount = FormattingHelpers.CountDigits(value);
-            int charsNeeded = digitCount + (int)((value >> 63) & 1);
-            Span<char> span = buffer.NonPortableCast<byte, char>();
+            #region Constants
 
-            if (span.Length < charsNeeded)
+            private const char Seperator = ',';
+
+            // Invariant formatting uses groups of 3 for each number group seperated by commas.
+            //   ex. 1,234,567,890
+            private const int GroupSize = 3;
+
+            #endregion Constants
+
+            private static bool TryFormatDecimalInt64(long value, byte precision, Span<byte> buffer, out int bytesWritten)
             {
-                bytesWritten = 0;
-                return false;
-            }
+                int digitCount = FormattingHelpers.CountDigits(value);
+                int charsNeeded = digitCount + (int)((value >> 63) & 1);
+                Span<char> span = buffer.NonPortableCast<byte, char>();
 
-            ref char utf16Bytes = ref span.DangerousGetPinnableReference();
-            int idx = 0;
-
-            if (value < 0)
-            {
-                Unsafe.Add(ref utf16Bytes, idx++) = Minus;
-
-                // Abs(long.MinValue) == long.MaxValue + 1, so we need to re-route to unsigned to handle value
-                if (value == long.MinValue)
+                if (span.Length < charsNeeded)
                 {
-                    if (!TryFormatDecimalUInt64((ulong)long.MaxValue + 1, precision, buffer.Slice(2), out bytesWritten))
-                        return false;
-
-                    bytesWritten += sizeof(char); // Add the minus sign
-                    return true;
+                    bytesWritten = 0;
+                    return false;
                 }
 
-                value = -value;
-            }
+                ref char utf16Bytes = ref span.DangerousGetPinnableReference();
+                int idx = 0;
 
-            if (precision != ParsedFormat.NoPrecision)
-            {
-                int leadingZeros = (int)precision - digitCount;
-                while (leadingZeros-- > 0)
-                    Unsafe.Add(ref utf16Bytes, idx++) = '0';
-            }
-
-            idx += FormattingHelpers.WriteDigits(value, digitCount, ref utf16Bytes, idx);
-
-            bytesWritten = idx * sizeof(char);
-            return true;
-        }
-
-        private static bool TryFormatDecimalUInt64(ulong value, byte precision, Span<byte> buffer, out int bytesWritten)
-        {
-            if (value <= long.MaxValue)
-                return TryFormatDecimalInt64((long)value, precision, buffer, out bytesWritten);
-
-            // Remove a single digit from the number. This will get it below long.MaxValue
-            // Then we call the faster long version and follow-up with writing the last
-            // digit. This ends up being faster by a factor of 2 than to just do the entire
-            // operation using the unsigned versions.
-            value = FormattingHelpers.DivMod(value, 10, out ulong lastDigit);
-
-            if (precision != ParsedFormat.NoPrecision && precision > 0)
-                precision -= 1;
-
-            if (!TryFormatDecimalInt64((long)value, precision, buffer, out bytesWritten))
-                return false;
-
-            Span<char> span = buffer.Slice(bytesWritten).NonPortableCast<byte, char>();
-
-            if (span.Length < sizeof(char))
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            ref char utf16Bytes = ref span.DangerousGetPinnableReference();
-            FormattingHelpers.WriteDigits(lastDigit, 1, ref utf16Bytes, 0);
-            bytesWritten += sizeof(char);
-            return true;
-        }
-
-        private static bool TryFormatNumericInt64(long value, byte precision, Span<byte> buffer, out int bytesWritten)
-        {
-            int digitCount = FormattingHelpers.CountDigits(value);
-            int groupSeperators = (int)FormattingHelpers.DivMod(digitCount, GroupSize, out long firstGroup);
-            if (firstGroup == 0)
-            {
-                firstGroup = 3;
-                groupSeperators--;
-            }
-
-            int trailingZeros = (precision == ParsedFormat.NoPrecision) ? 2 : precision;
-            int charsNeeded = (int)((value >> 63) & 1) + digitCount + groupSeperators;
-            int idx = charsNeeded;
-
-            if (trailingZeros > 0)
-                charsNeeded += trailingZeros + 1; // +1 for period.
-
-            Span<char> span = buffer.NonPortableCast<byte, char>();
-
-            if (span.Length < charsNeeded)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            ref char utf16Bytes = ref span.DangerousGetPinnableReference();
-            long v = value;
-
-            if (v < 0)
-            {
-                Unsafe.Add(ref utf16Bytes, 0) = Minus;
-
-                // Abs(long.MinValue) == long.MaxValue + 1, so we need to re-route to unsigned to handle value
-                if (v == long.MinValue)
+                if (value < 0)
                 {
-                    if (!TryFormatNumericUInt64((ulong)long.MaxValue + 1, precision, buffer.Slice(2), out bytesWritten))
-                        return false;
+                    Unsafe.Add(ref utf16Bytes, idx++) = Minus;
 
-                    bytesWritten += sizeof(char); // Add the minus sign
-                    return true;
+                    // Abs(long.MinValue) == long.MaxValue + 1, so we need to re-route to unsigned to handle value
+                    if (value == long.MinValue)
+                    {
+                        if (!TryFormatDecimalUInt64((ulong)long.MaxValue + 1, precision, buffer.Slice(2), out bytesWritten))
+                            return false;
+
+                        bytesWritten += sizeof(char); // Add the minus sign
+                        return true;
+                    }
+
+                    value = -value;
                 }
 
-                v = -v;
+                if (precision != ParsedFormat.NoPrecision)
+                {
+                    int leadingZeros = (int)precision - digitCount;
+                    while (leadingZeros-- > 0)
+                        Unsafe.Add(ref utf16Bytes, idx++) = '0';
+                }
+
+                idx += FormattingHelpers.WriteDigits(value, digitCount, ref utf16Bytes, idx);
+
+                bytesWritten = idx * sizeof(char);
+                return true;
             }
 
-            // Write out the trailing zeros
-            if (trailingZeros > 0)
+            private static bool TryFormatDecimalUInt64(ulong value, byte precision, Span<byte> buffer, out int bytesWritten)
             {
-                Unsafe.Add(ref utf16Bytes, idx) = Period;
-                FormattingHelpers.WriteDigits(0, trailingZeros, ref utf16Bytes, idx + 1);
+                if (value <= long.MaxValue)
+                    return TryFormatDecimalInt64((long)value, precision, buffer, out bytesWritten);
+
+                // Remove a single digit from the number. This will get it below long.MaxValue
+                // Then we call the faster long version and follow-up with writing the last
+                // digit. This ends up being faster by a factor of 2 than to just do the entire
+                // operation using the unsigned versions.
+                value = FormattingHelpers.DivMod(value, 10, out ulong lastDigit);
+
+                if (precision != ParsedFormat.NoPrecision && precision > 0)
+                    precision -= 1;
+
+                if (!TryFormatDecimalInt64((long)value, precision, buffer, out bytesWritten))
+                    return false;
+
+                Span<char> span = buffer.Slice(bytesWritten).NonPortableCast<byte, char>();
+
+                if (span.Length < sizeof(char))
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                ref char utf16Bytes = ref span.DangerousGetPinnableReference();
+                FormattingHelpers.WriteDigits(lastDigit, 1, ref utf16Bytes, 0);
+                bytesWritten += sizeof(char);
+                return true;
             }
 
-            // Starting from the back, write each group of digits except the first group
-            while (digitCount > 3)
+            private static bool TryFormatNumericInt64(long value, byte precision, Span<byte> buffer, out int bytesWritten)
             {
-                idx -= 3;
-                v = FormattingHelpers.DivMod(v, 1000, out long groupValue);
-                FormattingHelpers.WriteDigits(groupValue, 3, ref utf16Bytes, idx);
-                Unsafe.Add(ref utf16Bytes, --idx) = Seperator;
-                digitCount -= 3;
+                int digitCount = FormattingHelpers.CountDigits(value);
+                int groupSeperators = (int)FormattingHelpers.DivMod(digitCount, GroupSize, out long firstGroup);
+                if (firstGroup == 0)
+                {
+                    firstGroup = 3;
+                    groupSeperators--;
+                }
+
+                int trailingZeros = (precision == ParsedFormat.NoPrecision) ? 2 : precision;
+                int charsNeeded = (int)((value >> 63) & 1) + digitCount + groupSeperators;
+                int idx = charsNeeded;
+
+                if (trailingZeros > 0)
+                    charsNeeded += trailingZeros + 1; // +1 for period.
+
+                Span<char> span = buffer.NonPortableCast<byte, char>();
+
+                if (span.Length < charsNeeded)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                ref char utf16Bytes = ref span.DangerousGetPinnableReference();
+                long v = value;
+
+                if (v < 0)
+                {
+                    Unsafe.Add(ref utf16Bytes, 0) = Minus;
+
+                    // Abs(long.MinValue) == long.MaxValue + 1, so we need to re-route to unsigned to handle value
+                    if (v == long.MinValue)
+                    {
+                        if (!TryFormatNumericUInt64((ulong)long.MaxValue + 1, precision, buffer.Slice(2), out bytesWritten))
+                            return false;
+
+                        bytesWritten += sizeof(char); // Add the minus sign
+                        return true;
+                    }
+
+                    v = -v;
+                }
+
+                // Write out the trailing zeros
+                if (trailingZeros > 0)
+                {
+                    Unsafe.Add(ref utf16Bytes, idx) = Period;
+                    FormattingHelpers.WriteDigits(0, trailingZeros, ref utf16Bytes, idx + 1);
+                }
+
+                // Starting from the back, write each group of digits except the first group
+                while (digitCount > 3)
+                {
+                    idx -= 3;
+                    v = FormattingHelpers.DivMod(v, 1000, out long groupValue);
+                    FormattingHelpers.WriteDigits(groupValue, 3, ref utf16Bytes, idx);
+                    Unsafe.Add(ref utf16Bytes, --idx) = Seperator;
+                    digitCount -= 3;
+                }
+
+                // Write the first group of digits.
+                FormattingHelpers.WriteDigits(v, (int)firstGroup, ref utf16Bytes, idx - (int)firstGroup);
+
+                bytesWritten = charsNeeded * sizeof(char);
+                return true;
             }
 
-            // Write the first group of digits.
-            FormattingHelpers.WriteDigits(v, (int)firstGroup, ref utf16Bytes, idx - (int)firstGroup);
-
-            bytesWritten = charsNeeded * sizeof(char);
-            return true;
-        }
-
-        private static bool TryFormatNumericUInt64(ulong value, byte precision, Span<byte> buffer, out int bytesWritten)
-        {
-            if (value <= long.MaxValue)
-                return TryFormatNumericInt64((long)value, precision, buffer, out bytesWritten);
-
-            // The ulong path is much slower than the long path here, so we are doing the last group
-            // inside this method plus the zero padding but routing to the long version for the rest.
-            value = FormattingHelpers.DivMod(value, 1000, out ulong lastGroup);
-
-            if (!TryFormatNumericInt64((long)value, 0, buffer, out bytesWritten))
-                return false;
-
-            if (precision == ParsedFormat.NoPrecision)
-                precision = 2;
-
-            // Since this method routes entirely to the long version if the number is smaller than
-            // long.MaxValue, we are guaranteed to need to write 3 more digits here before the set
-            // of trailing zeros.
-
-            int extraChars = 4; // 3 digits + group seperator
-            if (precision > 0)
-                extraChars += precision + 1; // +1 for period.
-
-            Span<char> span = buffer.Slice(bytesWritten).NonPortableCast<byte, char>();
-
-            if (span.Length < extraChars)
+            private static bool TryFormatNumericUInt64(ulong value, byte precision, Span<byte> buffer, out int bytesWritten)
             {
-                bytesWritten = 0;
-                return false;
+                if (value <= long.MaxValue)
+                    return TryFormatNumericInt64((long)value, precision, buffer, out bytesWritten);
+
+                // The ulong path is much slower than the long path here, so we are doing the last group
+                // inside this method plus the zero padding but routing to the long version for the rest.
+                value = FormattingHelpers.DivMod(value, 1000, out ulong lastGroup);
+
+                if (!TryFormatNumericInt64((long)value, 0, buffer, out bytesWritten))
+                    return false;
+
+                if (precision == ParsedFormat.NoPrecision)
+                    precision = 2;
+
+                // Since this method routes entirely to the long version if the number is smaller than
+                // long.MaxValue, we are guaranteed to need to write 3 more digits here before the set
+                // of trailing zeros.
+
+                int extraChars = 4; // 3 digits + group seperator
+                if (precision > 0)
+                    extraChars += precision + 1; // +1 for period.
+
+                Span<char> span = buffer.Slice(bytesWritten).NonPortableCast<byte, char>();
+
+                if (span.Length < extraChars)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                ref char utf16Bytes = ref span.DangerousGetPinnableReference();
+                var idx = 0;
+
+                // Write the last group
+                Unsafe.Add(ref utf16Bytes, idx++) = Seperator;
+                idx += FormattingHelpers.WriteDigits(lastGroup, 3, ref utf16Bytes, idx);
+
+                // Write out the trailing zeros
+                if (precision > 0)
+                {
+                    Unsafe.Add(ref utf16Bytes, idx++) = Period;
+                    idx += FormattingHelpers.WriteDigits(0, precision, ref utf16Bytes, idx);
+                }
+
+                bytesWritten += extraChars * sizeof(char);
+                return true;
             }
 
-            ref char utf16Bytes = ref span.DangerousGetPinnableReference();
-            var idx = 0;
-
-            // Write the last group
-            Unsafe.Add(ref utf16Bytes, idx++) = Seperator;
-            idx += FormattingHelpers.WriteDigits(lastGroup, 3, ref utf16Bytes, idx);
-
-            // Write out the trailing zeros
-            if (precision > 0)
+            private static bool TryFormatHexUInt64(ulong value, byte precision, bool useLower, Span<byte> buffer, out int bytesWritten)
             {
-                Unsafe.Add(ref utf16Bytes, idx++) = Period;
-                idx += FormattingHelpers.WriteDigits(0, precision, ref utf16Bytes, idx);
+                const string HexTableLower = "0123456789abcdef";
+                const string HexTableUpper = "0123456789ABCDEF";
+
+                var digits = 1;
+                var v = value;
+                if (v > 0xFFFFFFFF)
+                {
+                    digits += 8;
+                    v >>= 0x20;
+                }
+                if (v > 0xFFFF)
+                {
+                    digits += 4;
+                    v >>= 0x10;
+                }
+                if (v > 0xFF)
+                {
+                    digits += 2;
+                    v >>= 0x8;
+                }
+                if (v > 0xF) digits++;
+
+                int paddingCount = (precision == ParsedFormat.NoPrecision) ? 0 : precision - digits;
+                if (paddingCount < 0) paddingCount = 0;
+
+                int charsNeeded = digits + paddingCount;
+                Span<char> span = buffer.NonPortableCast<byte, char>();
+
+                if (span.Length < charsNeeded)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                string hexTable = useLower ? HexTableLower : HexTableUpper;
+                ref char utf16Bytes = ref span.DangerousGetPinnableReference();
+                int idx = charsNeeded;
+
+                for (v = value; digits-- > 0; v >>= 4)
+                    Unsafe.Add(ref utf16Bytes, --idx) = hexTable[(int)(v & 0xF)];
+
+                while (paddingCount-- > 0)
+                    Unsafe.Add(ref utf16Bytes, --idx) = '0';
+
+                bytesWritten = charsNeeded * sizeof(char);
+                return true;
             }
-
-            bytesWritten += extraChars * sizeof(char);
-            return true;
-        }
-
-        private static bool TryFormatHexUInt64(ulong value, byte precision, bool useLower, Span<byte> buffer, out int bytesWritten)
-        {
-            const string HexTableLower = "0123456789abcdef";
-            const string HexTableUpper = "0123456789ABCDEF";
-
-            var digits = 1;
-            var v = value;
-            if (v > 0xFFFFFFFF)
-            {
-                digits += 8;
-                v >>= 0x20;
-            }
-            if (v > 0xFFFF)
-            {
-                digits += 4;
-                v >>= 0x10;
-            }
-            if (v > 0xFF)
-            {
-                digits += 2;
-                v >>= 0x8;
-            }
-            if (v > 0xF) digits++;
-
-            int paddingCount = (precision == ParsedFormat.NoPrecision) ? 0 : precision - digits;
-            if (paddingCount < 0) paddingCount = 0;
-
-            int charsNeeded = digits + paddingCount;
-            Span<char> span = buffer.NonPortableCast<byte, char>();
-
-            if (span.Length < charsNeeded)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            string hexTable = useLower ? HexTableLower : HexTableUpper;
-            ref char utf16Bytes = ref span.DangerousGetPinnableReference();
-            int idx = charsNeeded;
-
-            for (v = value; digits-- > 0; v >>= 4)
-                Unsafe.Add(ref utf16Bytes, --idx) = hexTable[(int)(v & 0xF)];
-
-            while (paddingCount-- > 0)
-                Unsafe.Add(ref utf16Bytes, --idx) = '0';
-
-            bytesWritten = charsNeeded * sizeof(char);
-            return true;
         }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Formatters/Utf16.Time.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Utf16.Time.cs
@@ -3,27 +3,29 @@
 
 using System.Runtime.CompilerServices;
 
-namespace System.Text.Formatters
+namespace System.Buffers
 {
-    public static partial class Utf16
+    public static partial class Formatters
     {
-        #region Constants
-
-        private const int DefaultFractionDigits = 7;
-
-        private const char TimeMarker = 'T';
-        private const char UtcMarker = 'Z';
-
-        private const char GMT1 = 'G';
-        private const char GMT2 = 'M';
-        private const char GMT3 = 'T';
-
-        private const char GMT1Lowercase = 'g';
-        private const char GMT2Lowercase = 'm';
-        private const char GMT3Lowercase = 't';
-
-        private static readonly char[][] DayAbbreviations = new char[][]
+        public static partial class Utf16
         {
+            #region Constants
+
+            private const int DefaultFractionDigits = 7;
+
+            private const char TimeMarker = 'T';
+            private const char UtcMarker = 'Z';
+
+            private const char GMT1 = 'G';
+            private const char GMT2 = 'M';
+            private const char GMT3 = 'T';
+
+            private const char GMT1Lowercase = 'g';
+            private const char GMT2Lowercase = 'm';
+            private const char GMT3Lowercase = 't';
+
+            private static readonly char[][] DayAbbreviations = new char[][]
+            {
                 new char[] { 'S', 'u', 'n' },
                 new char[] { 'M', 'o', 'n' },
                 new char[] { 'T', 'u', 'e' },
@@ -31,10 +33,10 @@ namespace System.Text.Formatters
                 new char[] { 'T', 'h', 'u' },
                 new char[] { 'F', 'r', 'i' },
                 new char[] { 'S', 'a', 't' },
-        };
+            };
 
-        private static readonly char[][] MonthAbbreviations = new char[][]
-        {
+            private static readonly char[][] MonthAbbreviations = new char[][]
+            {
                 new char[] { 'J', 'a', 'n' },
                 new char[] { 'F', 'e', 'b' },
                 new char[] { 'M', 'a', 'r' },
@@ -47,10 +49,10 @@ namespace System.Text.Formatters
                 new char[] { 'O', 'c', 't' },
                 new char[] { 'N', 'o', 'v' },
                 new char[] { 'D', 'e', 'c' },
-        };
+            };
 
-        private static readonly char[][] DayAbbreviationsLowercase = new char[][]
-        {
+            private static readonly char[][] DayAbbreviationsLowercase = new char[][]
+            {
                 new char[] { 's', 'u', 'n' },
                 new char[] { 'm', 'o', 'n' },
                 new char[] { 't', 'u', 'e' },
@@ -58,10 +60,10 @@ namespace System.Text.Formatters
                 new char[] { 't', 'h', 'u' },
                 new char[] { 'f', 'r', 'i' },
                 new char[] { 's', 'a', 't' },
-        };
+            };
 
-        private static readonly char[][] MonthAbbreviationsLowercase = new char[][]
-        {
+            private static readonly char[][] MonthAbbreviationsLowercase = new char[][]
+            {
                 new char[] { 'j', 'a', 'n' },
                 new char[] { 'f', 'e', 'b' },
                 new char[] { 'm', 'a', 'r' },
@@ -74,323 +76,324 @@ namespace System.Text.Formatters
                 new char[] { 'o', 'c', 't' },
                 new char[] { 'n', 'o', 'v' },
                 new char[] { 'd', 'e', 'c' },
-        };
+            };
 
-        private static readonly TimeSpan NullOffset = TimeSpan.MinValue;
+            private static readonly TimeSpan NullOffset = TimeSpan.MinValue;
 
-        #endregion Constants
+            #endregion Constants
 
-        private static bool TryFormatG(DateTime value, TimeSpan offset, Span<byte> buffer, out int bytesWritten)
-        {
-            const int MinimumCharsNeeded = 19;
-
-            int charsNeeded = MinimumCharsNeeded;
-            if (offset != NullOffset)
+            private static bool TryFormatG(DateTime value, TimeSpan offset, Span<byte> buffer, out int bytesWritten)
             {
-                charsNeeded += 7; // Space['+'|'-']hh:ss
-            }
+                const int MinimumCharsNeeded = 19;
 
-            bytesWritten = charsNeeded * sizeof(char);
-            if (buffer.Length < bytesWritten)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            Span<char> dst = buffer.NonPortableCast<byte, char>();
-            ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
-
-            FormattingHelpers.WriteDigits(value.Month, 2, ref utf16Bytes, 0);
-            Unsafe.Add(ref utf16Bytes, 2) = Slash;
-
-            FormattingHelpers.WriteDigits(value.Day, 2, ref utf16Bytes, 3);
-            Unsafe.Add(ref utf16Bytes, 5) = Slash;
-
-            FormattingHelpers.WriteDigits(value.Year, 4, ref utf16Bytes, 6);
-            Unsafe.Add(ref utf16Bytes, 10) = Space;
-
-            FormattingHelpers.WriteDigits(value.Hour, 2, ref utf16Bytes, 11);
-            Unsafe.Add(ref utf16Bytes, 13) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Minute, 2, ref utf16Bytes, 14);
-            Unsafe.Add(ref utf16Bytes, 16) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Second, 2, ref utf16Bytes, 17);
-
-            if (offset != NullOffset)
-            {
-                Unsafe.Add(ref utf16Bytes, 19) = Space;
-
-                long ticks = value.Ticks;
-                if (ticks < 0)
+                int charsNeeded = MinimumCharsNeeded;
+                if (offset != NullOffset)
                 {
-                    Unsafe.Add(ref utf16Bytes, 20) = Minus;
-                    ticks = -ticks;
+                    charsNeeded += 7; // Space['+'|'-']hh:ss
+                }
+
+                bytesWritten = charsNeeded * sizeof(char);
+                if (buffer.Length < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                Span<char> dst = buffer.NonPortableCast<byte, char>();
+                ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
+
+                FormattingHelpers.WriteDigits(value.Month, 2, ref utf16Bytes, 0);
+                Unsafe.Add(ref utf16Bytes, 2) = Slash;
+
+                FormattingHelpers.WriteDigits(value.Day, 2, ref utf16Bytes, 3);
+                Unsafe.Add(ref utf16Bytes, 5) = Slash;
+
+                FormattingHelpers.WriteDigits(value.Year, 4, ref utf16Bytes, 6);
+                Unsafe.Add(ref utf16Bytes, 10) = Space;
+
+                FormattingHelpers.WriteDigits(value.Hour, 2, ref utf16Bytes, 11);
+                Unsafe.Add(ref utf16Bytes, 13) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Minute, 2, ref utf16Bytes, 14);
+                Unsafe.Add(ref utf16Bytes, 16) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Second, 2, ref utf16Bytes, 17);
+
+                if (offset != NullOffset)
+                {
+                    Unsafe.Add(ref utf16Bytes, 19) = Space;
+
+                    long ticks = value.Ticks;
+                    if (ticks < 0)
+                    {
+                        Unsafe.Add(ref utf16Bytes, 20) = Minus;
+                        ticks = -ticks;
+                    }
+                    else
+                    {
+                        Unsafe.Add(ref utf16Bytes, 20) = Plus;
+                    }
+
+                    FormattingHelpers.WriteDigits(offset.Hours, 2, ref utf16Bytes, 21);
+                    Unsafe.Add(ref utf16Bytes, 23) = Colon;
+                    FormattingHelpers.WriteDigits(offset.Minutes, 2, ref utf16Bytes, 24);
+                }
+
+                return true;
+            }
+
+            private static bool TryFormatO(DateTime value, TimeSpan offset, Span<byte> buffer, out int bytesWritten)
+            {
+                const int MinimumCharsNeeded = 27;
+
+                int charsNeeded = MinimumCharsNeeded;
+                DateTimeKind kind = DateTimeKind.Local;
+
+                if (offset == NullOffset)
+                {
+                    kind = value.Kind;
+                    if (kind == DateTimeKind.Local)
+                    {
+                        offset = TimeZoneInfo.Local.GetUtcOffset(value);
+                        charsNeeded += 6;
+                    }
+                    else if (kind == DateTimeKind.Utc)
+                    {
+                        charsNeeded += 1;
+                    }
                 }
                 else
                 {
-                    Unsafe.Add(ref utf16Bytes, 20) = Plus;
+                    charsNeeded += 6;
                 }
 
-                FormattingHelpers.WriteDigits(offset.Hours, 2, ref utf16Bytes, 21);
-                Unsafe.Add(ref utf16Bytes, 23) = Colon;
-                FormattingHelpers.WriteDigits(offset.Minutes, 2, ref utf16Bytes, 24);
-            }
+                bytesWritten = charsNeeded * sizeof(char);
+                if (buffer.Length < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
 
-            return true;
-        }
+                Span<char> dst = buffer.NonPortableCast<byte, char>();
+                ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
 
-        private static bool TryFormatO(DateTime value, TimeSpan offset, Span<byte> buffer, out int bytesWritten)
-        {
-            const int MinimumCharsNeeded = 27;
+                FormattingHelpers.WriteDigits(value.Year, 4, ref utf16Bytes, 0);
+                Unsafe.Add(ref utf16Bytes, 4) = Minus;
 
-            int charsNeeded = MinimumCharsNeeded;
-            DateTimeKind kind = DateTimeKind.Local;
+                FormattingHelpers.WriteDigits(value.Month, 2, ref utf16Bytes, 5);
+                Unsafe.Add(ref utf16Bytes, 7) = Minus;
 
-            if (offset == NullOffset)
-            {
-                kind = value.Kind;
+                FormattingHelpers.WriteDigits(value.Day, 2, ref utf16Bytes, 8);
+                Unsafe.Add(ref utf16Bytes, 10) = TimeMarker;
+
+                FormattingHelpers.WriteDigits(value.Hour, 2, ref utf16Bytes, 11);
+                Unsafe.Add(ref utf16Bytes, 13) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Minute, 2, ref utf16Bytes, 14);
+                Unsafe.Add(ref utf16Bytes, 16) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Second, 2, ref utf16Bytes, 17);
+                Unsafe.Add(ref utf16Bytes, 19) = Period;
+
+                FormattingHelpers.DivMod(value.Ticks, TimeSpan.TicksPerSecond, out long fraction);
+                FormattingHelpers.WriteFractionDigits(fraction, DefaultFractionDigits, ref utf16Bytes, 20);
+
                 if (kind == DateTimeKind.Local)
                 {
-                    offset = TimeZoneInfo.Local.GetUtcOffset(value);
-                    charsNeeded += 6;
+                    int hours = offset.Hours;
+                    char sign = Plus;
+
+                    if (offset.Hours < 0)
+                    {
+                        hours = -offset.Hours;
+                        sign = Minus;
+                    }
+
+                    Unsafe.Add(ref utf16Bytes, 27) = sign;
+                    FormattingHelpers.WriteDigits(hours, 2, ref utf16Bytes, 28);
+                    Unsafe.Add(ref utf16Bytes, 30) = Colon;
+                    FormattingHelpers.WriteDigits(offset.Minutes, 2, ref utf16Bytes, 31);
                 }
                 else if (kind == DateTimeKind.Utc)
                 {
-                    charsNeeded += 1;
+                    Unsafe.Add(ref utf16Bytes, 27) = UtcMarker;
                 }
-            }
-            else
-            {
-                charsNeeded += 6;
+
+                return true;
             }
 
-            bytesWritten = charsNeeded * sizeof(char);
-            if (buffer.Length < bytesWritten)
+            private static bool TryFormatRfc1123(DateTime value, Span<byte> buffer, out int bytesWritten)
             {
-                bytesWritten = 0;
-                return false;
-            }
+                const int CharsNeeded = 29;
 
-            Span<char> dst = buffer.NonPortableCast<byte, char>();
-            ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
-
-            FormattingHelpers.WriteDigits(value.Year, 4, ref utf16Bytes, 0);
-            Unsafe.Add(ref utf16Bytes, 4) = Minus;
-
-            FormattingHelpers.WriteDigits(value.Month, 2, ref utf16Bytes, 5);
-            Unsafe.Add(ref utf16Bytes, 7) = Minus;
-
-            FormattingHelpers.WriteDigits(value.Day, 2, ref utf16Bytes, 8);
-            Unsafe.Add(ref utf16Bytes, 10) = TimeMarker;
-
-            FormattingHelpers.WriteDigits(value.Hour, 2, ref utf16Bytes, 11);
-            Unsafe.Add(ref utf16Bytes, 13) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Minute, 2, ref utf16Bytes, 14);
-            Unsafe.Add(ref utf16Bytes, 16) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Second, 2, ref utf16Bytes, 17);
-            Unsafe.Add(ref utf16Bytes, 19) = Period;
-
-            FormattingHelpers.DivMod(value.Ticks, TimeSpan.TicksPerSecond, out long fraction);
-            FormattingHelpers.WriteFractionDigits(fraction, DefaultFractionDigits, ref utf16Bytes, 20);
-
-            if (kind == DateTimeKind.Local)
-            {
-                int hours = offset.Hours;
-                char sign = Plus;
-
-                if (offset.Hours < 0)
+                bytesWritten = CharsNeeded * sizeof(char);
+                if (buffer.Length < bytesWritten)
                 {
-                    hours = -offset.Hours;
-                    sign = Minus;
+                    bytesWritten = 0;
+                    return false;
                 }
 
-                Unsafe.Add(ref utf16Bytes, 27) = sign;
-                FormattingHelpers.WriteDigits(hours, 2, ref utf16Bytes, 28);
-                Unsafe.Add(ref utf16Bytes, 30) = Colon;
-                FormattingHelpers.WriteDigits(offset.Minutes, 2, ref utf16Bytes, 31);
+                Span<char> dst = buffer.NonPortableCast<byte, char>();
+                ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
+
+                var dayAbbrev = DayAbbreviations[(int)value.DayOfWeek];
+                Unsafe.Add(ref utf16Bytes, 0) = dayAbbrev[0];
+                Unsafe.Add(ref utf16Bytes, 1) = dayAbbrev[1];
+                Unsafe.Add(ref utf16Bytes, 2) = dayAbbrev[2];
+                Unsafe.Add(ref utf16Bytes, 3) = Comma;
+                Unsafe.Add(ref utf16Bytes, 4) = Space;
+
+                FormattingHelpers.WriteDigits(value.Day, 2, ref utf16Bytes, 5);
+                Unsafe.Add(ref utf16Bytes, 7) = ' ';
+
+                var monthAbbrev = MonthAbbreviations[value.Month - 1];
+                Unsafe.Add(ref utf16Bytes, 8) = monthAbbrev[0];
+                Unsafe.Add(ref utf16Bytes, 9) = monthAbbrev[1];
+                Unsafe.Add(ref utf16Bytes, 10) = monthAbbrev[2];
+                Unsafe.Add(ref utf16Bytes, 11) = Space;
+
+                FormattingHelpers.WriteDigits(value.Year, 4, ref utf16Bytes, 12);
+                Unsafe.Add(ref utf16Bytes, 16) = Space;
+
+                FormattingHelpers.WriteDigits(value.Hour, 2, ref utf16Bytes, 17);
+                Unsafe.Add(ref utf16Bytes, 19) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Minute, 2, ref utf16Bytes, 20);
+                Unsafe.Add(ref utf16Bytes, 22) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Second, 2, ref utf16Bytes, 23);
+                Unsafe.Add(ref utf16Bytes, 25) = Space;
+
+                Unsafe.Add(ref utf16Bytes, 26) = GMT1;
+                Unsafe.Add(ref utf16Bytes, 27) = GMT2;
+                Unsafe.Add(ref utf16Bytes, 28) = GMT3;
+
+                return true;
             }
-            else if (kind == DateTimeKind.Utc)
+
+            private static bool TryFormatRfc1123Lowercase(DateTime value, Span<byte> buffer, out int bytesWritten)
             {
-                Unsafe.Add(ref utf16Bytes, 27) = UtcMarker;
+                const int CharsNeeded = 29;
+
+                bytesWritten = CharsNeeded * sizeof(char);
+                if (buffer.Length < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                Span<char> dst = buffer.NonPortableCast<byte, char>();
+                ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
+
+                var dayAbbrev = DayAbbreviationsLowercase[(int)value.DayOfWeek];
+                Unsafe.Add(ref utf16Bytes, 0) = dayAbbrev[0];
+                Unsafe.Add(ref utf16Bytes, 1) = dayAbbrev[1];
+                Unsafe.Add(ref utf16Bytes, 2) = dayAbbrev[2];
+                Unsafe.Add(ref utf16Bytes, 3) = Comma;
+                Unsafe.Add(ref utf16Bytes, 4) = Space;
+
+                FormattingHelpers.WriteDigits(value.Day, 2, ref utf16Bytes, 5);
+                Unsafe.Add(ref utf16Bytes, 7) = ' ';
+
+                var monthAbbrev = MonthAbbreviationsLowercase[value.Month - 1];
+                Unsafe.Add(ref utf16Bytes, 8) = monthAbbrev[0];
+                Unsafe.Add(ref utf16Bytes, 9) = monthAbbrev[1];
+                Unsafe.Add(ref utf16Bytes, 10) = monthAbbrev[2];
+                Unsafe.Add(ref utf16Bytes, 11) = Space;
+
+                FormattingHelpers.WriteDigits(value.Year, 4, ref utf16Bytes, 12);
+                Unsafe.Add(ref utf16Bytes, 16) = Space;
+
+                FormattingHelpers.WriteDigits(value.Hour, 2, ref utf16Bytes, 17);
+                Unsafe.Add(ref utf16Bytes, 19) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Minute, 2, ref utf16Bytes, 20);
+                Unsafe.Add(ref utf16Bytes, 22) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Second, 2, ref utf16Bytes, 23);
+                Unsafe.Add(ref utf16Bytes, 25) = Space;
+
+                Unsafe.Add(ref utf16Bytes, 26) = GMT1Lowercase;
+                Unsafe.Add(ref utf16Bytes, 27) = GMT2Lowercase;
+                Unsafe.Add(ref utf16Bytes, 28) = GMT3Lowercase;
+
+                return true;
             }
 
-            return true;
-        }
-
-        private static bool TryFormatRfc1123(DateTime value, Span<byte> buffer, out int bytesWritten)
-        {
-            const int CharsNeeded = 29;
-
-            bytesWritten = CharsNeeded * sizeof(char);
-            if (buffer.Length < bytesWritten)
+            private static bool TryFormatTimeSpan(TimeSpan value, char format, Span<byte> buffer, out int bytesWritten)
             {
-                bytesWritten = 0;
-                return false;
+                bool longForm = (format == 'G');
+                bool constant = (format == 't' || format == 'T' || format == 'c');
+
+                long ticks = value.Ticks;
+                int days = (int)FormattingHelpers.DivMod(ticks, TimeSpan.TicksPerDay, out long timeLeft);
+
+                bool showSign = false;
+                if (ticks < 0)
+                {
+                    showSign = true;
+                    days = -days;
+                    timeLeft = -timeLeft;
+                }
+
+                int hours = (int)FormattingHelpers.DivMod(timeLeft, TimeSpan.TicksPerHour, out timeLeft);
+                int minutes = (int)FormattingHelpers.DivMod(timeLeft, TimeSpan.TicksPerMinute, out timeLeft);
+                int seconds = (int)FormattingHelpers.DivMod(timeLeft, TimeSpan.TicksPerSecond, out long fraction);
+
+                int dayDigits = 0;
+                int hourDigits = (constant || longForm || hours > 9) ? 2 : 1;
+                int fractionDigits = 0;
+
+                bytesWritten = hourDigits + 6; // [h]h:mm:ss
+                if (showSign)
+                    bytesWritten += 1;  // [-]
+                if (longForm || days > 0)
+                {
+                    dayDigits = FormattingHelpers.CountDigits(days);
+                    bytesWritten += dayDigits + 1; // [d'.']
+                }
+                if (longForm || fraction > 0)
+                {
+                    fractionDigits = (longForm || constant) ? DefaultFractionDigits : FormattingHelpers.CountFractionDigits(fraction);
+                    bytesWritten += fractionDigits + 1; // ['.'fffffff] or ['.'FFFFFFF] for short-form
+                }
+
+                bytesWritten *= sizeof(char);
+                if (buffer.Length < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                Span<char> dst = buffer.NonPortableCast<byte, char>();
+                ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
+                int idx = 0;
+
+                if (showSign)
+                    Unsafe.Add(ref utf16Bytes, idx++) = Minus;
+
+                if (dayDigits > 0)
+                {
+                    idx += FormattingHelpers.WriteDigits(days, dayDigits, ref utf16Bytes, idx);
+                    Unsafe.Add(ref utf16Bytes, idx++) = constant ? Period : Colon;
+                }
+
+                idx += FormattingHelpers.WriteDigits(hours, hourDigits, ref utf16Bytes, idx);
+                Unsafe.Add(ref utf16Bytes, idx++) = Colon;
+
+                idx += FormattingHelpers.WriteDigits(minutes, 2, ref utf16Bytes, idx);
+                Unsafe.Add(ref utf16Bytes, idx++) = Colon;
+
+                idx += FormattingHelpers.WriteDigits(seconds, 2, ref utf16Bytes, idx);
+
+                if (fractionDigits > 0)
+                {
+                    Unsafe.Add(ref utf16Bytes, idx++) = Period;
+                    idx += FormattingHelpers.WriteFractionDigits(fraction, fractionDigits, ref utf16Bytes, idx);
+                }
+
+                return true;
             }
-
-            Span<char> dst = buffer.NonPortableCast<byte, char>();
-            ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
-
-            var dayAbbrev = DayAbbreviations[(int)value.DayOfWeek];
-            Unsafe.Add(ref utf16Bytes, 0) = dayAbbrev[0];
-            Unsafe.Add(ref utf16Bytes, 1) = dayAbbrev[1];
-            Unsafe.Add(ref utf16Bytes, 2) = dayAbbrev[2];
-            Unsafe.Add(ref utf16Bytes, 3) = Comma;
-            Unsafe.Add(ref utf16Bytes, 4) = Space;
-
-            FormattingHelpers.WriteDigits(value.Day, 2, ref utf16Bytes, 5);
-            Unsafe.Add(ref utf16Bytes, 7) = ' ';
-
-            var monthAbbrev = MonthAbbreviations[value.Month - 1];
-            Unsafe.Add(ref utf16Bytes, 8) = monthAbbrev[0];
-            Unsafe.Add(ref utf16Bytes, 9) = monthAbbrev[1];
-            Unsafe.Add(ref utf16Bytes, 10) = monthAbbrev[2];
-            Unsafe.Add(ref utf16Bytes, 11) = Space;
-
-            FormattingHelpers.WriteDigits(value.Year, 4, ref utf16Bytes, 12);
-            Unsafe.Add(ref utf16Bytes, 16) = Space;
-
-            FormattingHelpers.WriteDigits(value.Hour, 2, ref utf16Bytes, 17);
-            Unsafe.Add(ref utf16Bytes, 19) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Minute, 2, ref utf16Bytes, 20);
-            Unsafe.Add(ref utf16Bytes, 22) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Second, 2, ref utf16Bytes, 23);
-            Unsafe.Add(ref utf16Bytes, 25) = Space;
-
-            Unsafe.Add(ref utf16Bytes, 26) = GMT1;
-            Unsafe.Add(ref utf16Bytes, 27) = GMT2;
-            Unsafe.Add(ref utf16Bytes, 28) = GMT3;
-
-            return true;
-        }
-
-        private static bool TryFormatRfc1123Lowercase(DateTime value, Span<byte> buffer, out int bytesWritten)
-        {
-            const int CharsNeeded = 29;
-
-            bytesWritten = CharsNeeded * sizeof(char);
-            if (buffer.Length < bytesWritten)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            Span<char> dst = buffer.NonPortableCast<byte, char>();
-            ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
-
-            var dayAbbrev = DayAbbreviationsLowercase[(int)value.DayOfWeek];
-            Unsafe.Add(ref utf16Bytes, 0) = dayAbbrev[0];
-            Unsafe.Add(ref utf16Bytes, 1) = dayAbbrev[1];
-            Unsafe.Add(ref utf16Bytes, 2) = dayAbbrev[2];
-            Unsafe.Add(ref utf16Bytes, 3) = Comma;
-            Unsafe.Add(ref utf16Bytes, 4) = Space;
-
-            FormattingHelpers.WriteDigits(value.Day, 2, ref utf16Bytes, 5);
-            Unsafe.Add(ref utf16Bytes, 7) = ' ';
-
-            var monthAbbrev = MonthAbbreviationsLowercase[value.Month - 1];
-            Unsafe.Add(ref utf16Bytes, 8) = monthAbbrev[0];
-            Unsafe.Add(ref utf16Bytes, 9) = monthAbbrev[1];
-            Unsafe.Add(ref utf16Bytes, 10) = monthAbbrev[2];
-            Unsafe.Add(ref utf16Bytes, 11) = Space;
-
-            FormattingHelpers.WriteDigits(value.Year, 4, ref utf16Bytes, 12);
-            Unsafe.Add(ref utf16Bytes, 16) = Space;
-
-            FormattingHelpers.WriteDigits(value.Hour, 2, ref utf16Bytes, 17);
-            Unsafe.Add(ref utf16Bytes, 19) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Minute, 2, ref utf16Bytes, 20);
-            Unsafe.Add(ref utf16Bytes, 22) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Second, 2, ref utf16Bytes, 23);
-            Unsafe.Add(ref utf16Bytes, 25) = Space;
-
-            Unsafe.Add(ref utf16Bytes, 26) = GMT1Lowercase;
-            Unsafe.Add(ref utf16Bytes, 27) = GMT2Lowercase;
-            Unsafe.Add(ref utf16Bytes, 28) = GMT3Lowercase;
-
-            return true;
-        }
-
-        private static bool TryFormatTimeSpan(TimeSpan value, char format, Span<byte> buffer, out int bytesWritten)
-        {
-            bool longForm = (format == 'G');
-            bool constant = (format == 't' || format == 'T' || format == 'c');
-
-            long ticks = value.Ticks;
-            int days = (int)FormattingHelpers.DivMod(ticks, TimeSpan.TicksPerDay, out long timeLeft);
-
-            bool showSign = false;
-            if (ticks < 0)
-            {
-                showSign = true;
-                days = -days;
-                timeLeft = -timeLeft;
-            }
-
-            int hours = (int)FormattingHelpers.DivMod(timeLeft, TimeSpan.TicksPerHour, out timeLeft);
-            int minutes = (int)FormattingHelpers.DivMod(timeLeft, TimeSpan.TicksPerMinute, out timeLeft);
-            int seconds = (int)FormattingHelpers.DivMod(timeLeft, TimeSpan.TicksPerSecond, out long fraction);
-
-            int dayDigits = 0;
-            int hourDigits = (constant || longForm || hours > 9) ? 2 : 1;
-            int fractionDigits = 0;
-
-            bytesWritten = hourDigits + 6; // [h]h:mm:ss
-            if (showSign)
-                bytesWritten += 1;  // [-]
-            if (longForm || days > 0)
-            {
-                dayDigits = FormattingHelpers.CountDigits(days);
-                bytesWritten += dayDigits + 1; // [d'.']
-            }
-            if (longForm || fraction > 0)
-            {
-                fractionDigits = (longForm || constant) ? DefaultFractionDigits : FormattingHelpers.CountFractionDigits(fraction);
-                bytesWritten += fractionDigits + 1; // ['.'fffffff] or ['.'FFFFFFF] for short-form
-            }
-
-            bytesWritten *= sizeof(char);
-            if (buffer.Length < bytesWritten)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            Span<char> dst = buffer.NonPortableCast<byte, char>();
-            ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
-            int idx = 0;
-
-            if (showSign)
-                Unsafe.Add(ref utf16Bytes, idx++) = Minus;
-
-            if (dayDigits > 0)
-            {
-                idx += FormattingHelpers.WriteDigits(days, dayDigits, ref utf16Bytes, idx);
-                Unsafe.Add(ref utf16Bytes, idx++) = constant ? Period : Colon;
-            }
-
-            idx += FormattingHelpers.WriteDigits(hours, hourDigits, ref utf16Bytes, idx);
-            Unsafe.Add(ref utf16Bytes, idx++) = Colon;
-
-            idx += FormattingHelpers.WriteDigits(minutes, 2, ref utf16Bytes, idx);
-            Unsafe.Add(ref utf16Bytes, idx++) = Colon;
-
-            idx += FormattingHelpers.WriteDigits(seconds, 2, ref utf16Bytes, idx);
-
-            if (fractionDigits > 0)
-            {
-                Unsafe.Add(ref utf16Bytes, idx++) = Period;
-                idx += FormattingHelpers.WriteFractionDigits(fraction, fractionDigits, ref utf16Bytes, idx);
-            }
-
-            return true;
         }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Formatters/Utf16.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Utf16.cs
@@ -1,192 +1,198 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text.Formatters
+using System.Buffers.Text;
+using System.Text;
+
+namespace System.Buffers
 {
-    public static partial class Utf16
+    public static partial class Formatters
     {
-        #region Common constants
-
-        private const char Colon = ':';
-        private const char Comma = ',';
-        private const char Minus = '-';
-        private const char Period = '.';
-        private const char Plus = '+';
-        private const char Slash = '/';
-        private const char Space = ' ';
-
-        #endregion Common constants
-
-        #region Date / Time APIs
-
-        public static bool TryFormat(DateTimeOffset value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+        public static partial class Utf16
         {
-            TimeSpan offset = NullOffset;
-            char symbol = format.Symbol;
-            if (format.IsDefault)
+            #region Common constants
+
+            private const char Colon = ':';
+            private const char Comma = ',';
+            private const char Minus = '-';
+            private const char Period = '.';
+            private const char Plus = '+';
+            private const char Slash = '/';
+            private const char Space = ' ';
+
+            #endregion Common constants
+
+            #region Date / Time APIs
+
+            public static bool TryFormat(DateTimeOffset value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
             {
-                symbol = 'G';
-                offset = value.Offset;
+                TimeSpan offset = NullOffset;
+                char symbol = format.Symbol;
+                if (format.IsDefault)
+                {
+                    symbol = 'G';
+                    offset = value.Offset;
+                }
+
+                switch (symbol)
+                {
+                    case 'R':
+                        return TryFormatRfc1123(value.UtcDateTime, buffer, out bytesWritten);
+
+                    case 'l':
+                        return TryFormatRfc1123Lowercase(value.UtcDateTime, buffer, out bytesWritten);
+
+                    case 'O':
+                        return TryFormatO(value.DateTime, value.Offset, buffer, out bytesWritten);
+
+                    case 'G':
+                        return TryFormatG(value.DateTime, offset, buffer, out bytesWritten);
+
+                    default:
+                        throw new NotSupportedException();
+                }
             }
 
-            switch (symbol)
+            public static bool TryFormat(DateTime value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
             {
-                case 'R':
-                    return TryFormatRfc1123(value.UtcDateTime, buffer, out bytesWritten);
+                char symbol = format.IsDefault ? 'G' : format.Symbol;
 
-                case 'l':
-                    return TryFormatRfc1123Lowercase(value.UtcDateTime, buffer, out bytesWritten);
+                switch (symbol)
+                {
+                    case 'R':
+                        return TryFormatRfc1123(value, buffer, out bytesWritten);
 
-                case 'O':
-                    return TryFormatO(value.DateTime, value.Offset, buffer, out bytesWritten);
+                    case 'l':
+                        return TryFormatRfc1123Lowercase(value, buffer, out bytesWritten);
 
-                case 'G':
-                    return TryFormatG(value.DateTime, offset, buffer, out bytesWritten);
+                    case 'O':
+                        return TryFormatO(value, NullOffset, buffer, out bytesWritten);
 
-                default:
-                    throw new NotSupportedException();
+                    case 'G':
+                        return TryFormatG(value, NullOffset, buffer, out bytesWritten);
+
+                    default:
+                        throw new NotSupportedException();
+                }
             }
+
+            public static bool TryFormat(TimeSpan value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+            {
+                char symbol = format.IsDefault ? 'c' : format.Symbol;
+
+                switch (symbol)
+                {
+                    case 'G':
+                    case 'g':
+                    case 'c':
+                    case 't':
+                    case 'T':
+                        return TryFormatTimeSpan(value, symbol, buffer, out bytesWritten);
+
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+
+            #endregion Date / Time APIs
+
+            #region Integer APIs
+
+            public static bool TryFormat(byte value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, buffer, out bytesWritten, format);
+
+            public static bool TryFormat(sbyte value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, 0xff, buffer, out bytesWritten, format);
+
+            public static bool TryFormat(ushort value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, buffer, out bytesWritten, format);
+
+            public static bool TryFormat(short value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, 0xffff, buffer, out bytesWritten, format);
+
+            public static bool TryFormat(uint value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, buffer, out bytesWritten, format);
+
+            public static bool TryFormat(int value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, 0xffffffff, buffer, out bytesWritten, format);
+
+            public static bool TryFormat(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, buffer, out bytesWritten, format);
+
+            public static bool TryFormat(long value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, 0xffffffffffffffff, buffer, out bytesWritten, format);
+
+            static bool TryFormatCore(long value, ulong mask, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
+            {
+                if (format.IsDefault)
+                {
+                    format = 'G';
+                }
+
+                switch (format.Symbol)
+                {
+                    case 'd':
+                    case 'D':
+                    case 'G':
+                    case 'g':
+                        return TryFormatDecimalInt64(value, format.Precision, buffer, out bytesWritten);
+
+                    case 'n':
+                    case 'N':
+                        return TryFormatNumericInt64(value, format.Precision, buffer, out bytesWritten);
+
+                    case 'x':
+                        return TryFormatHexUInt64((ulong)value & mask, format.Precision, true, buffer, out bytesWritten);
+
+                    case 'X':
+                        return TryFormatHexUInt64((ulong)value & mask, format.Precision, false, buffer, out bytesWritten);
+
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+
+            static bool TryFormatCore(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
+            {
+                if (format.IsDefault)
+                {
+                    format = 'G';
+                }
+
+                switch (format.Symbol)
+                {
+                    case 'd':
+                    case 'D':
+                    case 'G':
+                    case 'g':
+                        return TryFormatDecimalUInt64(value, format.Precision, buffer, out bytesWritten);
+
+                    case 'n':
+                    case 'N':
+                        return TryFormatNumericUInt64(value, format.Precision, buffer, out bytesWritten);
+
+                    case 'x':
+                        return TryFormatHexUInt64(value, format.Precision, true, buffer, out bytesWritten);
+
+                    case 'X':
+                        return TryFormatHexUInt64(value, format.Precision, false, buffer, out bytesWritten);
+
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+
+            #endregion Integer APIs
+
+            #region Floating-point APIs
+
+            public static bool TryFormat(double value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => Custom.TryFormat(value, buffer, out bytesWritten, format, SymbolTable.InvariantUtf8);
+
+            public static bool TryFormat(float value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => Custom.TryFormat(value, buffer, out bytesWritten, format, SymbolTable.InvariantUtf8);
+
+            #endregion Floating-point APIs
         }
-
-        public static bool TryFormat(DateTime value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-        {
-            char symbol = format.IsDefault ? 'G' : format.Symbol;
-
-            switch (symbol)
-            {
-                case 'R':
-                    return TryFormatRfc1123(value, buffer, out bytesWritten);
-
-                case 'l':
-                    return TryFormatRfc1123Lowercase(value, buffer, out bytesWritten);
-
-                case 'O':
-                    return TryFormatO(value, NullOffset, buffer, out bytesWritten);
-
-                case 'G':
-                    return TryFormatG(value, NullOffset, buffer, out bytesWritten);
-
-                default:
-                    throw new NotSupportedException();
-            }
-        }
-
-        public static bool TryFormat(TimeSpan value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-        {
-            char symbol = format.IsDefault ? 'c' : format.Symbol;
-
-            switch (symbol)
-            {
-                case 'G':
-                case 'g':
-                case 'c':
-                case 't':
-                case 'T':
-                    return TryFormatTimeSpan(value, symbol, buffer, out bytesWritten);
-
-                default:
-                    throw new NotSupportedException();
-            }
-        }
-
-        #endregion Date / Time APIs
-
-        #region Integer APIs
-
-        public static bool TryFormat(byte value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, buffer, out bytesWritten, format);
-
-        public static bool TryFormat(sbyte value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, 0xff, buffer, out bytesWritten, format);
-
-        public static bool TryFormat(ushort value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, buffer, out bytesWritten, format);
-
-        public static bool TryFormat(short value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, 0xffff, buffer, out bytesWritten, format);
-
-        public static bool TryFormat(uint value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, buffer, out bytesWritten, format);
-
-        public static bool TryFormat(int value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, 0xffffffff, buffer, out bytesWritten, format);
-
-        public static bool TryFormat(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, buffer, out bytesWritten, format);
-
-        public static bool TryFormat(long value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, 0xffffffffffffffff, buffer, out bytesWritten, format);
-
-        static bool TryFormatCore(long value, ulong mask, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
-        {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
-            switch (format.Symbol)
-            {
-                case 'd':
-                case 'D':
-                case 'G':
-                case 'g':
-                    return TryFormatDecimalInt64(value, format.Precision, buffer, out bytesWritten);
-
-                case 'n':
-                case 'N':
-                    return TryFormatNumericInt64(value, format.Precision, buffer, out bytesWritten);
-
-                case 'x':
-                    return TryFormatHexUInt64((ulong)value & mask, format.Precision, true, buffer, out bytesWritten);
-
-                case 'X':
-                    return TryFormatHexUInt64((ulong)value & mask, format.Precision, false, buffer, out bytesWritten);
-
-                default:
-                    throw new NotSupportedException();
-            }
-        }
-
-        static bool TryFormatCore(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
-        {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
-            switch (format.Symbol)
-            {
-                case 'd':
-                case 'D':
-                case 'G':
-                case 'g':
-                    return TryFormatDecimalUInt64(value, format.Precision, buffer, out bytesWritten);
-
-                case 'n':
-                case 'N':
-                    return TryFormatNumericUInt64(value, format.Precision, buffer, out bytesWritten);
-
-                case 'x':
-                    return TryFormatHexUInt64(value, format.Precision, true, buffer, out bytesWritten);
-
-                case 'X':
-                    return TryFormatHexUInt64(value, format.Precision, false, buffer, out bytesWritten);
-
-                default:
-                    throw new NotSupportedException();
-            }
-        }
-
-        #endregion Integer APIs
-
-        #region Floating-point APIs
-
-        public static bool TryFormat(this double value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => Custom.TryFormat(value, buffer, out bytesWritten, format, SymbolTable.InvariantUtf8);
-
-        public static bool TryFormat(this float value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => Custom.TryFormat(value, buffer, out bytesWritten, format, SymbolTable.InvariantUtf8);
-
-        #endregion Floating-point APIs
     }
 }

--- a/src/System.Text.Primitives/System/Text/Formatters/Utf8.Guid.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Utf8.Guid.cs
@@ -2,90 +2,94 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
+using System.Text;
 
-namespace System.Text.Formatters
+namespace System.Buffers
 {
-    public static partial class Utf8
+    public static partial class Formatters
     {
-        #region Constants
-
-        private const int GuidChars = 32;
-
-        private const byte OpenBrace = (byte)'{';
-        private const byte CloseBrace = (byte)'}';
-
-        private const byte OpenParen = (byte)'(';
-        private const byte CloseParen = (byte)')';
-
-        private const byte Dash = (byte)'-';
-
-        #endregion Constants
-
-        public static unsafe bool TryFormat(Guid value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+        public static partial class Utf8
         {
-            bool dash = format.Symbol != 'N';
-            bool bookEnds = (format.Symbol == 'B') || (format.Symbol == 'P');
+            #region Constants
 
-            bytesWritten = GuidChars + (dash ? 4 : 0) + (bookEnds ? 2 : 0);
-            if (buffer.Length < bytesWritten)
+            private const int GuidChars = 32;
+
+            private const byte OpenBrace = (byte)'{';
+            private const byte CloseBrace = (byte)'}';
+
+            private const byte OpenParen = (byte)'(';
+            private const byte CloseParen = (byte)')';
+
+            private const byte Dash = (byte)'-';
+
+            #endregion Constants
+
+            public static unsafe bool TryFormat(Guid value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
             {
-                bytesWritten = 0;
-                return false;
+                bool dash = format.Symbol != 'N';
+                bool bookEnds = (format.Symbol == 'B') || (format.Symbol == 'P');
+
+                bytesWritten = GuidChars + (dash ? 4 : 0) + (bookEnds ? 2 : 0);
+                if (buffer.Length < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
+                byte* bytes = (byte*)&value;
+                int idx = 0;
+
+                if (bookEnds && format.Symbol == 'B')
+                    Unsafe.Add(ref utf8Bytes, idx++) = OpenBrace;
+                else if (bookEnds && format.Symbol == (byte)'P')
+                    Unsafe.Add(ref utf8Bytes, idx++) = OpenParen;
+
+                FormattingHelpers.WriteHexByte(bytes[3], ref utf8Bytes, idx);
+                FormattingHelpers.WriteHexByte(bytes[2], ref utf8Bytes, idx + 2);
+                FormattingHelpers.WriteHexByte(bytes[1], ref utf8Bytes, idx + 4);
+                FormattingHelpers.WriteHexByte(bytes[0], ref utf8Bytes, idx + 6);
+                idx += 8;
+
+                if (dash)
+                    Unsafe.Add(ref utf8Bytes, idx++) = Dash;
+
+                FormattingHelpers.WriteHexByte(bytes[5], ref utf8Bytes, idx);
+                FormattingHelpers.WriteHexByte(bytes[4], ref utf8Bytes, idx + 2);
+                idx += 4;
+
+                if (dash)
+                    Unsafe.Add(ref utf8Bytes, idx++) = Dash;
+
+                FormattingHelpers.WriteHexByte(bytes[7], ref utf8Bytes, idx);
+                FormattingHelpers.WriteHexByte(bytes[6], ref utf8Bytes, idx + 2);
+                idx += 4;
+
+                if (dash)
+                    Unsafe.Add(ref utf8Bytes, idx++) = Dash;
+
+                FormattingHelpers.WriteHexByte(bytes[8], ref utf8Bytes, idx);
+                FormattingHelpers.WriteHexByte(bytes[9], ref utf8Bytes, idx + 2);
+                idx += 4;
+
+                if (dash)
+                    Unsafe.Add(ref utf8Bytes, idx++) = Dash;
+
+                FormattingHelpers.WriteHexByte(bytes[10], ref utf8Bytes, idx);
+                FormattingHelpers.WriteHexByte(bytes[11], ref utf8Bytes, idx + 2);
+                FormattingHelpers.WriteHexByte(bytes[12], ref utf8Bytes, idx + 4);
+                FormattingHelpers.WriteHexByte(bytes[13], ref utf8Bytes, idx + 6);
+                FormattingHelpers.WriteHexByte(bytes[14], ref utf8Bytes, idx + 8);
+                FormattingHelpers.WriteHexByte(bytes[15], ref utf8Bytes, idx + 10);
+                idx += 12;
+
+                if (bookEnds && format.Symbol == 'B')
+                    Unsafe.Add(ref utf8Bytes, idx++) = CloseBrace;
+                else if (bookEnds && format.Symbol == 'P')
+                    Unsafe.Add(ref utf8Bytes, idx++) = CloseParen;
+
+                return true;
             }
-
-            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
-            byte* bytes = (byte*)&value;
-            int idx = 0;
-
-            if (bookEnds && format.Symbol == 'B')
-                Unsafe.Add(ref utf8Bytes, idx++) = OpenBrace;
-            else if (bookEnds && format.Symbol == (byte)'P')
-                Unsafe.Add(ref utf8Bytes, idx++) = OpenParen;
-
-            FormattingHelpers.WriteHexByte(bytes[3], ref utf8Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[2], ref utf8Bytes, idx + 2);
-            FormattingHelpers.WriteHexByte(bytes[1], ref utf8Bytes, idx + 4);
-            FormattingHelpers.WriteHexByte(bytes[0], ref utf8Bytes, idx + 6);
-            idx += 8;
-
-            if (dash)
-                Unsafe.Add(ref utf8Bytes, idx++) = Dash;
-
-            FormattingHelpers.WriteHexByte(bytes[5], ref utf8Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[4], ref utf8Bytes, idx + 2);
-            idx += 4;
-
-            if (dash)
-                Unsafe.Add(ref utf8Bytes, idx++) = Dash;
-
-            FormattingHelpers.WriteHexByte(bytes[7], ref utf8Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[6], ref utf8Bytes, idx + 2);
-            idx += 4;
-
-            if (dash)
-                Unsafe.Add(ref utf8Bytes, idx++) = Dash;
-
-            FormattingHelpers.WriteHexByte(bytes[8], ref utf8Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[9], ref utf8Bytes, idx + 2);
-            idx += 4;
-
-            if (dash)
-                Unsafe.Add(ref utf8Bytes, idx++) = Dash;
-
-            FormattingHelpers.WriteHexByte(bytes[10], ref utf8Bytes, idx);
-            FormattingHelpers.WriteHexByte(bytes[11], ref utf8Bytes, idx + 2);
-            FormattingHelpers.WriteHexByte(bytes[12], ref utf8Bytes, idx + 4);
-            FormattingHelpers.WriteHexByte(bytes[13], ref utf8Bytes, idx + 6);
-            FormattingHelpers.WriteHexByte(bytes[14], ref utf8Bytes, idx + 8);
-            FormattingHelpers.WriteHexByte(bytes[15], ref utf8Bytes, idx + 10);
-            idx += 12;
-
-            if (bookEnds && format.Symbol == 'B')
-                Unsafe.Add(ref utf8Bytes, idx++) = CloseBrace;
-            else if (bookEnds && format.Symbol == 'P')
-                Unsafe.Add(ref utf8Bytes, idx++) = CloseParen;
-
-            return true;
         }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Formatters/Utf8.Integer.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Utf8.Integer.cs
@@ -2,251 +2,255 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
+using System.Text;
 
-namespace System.Text.Formatters
+namespace System.Buffers
 {
-    public static partial class Utf8
+    public static partial class Formatters
     {
-        #region Constants
-
-        private const byte Seperator = (byte)',';
-
-        // Invariant formatting uses groups of 3 for each number group seperated by commas.
-        //   ex. 1,234,567,890
-        private const int GroupSize = 3;
-
-        #endregion Constants
-
-        private static bool TryFormatDecimalInt64(long value, byte precision, Span<byte> buffer, out int bytesWritten)
+        public static partial class Utf8
         {
-            int digitCount = FormattingHelpers.CountDigits(value);
-            int bytesNeeded = digitCount + (int)((value >> 63) & 1);
+            #region Constants
 
-            if (buffer.Length < bytesNeeded)
+            private const byte Seperator = (byte)',';
+
+            // Invariant formatting uses groups of 3 for each number group seperated by commas.
+            //   ex. 1,234,567,890
+            private const int GroupSize = 3;
+
+            #endregion Constants
+
+            private static bool TryFormatDecimalInt64(long value, byte precision, Span<byte> buffer, out int bytesWritten)
             {
-                bytesWritten = 0;
-                return false;
-            }
+                int digitCount = FormattingHelpers.CountDigits(value);
+                int bytesNeeded = digitCount + (int)((value >> 63) & 1);
 
-            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
-            int idx = 0;
-
-            if (value < 0)
-            {
-                Unsafe.Add(ref utf8Bytes, idx++) = Minus;
-
-                // Abs(long.MinValue) == long.MaxValue + 1, so we need to re-route to unsigned to handle value
-                if (value == long.MinValue)
+                if (buffer.Length < bytesNeeded)
                 {
-                    if (!TryFormatDecimalUInt64((ulong)long.MaxValue + 1, precision, buffer.Slice(1), out bytesWritten))
-                        return false;
-
-                    bytesWritten += 1; // Add the minus sign
-                    return true;
+                    bytesWritten = 0;
+                    return false;
                 }
 
-                value = -value;
-            }
+                ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
+                int idx = 0;
 
-            if (precision != ParsedFormat.NoPrecision)
-            {
-                int leadingZeros = (int)precision - digitCount;
-                while (leadingZeros-- > 0)
-                    Unsafe.Add(ref utf8Bytes, idx++) = (byte)'0';
-            }
-
-            idx += FormattingHelpers.WriteDigits(value, digitCount, ref utf8Bytes, idx);
-
-            bytesWritten = idx;
-            return true;
-        }
-
-        private static bool TryFormatDecimalUInt64(ulong value, byte precision, Span<byte> buffer, out int bytesWritten)
-        {
-            if (value <= long.MaxValue)
-                return TryFormatDecimalInt64((long)value, precision, buffer, out bytesWritten);
-
-            // Remove a single digit from the number. This will get it below long.MaxValue
-            // Then we call the faster long version and follow-up with writing the last
-            // digit. This ends up being faster by a factor of 2 than to just do the entire
-            // operation using the unsigned versions.
-            value = FormattingHelpers.DivMod(value, 10, out ulong lastDigit);
-
-            if (precision != ParsedFormat.NoPrecision && precision > 0)
-                precision -= 1;
-
-            if (!TryFormatDecimalInt64((long)value, precision, buffer, out bytesWritten))
-                return false;
-
-            if (buffer.Length - 1 < bytesWritten)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
-            bytesWritten += FormattingHelpers.WriteDigits(lastDigit, 1, ref utf8Bytes, bytesWritten);
-            return true;
-        }
-
-        private static bool TryFormatNumericInt64(long value, byte precision, Span<byte> buffer, out int bytesWritten)
-        {
-            int digitCount = FormattingHelpers.CountDigits(value);
-            int groupSeperators = (int)FormattingHelpers.DivMod(digitCount, GroupSize, out long firstGroup);
-            if (firstGroup == 0)
-            {
-                firstGroup = 3;
-                groupSeperators--;
-            }
-
-            int trailingZeros = (precision == ParsedFormat.NoPrecision) ? 2 : precision;
-            int idx = (int)((value >> 63) & 1) + digitCount + groupSeperators;
-
-            bytesWritten = idx;
-            if (trailingZeros > 0)
-                bytesWritten += trailingZeros + 1; // +1 for period.
-
-            if (buffer.Length < bytesWritten)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
-            long v = value;
-
-            if (v < 0)
-            {
-                Unsafe.Add(ref utf8Bytes, 0) = Minus;
-
-                // Abs(long.MinValue) == long.MaxValue + 1, so we need to re-route to unsigned to handle value
-                if (v == long.MinValue)
+                if (value < 0)
                 {
-                    if (!TryFormatNumericUInt64((ulong)long.MaxValue + 1, precision, buffer.Slice(1), out bytesWritten))
-                        return false;
+                    Unsafe.Add(ref utf8Bytes, idx++) = Minus;
 
-                    bytesWritten += 1; // Add the minus sign
-                    return true;
+                    // Abs(long.MinValue) == long.MaxValue + 1, so we need to re-route to unsigned to handle value
+                    if (value == long.MinValue)
+                    {
+                        if (!TryFormatDecimalUInt64((ulong)long.MaxValue + 1, precision, buffer.Slice(1), out bytesWritten))
+                            return false;
+
+                        bytesWritten += 1; // Add the minus sign
+                        return true;
+                    }
+
+                    value = -value;
                 }
 
-                v = -v;
+                if (precision != ParsedFormat.NoPrecision)
+                {
+                    int leadingZeros = (int)precision - digitCount;
+                    while (leadingZeros-- > 0)
+                        Unsafe.Add(ref utf8Bytes, idx++) = (byte)'0';
+                }
+
+                idx += FormattingHelpers.WriteDigits(value, digitCount, ref utf8Bytes, idx);
+
+                bytesWritten = idx;
+                return true;
             }
 
-            // Write out the trailing zeros
-            if (trailingZeros > 0)
+            private static bool TryFormatDecimalUInt64(ulong value, byte precision, Span<byte> buffer, out int bytesWritten)
             {
-                Unsafe.Add(ref utf8Bytes, idx) = Period;
-                FormattingHelpers.WriteDigits(0, trailingZeros, ref utf8Bytes, idx + 1);
+                if (value <= long.MaxValue)
+                    return TryFormatDecimalInt64((long)value, precision, buffer, out bytesWritten);
+
+                // Remove a single digit from the number. This will get it below long.MaxValue
+                // Then we call the faster long version and follow-up with writing the last
+                // digit. This ends up being faster by a factor of 2 than to just do the entire
+                // operation using the unsigned versions.
+                value = FormattingHelpers.DivMod(value, 10, out ulong lastDigit);
+
+                if (precision != ParsedFormat.NoPrecision && precision > 0)
+                    precision -= 1;
+
+                if (!TryFormatDecimalInt64((long)value, precision, buffer, out bytesWritten))
+                    return false;
+
+                if (buffer.Length - 1 < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
+                bytesWritten += FormattingHelpers.WriteDigits(lastDigit, 1, ref utf8Bytes, bytesWritten);
+                return true;
             }
 
-            // Starting from the back, write each group of digits except the first group
-            while (digitCount > 3)
+            private static bool TryFormatNumericInt64(long value, byte precision, Span<byte> buffer, out int bytesWritten)
             {
-                digitCount -= 3;
-                idx -= 3;
-                v = FormattingHelpers.DivMod(v, 1000, out long groupValue);
-                FormattingHelpers.WriteDigits(groupValue, 3, ref utf8Bytes, idx);
-                Unsafe.Add(ref utf8Bytes, --idx) = Seperator;
+                int digitCount = FormattingHelpers.CountDigits(value);
+                int groupSeperators = (int)FormattingHelpers.DivMod(digitCount, GroupSize, out long firstGroup);
+                if (firstGroup == 0)
+                {
+                    firstGroup = 3;
+                    groupSeperators--;
+                }
+
+                int trailingZeros = (precision == ParsedFormat.NoPrecision) ? 2 : precision;
+                int idx = (int)((value >> 63) & 1) + digitCount + groupSeperators;
+
+                bytesWritten = idx;
+                if (trailingZeros > 0)
+                    bytesWritten += trailingZeros + 1; // +1 for period.
+
+                if (buffer.Length < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
+                long v = value;
+
+                if (v < 0)
+                {
+                    Unsafe.Add(ref utf8Bytes, 0) = Minus;
+
+                    // Abs(long.MinValue) == long.MaxValue + 1, so we need to re-route to unsigned to handle value
+                    if (v == long.MinValue)
+                    {
+                        if (!TryFormatNumericUInt64((ulong)long.MaxValue + 1, precision, buffer.Slice(1), out bytesWritten))
+                            return false;
+
+                        bytesWritten += 1; // Add the minus sign
+                        return true;
+                    }
+
+                    v = -v;
+                }
+
+                // Write out the trailing zeros
+                if (trailingZeros > 0)
+                {
+                    Unsafe.Add(ref utf8Bytes, idx) = Period;
+                    FormattingHelpers.WriteDigits(0, trailingZeros, ref utf8Bytes, idx + 1);
+                }
+
+                // Starting from the back, write each group of digits except the first group
+                while (digitCount > 3)
+                {
+                    digitCount -= 3;
+                    idx -= 3;
+                    v = FormattingHelpers.DivMod(v, 1000, out long groupValue);
+                    FormattingHelpers.WriteDigits(groupValue, 3, ref utf8Bytes, idx);
+                    Unsafe.Add(ref utf8Bytes, --idx) = Seperator;
+                }
+
+                // Write the first group of digits.
+                FormattingHelpers.WriteDigits(v, (int)firstGroup, ref utf8Bytes, idx - (int)firstGroup);
+
+                return true;
             }
 
-            // Write the first group of digits.
-            FormattingHelpers.WriteDigits(v, (int)firstGroup, ref utf8Bytes, idx - (int)firstGroup);
-
-            return true;
-        }
-
-        private static bool TryFormatNumericUInt64(ulong value, byte precision, Span<byte> buffer, out int bytesWritten)
-        {
-            if (value <= long.MaxValue)
-                return TryFormatNumericInt64((long)value, precision, buffer, out bytesWritten);
-
-            // The ulong path is much slower than the long path here, so we are doing the last group
-            // inside this method plus the zero padding but routing to the long version for the rest.
-            value = FormattingHelpers.DivMod(value, 1000, out ulong lastGroup);
-
-            if (!TryFormatNumericInt64((long)value, 0, buffer, out bytesWritten))
-                return false;
-
-            if (precision == ParsedFormat.NoPrecision)
-                precision = 2;
-
-            int idx = bytesWritten;
-
-            // Since this method routes entirely to the long version if the number is smaller than
-            // long.MaxValue, we are guaranteed to need to write 3 more digits here before the set
-            // of trailing zeros.
-
-            bytesWritten += 4; // 3 digits + group seperator
-            if (precision > 0)
-                bytesWritten += precision + 1; // +1 for period.
-
-            if (buffer.Length < bytesWritten)
+            private static bool TryFormatNumericUInt64(ulong value, byte precision, Span<byte> buffer, out int bytesWritten)
             {
-                bytesWritten = 0;
-                return false;
+                if (value <= long.MaxValue)
+                    return TryFormatNumericInt64((long)value, precision, buffer, out bytesWritten);
+
+                // The ulong path is much slower than the long path here, so we are doing the last group
+                // inside this method plus the zero padding but routing to the long version for the rest.
+                value = FormattingHelpers.DivMod(value, 1000, out ulong lastGroup);
+
+                if (!TryFormatNumericInt64((long)value, 0, buffer, out bytesWritten))
+                    return false;
+
+                if (precision == ParsedFormat.NoPrecision)
+                    precision = 2;
+
+                int idx = bytesWritten;
+
+                // Since this method routes entirely to the long version if the number is smaller than
+                // long.MaxValue, we are guaranteed to need to write 3 more digits here before the set
+                // of trailing zeros.
+
+                bytesWritten += 4; // 3 digits + group seperator
+                if (precision > 0)
+                    bytesWritten += precision + 1; // +1 for period.
+
+                if (buffer.Length < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
+
+                // Write the last group
+                Unsafe.Add(ref utf8Bytes, idx++) = Seperator;
+                idx += FormattingHelpers.WriteDigits(lastGroup, 3, ref utf8Bytes, idx);
+
+                // Write out the trailing zeros
+                if (precision > 0)
+                {
+                    Unsafe.Add(ref utf8Bytes, idx) = Period;
+                    FormattingHelpers.WriteDigits(0, precision, ref utf8Bytes, idx + 1);
+                }
+
+                return true;
             }
 
-            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
-
-            // Write the last group
-            Unsafe.Add(ref utf8Bytes, idx++) = Seperator;
-            idx += FormattingHelpers.WriteDigits(lastGroup, 3, ref utf8Bytes, idx);
-
-            // Write out the trailing zeros
-            if (precision > 0)
+            private static bool TryFormatHexUInt64(ulong value, byte precision, bool useLower, Span<byte> buffer, out int bytesWritten)
             {
-                Unsafe.Add(ref utf8Bytes, idx) = Period;
-                FormattingHelpers.WriteDigits(0, precision, ref utf8Bytes, idx + 1);
+                const string HexTableLower = "0123456789abcdef";
+                const string HexTableUpper = "0123456789ABCDEF";
+
+                var digits = 1;
+                var v = value;
+                if (v > 0xFFFFFFFF)
+                {
+                    digits += 8;
+                    v >>= 0x20;
+                }
+                if (v > 0xFFFF)
+                {
+                    digits += 4;
+                    v >>= 0x10;
+                }
+                if (v > 0xFF)
+                {
+                    digits += 2;
+                    v >>= 0x8;
+                }
+                if (v > 0xF) digits++;
+
+                int paddingCount = (precision == ParsedFormat.NoPrecision) ? 0 : precision - digits;
+                if (paddingCount < 0) paddingCount = 0;
+
+                bytesWritten = digits + paddingCount;
+                if (buffer.Length < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                string hexTable = useLower ? HexTableLower : HexTableUpper;
+                ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
+                int idx = bytesWritten;
+
+                for (v = value; digits-- > 0; v >>= 4)
+                    Unsafe.Add(ref utf8Bytes, --idx) = (byte)hexTable[(int)(v & 0xF)];
+
+                while (paddingCount-- > 0)
+                    Unsafe.Add(ref utf8Bytes, --idx) = (byte)'0';
+
+                return true;
             }
-
-            return true;
-        }
-
-        private static bool TryFormatHexUInt64(ulong value, byte precision, bool useLower, Span<byte> buffer, out int bytesWritten)
-        {
-            const string HexTableLower = "0123456789abcdef";
-            const string HexTableUpper = "0123456789ABCDEF";
-
-            var digits = 1;
-            var v = value;
-            if (v > 0xFFFFFFFF)
-            {
-                digits += 8;
-                v >>= 0x20;
-            }
-            if (v > 0xFFFF)
-            {
-                digits += 4;
-                v >>= 0x10;
-            }
-            if (v > 0xFF)
-            {
-                digits += 2;
-                v >>= 0x8;
-            }
-            if (v > 0xF) digits++;
-
-            int paddingCount = (precision == ParsedFormat.NoPrecision) ? 0 : precision - digits;
-            if (paddingCount < 0) paddingCount = 0;
-
-            bytesWritten = digits + paddingCount;
-            if (buffer.Length < bytesWritten)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            string hexTable = useLower ? HexTableLower : HexTableUpper;
-            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
-            int idx = bytesWritten;
-
-            for (v = value; digits-- > 0; v >>= 4)
-                Unsafe.Add(ref utf8Bytes, --idx) = (byte)hexTable[(int)(v & 0xF)];
-
-            while (paddingCount-- > 0)
-                Unsafe.Add(ref utf8Bytes, --idx) = (byte)'0';
-
-            return true;
         }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Formatters/Utf8.Time.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Utf8.Time.cs
@@ -3,27 +3,29 @@
 
 using System.Runtime.CompilerServices;
 
-namespace System.Text.Formatters
+namespace System.Buffers
 {
-    public static partial class Utf8
+    public static partial class Formatters
     {
-        #region Constants
-
-        private const int DefaultFractionDigits = 7;
-
-        private const byte TimeMarker = (byte)'T';
-        private const byte UtcMarker = (byte)'Z';
-
-        private const byte GMT1 = (byte)'G';
-        private const byte GMT2 = (byte)'M';
-        private const byte GMT3 = (byte)'T';
-
-        private const byte GMT1Lowercase = (byte)'g';
-        private const byte GMT2Lowercase = (byte)'m';
-        private const byte GMT3Lowercase = (byte)'t';
-
-        private static readonly byte[][] DayAbbreviations = new byte[][]
+        public static partial class Utf8
         {
+            #region Constants
+
+            private const int DefaultFractionDigits = 7;
+
+            private const byte TimeMarker = (byte)'T';
+            private const byte UtcMarker = (byte)'Z';
+
+            private const byte GMT1 = (byte)'G';
+            private const byte GMT2 = (byte)'M';
+            private const byte GMT3 = (byte)'T';
+
+            private const byte GMT1Lowercase = (byte)'g';
+            private const byte GMT2Lowercase = (byte)'m';
+            private const byte GMT3Lowercase = (byte)'t';
+
+            private static readonly byte[][] DayAbbreviations = new byte[][]
+            {
                 new byte[] { (byte)'S', (byte)'u', (byte)'n' },
                 new byte[] { (byte)'M', (byte)'o', (byte)'n' },
                 new byte[] { (byte)'T', (byte)'u', (byte)'e' },
@@ -31,10 +33,10 @@ namespace System.Text.Formatters
                 new byte[] { (byte)'T', (byte)'h', (byte)'u' },
                 new byte[] { (byte)'F', (byte)'r', (byte)'i' },
                 new byte[] { (byte)'S', (byte)'a', (byte)'t' },
-        };
+            };
 
-        private static readonly byte[][] DayAbbreviationsLowercase = new byte[][]
-        {
+            private static readonly byte[][] DayAbbreviationsLowercase = new byte[][]
+            {
                 new byte[] { (byte)'s', (byte)'u', (byte)'n' },
                 new byte[] { (byte)'m', (byte)'o', (byte)'n' },
                 new byte[] { (byte)'t', (byte)'u', (byte)'e' },
@@ -42,10 +44,10 @@ namespace System.Text.Formatters
                 new byte[] { (byte)'t', (byte)'h', (byte)'u' },
                 new byte[] { (byte)'f', (byte)'r', (byte)'i' },
                 new byte[] { (byte)'s', (byte)'a', (byte)'t' },
-        };
+            };
 
-        private static readonly byte[][] MonthAbbreviations = new byte[][]
-        {
+            private static readonly byte[][] MonthAbbreviations = new byte[][]
+            {
                 new byte[] { (byte)'J', (byte)'a', (byte)'n' },
                 new byte[] { (byte)'F', (byte)'e', (byte)'b' },
                 new byte[] { (byte)'M', (byte)'a', (byte)'r' },
@@ -58,10 +60,10 @@ namespace System.Text.Formatters
                 new byte[] { (byte)'O', (byte)'c', (byte)'t' },
                 new byte[] { (byte)'N', (byte)'o', (byte)'v' },
                 new byte[] { (byte)'D', (byte)'e', (byte)'c' },
-        };
+            };
 
-        private static readonly byte[][] MonthAbbreviationsLowercase = new byte[][]
-        {
+            private static readonly byte[][] MonthAbbreviationsLowercase = new byte[][]
+            {
                 new byte[] { (byte)'j', (byte)'a', (byte)'n' },
                 new byte[] { (byte)'f', (byte)'e', (byte)'b' },
                 new byte[] { (byte)'m', (byte)'a', (byte)'r' },
@@ -74,315 +76,316 @@ namespace System.Text.Formatters
                 new byte[] { (byte)'o', (byte)'c', (byte)'t' },
                 new byte[] { (byte)'n', (byte)'o', (byte)'v' },
                 new byte[] { (byte)'d', (byte)'e', (byte)'c' },
-        };
+            };
 
-        private static readonly TimeSpan NullOffset = TimeSpan.MinValue;
+            private static readonly TimeSpan NullOffset = TimeSpan.MinValue;
 
-        #endregion Constants
+            #endregion Constants
 
-        private static bool TryFormatG(DateTime value, TimeSpan offset, Span<byte> buffer, out int bytesWritten)
-        {
-            const int MinimumBytesNeeded = 19;
-
-            bytesWritten = MinimumBytesNeeded;
-            if (offset != NullOffset)
+            private static bool TryFormatG(DateTime value, TimeSpan offset, Span<byte> buffer, out int bytesWritten)
             {
-                bytesWritten += 7; // Space['+'|'-']hh:ss
-            }
+                const int MinimumBytesNeeded = 19;
 
-            if (buffer.Length < bytesWritten)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
-
-            FormattingHelpers.WriteDigits(value.Month, 2, ref utf8Bytes, 0);
-            Unsafe.Add(ref utf8Bytes, 2) = Slash;
-
-            FormattingHelpers.WriteDigits(value.Day, 2, ref utf8Bytes, 3);
-            Unsafe.Add(ref utf8Bytes, 5) = Slash;
-
-            FormattingHelpers.WriteDigits(value.Year, 4, ref utf8Bytes, 6);
-            Unsafe.Add(ref utf8Bytes, 10) = Space;
-
-            FormattingHelpers.WriteDigits(value.Hour, 2, ref utf8Bytes, 11);
-            Unsafe.Add(ref utf8Bytes, 13) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Minute, 2, ref utf8Bytes, 14);
-            Unsafe.Add(ref utf8Bytes, 16) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Second, 2, ref utf8Bytes, 17);
-
-            if (offset != NullOffset)
-            {
-                Unsafe.Add(ref utf8Bytes, 19) = Space;
-
-                long ticks = value.Ticks;
-                if (ticks < 0)
+                bytesWritten = MinimumBytesNeeded;
+                if (offset != NullOffset)
                 {
-                    Unsafe.Add(ref utf8Bytes, 20) = Minus;
-                    ticks = -ticks;
+                    bytesWritten += 7; // Space['+'|'-']hh:ss
+                }
+
+                if (buffer.Length < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
+
+                FormattingHelpers.WriteDigits(value.Month, 2, ref utf8Bytes, 0);
+                Unsafe.Add(ref utf8Bytes, 2) = Slash;
+
+                FormattingHelpers.WriteDigits(value.Day, 2, ref utf8Bytes, 3);
+                Unsafe.Add(ref utf8Bytes, 5) = Slash;
+
+                FormattingHelpers.WriteDigits(value.Year, 4, ref utf8Bytes, 6);
+                Unsafe.Add(ref utf8Bytes, 10) = Space;
+
+                FormattingHelpers.WriteDigits(value.Hour, 2, ref utf8Bytes, 11);
+                Unsafe.Add(ref utf8Bytes, 13) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Minute, 2, ref utf8Bytes, 14);
+                Unsafe.Add(ref utf8Bytes, 16) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Second, 2, ref utf8Bytes, 17);
+
+                if (offset != NullOffset)
+                {
+                    Unsafe.Add(ref utf8Bytes, 19) = Space;
+
+                    long ticks = value.Ticks;
+                    if (ticks < 0)
+                    {
+                        Unsafe.Add(ref utf8Bytes, 20) = Minus;
+                        ticks = -ticks;
+                    }
+                    else
+                    {
+                        Unsafe.Add(ref utf8Bytes, 20) = Plus;
+                    }
+
+                    FormattingHelpers.WriteDigits(offset.Hours, 2, ref utf8Bytes, 21);
+                    Unsafe.Add(ref utf8Bytes, 23) = Colon;
+                    FormattingHelpers.WriteDigits(offset.Minutes, 2, ref utf8Bytes, 24);
+                }
+
+                return true;
+            }
+
+            private static bool TryFormatO(DateTime value, TimeSpan offset, Span<byte> buffer, out int bytesWritten)
+            {
+                const int MinimumBytesNeeded = 27;
+
+                bytesWritten = MinimumBytesNeeded;
+                DateTimeKind kind = DateTimeKind.Local;
+
+                if (offset == NullOffset)
+                {
+                    kind = value.Kind;
+                    if (kind == DateTimeKind.Local)
+                    {
+                        offset = TimeZoneInfo.Local.GetUtcOffset(value);
+                        bytesWritten += 6;
+                    }
+                    else if (kind == DateTimeKind.Utc)
+                    {
+                        bytesWritten += 1;
+                    }
                 }
                 else
                 {
-                    Unsafe.Add(ref utf8Bytes, 20) = Plus;
+                    bytesWritten += 6;
                 }
 
-                FormattingHelpers.WriteDigits(offset.Hours, 2, ref utf8Bytes, 21);
-                Unsafe.Add(ref utf8Bytes, 23) = Colon;
-                FormattingHelpers.WriteDigits(offset.Minutes, 2, ref utf8Bytes, 24);
-            }
+                if (buffer.Length < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
 
-            return true;
-        }
+                ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
 
-        private static bool TryFormatO(DateTime value, TimeSpan offset, Span<byte> buffer, out int bytesWritten)
-        {
-            const int MinimumBytesNeeded = 27;
+                FormattingHelpers.WriteDigits(value.Year, 4, ref utf8Bytes, 0);
+                Unsafe.Add(ref utf8Bytes, 4) = Minus;
 
-            bytesWritten = MinimumBytesNeeded;
-            DateTimeKind kind = DateTimeKind.Local;
+                FormattingHelpers.WriteDigits(value.Month, 2, ref utf8Bytes, 5);
+                Unsafe.Add(ref utf8Bytes, 7) = Minus;
 
-            if (offset == NullOffset)
-            {
-                kind = value.Kind;
+                FormattingHelpers.WriteDigits(value.Day, 2, ref utf8Bytes, 8);
+                Unsafe.Add(ref utf8Bytes, 10) = TimeMarker;
+
+                FormattingHelpers.WriteDigits(value.Hour, 2, ref utf8Bytes, 11);
+                Unsafe.Add(ref utf8Bytes, 13) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Minute, 2, ref utf8Bytes, 14);
+                Unsafe.Add(ref utf8Bytes, 16) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Second, 2, ref utf8Bytes, 17);
+                Unsafe.Add(ref utf8Bytes, 19) = Period;
+
+                FormattingHelpers.DivMod(value.Ticks, TimeSpan.TicksPerSecond, out long fraction);
+                FormattingHelpers.WriteDigits(fraction, DefaultFractionDigits, ref utf8Bytes, 20);
+
                 if (kind == DateTimeKind.Local)
                 {
-                    offset = TimeZoneInfo.Local.GetUtcOffset(value);
-                    bytesWritten += 6;
+                    int hours = offset.Hours;
+                    byte sign = Plus;
+
+                    if (offset.Hours < 0)
+                    {
+                        hours = -offset.Hours;
+                        sign = Minus;
+                    }
+
+                    Unsafe.Add(ref utf8Bytes, 27) = sign;
+                    FormattingHelpers.WriteDigits(hours, 2, ref utf8Bytes, 28);
+                    Unsafe.Add(ref utf8Bytes, 30) = Colon;
+                    FormattingHelpers.WriteDigits(offset.Minutes, 2, ref utf8Bytes, 31);
                 }
                 else if (kind == DateTimeKind.Utc)
                 {
-                    bytesWritten += 1;
+                    Unsafe.Add(ref utf8Bytes, 27) = UtcMarker;
                 }
-            }
-            else
-            {
-                bytesWritten += 6;
+
+                return true;
             }
 
-            if (buffer.Length < bytesWritten)
+            private static bool TryFormatRfc1123(DateTime value, Span<byte> buffer, out int bytesWritten)
             {
-                bytesWritten = 0;
-                return false;
-            }
+                const int BytesNeeded = 29;
 
-            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
-
-            FormattingHelpers.WriteDigits(value.Year, 4, ref utf8Bytes, 0);
-            Unsafe.Add(ref utf8Bytes, 4) = Minus;
-
-            FormattingHelpers.WriteDigits(value.Month, 2, ref utf8Bytes, 5);
-            Unsafe.Add(ref utf8Bytes, 7) = Minus;
-
-            FormattingHelpers.WriteDigits(value.Day, 2, ref utf8Bytes, 8);
-            Unsafe.Add(ref utf8Bytes, 10) = TimeMarker;
-
-            FormattingHelpers.WriteDigits(value.Hour, 2, ref utf8Bytes, 11);
-            Unsafe.Add(ref utf8Bytes, 13) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Minute, 2, ref utf8Bytes, 14);
-            Unsafe.Add(ref utf8Bytes, 16) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Second, 2, ref utf8Bytes, 17);
-            Unsafe.Add(ref utf8Bytes, 19) = Period;
-
-            FormattingHelpers.DivMod(value.Ticks, TimeSpan.TicksPerSecond, out long fraction);
-            FormattingHelpers.WriteDigits(fraction, DefaultFractionDigits, ref utf8Bytes, 20);
-
-            if (kind == DateTimeKind.Local)
-            {
-                int hours = offset.Hours;
-                byte sign = Plus;
-
-                if (offset.Hours < 0)
+                bytesWritten = BytesNeeded;
+                if (buffer.Length < bytesWritten)
                 {
-                    hours = -offset.Hours;
-                    sign = Minus;
+                    bytesWritten = 0;
+                    return false;
                 }
 
-                Unsafe.Add(ref utf8Bytes, 27) = sign;
-                FormattingHelpers.WriteDigits(hours, 2, ref utf8Bytes, 28);
-                Unsafe.Add(ref utf8Bytes, 30) = Colon;
-                FormattingHelpers.WriteDigits(offset.Minutes, 2, ref utf8Bytes, 31);
+                ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
+
+                var dayAbbrev = DayAbbreviations[(int)value.DayOfWeek];
+                Unsafe.Add(ref utf8Bytes, 0) = dayAbbrev[0];
+                Unsafe.Add(ref utf8Bytes, 1) = dayAbbrev[1];
+                Unsafe.Add(ref utf8Bytes, 2) = dayAbbrev[2];
+                Unsafe.Add(ref utf8Bytes, 3) = Comma;
+                Unsafe.Add(ref utf8Bytes, 4) = Space;
+
+                FormattingHelpers.WriteDigits(value.Day, 2, ref utf8Bytes, 5);
+                Unsafe.Add(ref utf8Bytes, 7) = (byte)' ';
+
+                var monthAbbrev = MonthAbbreviations[value.Month - 1];
+                Unsafe.Add(ref utf8Bytes, 8) = monthAbbrev[0];
+                Unsafe.Add(ref utf8Bytes, 9) = monthAbbrev[1];
+                Unsafe.Add(ref utf8Bytes, 10) = monthAbbrev[2];
+                Unsafe.Add(ref utf8Bytes, 11) = Space;
+
+                FormattingHelpers.WriteDigits(value.Year, 4, ref utf8Bytes, 12);
+                Unsafe.Add(ref utf8Bytes, 16) = Space;
+
+                FormattingHelpers.WriteDigits(value.Hour, 2, ref utf8Bytes, 17);
+                Unsafe.Add(ref utf8Bytes, 19) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Minute, 2, ref utf8Bytes, 20);
+                Unsafe.Add(ref utf8Bytes, 22) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Second, 2, ref utf8Bytes, 23);
+                Unsafe.Add(ref utf8Bytes, 25) = Space;
+
+                Unsafe.Add(ref utf8Bytes, 26) = GMT1;
+                Unsafe.Add(ref utf8Bytes, 27) = GMT2;
+                Unsafe.Add(ref utf8Bytes, 28) = GMT3;
+
+                return true;
             }
-            else if (kind == DateTimeKind.Utc)
+
+            private static bool TryFormatRfc1123Lowercase(DateTime value, Span<byte> buffer, out int bytesWritten)
             {
-                Unsafe.Add(ref utf8Bytes, 27) = UtcMarker;
+                const int BytesNeeded = 29;
+
+                bytesWritten = BytesNeeded;
+                if (buffer.Length < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
+
+                var dayAbbrev = DayAbbreviationsLowercase[(int)value.DayOfWeek];
+                Unsafe.Add(ref utf8Bytes, 0) = dayAbbrev[0];
+                Unsafe.Add(ref utf8Bytes, 1) = dayAbbrev[1];
+                Unsafe.Add(ref utf8Bytes, 2) = dayAbbrev[2];
+                Unsafe.Add(ref utf8Bytes, 3) = Comma;
+                Unsafe.Add(ref utf8Bytes, 4) = Space;
+
+                FormattingHelpers.WriteDigits(value.Day, 2, ref utf8Bytes, 5);
+                Unsafe.Add(ref utf8Bytes, 7) = (byte)' ';
+
+                var monthAbbrev = MonthAbbreviationsLowercase[value.Month - 1];
+                Unsafe.Add(ref utf8Bytes, 8) = monthAbbrev[0];
+                Unsafe.Add(ref utf8Bytes, 9) = monthAbbrev[1];
+                Unsafe.Add(ref utf8Bytes, 10) = monthAbbrev[2];
+                Unsafe.Add(ref utf8Bytes, 11) = Space;
+
+                FormattingHelpers.WriteDigits(value.Year, 4, ref utf8Bytes, 12);
+                Unsafe.Add(ref utf8Bytes, 16) = Space;
+
+                FormattingHelpers.WriteDigits(value.Hour, 2, ref utf8Bytes, 17);
+                Unsafe.Add(ref utf8Bytes, 19) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Minute, 2, ref utf8Bytes, 20);
+                Unsafe.Add(ref utf8Bytes, 22) = Colon;
+
+                FormattingHelpers.WriteDigits(value.Second, 2, ref utf8Bytes, 23);
+                Unsafe.Add(ref utf8Bytes, 25) = Space;
+
+                Unsafe.Add(ref utf8Bytes, 26) = GMT1Lowercase;
+                Unsafe.Add(ref utf8Bytes, 27) = GMT2Lowercase;
+                Unsafe.Add(ref utf8Bytes, 28) = GMT3Lowercase;
+
+                return true;
             }
 
-            return true;
-        }
-
-        private static bool TryFormatRfc1123(DateTime value, Span<byte> buffer, out int bytesWritten)
-        {
-            const int BytesNeeded = 29;
-
-            bytesWritten = BytesNeeded;
-            if (buffer.Length < bytesWritten)
+            private static bool TryFormatTimeSpan(TimeSpan value, char format, Span<byte> buffer, out int bytesWritten)
             {
-                bytesWritten = 0;
-                return false;
+                bool longForm = (format == 'G');
+                bool constant = (format == 't' || format == 'T' || format == 'c');
+
+                long ticks = value.Ticks;
+                int days = (int)FormattingHelpers.DivMod(ticks, TimeSpan.TicksPerDay, out long timeLeft);
+
+                bool showSign = false;
+                if (ticks < 0)
+                {
+                    showSign = true;
+                    days = -days;
+                    timeLeft = -timeLeft;
+                }
+
+                int hours = (int)FormattingHelpers.DivMod(timeLeft, TimeSpan.TicksPerHour, out timeLeft);
+                int minutes = (int)FormattingHelpers.DivMod(timeLeft, TimeSpan.TicksPerMinute, out timeLeft);
+                int seconds = (int)FormattingHelpers.DivMod(timeLeft, TimeSpan.TicksPerSecond, out long fraction);
+
+                int dayDigits = 0;
+                int hourDigits = (constant || longForm || hours > 9) ? 2 : 1;
+                int fractionDigits = 0;
+
+                bytesWritten = hourDigits + 6; // [h]h:mm:ss
+                if (showSign)
+                    bytesWritten += 1;  // [-]
+                if (longForm || days > 0)
+                {
+                    dayDigits = FormattingHelpers.CountDigits(days);
+                    bytesWritten += dayDigits + 1; // [d'.']
+                }
+                if (longForm || fraction > 0)
+                {
+                    fractionDigits = (longForm || constant) ? DefaultFractionDigits : FormattingHelpers.CountFractionDigits(fraction);
+                    bytesWritten += fractionDigits + 1; // ['.'fffffff] or ['.'FFFFFFF] for short-form
+                }
+
+                if (buffer.Length < bytesWritten)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
+                int idx = 0;
+
+                if (showSign)
+                    Unsafe.Add(ref utf8Bytes, idx++) = Minus;
+
+                if (dayDigits > 0)
+                {
+                    idx += FormattingHelpers.WriteDigits(days, dayDigits, ref utf8Bytes, idx);
+                    Unsafe.Add(ref utf8Bytes, idx++) = constant ? Period : Colon;
+                }
+
+                idx += FormattingHelpers.WriteDigits(hours, hourDigits, ref utf8Bytes, idx);
+                Unsafe.Add(ref utf8Bytes, idx++) = Colon;
+
+                idx += FormattingHelpers.WriteDigits(minutes, 2, ref utf8Bytes, idx);
+                Unsafe.Add(ref utf8Bytes, idx++) = Colon;
+
+                idx += FormattingHelpers.WriteDigits(seconds, 2, ref utf8Bytes, idx);
+
+                if (fractionDigits > 0)
+                {
+                    Unsafe.Add(ref utf8Bytes, idx++) = Period;
+                    idx += FormattingHelpers.WriteFractionDigits(fraction, fractionDigits, ref utf8Bytes, idx);
+                }
+
+                return true;
             }
-
-            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
-
-            var dayAbbrev = DayAbbreviations[(int)value.DayOfWeek];
-            Unsafe.Add(ref utf8Bytes, 0) = dayAbbrev[0];
-            Unsafe.Add(ref utf8Bytes, 1) = dayAbbrev[1];
-            Unsafe.Add(ref utf8Bytes, 2) = dayAbbrev[2];
-            Unsafe.Add(ref utf8Bytes, 3) = Comma;
-            Unsafe.Add(ref utf8Bytes, 4) = Space;
-
-            FormattingHelpers.WriteDigits(value.Day, 2, ref utf8Bytes, 5);
-            Unsafe.Add(ref utf8Bytes, 7) = (byte)' ';
-
-            var monthAbbrev = MonthAbbreviations[value.Month - 1];
-            Unsafe.Add(ref utf8Bytes, 8) = monthAbbrev[0];
-            Unsafe.Add(ref utf8Bytes, 9) = monthAbbrev[1];
-            Unsafe.Add(ref utf8Bytes, 10) = monthAbbrev[2];
-            Unsafe.Add(ref utf8Bytes, 11) = Space;
-
-            FormattingHelpers.WriteDigits(value.Year, 4, ref utf8Bytes, 12);
-            Unsafe.Add(ref utf8Bytes, 16) = Space;
-
-            FormattingHelpers.WriteDigits(value.Hour, 2, ref utf8Bytes, 17);
-            Unsafe.Add(ref utf8Bytes, 19) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Minute, 2, ref utf8Bytes, 20);
-            Unsafe.Add(ref utf8Bytes, 22) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Second, 2, ref utf8Bytes, 23);
-            Unsafe.Add(ref utf8Bytes, 25) = Space;
-
-            Unsafe.Add(ref utf8Bytes, 26) = GMT1;
-            Unsafe.Add(ref utf8Bytes, 27) = GMT2;
-            Unsafe.Add(ref utf8Bytes, 28) = GMT3;
-
-            return true;
-        }
-
-        private static bool TryFormatRfc1123Lowercase(DateTime value, Span<byte> buffer, out int bytesWritten)
-        {
-            const int BytesNeeded = 29;
-
-            bytesWritten = BytesNeeded;
-            if (buffer.Length < bytesWritten)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
-
-            var dayAbbrev = DayAbbreviationsLowercase[(int)value.DayOfWeek];
-            Unsafe.Add(ref utf8Bytes, 0) = dayAbbrev[0];
-            Unsafe.Add(ref utf8Bytes, 1) = dayAbbrev[1];
-            Unsafe.Add(ref utf8Bytes, 2) = dayAbbrev[2];
-            Unsafe.Add(ref utf8Bytes, 3) = Comma;
-            Unsafe.Add(ref utf8Bytes, 4) = Space;
-
-            FormattingHelpers.WriteDigits(value.Day, 2, ref utf8Bytes, 5);
-            Unsafe.Add(ref utf8Bytes, 7) = (byte)' ';
-
-            var monthAbbrev = MonthAbbreviationsLowercase[value.Month - 1];
-            Unsafe.Add(ref utf8Bytes, 8) = monthAbbrev[0];
-            Unsafe.Add(ref utf8Bytes, 9) = monthAbbrev[1];
-            Unsafe.Add(ref utf8Bytes, 10) = monthAbbrev[2];
-            Unsafe.Add(ref utf8Bytes, 11) = Space;
-
-            FormattingHelpers.WriteDigits(value.Year, 4, ref utf8Bytes, 12);
-            Unsafe.Add(ref utf8Bytes, 16) = Space;
-
-            FormattingHelpers.WriteDigits(value.Hour, 2, ref utf8Bytes, 17);
-            Unsafe.Add(ref utf8Bytes, 19) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Minute, 2, ref utf8Bytes, 20);
-            Unsafe.Add(ref utf8Bytes, 22) = Colon;
-
-            FormattingHelpers.WriteDigits(value.Second, 2, ref utf8Bytes, 23);
-            Unsafe.Add(ref utf8Bytes, 25) = Space;
-
-            Unsafe.Add(ref utf8Bytes, 26) = GMT1Lowercase;
-            Unsafe.Add(ref utf8Bytes, 27) = GMT2Lowercase;
-            Unsafe.Add(ref utf8Bytes, 28) = GMT3Lowercase;
-
-            return true;
-        }
-
-        private static bool TryFormatTimeSpan(TimeSpan value, char format, Span<byte> buffer, out int bytesWritten)
-        {
-            bool longForm = (format == 'G');
-            bool constant = (format == 't' || format == 'T' || format == 'c');
-
-            long ticks = value.Ticks;
-            int days = (int)FormattingHelpers.DivMod(ticks, TimeSpan.TicksPerDay, out long timeLeft);
-
-            bool showSign = false;
-            if (ticks < 0)
-            {
-                showSign = true;
-                days = -days;
-                timeLeft = -timeLeft;
-            }
-
-            int hours = (int)FormattingHelpers.DivMod(timeLeft, TimeSpan.TicksPerHour, out timeLeft);
-            int minutes = (int)FormattingHelpers.DivMod(timeLeft, TimeSpan.TicksPerMinute, out timeLeft);
-            int seconds = (int)FormattingHelpers.DivMod(timeLeft, TimeSpan.TicksPerSecond, out long fraction);
-
-            int dayDigits = 0;
-            int hourDigits = (constant || longForm || hours > 9) ? 2 : 1;
-            int fractionDigits = 0;
-
-            bytesWritten = hourDigits + 6; // [h]h:mm:ss
-            if (showSign)
-                bytesWritten += 1;  // [-]
-            if (longForm || days > 0)
-            {
-                dayDigits = FormattingHelpers.CountDigits(days);
-                bytesWritten += dayDigits + 1; // [d'.']
-            }
-            if (longForm || fraction > 0)
-            {
-                fractionDigits = (longForm || constant) ? DefaultFractionDigits : FormattingHelpers.CountFractionDigits(fraction);
-                bytesWritten += fractionDigits + 1; // ['.'fffffff] or ['.'FFFFFFF] for short-form
-            }
-
-            if (buffer.Length < bytesWritten)
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
-            int idx = 0;
-
-            if (showSign)
-                Unsafe.Add(ref utf8Bytes, idx++) = Minus;
-
-            if (dayDigits > 0)
-            {
-                idx += FormattingHelpers.WriteDigits(days, dayDigits, ref utf8Bytes, idx);
-                Unsafe.Add(ref utf8Bytes, idx++) = constant ? Period : Colon;
-            }
-
-            idx += FormattingHelpers.WriteDigits(hours, hourDigits, ref utf8Bytes, idx);
-            Unsafe.Add(ref utf8Bytes, idx++) = Colon;
-
-            idx += FormattingHelpers.WriteDigits(minutes, 2, ref utf8Bytes, idx);
-            Unsafe.Add(ref utf8Bytes, idx++) = Colon;
-
-            idx += FormattingHelpers.WriteDigits(seconds, 2, ref utf8Bytes, idx);
-
-            if (fractionDigits > 0)
-            {
-                Unsafe.Add(ref utf8Bytes, idx++) = Period;
-                idx += FormattingHelpers.WriteFractionDigits(fraction, fractionDigits, ref utf8Bytes, idx);
-            }
-
-            return true;
         }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Formatters/Utf8.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Utf8.cs
@@ -1,192 +1,198 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text.Formatters
+using System.Buffers.Text;
+using System.Text;
+
+namespace System.Buffers
 {
-    public static partial class Utf8
+    public static partial class Formatters
     {
-        #region Common constants
-
-        private const byte Colon = (byte)':';
-        private const byte Comma = (byte)',';
-        private const byte Minus = (byte)'-';
-        private const byte Period = (byte)'.';
-        private const byte Plus = (byte)'+';
-        private const byte Slash = (byte)'/';
-        private const byte Space = (byte)' ';
-
-        #endregion Common constants
-
-        #region Date / Time APIs
-
-        public static bool TryFormat(DateTimeOffset value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+        public static partial class Utf8
         {
-            TimeSpan offset = NullOffset;
-            char symbol = format.Symbol;
-            if (format.IsDefault)
+            #region Common constants
+
+            private const byte Colon = (byte)':';
+            private const byte Comma = (byte)',';
+            private const byte Minus = (byte)'-';
+            private const byte Period = (byte)'.';
+            private const byte Plus = (byte)'+';
+            private const byte Slash = (byte)'/';
+            private const byte Space = (byte)' ';
+
+            #endregion Common constants
+
+            #region Date / Time APIs
+
+            public static bool TryFormat(DateTimeOffset value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
             {
-                symbol = 'G';
-                offset = value.Offset;
+                TimeSpan offset = NullOffset;
+                char symbol = format.Symbol;
+                if (format.IsDefault)
+                {
+                    symbol = 'G';
+                    offset = value.Offset;
+                }
+
+                switch (symbol)
+                {
+                    case 'R':
+                        return TryFormatRfc1123(value.UtcDateTime, buffer, out bytesWritten);
+
+                    case 'l':
+                        return TryFormatRfc1123Lowercase(value.UtcDateTime, buffer, out bytesWritten);
+
+                    case 'O':
+                        return TryFormatO(value.DateTime, value.Offset, buffer, out bytesWritten);
+
+                    case 'G':
+                        return TryFormatG(value.DateTime, offset, buffer, out bytesWritten);
+
+                    default:
+                        throw new NotSupportedException();
+                }
             }
 
-            switch (symbol)
+            public static bool TryFormat(DateTime value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
             {
-                case 'R':
-                    return TryFormatRfc1123(value.UtcDateTime, buffer, out bytesWritten);
+                char symbol = format.IsDefault ? 'G' : format.Symbol;
 
-                case 'l':
-                    return TryFormatRfc1123Lowercase(value.UtcDateTime, buffer, out bytesWritten);
+                switch (symbol)
+                {
+                    case 'R':
+                        return TryFormatRfc1123(value, buffer, out bytesWritten);
 
-                case 'O':
-                    return TryFormatO(value.DateTime, value.Offset, buffer, out bytesWritten);
+                    case 'l':
+                        return TryFormatRfc1123Lowercase(value, buffer, out bytesWritten);
 
-                case 'G':
-                    return TryFormatG(value.DateTime, offset, buffer, out bytesWritten);
+                    case 'O':
+                        return TryFormatO(value, NullOffset, buffer, out bytesWritten);
 
-                default:
-                    throw new NotSupportedException();
+                    case 'G':
+                        return TryFormatG(value, NullOffset, buffer, out bytesWritten);
+
+                    default:
+                        throw new NotSupportedException();
+                }
             }
+
+            public static bool TryFormat(TimeSpan value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+            {
+                char symbol = format.IsDefault ? 'c' : format.Symbol;
+
+                switch (symbol)
+                {
+                    case 'G':
+                    case 'g':
+                    case 'c':
+                    case 't':
+                    case 'T':
+                        return TryFormatTimeSpan(value, symbol, buffer, out bytesWritten);
+
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+
+            #endregion Date / Time APIs
+
+            #region Integer APIs
+
+            public static bool TryFormat(byte value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, buffer, out bytesWritten, format);
+
+            public static bool TryFormat(sbyte value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, 0xff, buffer, out bytesWritten, format);
+
+            public static bool TryFormat(ushort value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, buffer, out bytesWritten, format);
+
+            public static bool TryFormat(short value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, 0xffff, buffer, out bytesWritten, format);
+
+            public static bool TryFormat(uint value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, buffer, out bytesWritten, format);
+
+            public static bool TryFormat(int value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, 0xffffffff, buffer, out bytesWritten, format);
+
+            public static bool TryFormat(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, buffer, out bytesWritten, format);
+
+            public static bool TryFormat(long value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => TryFormatCore(value, 0xffffffffffffffff, buffer, out bytesWritten, format);
+
+            static bool TryFormatCore(long value, ulong mask, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
+            {
+                if (format.IsDefault)
+                {
+                    format = 'G';
+                }
+
+                switch (format.Symbol)
+                {
+                    case 'd':
+                    case 'D':
+                    case 'G':
+                    case 'g':
+                        return TryFormatDecimalInt64(value, format.Precision, buffer, out bytesWritten);
+
+                    case 'n':
+                    case 'N':
+                        return TryFormatNumericInt64(value, format.Precision, buffer, out bytesWritten);
+
+                    case 'x':
+                        return TryFormatHexUInt64((ulong)value & mask, format.Precision, true, buffer, out bytesWritten);
+
+                    case 'X':
+                        return TryFormatHexUInt64((ulong)value & mask, format.Precision, false, buffer, out bytesWritten);
+
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+
+            static bool TryFormatCore(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
+            {
+                if (format.IsDefault)
+                {
+                    format = 'G';
+                }
+
+                switch (format.Symbol)
+                {
+                    case 'd':
+                    case 'D':
+                    case 'G':
+                    case 'g':
+                        return TryFormatDecimalUInt64(value, format.Precision, buffer, out bytesWritten);
+
+                    case 'n':
+                    case 'N':
+                        return TryFormatNumericUInt64(value, format.Precision, buffer, out bytesWritten);
+
+                    case 'x':
+                        return TryFormatHexUInt64(value, format.Precision, true, buffer, out bytesWritten);
+
+                    case 'X':
+                        return TryFormatHexUInt64(value, format.Precision, false, buffer, out bytesWritten);
+
+                    default:
+                        throw new NotSupportedException();
+                }
+            }
+
+            #endregion Integer APIs
+
+            #region Floating-point APIs
+
+            public static bool TryFormat(double value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => Custom.TryFormat(value, buffer, out bytesWritten, format, SymbolTable.InvariantUtf8);
+
+            public static bool TryFormat(float value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
+                => Custom.TryFormat(value, buffer, out bytesWritten, format, SymbolTable.InvariantUtf8);
+
+            #endregion Floating-point APIs
         }
-
-        public static bool TryFormat(DateTime value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-        {
-            char symbol = format.IsDefault ? 'G' : format.Symbol;
-
-            switch (symbol)
-            {
-                case 'R':
-                    return TryFormatRfc1123(value, buffer, out bytesWritten);
-
-                case 'l':
-                    return TryFormatRfc1123Lowercase(value, buffer, out bytesWritten);
-
-                case 'O':
-                    return TryFormatO(value, NullOffset, buffer, out bytesWritten);
-
-                case 'G':
-                    return TryFormatG(value, NullOffset, buffer, out bytesWritten);
-
-                default:
-                    throw new NotSupportedException();
-            }
-        }
-
-        public static bool TryFormat(TimeSpan value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-        {
-            char symbol = format.IsDefault ? 'c' : format.Symbol;
-
-            switch (symbol)
-            {
-                case 'G':
-                case 'g':
-                case 'c':
-                case 't':
-                case 'T':
-                    return TryFormatTimeSpan(value, symbol, buffer, out bytesWritten);
-
-                default:
-                    throw new NotSupportedException();
-            }
-        }
-
-        #endregion Date / Time APIs
-
-        #region Integer APIs
-
-        public static bool TryFormat(byte value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, buffer, out bytesWritten, format);
-
-        public static bool TryFormat(sbyte value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, 0xff, buffer, out bytesWritten, format);
-
-        public static bool TryFormat(ushort value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, buffer, out bytesWritten, format);
-
-        public static bool TryFormat(short value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, 0xffff, buffer, out bytesWritten, format);
-
-        public static bool TryFormat(uint value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, buffer, out bytesWritten, format);
-
-        public static bool TryFormat(int value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, 0xffffffff, buffer, out bytesWritten, format);
-
-        public static bool TryFormat(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, buffer, out bytesWritten, format);
-
-        public static bool TryFormat(long value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => TryFormatCore(value, 0xffffffffffffffff, buffer, out bytesWritten, format);
-
-        static bool TryFormatCore(long value, ulong mask, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
-        {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
-            switch (format.Symbol)
-            {
-                case 'd':
-                case 'D':
-                case 'G':
-                case 'g':
-                    return TryFormatDecimalInt64(value, format.Precision, buffer, out bytesWritten);
-
-                case 'n':
-                case 'N':
-                    return TryFormatNumericInt64(value, format.Precision, buffer, out bytesWritten);
-
-                case 'x':
-                    return TryFormatHexUInt64((ulong)value & mask, format.Precision, true, buffer, out bytesWritten);
-
-                case 'X':
-                    return TryFormatHexUInt64((ulong)value & mask, format.Precision, false, buffer, out bytesWritten);
-
-                default:
-                    throw new NotSupportedException();
-            }
-        }
-
-        static bool TryFormatCore(ulong value, Span<byte> buffer, out int bytesWritten, ParsedFormat format)
-        {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
-            switch (format.Symbol)
-            {
-                case 'd':
-                case 'D':
-                case 'G':
-                case 'g':
-                    return TryFormatDecimalUInt64(value, format.Precision, buffer, out bytesWritten);
-
-                case 'n':
-                case 'N':
-                    return TryFormatNumericUInt64(value, format.Precision, buffer, out bytesWritten);
-
-                case 'x':
-                    return TryFormatHexUInt64(value, format.Precision, true, buffer, out bytesWritten);
-
-                case 'X':
-                    return TryFormatHexUInt64(value, format.Precision, false, buffer, out bytesWritten);
-
-                default:
-                    throw new NotSupportedException();
-            }
-        }
-
-        #endregion Integer APIs
-
-        #region Floating-point APIs
-
-        public static bool TryFormat(this double value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => Custom.TryFormat(value, buffer, out bytesWritten, format, SymbolTable.InvariantUtf8);
-
-        public static bool TryFormat(this float value, Span<byte> buffer, out int bytesWritten, ParsedFormat format = default)
-            => Custom.TryFormat(value, buffer, out bytesWritten, format, SymbolTable.InvariantUtf8);
-
-        #endregion Floating-point APIs
     }
 }

--- a/src/System.Text.Primitives/System/Text/IBufferFormattable.cs
+++ b/src/System.Text.Primitives/System/Text/IBufferFormattable.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 
-namespace System.Text
+using System.Text;
+
+namespace System.Buffers.Text
 {
     public interface IBufferFormattable
     {

--- a/src/System.Text.Primitives/System/Text/ParsedFormat.cs
+++ b/src/System.Text.Primitives/System/Text/ParsedFormat.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text
+using System.Buffers;
+
+namespace System
 {
     public struct ParsedFormat
     {
@@ -41,7 +43,7 @@ namespace System.Text
             {
                 var span = format.Slice(1);
 
-                if (!PrimitiveParser.InvariantUtf16.TryParseByte(span, out precision))
+                if (!Parsers.Utf16.TryParseByte(span, out precision))
                     throw new FormatException("format");
 
                 if (precision > MaxPrecision)

--- a/src/System.Text.Primitives/System/Text/Parsers/InvariantBool.cs
+++ b/src/System.Text.Primitives/System/Text/Parsers/InvariantBool.cs
@@ -6,11 +6,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text
+namespace System.Buffers
 {
-    public static partial class PrimitiveParser
+    public static partial class Parsers
     {
-        public static partial class InvariantUtf8
+        public static partial class Utf8
         {
             public unsafe static bool TryParseBoolean(byte* text, int length, out bool value)
             {
@@ -137,7 +137,7 @@ namespace System.Text
                 return false;
             }
         }
-        public static partial class InvariantUtf16
+        public static partial class Utf16
         {
             public unsafe static bool TryParseBoolean(char* text, int length, out bool value)
             {

--- a/src/System.Text.Primitives/System/Text/Parsers/InvariantSigned.cs
+++ b/src/System.Text.Primitives/System/Text/Parsers/InvariantSigned.cs
@@ -6,11 +6,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text
+namespace System.Buffers
 {
-    public static partial class PrimitiveParser
+    public static partial class Parsers
     {
-        public static partial class InvariantUtf8
+        public static partial class Utf8
         {
             #region SByte
             public unsafe static bool TryParseSByte(byte* text, int length, out sbyte value)
@@ -1192,7 +1192,7 @@ namespace System.Text
             #endregion
 
         }
-        public static partial class InvariantUtf16
+        public static partial class Utf16
         {
             #region SByte
             public unsafe static bool TryParseSByte(char* text, int length, out sbyte value)

--- a/src/System.Text.Primitives/System/Text/Parsers/InvariantSignedHex.cs
+++ b/src/System.Text.Primitives/System/Text/Parsers/InvariantSignedHex.cs
@@ -6,11 +6,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text
+namespace System.Buffers
 {
-    public static partial class PrimitiveParser
+    public static partial class Parsers
     {
-        public static partial class InvariantUtf8
+        public static partial class Utf8
         {
             public static partial class Hex
             {
@@ -1300,7 +1300,7 @@ namespace System.Text
 
             }
         }
-        public static partial class InvariantUtf16
+        public static partial class Utf16
         {
             public static partial class Hex
             {

--- a/src/System.Text.Primitives/System/Text/Parsers/InvariantUnsigned.cs
+++ b/src/System.Text.Primitives/System/Text/Parsers/InvariantUnsigned.cs
@@ -6,11 +6,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text
+namespace System.Buffers
 {
-    public static partial class PrimitiveParser
+    public static partial class Parsers
     {
-        public static partial class InvariantUtf8
+        public static partial class Utf8
         {
             #region Byte
             public unsafe static bool TryParseByte(byte* text, int length, out byte value)
@@ -1169,7 +1169,7 @@ namespace System.Text
             #endregion
 
         }
-        public static partial class InvariantUtf16
+        public static partial class Utf16
         {
             #region Byte
             public unsafe static bool TryParseByte(char* text, int length, out byte value)

--- a/src/System.Text.Primitives/System/Text/Parsers/InvariantUnsignedHex.cs
+++ b/src/System.Text.Primitives/System/Text/Parsers/InvariantUnsignedHex.cs
@@ -6,11 +6,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text
+namespace System.Buffers
 {
-    public static partial class PrimitiveParser
+    public static partial class Parsers
     {
-        public static partial class InvariantUtf8
+        public static partial class Utf8
         {
             public static partial class Hex
             {
@@ -1300,7 +1300,7 @@ namespace System.Text
 
             }
         }
-        public static partial class InvariantUtf16
+        public static partial class Utf16
         {
             public static partial class Hex
             {

--- a/src/System.Text.Primitives/System/Text/Parsers/InvariantUtf16_decimal.cs
+++ b/src/System.Text.Primitives/System/Text/Parsers/InvariantUtf16_decimal.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-
-namespace System.Text
+namespace System.Buffers
 {
-    public static partial class PrimitiveParser
+    public static partial class Parsers
     {
-        public static partial class InvariantUtf16
+        public static partial class Utf16
         {
             public unsafe static bool TryParseDecimal(char* text, int length, out decimal value)
             {

--- a/src/System.Text.Primitives/System/Text/Parsers/InvariantUtf8_decimal.cs
+++ b/src/System.Text.Primitives/System/Text/Parsers/InvariantUtf8_decimal.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 
-namespace System.Text
+namespace System.Buffers
 {
-    public static partial class PrimitiveParser
+    public static partial class Parsers
     {
-        public static partial class InvariantUtf8
+        public static partial class Utf8
         {
             public unsafe static bool TryParseDecimal(byte* text, int length, out decimal value)
             {

--- a/src/System.Text.Primitives/System/Text/Parsers/PrimitiveParser.cs
+++ b/src/System.Text.Primitives/System/Text/Parsers/PrimitiveParser.cs
@@ -2,10 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
+using System.Text;
 
-namespace System.Text
+namespace System.Buffers
 {
-    public static partial class PrimitiveParser
+    public static partial class Parsers
     {
         const int ByteOverflowLength = 3;
         const int ByteOverflowLengthHex = 2;

--- a/src/System.Text.Primitives/System/Text/Parsers/PrimitiveParser_Boolean.cs
+++ b/src/System.Text.Primitives/System/Text/Parsers/PrimitiveParser_Boolean.cs
@@ -1,32 +1,36 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
+using System.Text;
 
-namespace System.Text
+namespace System.Buffers
 {
-    public static partial class PrimitiveParser
+    public static partial class Parsers
     {
-        public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value, out int bytesConsumed, SymbolTable symbolTable = null)
-        {
-            symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
-
-            bytesConsumed = 0;
-            value = default;
-
-            if (symbolTable == SymbolTable.InvariantUtf8)
+        public static partial class Custom {
+            public static bool TryParseBoolean(ReadOnlySpan<byte> text, out bool value, out int bytesConsumed, SymbolTable symbolTable = null)
             {
-                return InvariantUtf8.TryParseBoolean(text, out value, out bytesConsumed);
-            }
-            if (symbolTable == SymbolTable.InvariantUtf16)
-            {
-                ReadOnlySpan<char> textChars = text.NonPortableCast<byte, char>();
-                int charactersConsumed;
-                bool result = InvariantUtf16.TryParseBoolean(textChars, out value, out charactersConsumed);
-                bytesConsumed = charactersConsumed * sizeof(char);
-                return result;
-            }
+                symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
 
-            return false;
+                bytesConsumed = 0;
+                value = default;
+
+                if (symbolTable == SymbolTable.InvariantUtf8)
+                {
+                    return Utf8.TryParseBoolean(text, out value, out bytesConsumed);
+                }
+                if (symbolTable == SymbolTable.InvariantUtf16)
+                {
+                    ReadOnlySpan<char> textChars = text.NonPortableCast<byte, char>();
+                    int charactersConsumed;
+                    bool result = Utf16.TryParseBoolean(textChars, out value, out charactersConsumed);
+                    bytesConsumed = charactersConsumed * sizeof(char);
+                    return result;
+                }
+
+                return false;
+            }
         }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Parsers/PrimitiveParser_Decimal.cs
+++ b/src/System.Text.Primitives/System/Text/Parsers/PrimitiveParser_Decimal.cs
@@ -2,31 +2,37 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 
-namespace System.Text
+using System.Buffers.Text;
+using System.Text;
+
+namespace System.Buffers
 {
-    public static partial class PrimitiveParser
+    public static partial class Parsers
     {
-        public static bool TryParseDecimal(ReadOnlySpan<byte> text, out decimal value, out int bytesConsumed, SymbolTable symbolTable = null)
+        public static partial class Custom
         {
-            symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
-
-            bytesConsumed = 0;
-            value = default;
-
-            if (symbolTable == SymbolTable.InvariantUtf8)
+            public static bool TryParseDecimal(ReadOnlySpan<byte> text, out decimal value, out int bytesConsumed, SymbolTable symbolTable = null)
             {
-                return InvariantUtf8.TryParseDecimal(text, out value, out bytesConsumed);
-            }
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-            {
-                ReadOnlySpan<char> textChars = text.NonPortableCast<byte, char>();
-                int charactersConsumed;
-                bool result = InvariantUtf16.TryParseDecimal(textChars, out value, out charactersConsumed);
-                bytesConsumed = charactersConsumed * sizeof(char);
-                return result;
-            }
+                symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
 
-            return false;
+                bytesConsumed = 0;
+                value = default;
+
+                if (symbolTable == SymbolTable.InvariantUtf8)
+                {
+                    return Utf8.TryParseDecimal(text, out value, out bytesConsumed);
+                }
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                {
+                    ReadOnlySpan<char> textChars = text.NonPortableCast<byte, char>();
+                    int charactersConsumed;
+                    bool result = Utf16.TryParseDecimal(textChars, out value, out charactersConsumed);
+                    bytesConsumed = charactersConsumed * sizeof(char);
+                    return result;
+                }
+
+                return false;
+            }
         }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Parsers/Signed.cs
+++ b/src/System.Text.Primitives/System/Text/Parsers/Signed.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
 using System.Runtime.CompilerServices;
 
-namespace System.Text
+namespace System.Buffers
 {
-    public static partial class PrimitiveParser
+    public static partial class Parsers
     {
         #region Helpers
 
@@ -64,465 +65,468 @@ namespace System.Text
 
         #endregion
 
-        public static bool TryParseSByte(ReadOnlySpan<byte> text, out sbyte value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
+        public static partial class Custom
         {
-            symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
-
-            if (!format.IsDefault && format.HasPrecision)
+            public static bool TryParseSByte(ReadOnlySpan<byte> text, out sbyte value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
             {
-                throw new NotImplementedException("Format with precision not supported.");
-            }
+                symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
 
-            if (symbolTable == SymbolTable.InvariantUtf8)
-            {
-                if (IsHexFormat(format))
+                if (!format.IsDefault && format.HasPrecision)
                 {
-                    return InvariantUtf8.Hex.TryParseSByte(text, out value, out bytesConsumed);
-                }
-                else
-                {
-                    return InvariantUtf8.TryParseSByte(text, out value, out bytesConsumed);
-                }
-            }
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-            {
-                ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
-                int charsConsumed;
-                bool result;
-                if (IsHexFormat(format))
-                {
-                    result = InvariantUtf16.Hex.TryParseSByte(utf16Text, out value, out charsConsumed);
-                }
-                else
-                {
-                    result = InvariantUtf16.TryParseSByte(utf16Text, out value, out charsConsumed);
-                }
-                bytesConsumed = charsConsumed * sizeof(char);
-                return result;
-            }
-
-            if (IsHexFormat(format))
-            {
-                throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
-            }
-
-            if (!(format.IsDefault || format.Symbol == 'G' || format.Symbol == 'g'))
-            {
-                throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
-            }
-
-            SymbolTable.Symbol nextSymbol;
-            int thisSymbolConsumed;
-            if (!symbolTable.TryParse(text, out nextSymbol, out thisSymbolConsumed))
-            {
-                value = default;
-                bytesConsumed = 0;
-                return false;
-            }
-
-            int sign = 1;
-            if (nextSymbol == SymbolTable.Symbol.MinusSign)
-            {
-                sign = -1;
-            }
-
-            int signConsumed = 0;
-            if (nextSymbol == SymbolTable.Symbol.PlusSign || nextSymbol == SymbolTable.Symbol.MinusSign)
-            {
-                signConsumed = thisSymbolConsumed;
-                if (!symbolTable.TryParse(text.Slice(signConsumed), out nextSymbol, out thisSymbolConsumed))
-                {
-                    value = default;
-                    bytesConsumed = 0;
-                    return false;
-                }
-            }
-
-            if (nextSymbol > SymbolTable.Symbol.D9)
-            {
-                value = default;
-                bytesConsumed = 0;
-                return false;
-            }
-
-            int parsedValue = (int)nextSymbol;
-            int index = signConsumed + thisSymbolConsumed;
-
-            while (index < text.Length)
-            {
-                bool success = symbolTable.TryParse(text.Slice(index), out nextSymbol, out thisSymbolConsumed);
-                if (!success || nextSymbol > SymbolTable.Symbol.D9)
-                {
-                    bytesConsumed = index;
-                    value = (sbyte)(parsedValue * sign);
-                    return true;
+                    throw new NotImplementedException("Format with precision not supported.");
                 }
 
-                // If parsedValue > (sbyte.MaxValue / 10), any more appended digits will cause overflow.
-                // if parsedValue == (sbyte.MaxValue / 10), any nextDigit greater than 7 or 8 (depending on sign) implies overflow.
-                bool positive = sign > 0;
-                bool nextDigitTooLarge = nextSymbol > SymbolTable.Symbol.D8 || (positive && nextSymbol > SymbolTable.Symbol.D7);
-                if (parsedValue > sbyte.MaxValue / 10 || (parsedValue == sbyte.MaxValue / 10 && nextDigitTooLarge))
+                if (symbolTable == SymbolTable.InvariantUtf8)
                 {
-                    bytesConsumed = 0;
-                    value = default;
-                    return false;
-                }
-
-                index += thisSymbolConsumed;
-                parsedValue = parsedValue * 10 + (int)nextSymbol;
-            }
-
-            bytesConsumed = text.Length;
-            value = (sbyte)(parsedValue * sign);
-            return true;
-        }
-
-        public static bool TryParseInt16(ReadOnlySpan<byte> text, out short value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
-
-            if (!format.IsDefault && format.HasPrecision)
-            {
-                throw new NotImplementedException("Format with precision not supported.");
-            }
-
-            if (symbolTable == SymbolTable.InvariantUtf8)
-            {
-                if (IsHexFormat(format))
-                {
-                    return InvariantUtf8.Hex.TryParseInt16(text, out value, out bytesConsumed);
-                }
-                else
-                {
-                    return InvariantUtf8.TryParseInt16(text, out value, out bytesConsumed);
-                }
-            }
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-            {
-                ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
-                int charsConsumed;
-                bool result;
-                if (IsHexFormat(format))
-                {
-                    result = InvariantUtf16.Hex.TryParseInt16(utf16Text, out value, out charsConsumed);
-                }
-                else
-                {
-                    result = InvariantUtf16.TryParseInt16(utf16Text, out value, out charsConsumed);
-                }
-                bytesConsumed = charsConsumed * sizeof(char);
-                return result;
-            }
-
-            if (IsHexFormat(format))
-            {
-                throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
-            }
-
-            if (!(format.IsDefault || format.Symbol == 'G' || format.Symbol == 'g'))
-            {
-                throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
-            }
-
-            SymbolTable.Symbol nextSymbol;
-            int thisSymbolConsumed;
-            if (!symbolTable.TryParse(text, out nextSymbol, out thisSymbolConsumed))
-            {
-                value = default;
-                bytesConsumed = 0;
-                return false;
-            }
-
-            int sign = 1;
-            if ((SymbolTable.Symbol)nextSymbol == SymbolTable.Symbol.MinusSign)
-            {
-                sign = -1;
-            }
-
-            int signConsumed = 0;
-            if (nextSymbol == SymbolTable.Symbol.PlusSign || nextSymbol == SymbolTable.Symbol.MinusSign)
-            {
-                signConsumed = thisSymbolConsumed;
-                if (!symbolTable.TryParse(text.Slice(signConsumed), out nextSymbol, out thisSymbolConsumed))
-                {
-                    value = default;
-                    bytesConsumed = 0;
-                    return false;
-                }
-            }
-
-            if (nextSymbol > SymbolTable.Symbol.D9)
-            {
-                value = default;
-                bytesConsumed = 0;
-                return false;
-            }
-
-            int parsedValue = (int)nextSymbol;
-            int index = signConsumed + thisSymbolConsumed;
-
-            while (index < text.Length)
-            {
-                bool success = symbolTable.TryParse(text.Slice(index), out nextSymbol, out thisSymbolConsumed);
-                if (!success || nextSymbol > SymbolTable.Symbol.D9)
-                {
-                    bytesConsumed = index;
-                    value = (short)(parsedValue * sign);
-                    return true;
-                }
-
-                // If parsedValue > (short.MaxValue / 10), any more appended digits will cause overflow.
-                // if parsedValue == (short.MaxValue / 10), any nextDigit greater than 7 or 8 (depending on sign) implies overflow.
-                bool positive = sign > 0;
-                bool nextDigitTooLarge = nextSymbol > SymbolTable.Symbol.D8 || (positive && nextSymbol > SymbolTable.Symbol.D7);
-                if (parsedValue > short.MaxValue / 10 || (parsedValue == short.MaxValue / 10 && nextDigitTooLarge))
-                {
-                    bytesConsumed = 0;
-                    value = default;
-                    return false;
-                }
-
-                index += thisSymbolConsumed;
-                parsedValue = parsedValue * 10 + (int)nextSymbol;
-            }
-
-            bytesConsumed = text.Length;
-            value = (short)(parsedValue * sign);
-            return true;
-        }
-
-        public static bool TryParseInt32(ReadOnlySpan<byte> text, out int value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            bool isDefault = format.IsDefault;
-            symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
-
-            if (!isDefault && format.HasPrecision)
-            {
-                throw new NotImplementedException("Format with precision not supported.");
-            }
-
-            bool isHex = IsHexFormat(format);
-
-            if (symbolTable == SymbolTable.InvariantUtf8)
-            {
-                return isHex ? InvariantUtf8.Hex.TryParseInt32(text, out value, out bytesConsumed) :
-                        InvariantUtf8.TryParseInt32(text, out value, out bytesConsumed);
-            }
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-            {
-                /*return isHex ? InvariantUtf16.Hex.TryParseInt32(text, out value, out bytesConsumed) :
-                    InvariantUtf16.TryParseInt32(text, out value, out bytesConsumed);*/
-                ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
-                bool result = isHex ? InvariantUtf16.Hex.TryParseInt32(utf16Text, out value, out int charsConsumed) :
-                    InvariantUtf16.TryParseInt32(utf16Text, out value, out charsConsumed);
-                bytesConsumed = charsConsumed * sizeof(char);
-                return result;
-            }
-
-            if (isHex)
-            {
-                throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
-            }
-
-            if (!(isDefault || format.Symbol == 'G' || format.Symbol == 'g'))
-            {
-                throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
-            }
-
-            int textLength = text.Length;
-            if (textLength < 1) goto FalseExit;
-
-            if (!symbolTable.TryParse(text, out SymbolTable.Symbol symbol, out int consumed)) goto FalseExit;
-
-            sbyte sign = 1;
-            int index = 0;
-            if (symbol == SymbolTable.Symbol.MinusSign)
-            {
-                sign = -1;
-                index += consumed;
-                if (index >= textLength) goto FalseExit;
-                if (!symbolTable.TryParse(text.Slice(index), out symbol, out consumed)) goto FalseExit;
-            }
-            else if (symbol == SymbolTable.Symbol.PlusSign)
-            {
-                index += consumed;
-                if (index >= textLength) goto FalseExit;
-                if (!symbolTable.TryParse(text.Slice(index), out symbol, out consumed)) goto FalseExit;
-            }
-
-            int answer = 0;
-            if (IsValid(symbol))
-            {
-                int numBytes = consumed;
-                if (symbol == SymbolTable.Symbol.D0)
-                {
-                    do
+                    if (IsHexFormat(format))
                     {
-                        index += consumed;
-                        if (index >= textLength) goto Done;
-                        if (!symbolTable.TryParse(text.Slice(index), out symbol, out consumed)) goto Done;
-                    } while (symbol == SymbolTable.Symbol.D0);
-                    if (!IsValid(symbol)) goto Done;
+                        return Utf8.Hex.TryParseSByte(text, out value, out bytesConsumed);
+                    }
+                    else
+                    {
+                        return Utf8.TryParseSByte(text, out value, out bytesConsumed);
+                    }
+                }
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                {
+                    ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
+                    int charsConsumed;
+                    bool result;
+                    if (IsHexFormat(format))
+                    {
+                        result = Utf16.Hex.TryParseSByte(utf16Text, out value, out charsConsumed);
+                    }
+                    else
+                    {
+                        result = Utf16.TryParseSByte(utf16Text, out value, out charsConsumed);
+                    }
+                    bytesConsumed = charsConsumed * sizeof(char);
+                    return result;
                 }
 
-                int firstNonZeroDigitIndex = index;
-                if (textLength - firstNonZeroDigitIndex < Int32OverflowLength * numBytes)
+                if (IsHexFormat(format))
                 {
-                    do
-                    {
-                        answer = answer * 10 + (int)symbol;
-                        index += consumed;
-                        if (index >= textLength) goto Done;
-                        if (!symbolTable.TryParse(text.Slice(index), out symbol, out consumed)) goto Done;
-                    } while (IsValid(symbol));
+                    throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
                 }
-                else
+
+                if (!(format.IsDefault || format.Symbol == 'G' || format.Symbol == 'g'))
                 {
-                    do
+                    throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
+                }
+
+                SymbolTable.Symbol nextSymbol;
+                int thisSymbolConsumed;
+                if (!symbolTable.TryParse(text, out nextSymbol, out thisSymbolConsumed))
+                {
+                    value = default;
+                    bytesConsumed = 0;
+                    return false;
+                }
+
+                int sign = 1;
+                if (nextSymbol == SymbolTable.Symbol.MinusSign)
+                {
+                    sign = -1;
+                }
+
+                int signConsumed = 0;
+                if (nextSymbol == SymbolTable.Symbol.PlusSign || nextSymbol == SymbolTable.Symbol.MinusSign)
+                {
+                    signConsumed = thisSymbolConsumed;
+                    if (!symbolTable.TryParse(text.Slice(signConsumed), out nextSymbol, out thisSymbolConsumed))
                     {
-                        answer = answer * 10 + (int)symbol;
-                        index += consumed;
-                        if (index - firstNonZeroDigitIndex == (Int32OverflowLength - 1) * numBytes)
+                        value = default;
+                        bytesConsumed = 0;
+                        return false;
+                    }
+                }
+
+                if (nextSymbol > SymbolTable.Symbol.D9)
+                {
+                    value = default;
+                    bytesConsumed = 0;
+                    return false;
+                }
+
+                int parsedValue = (int)nextSymbol;
+                int index = signConsumed + thisSymbolConsumed;
+
+                while (index < text.Length)
+                {
+                    bool success = symbolTable.TryParse(text.Slice(index), out nextSymbol, out thisSymbolConsumed);
+                    if (!success || nextSymbol > SymbolTable.Symbol.D9)
+                    {
+                        bytesConsumed = index;
+                        value = (sbyte)(parsedValue * sign);
+                        return true;
+                    }
+
+                    // If parsedValue > (sbyte.MaxValue / 10), any more appended digits will cause overflow.
+                    // if parsedValue == (sbyte.MaxValue / 10), any nextDigit greater than 7 or 8 (depending on sign) implies overflow.
+                    bool positive = sign > 0;
+                    bool nextDigitTooLarge = nextSymbol > SymbolTable.Symbol.D8 || (positive && nextSymbol > SymbolTable.Symbol.D7);
+                    if (parsedValue > sbyte.MaxValue / 10 || (parsedValue == sbyte.MaxValue / 10 && nextDigitTooLarge))
+                    {
+                        bytesConsumed = 0;
+                        value = default;
+                        return false;
+                    }
+
+                    index += thisSymbolConsumed;
+                    parsedValue = parsedValue * 10 + (int)nextSymbol;
+                }
+
+                bytesConsumed = text.Length;
+                value = (sbyte)(parsedValue * sign);
+                return true;
+            }
+
+            public static bool TryParseInt16(ReadOnlySpan<byte> text, out short value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
+
+                if (!format.IsDefault && format.HasPrecision)
+                {
+                    throw new NotImplementedException("Format with precision not supported.");
+                }
+
+                if (symbolTable == SymbolTable.InvariantUtf8)
+                {
+                    if (IsHexFormat(format))
+                    {
+                        return Utf8.Hex.TryParseInt16(text, out value, out bytesConsumed);
+                    }
+                    else
+                    {
+                        return Utf8.TryParseInt16(text, out value, out bytesConsumed);
+                    }
+                }
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                {
+                    ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
+                    int charsConsumed;
+                    bool result;
+                    if (IsHexFormat(format))
+                    {
+                        result = Utf16.Hex.TryParseInt16(utf16Text, out value, out charsConsumed);
+                    }
+                    else
+                    {
+                        result = Utf16.TryParseInt16(utf16Text, out value, out charsConsumed);
+                    }
+                    bytesConsumed = charsConsumed * sizeof(char);
+                    return result;
+                }
+
+                if (IsHexFormat(format))
+                {
+                    throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
+                }
+
+                if (!(format.IsDefault || format.Symbol == 'G' || format.Symbol == 'g'))
+                {
+                    throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
+                }
+
+                SymbolTable.Symbol nextSymbol;
+                int thisSymbolConsumed;
+                if (!symbolTable.TryParse(text, out nextSymbol, out thisSymbolConsumed))
+                {
+                    value = default;
+                    bytesConsumed = 0;
+                    return false;
+                }
+
+                int sign = 1;
+                if ((SymbolTable.Symbol)nextSymbol == SymbolTable.Symbol.MinusSign)
+                {
+                    sign = -1;
+                }
+
+                int signConsumed = 0;
+                if (nextSymbol == SymbolTable.Symbol.PlusSign || nextSymbol == SymbolTable.Symbol.MinusSign)
+                {
+                    signConsumed = thisSymbolConsumed;
+                    if (!symbolTable.TryParse(text.Slice(signConsumed), out nextSymbol, out thisSymbolConsumed))
+                    {
+                        value = default;
+                        bytesConsumed = 0;
+                        return false;
+                    }
+                }
+
+                if (nextSymbol > SymbolTable.Symbol.D9)
+                {
+                    value = default;
+                    bytesConsumed = 0;
+                    return false;
+                }
+
+                int parsedValue = (int)nextSymbol;
+                int index = signConsumed + thisSymbolConsumed;
+
+                while (index < text.Length)
+                {
+                    bool success = symbolTable.TryParse(text.Slice(index), out nextSymbol, out thisSymbolConsumed);
+                    if (!success || nextSymbol > SymbolTable.Symbol.D9)
+                    {
+                        bytesConsumed = index;
+                        value = (short)(parsedValue * sign);
+                        return true;
+                    }
+
+                    // If parsedValue > (short.MaxValue / 10), any more appended digits will cause overflow.
+                    // if parsedValue == (short.MaxValue / 10), any nextDigit greater than 7 or 8 (depending on sign) implies overflow.
+                    bool positive = sign > 0;
+                    bool nextDigitTooLarge = nextSymbol > SymbolTable.Symbol.D8 || (positive && nextSymbol > SymbolTable.Symbol.D7);
+                    if (parsedValue > short.MaxValue / 10 || (parsedValue == short.MaxValue / 10 && nextDigitTooLarge))
+                    {
+                        bytesConsumed = 0;
+                        value = default;
+                        return false;
+                    }
+
+                    index += thisSymbolConsumed;
+                    parsedValue = parsedValue * 10 + (int)nextSymbol;
+                }
+
+                bytesConsumed = text.Length;
+                value = (short)(parsedValue * sign);
+                return true;
+            }
+
+            public static bool TryParseInt32(ReadOnlySpan<byte> text, out int value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                bool isDefault = format.IsDefault;
+                symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
+
+                if (!isDefault && format.HasPrecision)
+                {
+                    throw new NotImplementedException("Format with precision not supported.");
+                }
+
+                bool isHex = IsHexFormat(format);
+
+                if (symbolTable == SymbolTable.InvariantUtf8)
+                {
+                    return isHex ? Utf8.Hex.TryParseInt32(text, out value, out bytesConsumed) :
+                            Utf8.TryParseInt32(text, out value, out bytesConsumed);
+                }
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                {
+                    /*return isHex ? InvariantUtf16.Hex.TryParseInt32(text, out value, out bytesConsumed) :
+                        InvariantUtf16.TryParseInt32(text, out value, out bytesConsumed);*/
+                    ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
+                    bool result = isHex ? Utf16.Hex.TryParseInt32(utf16Text, out value, out int charsConsumed) :
+                        Utf16.TryParseInt32(utf16Text, out value, out charsConsumed);
+                    bytesConsumed = charsConsumed * sizeof(char);
+                    return result;
+                }
+
+                if (isHex)
+                {
+                    throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
+                }
+
+                if (!(isDefault || format.Symbol == 'G' || format.Symbol == 'g'))
+                {
+                    throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
+                }
+
+                int textLength = text.Length;
+                if (textLength < 1) goto FalseExit;
+
+                if (!symbolTable.TryParse(text, out SymbolTable.Symbol symbol, out int consumed)) goto FalseExit;
+
+                sbyte sign = 1;
+                int index = 0;
+                if (symbol == SymbolTable.Symbol.MinusSign)
+                {
+                    sign = -1;
+                    index += consumed;
+                    if (index >= textLength) goto FalseExit;
+                    if (!symbolTable.TryParse(text.Slice(index), out symbol, out consumed)) goto FalseExit;
+                }
+                else if (symbol == SymbolTable.Symbol.PlusSign)
+                {
+                    index += consumed;
+                    if (index >= textLength) goto FalseExit;
+                    if (!symbolTable.TryParse(text.Slice(index), out symbol, out consumed)) goto FalseExit;
+                }
+
+                int answer = 0;
+                if (IsValid(symbol))
+                {
+                    int numBytes = consumed;
+                    if (symbol == SymbolTable.Symbol.D0)
+                    {
+                        do
                         {
+                            index += consumed;
+                            if (index >= textLength) goto Done;
                             if (!symbolTable.TryParse(text.Slice(index), out symbol, out consumed)) goto Done;
-                            if (IsValid(symbol))
+                        } while (symbol == SymbolTable.Symbol.D0);
+                        if (!IsValid(symbol)) goto Done;
+                    }
+
+                    int firstNonZeroDigitIndex = index;
+                    if (textLength - firstNonZeroDigitIndex < Int32OverflowLength * numBytes)
+                    {
+                        do
+                        {
+                            answer = answer * 10 + (int)symbol;
+                            index += consumed;
+                            if (index >= textLength) goto Done;
+                            if (!symbolTable.TryParse(text.Slice(index), out symbol, out consumed)) goto Done;
+                        } while (IsValid(symbol));
+                    }
+                    else
+                    {
+                        do
+                        {
+                            answer = answer * 10 + (int)symbol;
+                            index += consumed;
+                            if (index - firstNonZeroDigitIndex == (Int32OverflowLength - 1) * numBytes)
                             {
-                                if (WillOverFlow(answer, (int)symbol, sign)) goto FalseExit;
-                                answer = answer * 10 + (int)symbol;
-                                index += consumed;
+                                if (!symbolTable.TryParse(text.Slice(index), out symbol, out consumed)) goto Done;
+                                if (IsValid(symbol))
+                                {
+                                    if (WillOverFlow(answer, (int)symbol, sign)) goto FalseExit;
+                                    answer = answer * 10 + (int)symbol;
+                                    index += consumed;
+                                }
+                                goto Done;
                             }
-                            goto Done;
-                        }
-                        if (!symbolTable.TryParse(text.Slice(index), out symbol, out consumed)) goto Done;
-                    } while (IsValid(symbol));
+                            if (!symbolTable.TryParse(text.Slice(index), out symbol, out consumed)) goto Done;
+                        } while (IsValid(symbol));
+                    }
+                    goto Done;
                 }
-                goto Done;
-            }
 
-            FalseExit:
-            bytesConsumed = 0;
-            value = 0;
-            return false;
-
-            Done:
-            bytesConsumed = index;
-            value = answer * sign;
-            return true;
-        }
-
-        public static bool TryParseInt64(ReadOnlySpan<byte> text, out long value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
-
-            if (!format.IsDefault && format.HasPrecision)
-            {
-                throw new NotImplementedException("Format with precision not supported.");
-            }
-
-            if (symbolTable == SymbolTable.InvariantUtf8)
-            {
-                if (IsHexFormat(format))
-                {
-                    return InvariantUtf8.Hex.TryParseInt64(text, out value, out bytesConsumed);
-                }
-                else
-                {
-                    return InvariantUtf8.TryParseInt64(text, out value, out bytesConsumed);
-                }
-            }
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-            {
-                ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
-                int charsConsumed;
-                bool result;
-                if (IsHexFormat(format))
-                {
-                    result = InvariantUtf16.Hex.TryParseInt64(utf16Text, out value, out charsConsumed);
-                }
-                else
-                {
-                    result = InvariantUtf16.TryParseInt64(utf16Text, out value, out charsConsumed);
-                }
-                bytesConsumed = charsConsumed * sizeof(char);
-                return result;
-            }
-
-            if (IsHexFormat(format))
-            {
-                throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
-            }
-
-            if (!(format.IsDefault || format.Symbol == 'G' || format.Symbol == 'g'))
-            {
-                throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
-            }
-
-            SymbolTable.Symbol nextSymbol;
-            int thisSymbolConsumed;
-            if (!symbolTable.TryParse(text, out nextSymbol, out thisSymbolConsumed))
-            {
-                value = default;
+                FalseExit:
                 bytesConsumed = 0;
+                value = 0;
                 return false;
+
+                Done:
+                bytesConsumed = index;
+                value = answer * sign;
+                return true;
             }
 
-            int sign = 1;
-            if (nextSymbol == SymbolTable.Symbol.MinusSign)
+            public static bool TryParseInt64(ReadOnlySpan<byte> text, out long value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
             {
-                sign = -1;
-            }
+                symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
 
-            int signConsumed = 0;
-            if (nextSymbol == SymbolTable.Symbol.PlusSign || nextSymbol == SymbolTable.Symbol.MinusSign)
-            {
-                signConsumed = thisSymbolConsumed;
-                if (!symbolTable.TryParse(text.Slice(signConsumed), out nextSymbol, out thisSymbolConsumed))
+                if (!format.IsDefault && format.HasPrecision)
+                {
+                    throw new NotImplementedException("Format with precision not supported.");
+                }
+
+                if (symbolTable == SymbolTable.InvariantUtf8)
+                {
+                    if (IsHexFormat(format))
+                    {
+                        return Utf8.Hex.TryParseInt64(text, out value, out bytesConsumed);
+                    }
+                    else
+                    {
+                        return Utf8.TryParseInt64(text, out value, out bytesConsumed);
+                    }
+                }
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                {
+                    ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
+                    int charsConsumed;
+                    bool result;
+                    if (IsHexFormat(format))
+                    {
+                        result = Utf16.Hex.TryParseInt64(utf16Text, out value, out charsConsumed);
+                    }
+                    else
+                    {
+                        result = Utf16.TryParseInt64(utf16Text, out value, out charsConsumed);
+                    }
+                    bytesConsumed = charsConsumed * sizeof(char);
+                    return result;
+                }
+
+                if (IsHexFormat(format))
+                {
+                    throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
+                }
+
+                if (!(format.IsDefault || format.Symbol == 'G' || format.Symbol == 'g'))
+                {
+                    throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
+                }
+
+                SymbolTable.Symbol nextSymbol;
+                int thisSymbolConsumed;
+                if (!symbolTable.TryParse(text, out nextSymbol, out thisSymbolConsumed))
                 {
                     value = default;
                     bytesConsumed = 0;
                     return false;
                 }
-            }
 
-            if (nextSymbol > SymbolTable.Symbol.D9)
-            {
-                value = default;
-                bytesConsumed = 0;
-                return false;
-            }
-
-            long parsedValue = (long)nextSymbol;
-            int index = signConsumed + thisSymbolConsumed;
-
-            while (index < text.Length)
-            {
-                bool success = symbolTable.TryParse(text.Slice(index), out nextSymbol, out thisSymbolConsumed);
-                if (!success || nextSymbol > SymbolTable.Symbol.D9)
+                int sign = 1;
+                if (nextSymbol == SymbolTable.Symbol.MinusSign)
                 {
-                    bytesConsumed = index;
-                    value = (long)(parsedValue * sign);
-                    return true;
+                    sign = -1;
                 }
 
-                // If parsedValue > (long.MaxValue / 10), any more appended digits will cause overflow.
-                // if parsedValue == (long.MaxValue / 10), any nextDigit greater than 7 or 8 (depending on sign) implies overflow.
-                bool positive = sign > 0;
-                bool nextDigitTooLarge = nextSymbol > SymbolTable.Symbol.D8 || (positive && nextSymbol > SymbolTable.Symbol.D7);
-                if (parsedValue > long.MaxValue / 10 || (parsedValue == long.MaxValue / 10 && nextDigitTooLarge))
+                int signConsumed = 0;
+                if (nextSymbol == SymbolTable.Symbol.PlusSign || nextSymbol == SymbolTable.Symbol.MinusSign)
                 {
-                    bytesConsumed = 0;
+                    signConsumed = thisSymbolConsumed;
+                    if (!symbolTable.TryParse(text.Slice(signConsumed), out nextSymbol, out thisSymbolConsumed))
+                    {
+                        value = default;
+                        bytesConsumed = 0;
+                        return false;
+                    }
+                }
+
+                if (nextSymbol > SymbolTable.Symbol.D9)
+                {
                     value = default;
+                    bytesConsumed = 0;
                     return false;
                 }
 
-                index += thisSymbolConsumed;
-                parsedValue = parsedValue * 10 + (long)nextSymbol;
-            }
+                long parsedValue = (long)nextSymbol;
+                int index = signConsumed + thisSymbolConsumed;
 
-            bytesConsumed = text.Length;
-            value = (long)(parsedValue * sign);
-            return true;
+                while (index < text.Length)
+                {
+                    bool success = symbolTable.TryParse(text.Slice(index), out nextSymbol, out thisSymbolConsumed);
+                    if (!success || nextSymbol > SymbolTable.Symbol.D9)
+                    {
+                        bytesConsumed = index;
+                        value = (long)(parsedValue * sign);
+                        return true;
+                    }
+
+                    // If parsedValue > (long.MaxValue / 10), any more appended digits will cause overflow.
+                    // if parsedValue == (long.MaxValue / 10), any nextDigit greater than 7 or 8 (depending on sign) implies overflow.
+                    bool positive = sign > 0;
+                    bool nextDigitTooLarge = nextSymbol > SymbolTable.Symbol.D8 || (positive && nextSymbol > SymbolTable.Symbol.D7);
+                    if (parsedValue > long.MaxValue / 10 || (parsedValue == long.MaxValue / 10 && nextDigitTooLarge))
+                    {
+                        bytesConsumed = 0;
+                        value = default;
+                        return false;
+                    }
+
+                    index += thisSymbolConsumed;
+                    parsedValue = parsedValue * 10 + (long)nextSymbol;
+                }
+
+                bytesConsumed = text.Length;
+                value = (long)(parsedValue * sign);
+                return true;
+            }
         }
     }
 }

--- a/src/System.Text.Primitives/System/Text/Parsers/Unsigned.cs
+++ b/src/System.Text.Primitives/System/Text/Parsers/Unsigned.cs
@@ -1,385 +1,390 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text
+using System.Buffers.Text;
+using System.Text;
+
+namespace System.Buffers
 {
-    public static partial class PrimitiveParser
+    public static partial class Parsers
     {
-
-        public static bool TryParseByte(ReadOnlySpan<byte> text, out byte value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
+        public static partial class Custom
         {
-            symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
-
-            if (!format.IsDefault && format.HasPrecision)
+            public static bool TryParseByte(ReadOnlySpan<byte> text, out byte value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
             {
-                throw new NotImplementedException("Format with precision not supported.");
-            }
+                symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
 
-            if (symbolTable == SymbolTable.InvariantUtf8)
-            {
+                if (!format.IsDefault && format.HasPrecision)
+                {
+                    throw new NotImplementedException("Format with precision not supported.");
+                }
+
+                if (symbolTable == SymbolTable.InvariantUtf8)
+                {
+                    if (IsHexFormat(format))
+                    {
+                        return Utf8.Hex.TryParseByte(text, out value, out bytesConsumed);
+                    }
+                    else
+                    {
+                        return Utf8.TryParseByte(text, out value, out bytesConsumed);
+                    }
+                }
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                {
+                    ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
+                    int charsConsumed;
+                    bool result;
+                    if (IsHexFormat(format))
+                    {
+                        result = Utf16.Hex.TryParseByte(utf16Text, out value, out charsConsumed);
+                    }
+                    else
+                    {
+                        result = Utf16.TryParseByte(utf16Text, out value, out charsConsumed);
+                    }
+                    bytesConsumed = charsConsumed * sizeof(char);
+                    return result;
+                }
+
                 if (IsHexFormat(format))
                 {
-                    return InvariantUtf8.Hex.TryParseByte(text, out value, out bytesConsumed);
-                }
-                else
-                {
-                    return InvariantUtf8.TryParseByte(text, out value, out bytesConsumed);
-                }
-            }
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-            {
-                ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
-                int charsConsumed;
-                bool result;
-                if (IsHexFormat(format))
-                {
-                    result = InvariantUtf16.Hex.TryParseByte(utf16Text, out value, out charsConsumed);
-                }
-                else
-                {
-                    result = InvariantUtf16.TryParseByte(utf16Text, out value, out charsConsumed);
-                }
-                bytesConsumed = charsConsumed * sizeof(char);
-                return result;
-            }
-
-            if (IsHexFormat(format))
-            {
-                throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
-            }
-
-            if (!(format.IsDefault || format.Symbol == 'G' || format.Symbol == 'g'))
-            {
-                throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
-            }
-
-            SymbolTable.Symbol nextSymbol;
-            int thisSymbolConsumed;
-            if (!symbolTable.TryParse(text, out nextSymbol, out thisSymbolConsumed))
-            {
-                value = default;
-                bytesConsumed = 0;
-                return false;
-            }
-
-            if (nextSymbol > SymbolTable.Symbol.D9)
-            {
-                value = default;
-                bytesConsumed = 0;
-                return false;
-            }
-
-            uint parsedValue = (uint)nextSymbol;
-            int index = thisSymbolConsumed;
-
-            while (index < text.Length)
-            {
-                bool success = symbolTable.TryParse(text.Slice(index), out nextSymbol, out thisSymbolConsumed);
-                if (!success || nextSymbol > SymbolTable.Symbol.D9)
-                {
-                    bytesConsumed = index;
-                    value = (byte) parsedValue;
-                    return true;
+                    throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
                 }
 
-                // If parsedValue > (byte.MaxValue / 10), any more appended digits will cause overflow.
-                // if parsedValue == (byte.MaxValue / 10), any nextDigit greater than 5 implies overflow.
-                if (parsedValue > byte.MaxValue / 10 || (parsedValue == byte.MaxValue / 10 && nextSymbol > SymbolTable.Symbol.D5))
+                if (!(format.IsDefault || format.Symbol == 'G' || format.Symbol == 'g'))
                 {
-                    bytesConsumed = 0;
+                    throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
+                }
+
+                SymbolTable.Symbol nextSymbol;
+                int thisSymbolConsumed;
+                if (!symbolTable.TryParse(text, out nextSymbol, out thisSymbolConsumed))
+                {
                     value = default;
+                    bytesConsumed = 0;
                     return false;
                 }
 
-                index += thisSymbolConsumed;
-                parsedValue = parsedValue * 10 + (uint)nextSymbol;
-            }
-
-            bytesConsumed = text.Length;
-            value = (byte) parsedValue;
-            return true;
-        }
-
-        public static bool TryParseUInt16(ReadOnlySpan<byte> text, out ushort value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
-
-            if (!format.IsDefault && format.HasPrecision)
-            {
-                throw new NotImplementedException("Format with precision not supported.");
-            }
-
-            if (symbolTable == SymbolTable.InvariantUtf8)
-            {
-                if (IsHexFormat(format))
+                if (nextSymbol > SymbolTable.Symbol.D9)
                 {
-                    return InvariantUtf8.Hex.TryParseUInt16(text, out value, out bytesConsumed);
-                }
-                else
-                {
-                    return InvariantUtf8.TryParseUInt16(text, out value, out bytesConsumed);
-                }
-            }
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-            {
-                ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
-                int charsConsumed;
-                bool result;
-                if (IsHexFormat(format))
-                {
-                    result = InvariantUtf16.Hex.TryParseUInt16(utf16Text, out value, out charsConsumed);
-                }
-                else
-                {
-                    result = InvariantUtf16.TryParseUInt16(utf16Text, out value, out charsConsumed);
-                }
-                bytesConsumed = charsConsumed * sizeof(char);
-                return result;
-            }
-
-            if (IsHexFormat(format))
-            {
-                throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
-            }
-
-            if (!(format.IsDefault || format.Symbol == 'G' || format.Symbol == 'g'))
-            {
-                throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
-            }
-
-            SymbolTable.Symbol nextSymbol;
-            int thisSymbolConsumed;
-            if (!symbolTable.TryParse(text, out nextSymbol, out thisSymbolConsumed))
-            {
-                value = default;
-                bytesConsumed = 0;
-                return false;
-            }
-
-            if (nextSymbol > SymbolTable.Symbol.D9)
-            {
-                value = default;
-                bytesConsumed = 0;
-                return false;
-            }
-
-            uint parsedValue = (uint)nextSymbol;
-            int index = thisSymbolConsumed;
-
-            while (index < text.Length)
-            {
-                bool success = symbolTable.TryParse(text.Slice(index), out nextSymbol, out thisSymbolConsumed);
-                if (!success || nextSymbol > SymbolTable.Symbol.D9)
-                {
-                    bytesConsumed = index;
-                    value = (ushort) parsedValue;
-                    return true;
-                }
-
-                // If parsedValue > (ushort.MaxValue / 10), any more appended digits will cause overflow.
-                // if parsedValue == (ushort.MaxValue / 10), any nextDigit greater than 5 implies overflow.
-                if (parsedValue > ushort.MaxValue / 10 || (parsedValue == ushort.MaxValue / 10 && nextSymbol > SymbolTable.Symbol.D5))
-                {
-                    bytesConsumed = 0;
                     value = default;
+                    bytesConsumed = 0;
                     return false;
                 }
 
-                index += thisSymbolConsumed;
-                parsedValue = parsedValue * 10 + (uint)nextSymbol;
+                uint parsedValue = (uint)nextSymbol;
+                int index = thisSymbolConsumed;
+
+                while (index < text.Length)
+                {
+                    bool success = symbolTable.TryParse(text.Slice(index), out nextSymbol, out thisSymbolConsumed);
+                    if (!success || nextSymbol > SymbolTable.Symbol.D9)
+                    {
+                        bytesConsumed = index;
+                        value = (byte)parsedValue;
+                        return true;
+                    }
+
+                    // If parsedValue > (byte.MaxValue / 10), any more appended digits will cause overflow.
+                    // if parsedValue == (byte.MaxValue / 10), any nextDigit greater than 5 implies overflow.
+                    if (parsedValue > byte.MaxValue / 10 || (parsedValue == byte.MaxValue / 10 && nextSymbol > SymbolTable.Symbol.D5))
+                    {
+                        bytesConsumed = 0;
+                        value = default;
+                        return false;
+                    }
+
+                    index += thisSymbolConsumed;
+                    parsedValue = parsedValue * 10 + (uint)nextSymbol;
+                }
+
+                bytesConsumed = text.Length;
+                value = (byte)parsedValue;
+                return true;
             }
 
-            bytesConsumed = text.Length;
-            value = (ushort) parsedValue;
-            return true;
-        }
-
-        public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
-
-            if (!format.IsDefault && format.HasPrecision)
+            public static bool TryParseUInt16(ReadOnlySpan<byte> text, out ushort value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
             {
-                throw new NotImplementedException("Format with precision not supported.");
-            }
+                symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
 
-            if (symbolTable == SymbolTable.InvariantUtf8)
-            {
+                if (!format.IsDefault && format.HasPrecision)
+                {
+                    throw new NotImplementedException("Format with precision not supported.");
+                }
+
+                if (symbolTable == SymbolTable.InvariantUtf8)
+                {
+                    if (IsHexFormat(format))
+                    {
+                        return Utf8.Hex.TryParseUInt16(text, out value, out bytesConsumed);
+                    }
+                    else
+                    {
+                        return Utf8.TryParseUInt16(text, out value, out bytesConsumed);
+                    }
+                }
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                {
+                    ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
+                    int charsConsumed;
+                    bool result;
+                    if (IsHexFormat(format))
+                    {
+                        result = Utf16.Hex.TryParseUInt16(utf16Text, out value, out charsConsumed);
+                    }
+                    else
+                    {
+                        result = Utf16.TryParseUInt16(utf16Text, out value, out charsConsumed);
+                    }
+                    bytesConsumed = charsConsumed * sizeof(char);
+                    return result;
+                }
+
                 if (IsHexFormat(format))
                 {
-                    return InvariantUtf8.Hex.TryParseUInt32(text, out value, out bytesConsumed);
-                }
-                else
-                {
-                    return InvariantUtf8.TryParseUInt32(text, out value, out bytesConsumed);
-                }
-            }
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-            {
-                ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
-                int charsConsumed;
-                bool result;
-                if (IsHexFormat(format))
-                {
-                    result = InvariantUtf16.Hex.TryParseUInt32(utf16Text, out value, out charsConsumed);
-                }
-                else
-                {
-                    result = InvariantUtf16.TryParseUInt32(utf16Text, out value, out charsConsumed);
-                }
-                bytesConsumed = charsConsumed * sizeof(char);
-                return result;
-            }
-
-            if (IsHexFormat(format))
-            {
-                throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
-            }
-
-            if (!(format.IsDefault || format.Symbol == 'G' || format.Symbol == 'g'))
-            {
-                throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
-            }
-
-            SymbolTable.Symbol nextSymbol;
-            int thisSymbolConsumed;
-            if (!symbolTable.TryParse(text, out nextSymbol, out thisSymbolConsumed))
-            {
-                value = default;
-                bytesConsumed = 0;
-                return false;
-            }
-
-            if (nextSymbol > SymbolTable.Symbol.D9)
-            {
-                value = default;
-                bytesConsumed = 0;
-                return false;
-            }
-
-            uint parsedValue = (uint)nextSymbol;
-            int index = thisSymbolConsumed;
-
-            while (index < text.Length)
-            {
-                bool success = symbolTable.TryParse(text.Slice(index), out nextSymbol, out thisSymbolConsumed);
-                if (!success || nextSymbol > SymbolTable.Symbol.D9)
-                {
-                    bytesConsumed = index;
-                    value = (uint) parsedValue;
-                    return true;
+                    throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
                 }
 
-                // If parsedValue > (uint.MaxValue / 10), any more appended digits will cause overflow.
-                // if parsedValue == (uint.MaxValue / 10), any nextDigit greater than 5 implies overflow.
-                if (parsedValue > uint.MaxValue / 10 || (parsedValue == uint.MaxValue / 10 && nextSymbol > SymbolTable.Symbol.D5))
+                if (!(format.IsDefault || format.Symbol == 'G' || format.Symbol == 'g'))
                 {
-                    bytesConsumed = 0;
+                    throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
+                }
+
+                SymbolTable.Symbol nextSymbol;
+                int thisSymbolConsumed;
+                if (!symbolTable.TryParse(text, out nextSymbol, out thisSymbolConsumed))
+                {
                     value = default;
+                    bytesConsumed = 0;
                     return false;
                 }
 
-                index += thisSymbolConsumed;
-                parsedValue = parsedValue * 10 + (uint)nextSymbol;
-            }
-
-            bytesConsumed = text.Length;
-            value = (uint) parsedValue;
-            return true;
-        }
-
-        public static bool TryParseUInt64(ReadOnlySpan<byte> text, out ulong value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
-        {
-            symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
-
-            if (!format.IsDefault && format.HasPrecision)
-            {
-                throw new NotImplementedException("Format with precision not supported.");
-            }
-
-            if (symbolTable == SymbolTable.InvariantUtf8)
-            {
-                if (IsHexFormat(format))
+                if (nextSymbol > SymbolTable.Symbol.D9)
                 {
-                    return InvariantUtf8.Hex.TryParseUInt64(text, out value, out bytesConsumed);
-                }
-                else
-                {
-                    return InvariantUtf8.TryParseUInt64(text, out value, out bytesConsumed);
-                }
-            }
-            else if (symbolTable == SymbolTable.InvariantUtf16)
-            {
-                ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
-                int charsConsumed;
-                bool result;
-                if (IsHexFormat(format))
-                {
-                    result = InvariantUtf16.Hex.TryParseUInt64(utf16Text, out value, out charsConsumed);
-                }
-                else
-                {
-                    result = InvariantUtf16.TryParseUInt64(utf16Text, out value, out charsConsumed);
-                }
-                bytesConsumed = charsConsumed * sizeof(char);
-                return result;
-            }
-
-            if (IsHexFormat(format))
-            {
-                throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
-            }
-
-            if (!(format.IsDefault || format.Symbol == 'G' || format.Symbol == 'g'))
-            {
-                throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
-            }
-
-            SymbolTable.Symbol nextSymbol;
-            int thisSymbolConsumed;
-            if (!symbolTable.TryParse(text, out nextSymbol, out thisSymbolConsumed))
-            {
-                value = default;
-                bytesConsumed = 0;
-                return false;
-            }
-
-            if (nextSymbol > SymbolTable.Symbol.D9)
-            {
-                value = default;
-                bytesConsumed = 0;
-                return false;
-            }
-
-            ulong parsedValue = (uint)nextSymbol;
-            int index = thisSymbolConsumed;
-
-            while (index < text.Length)
-            {
-                bool success = symbolTable.TryParse(text.Slice(index), out nextSymbol, out thisSymbolConsumed);
-                if (!success || nextSymbol > SymbolTable.Symbol.D9)
-                {
-                    bytesConsumed = index;
-                    value = (ulong) parsedValue;
-                    return true;
-                }
-
-                // If parsedValue > (ulong.MaxValue / 10), any more appended digits will cause overflow.
-                // if parsedValue == (ulong.MaxValue / 10), any nextDigit greater than 5 implies overflow.
-                if (parsedValue > ulong.MaxValue / 10 || (parsedValue == ulong.MaxValue / 10 && nextSymbol > SymbolTable.Symbol.D5))
-                {
-                    bytesConsumed = 0;
                     value = default;
+                    bytesConsumed = 0;
                     return false;
                 }
 
-                index += thisSymbolConsumed;
-                parsedValue = parsedValue * 10 + (uint)nextSymbol;
+                uint parsedValue = (uint)nextSymbol;
+                int index = thisSymbolConsumed;
+
+                while (index < text.Length)
+                {
+                    bool success = symbolTable.TryParse(text.Slice(index), out nextSymbol, out thisSymbolConsumed);
+                    if (!success || nextSymbol > SymbolTable.Symbol.D9)
+                    {
+                        bytesConsumed = index;
+                        value = (ushort)parsedValue;
+                        return true;
+                    }
+
+                    // If parsedValue > (ushort.MaxValue / 10), any more appended digits will cause overflow.
+                    // if parsedValue == (ushort.MaxValue / 10), any nextDigit greater than 5 implies overflow.
+                    if (parsedValue > ushort.MaxValue / 10 || (parsedValue == ushort.MaxValue / 10 && nextSymbol > SymbolTable.Symbol.D5))
+                    {
+                        bytesConsumed = 0;
+                        value = default;
+                        return false;
+                    }
+
+                    index += thisSymbolConsumed;
+                    parsedValue = parsedValue * 10 + (uint)nextSymbol;
+                }
+
+                bytesConsumed = text.Length;
+                value = (ushort)parsedValue;
+                return true;
             }
 
-            bytesConsumed = text.Length;
-            value = (ulong) parsedValue;
-            return true;
+            public static bool TryParseUInt32(ReadOnlySpan<byte> text, out uint value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
+
+                if (!format.IsDefault && format.HasPrecision)
+                {
+                    throw new NotImplementedException("Format with precision not supported.");
+                }
+
+                if (symbolTable == SymbolTable.InvariantUtf8)
+                {
+                    if (IsHexFormat(format))
+                    {
+                        return Utf8.Hex.TryParseUInt32(text, out value, out bytesConsumed);
+                    }
+                    else
+                    {
+                        return Utf8.TryParseUInt32(text, out value, out bytesConsumed);
+                    }
+                }
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                {
+                    ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
+                    int charsConsumed;
+                    bool result;
+                    if (IsHexFormat(format))
+                    {
+                        result = Utf16.Hex.TryParseUInt32(utf16Text, out value, out charsConsumed);
+                    }
+                    else
+                    {
+                        result = Utf16.TryParseUInt32(utf16Text, out value, out charsConsumed);
+                    }
+                    bytesConsumed = charsConsumed * sizeof(char);
+                    return result;
+                }
+
+                if (IsHexFormat(format))
+                {
+                    throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
+                }
+
+                if (!(format.IsDefault || format.Symbol == 'G' || format.Symbol == 'g'))
+                {
+                    throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
+                }
+
+                SymbolTable.Symbol nextSymbol;
+                int thisSymbolConsumed;
+                if (!symbolTable.TryParse(text, out nextSymbol, out thisSymbolConsumed))
+                {
+                    value = default;
+                    bytesConsumed = 0;
+                    return false;
+                }
+
+                if (nextSymbol > SymbolTable.Symbol.D9)
+                {
+                    value = default;
+                    bytesConsumed = 0;
+                    return false;
+                }
+
+                uint parsedValue = (uint)nextSymbol;
+                int index = thisSymbolConsumed;
+
+                while (index < text.Length)
+                {
+                    bool success = symbolTable.TryParse(text.Slice(index), out nextSymbol, out thisSymbolConsumed);
+                    if (!success || nextSymbol > SymbolTable.Symbol.D9)
+                    {
+                        bytesConsumed = index;
+                        value = (uint)parsedValue;
+                        return true;
+                    }
+
+                    // If parsedValue > (uint.MaxValue / 10), any more appended digits will cause overflow.
+                    // if parsedValue == (uint.MaxValue / 10), any nextDigit greater than 5 implies overflow.
+                    if (parsedValue > uint.MaxValue / 10 || (parsedValue == uint.MaxValue / 10 && nextSymbol > SymbolTable.Symbol.D5))
+                    {
+                        bytesConsumed = 0;
+                        value = default;
+                        return false;
+                    }
+
+                    index += thisSymbolConsumed;
+                    parsedValue = parsedValue * 10 + (uint)nextSymbol;
+                }
+
+                bytesConsumed = text.Length;
+                value = (uint)parsedValue;
+                return true;
+            }
+
+            public static bool TryParseUInt64(ReadOnlySpan<byte> text, out ulong value, out int bytesConsumed, ParsedFormat format = default, SymbolTable symbolTable = null)
+            {
+                symbolTable = symbolTable ?? SymbolTable.InvariantUtf8;
+
+                if (!format.IsDefault && format.HasPrecision)
+                {
+                    throw new NotImplementedException("Format with precision not supported.");
+                }
+
+                if (symbolTable == SymbolTable.InvariantUtf8)
+                {
+                    if (IsHexFormat(format))
+                    {
+                        return Utf8.Hex.TryParseUInt64(text, out value, out bytesConsumed);
+                    }
+                    else
+                    {
+                        return Utf8.TryParseUInt64(text, out value, out bytesConsumed);
+                    }
+                }
+                else if (symbolTable == SymbolTable.InvariantUtf16)
+                {
+                    ReadOnlySpan<char> utf16Text = text.NonPortableCast<byte, char>();
+                    int charsConsumed;
+                    bool result;
+                    if (IsHexFormat(format))
+                    {
+                        result = Utf16.Hex.TryParseUInt64(utf16Text, out value, out charsConsumed);
+                    }
+                    else
+                    {
+                        result = Utf16.TryParseUInt64(utf16Text, out value, out charsConsumed);
+                    }
+                    bytesConsumed = charsConsumed * sizeof(char);
+                    return result;
+                }
+
+                if (IsHexFormat(format))
+                {
+                    throw new NotImplementedException("The only supported encodings for hexadecimal parsing are InvariantUtf8 and InvariantUtf16.");
+                }
+
+                if (!(format.IsDefault || format.Symbol == 'G' || format.Symbol == 'g'))
+                {
+                    throw new NotImplementedException(String.Format("Format '{0}' not supported.", format.Symbol));
+                }
+
+                SymbolTable.Symbol nextSymbol;
+                int thisSymbolConsumed;
+                if (!symbolTable.TryParse(text, out nextSymbol, out thisSymbolConsumed))
+                {
+                    value = default;
+                    bytesConsumed = 0;
+                    return false;
+                }
+
+                if (nextSymbol > SymbolTable.Symbol.D9)
+                {
+                    value = default;
+                    bytesConsumed = 0;
+                    return false;
+                }
+
+                ulong parsedValue = (uint)nextSymbol;
+                int index = thisSymbolConsumed;
+
+                while (index < text.Length)
+                {
+                    bool success = symbolTable.TryParse(text.Slice(index), out nextSymbol, out thisSymbolConsumed);
+                    if (!success || nextSymbol > SymbolTable.Symbol.D9)
+                    {
+                        bytesConsumed = index;
+                        value = (ulong)parsedValue;
+                        return true;
+                    }
+
+                    // If parsedValue > (ulong.MaxValue / 10), any more appended digits will cause overflow.
+                    // if parsedValue == (ulong.MaxValue / 10), any nextDigit greater than 5 implies overflow.
+                    if (parsedValue > ulong.MaxValue / 10 || (parsedValue == ulong.MaxValue / 10 && nextSymbol > SymbolTable.Symbol.D5))
+                    {
+                        bytesConsumed = 0;
+                        value = default;
+                        return false;
+                    }
+
+                    index += thisSymbolConsumed;
+                    parsedValue = parsedValue * 10 + (uint)nextSymbol;
+                }
+
+                bytesConsumed = text.Length;
+                value = (ulong)parsedValue;
+                return true;
+            }
         }
     }
 }

--- a/src/System.Text.Primitives/System/Text/ParsingTrie.cs
+++ b/src/System.Text.Primitives/System/Text/ParsingTrie.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Collections.Generic;
 
-namespace System.Text
+namespace System.Buffers.Text
 {
     internal static class ParsingTrie
     {

--- a/src/System.Text.Primitives/System/Text/SymbolTable.Symbol.cs
+++ b/src/System.Text.Primitives/System/Text/SymbolTable.Symbol.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text
+namespace System.Buffers.Text
 {
     public partial class SymbolTable
     {

--- a/src/System.Text.Primitives/System/Text/SymbolTable.Utf16.cs
+++ b/src/System.Text.Primitives/System/Text/SymbolTable.Utf16.cs
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Buffers;
 using System.Runtime.CompilerServices;
 
-namespace System.Text
+namespace System.Buffers.Text
 {
     public partial class SymbolTable
     {
@@ -53,7 +52,7 @@ namespace System.Text
 
             public override bool TryEncode(ReadOnlySpan<byte> utf8, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
             {
-                var status = Encoders.Utf8.ToUtf16(utf8, destination, out bytesConsumed, out bytesWritten);
+                var status = Encodings.Utf8.ToUtf16(utf8, destination, out bytesConsumed, out bytesWritten);
                 if (status != OperationStatus.Done)
                 {
                     bytesConsumed = bytesWritten = 0;
@@ -84,7 +83,7 @@ namespace System.Text
 
             public override bool TryParse(ReadOnlySpan<byte> source, Span<byte> utf8, out int bytesConsumed, out int bytesWritten)
             {
-                var status = Encoders.Utf16.ToUtf8(source, utf8, out bytesConsumed, out bytesWritten);
+                var status = Encodings.Utf16.ToUtf8(source, utf8, out bytesConsumed, out bytesWritten);
                 if (status != OperationStatus.Done)
                 {
                     bytesConsumed = bytesWritten = 0;

--- a/src/System.Text.Primitives/System/Text/SymbolTable.Utf8.cs
+++ b/src/System.Text.Primitives/System/Text/SymbolTable.Utf8.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
-
-namespace System.Text
+namespace System.Buffers.Text
 {
     public partial class SymbolTable
     {

--- a/src/System.Text.Primitives/System/Text/SymbolTable.cs
+++ b/src/System.Text.Primitives/System/Text/SymbolTable.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Text
+namespace System.Buffers.Text
 {
     public abstract partial class SymbolTable
     {
@@ -131,9 +131,7 @@ namespace System.Text
             bytesConsumed = 0;
             while (srcLength > bytesConsumed)
             {
-                var status = Encoders.Utf16.ToUtf8(srcBytes, temp, out int consumed, out int written);
-                if (status == Buffers.OperationStatus.InvalidData)
-                    goto ExitFailed;
+                if(Encodings.Utf16.ToUtf8(srcBytes, temp, out int consumed, out int written) == OperationStatus.InvalidData)                     goto ExitFailed;
 
                 srcBytes = srcBytes.Slice(consumed);
                 bytesConsumed += consumed;

--- a/src/System.Text.Utf8String/System/Text/Utf8String.cs
+++ b/src/System.Text.Utf8String/System/Text/Utf8String.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -127,14 +128,14 @@ namespace System.Text.Utf8
 
         public override string ToString()
         {
-            var status = Encoders.Utf8.ToUtf16Length(this.Bytes, out int needed);
+            var status = Encodings.Utf8.ToUtf16Length(this.Bytes, out int needed);
             if (status != Buffers.OperationStatus.Done)
                 return string.Empty;
 
             // UTF-16 is 2 bytes per char
             var chars = new char[needed >> 1];
             var utf16 = new Span<char>(chars).AsBytes();
-            status = Encoders.Utf8.ToUtf16(this.Bytes, utf16, out int consumed, out int written);
+            status = Encodings.Utf8.ToUtf16(this.Bytes, utf16, out int consumed, out int written);
             if (status != Buffers.OperationStatus.Done)
                 return string.Empty;
 
@@ -620,12 +621,12 @@ namespace System.Text.Utf8
         private static byte[] GetUtf8BytesFromString(string str)
         {
             var utf16 = str.AsReadOnlySpan().AsBytes();
-            var status = Encoders.Utf16.ToUtf8Length(utf16, out int needed);
+            var status = Encodings.Utf16.ToUtf8Length(utf16, out int needed);
             if (status != Buffers.OperationStatus.Done)
                 return null;
 
             var utf8 = new byte[needed];
-            status = Encoders.Utf16.ToUtf8(utf16, utf8, out int consumed, out int written);
+            status = Encodings.Utf16.ToUtf8(utf16, utf8, out int consumed, out int written);
             if (status != Buffers.OperationStatus.Done)
                 // This shouldn't happen...
                 return null;

--- a/tests/Benchmarks/BytesReaderBench.cs
+++ b/tests/Benchmarks/BytesReaderBench.cs
@@ -5,6 +5,7 @@
 using Microsoft.Xunit.Performance;
 using System;
 using System.Buffers;
+using System.Buffers.Text;
 using System.Text;
 
 public class BytesReaderBench

--- a/tests/Benchmarks/E2EPipelineNoIO.cs
+++ b/tests/Benchmarks/E2EPipelineNoIO.cs
@@ -10,6 +10,7 @@ using System.IO.Pipelines.Samples;
 using System.IO.Pipelines;
 using System.Text.Formatting;
 using System.Text.Json;
+using System.Buffers.Text;
 
 public partial class E2EPipelineTests
 {

--- a/tests/Benchmarks/GetAsciiStringBench.cs
+++ b/tests/Benchmarks/GetAsciiStringBench.cs
@@ -6,8 +6,8 @@ using Xunit;
 using Microsoft.Xunit.Performance;
 using System;
 using System.Text;
-using System.Text.Encoders;
 using System.Text.Utf8;
+using System.Buffers;
 
 public class AsciiDecodingBench
 {
@@ -22,7 +22,7 @@ public class AsciiDecodingBench
         foreach (var iteration in Benchmark.Iterations) {
             using (iteration.StartMeasurement()) {
                 for (int i = 0; i < Benchmark.InnerIterationCount; i++) {
-                    str = Ascii.ToUtf16String(bytes);
+                    str = Encodings.Ascii.ToUtf16String(bytes);
                     len += str.Length;
                 }
             }

--- a/tests/System.Buffers.Experimental.Tests/BytesReader.cs
+++ b/tests/System.Buffers.Experimental.Tests/BytesReader.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Buffers.Text;
 using System.Collections.Sequences;
 using System.Text;
 using System.Text.Utf8;

--- a/tests/System.IO.Pipelines.Extensions.Tests/PipelineWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Extensions.Tests/PipelineWriterFacts.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Text;
 using System.Text.Formatting;
 using System.Threading;

--- a/tests/System.IO.Pipelines.Extensions.Tests/ReadableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Extensions.Tests/ReadableBufferFacts.cs
@@ -5,6 +5,7 @@
 using System.Binary;
 using System.Buffers;
 using System.Buffers.Pools;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Collections.Sequences;
 using System.Globalization;

--- a/tests/System.IO.Pipelines.Extensions.Tests/SocketsFacts.cs
+++ b/tests/System.IO.Pipelines.Extensions.Tests/SocketsFacts.cs
@@ -12,6 +12,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using System.Text.Formatting;
+using System.Buffers.Text;
 
 namespace System.IO.Pipelines.Tests
 {

--- a/tests/System.IO.Pipelines.Extensions.Tests/WritableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Extensions.Tests/WritableBufferFacts.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.IO.Pipelines.Text.Primitives;
 using Xunit;
 using System.Text.Formatting;
+using System.Buffers.Text;
 
 namespace System.IO.Pipelines.Tests
 {

--- a/tests/System.Text.Formatting.Tests/CustomCulture.cs
+++ b/tests/System.Text.Formatting.Tests/CustomCulture.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using Xunit;
 
 namespace System.Text.Formatting.Tests

--- a/tests/System.Text.Formatting.Tests/CustomSymbolTable.cs
+++ b/tests/System.Text.Formatting.Tests/CustomSymbolTable.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
+
 namespace System.Text.Formatting.Tests
 {
     public class CustomUtf16SymbolTable : SymbolTable

--- a/tests/System.Text.Formatting.Tests/CustomTypeFormatting.cs
+++ b/tests/System.Text.Formatting.Tests/CustomTypeFormatting.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.IO;
 using Xunit;
 

--- a/tests/System.Text.Formatting.Tests/PerformanceTests.cs
+++ b/tests/System.Text.Formatting.Tests/PerformanceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;

--- a/tests/System.Text.Formatting.Tests/PrimitiveFormattingTests-Time.cs
+++ b/tests/System.Text.Formatting.Tests/PrimitiveFormattingTests-Time.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
 using System.Globalization;
 using Xunit;
 

--- a/tests/System.Text.Formatting.Tests/PrimitiveFormattingTests.cs
+++ b/tests/System.Text.Formatting.Tests/PrimitiveFormattingTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Globalization;
 using System.IO;
 using System.Text.Utf8;

--- a/tests/System.Text.Formatting.Tests/SequenceFormatterTests.cs
+++ b/tests/System.Text.Formatting.Tests/SequenceFormatterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
 using System.Collections.Sequences;
 using Xunit;
 

--- a/tests/System.Text.Http.Parser.Tests/HttpParserBasicTests.cs
+++ b/tests/System.Text.Http.Parser.Tests/HttpParserBasicTests.cs
@@ -5,7 +5,6 @@ using Xunit;
 using System.IO.Pipelines;
 using System.Collections.Generic;
 using System.Buffers;
-using System.Text.Encoders;
 
 namespace System.Text.Http.Parser.Tests
 {
@@ -151,8 +150,8 @@ namespace System.Text.Http.Parser.Tests
 
         public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
         {
-            var nameString = Ascii.ToUtf16String(name);
-            var valueString = Ascii.ToUtf16String(value);
+            var nameString = Encodings.Ascii.ToUtf16String(name);
+            var valueString = Encodings.Ascii.ToUtf16String(value);
             Headers.Add(nameString, valueString);
         }
 
@@ -160,9 +159,9 @@ namespace System.Text.Http.Parser.Tests
         {
             Method = method;
             Version = version;
-            Path = Ascii.ToUtf16String(path);
-            Query = Ascii.ToUtf16String(query);
-            Target = Ascii.ToUtf16String(target);
+            Path = Encodings.Ascii.ToUtf16String(path);
+            Query = Encodings.Ascii.ToUtf16String(query);
+            Target = Encodings.Ascii.ToUtf16String(target);
         }
     }
 }

--- a/tests/System.Text.Http.Parser.Tests/HttpParserTests.cs
+++ b/tests/System.Text.Http.Parser.Tests/HttpParserTests.cs
@@ -5,7 +5,6 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.IO.Pipelines;
 using System.Linq;
-using System.Text.Encoders;
 using Xunit;
 
 namespace System.Text.Http.Parser.Tests
@@ -410,16 +409,16 @@ namespace System.Text.Http.Parser.Tests
 
             public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
             {
-                Headers[Ascii.ToUtf16String(name)] = Ascii.ToUtf16String(value);
+                Headers[Encodings.Ascii.ToUtf16String(name)] = Encodings.Ascii.ToUtf16String(value);
             }
 
             public void OnStartLine(Http.Method method, Http.Version version, ReadOnlySpan<byte> target, ReadOnlySpan<byte> path, ReadOnlySpan<byte> query, ReadOnlySpan<byte> customMethod, bool pathEncoded)
             {
-                Method = method != Http.Method.Custom ? method.ToString().ToUpper() : Ascii.ToUtf16String(customMethod);
+                Method = method != Http.Method.Custom ? method.ToString().ToUpper() : Encodings.Ascii.ToUtf16String(customMethod);
                 Version = ToString(version);
-                RawTarget = Ascii.ToUtf16String(target);
-                RawPath = Ascii.ToUtf16String(path);
-                Query = Ascii.ToUtf16String(query);
+                RawTarget = Encodings.Ascii.ToUtf16String(target);
+                RawPath = Encodings.Ascii.ToUtf16String(path);
+                Query = Encodings.Ascii.ToUtf16String(query);
                 PathEncoded = pathEncoded;
             }
 

--- a/tests/System.Text.Http.Tests/GivenAnHttpHeaders.cs
+++ b/tests/System.Text.Http.Tests/GivenAnHttpHeaders.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Xunit;
 using System.Text.Utf8;
 using System.Text.Http.SingleSegment;
+using System.Buffers.Text;
 
 namespace System.Text.Http.Tests
 {

--- a/tests/System.Text.Http.Tests/GivenIFormatterExtensionsForHttp.cs
+++ b/tests/System.Text.Http.Tests/GivenIFormatterExtensionsForHttp.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Text.Formatting;
 using System.Text.Utf8;
 using Xunit;

--- a/tests/System.Text.Http.Tests/HttpRequestTests.cs
+++ b/tests/System.Text.Http.Tests/HttpRequestTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Collections.Sequences;
 using Xunit;

--- a/tests/System.Text.Json.Tests.Dynamic/JsonDynamicObjectTests.cs
+++ b/tests/System.Text.Json.Tests.Dynamic/JsonDynamicObjectTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers.Text;
 using System.Text.Formatting;
 using System.Text.Utf8;
 using Xunit;

--- a/tests/System.Text.Json.Tests/JsonPerfTests.cs
+++ b/tests/System.Text.Json.Tests/JsonPerfTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers.Text;
 using Xunit;
 
 namespace System.Text.Json.Tests

--- a/tests/System.Text.Json.Tests/JsonReaderPerfTests.cs
+++ b/tests/System.Text.Json.Tests/JsonReaderPerfTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using Microsoft.Xunit.Performance;
 using System.IO;
 using System.Text.Json.Tests.Resources;
+using System.Buffers.Text;
 
 namespace System.Text.Json.Tests
 {

--- a/tests/System.Text.Json.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.Json.Tests/JsonReaderTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Text.Json.Tests.Resources;
 using Xunit;
@@ -301,7 +303,7 @@ namespace System.Text.Json.Tests
                     value.StringValue = ReadString(ref jsonReader);
                     break;
                 case Value.ValueType.Number:
-                    PrimitiveParser.TryParseDecimal(jsonReader.Value, out decimal num, out consumed, jsonReader.SymbolTable);
+                    Parsers.Custom.TryParseDecimal(jsonReader.Value, out decimal num, out consumed, jsonReader.SymbolTable);
                     value.NumberValue = Convert.ToDouble(num);
                     break;
                 case Value.ValueType.True:
@@ -410,7 +412,7 @@ namespace System.Text.Json.Tests
         {
             if (jsonReader.SymbolTable == SymbolTable.InvariantUtf8)
             {
-                var status = Encoders.Utf8.ToUtf16Length(jsonReader.Value, out int needed);
+                var status = Encodings.Utf8.ToUtf16Length(jsonReader.Value, out int needed);
                 Assert.Equal(Buffers.OperationStatus.Done, status);
 
                 var text = new string(' ', needed);
@@ -420,7 +422,7 @@ namespace System.Text.Json.Tests
                     {
                         var dst = new Span<byte>((byte*)pChars, needed);
 
-                        status = Encoders.Utf8.ToUtf16(jsonReader.Value, dst, out int consumed, out int written);
+                        status = Encodings.Utf8.ToUtf16(jsonReader.Value, dst, out int consumed, out int written);
                         Assert.Equal(Buffers.OperationStatus.Done, status);
                     }
                 }

--- a/tests/System.Text.Json.Tests/JsonWriterTests.cs
+++ b/tests/System.Text.Json.Tests/JsonWriterTests.cs
@@ -4,6 +4,7 @@
 
 using Xunit;
 using System.Text.Formatting;
+using System.Buffers.Text;
 
 namespace System.Text.Json.Tests
 {

--- a/tests/System.Text.Json.Tests/PerfSmokeTests.cs
+++ b/tests/System.Text.Json.Tests/PerfSmokeTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;

--- a/tests/System.Text.Primitives.Tests/Encoding/AsciiCasingTests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/AsciiCasingTests.cs
@@ -3,10 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
-using System.Text.Encoders;
+using System.Text;
 using Xunit;
 
-namespace System.Text.Encodings.Tests
+namespace System.Buffers.Tests
 {
     public class AsciiCasingTests
     {
@@ -20,7 +20,7 @@ namespace System.Text.Encodings.Tests
             buffer.AsSpan().CopyTo(copy);
             var output = new byte[buffer.Length];
 
-            var status = Ascii.ToUpper(buffer, output, out int processedBytes);
+            var status = Encodings.Ascii.ToUpper(buffer, output, out int processedBytes);
             Assert.Equal(expectedStatus, status);
             Assert.Equal(expectedProcessed, processedBytes);
 
@@ -39,7 +39,7 @@ namespace System.Text.Encodings.Tests
             var copy = new byte[buffer.Length];
             buffer.AsSpan().CopyTo(copy);
 
-            var status = Ascii.ToUpperInPlace(buffer, out int processedBytes);
+            var status = Encodings.Ascii.ToUpperInPlace(buffer, out int processedBytes);
             Assert.Equal(expectedStatus, status);
             Assert.Equal(expectedProcessed, processedBytes);
 
@@ -57,7 +57,7 @@ namespace System.Text.Encodings.Tests
             buffer.AsSpan().CopyTo(copy);
             var output = new byte[buffer.Length];
 
-            var status = Ascii.ToLower(buffer, output, out int processedBytes);
+            var status = Encodings.Ascii.ToLower(buffer, output, out int processedBytes);
             Assert.Equal(expectedStatus, status);
             Assert.Equal(expectedProcessed, processedBytes);
 
@@ -76,7 +76,7 @@ namespace System.Text.Encodings.Tests
             var copy = new byte[buffer.Length];
             buffer.AsSpan().CopyTo(copy);
 
-            var status = Ascii.ToLowerInPlace(buffer, out int processedBytes);
+            var status = Encodings.Ascii.ToLowerInPlace(buffer, out int processedBytes);
             Assert.Equal(expectedStatus, status);
             Assert.Equal(expectedProcessed, processedBytes);
 

--- a/tests/System.Text.Primitives.Tests/Encoding/EncodeIntoUtf8Tests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/EncodeIntoUtf8Tests.cs
@@ -15,12 +15,12 @@ namespace System.Text.Primitives.Tests.Encoding
         public void InputEmptyFromUtf16()
         {
             // Destination has zero storage
-            Assert.Equal(OperationStatus.Done, Encoders.Utf16.ToUtf8(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, out int consumed, out int written));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf16.ToUtf8(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, out int consumed, out int written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
 
             // Destination has non-zero storage
-            Assert.Equal(OperationStatus.Done, Encoders.Utf16.ToUtf8(ReadOnlySpan<byte>.Empty, new byte[1], out consumed, out written));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf16.ToUtf8(ReadOnlySpan<byte>.Empty, new byte[1], out consumed, out written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
         }
@@ -29,12 +29,12 @@ namespace System.Text.Primitives.Tests.Encoding
         public void InputEmptyFromUtf32()
         {
             // Destination has zero storage
-            Assert.Equal(OperationStatus.Done, Encoders.Utf32.ToUtf8(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, out int consumed, out int written));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf32.ToUtf8(ReadOnlySpan<byte>.Empty, Span<byte>.Empty, out int consumed, out int written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
 
             // Destination has non-zero storage
-            Assert.Equal(OperationStatus.Done, Encoders.Utf32.ToUtf8(ReadOnlySpan<byte>.Empty, new byte[1], out consumed, out written));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf32.ToUtf8(ReadOnlySpan<byte>.Empty, new byte[1], out consumed, out written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
         }
@@ -45,7 +45,7 @@ namespace System.Text.Primitives.Tests.Encoding
             string inputString = TextEncoderTestHelper.GenerateValidString(TextEncoderConstants.DataLength, 0, TextEncoderConstants.Utf8ThreeBytesLastCodePoint);
             ReadOnlySpan<byte> input = Text.Encoding.Unicode.GetBytes(inputString);
 
-            Assert.Equal(OperationStatus.DestinationTooSmall, Encoders.Utf16.ToUtf8(input, Span<byte>.Empty, out int consumed, out int written));
+            Assert.Equal(OperationStatus.DestinationTooSmall, Encodings.Utf16.ToUtf8(input, Span<byte>.Empty, out int consumed, out int written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
         }
@@ -56,7 +56,7 @@ namespace System.Text.Primitives.Tests.Encoding
             string inputString = TextEncoderTestHelper.GenerateValidString(TextEncoderConstants.DataLength, 0, TextEncoderConstants.Utf8ThreeBytesLastCodePoint);
             ReadOnlySpan<byte> input = Text.Encoding.UTF32.GetBytes(inputString);
 
-            Assert.Equal(OperationStatus.DestinationTooSmall, Encoders.Utf32.ToUtf8(input, Span<byte>.Empty, out int consumed, out int written));
+            Assert.Equal(OperationStatus.DestinationTooSmall, Encodings.Utf32.ToUtf8(input, Span<byte>.Empty, out int consumed, out int written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
         }
@@ -74,7 +74,7 @@ namespace System.Text.Primitives.Tests.Encoding
                 for (int j = 0; j < BufferSizeRange * 4; j++)
                 {
                     Span<byte> output = new byte[j];
-                    var status = Encoders.Utf16.ToUtf8(input, output, out int consumed, out int written);
+                    var status = Encodings.Utf16.ToUtf8(input, output, out int consumed, out int written);
                     if (status == OperationStatus.DestinationTooSmall)
                     {
                         Assert.True(consumed < input.Length, "consumed is too large");
@@ -105,7 +105,7 @@ namespace System.Text.Primitives.Tests.Encoding
                 for (int j = 0; j < BufferSizeRange * 4; j++)
                 {
                     Span<byte> output = new byte[j];
-                    var status = Encoders.Utf32.ToUtf8(input, output, out int consumed, out int written);
+                    var status = Encodings.Utf32.ToUtf8(input, output, out int consumed, out int written);
                     if (status == OperationStatus.DestinationTooSmall)
                     {
                         Assert.True(consumed < input.Length, "consumed is too large");
@@ -131,7 +131,7 @@ namespace System.Text.Primitives.Tests.Encoding
             Span<byte> expected = Text.Encoding.UTF8.GetBytes(inputString);
 
             Span<byte> output = new byte[expected.Length / 2];
-            Assert.Equal(OperationStatus.DestinationTooSmall, Encoders.Utf16.ToUtf8(input, output, out int consumed, out int written));
+            Assert.Equal(OperationStatus.DestinationTooSmall, Encodings.Utf16.ToUtf8(input, output, out int consumed, out int written));
             Assert.True(consumed < input.Length, "Unexpectedly consumed entire input");
             Assert.True(written < expected.Length, "Unexpectedly wrote entire output");
             Assert.True(expected.Slice(0, written).SequenceEqual(output.Slice(0, written)), "Incorrect byte sequence");
@@ -139,7 +139,7 @@ namespace System.Text.Primitives.Tests.Encoding
             input = input.Slice(consumed);
             expected = expected.Slice(written);
             output = new byte[expected.Length];
-            Assert.Equal(OperationStatus.Done, Encoders.Utf16.ToUtf8(input, output, out consumed, out written));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf16.ToUtf8(input, output, out consumed, out written));
             Assert.Equal(input.Length, consumed);
             Assert.Equal(expected.Length, written);
             Assert.True(expected.SequenceEqual(output), "Incorrect byte sequence");
@@ -153,7 +153,7 @@ namespace System.Text.Primitives.Tests.Encoding
             Span<byte> expected = Text.Encoding.UTF8.GetBytes(inputString);
 
             Span<byte> output = new byte[expected.Length / 2];
-            Assert.Equal(OperationStatus.DestinationTooSmall, Encoders.Utf32.ToUtf8(input, output, out int consumed, out int written));
+            Assert.Equal(OperationStatus.DestinationTooSmall, Encodings.Utf32.ToUtf8(input, output, out int consumed, out int written));
             Assert.True(consumed < input.Length, "Unexpectedly consumed entire input");
             Assert.True(written < expected.Length, "Unexpectedly wrote entire output");
             Assert.True(expected.Slice(0, written).SequenceEqual(output.Slice(0, written)), "Incorrect byte sequence");
@@ -161,7 +161,7 @@ namespace System.Text.Primitives.Tests.Encoding
             input = input.Slice(consumed);
             expected = expected.Slice(written);
             output = new byte[expected.Length];
-            Assert.Equal(OperationStatus.Done, Encoders.Utf32.ToUtf8(input, output, out consumed, out written));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf32.ToUtf8(input, output, out consumed, out written));
             Assert.Equal(input.Length, consumed);
             Assert.Equal(expected.Length, written);
             Assert.True(expected.SequenceEqual(output), "Incorrect byte sequence");
@@ -178,11 +178,11 @@ namespace System.Text.Primitives.Tests.Encoding
             Span<byte> expected2 = Text.Encoding.UTF8.GetBytes(inputString2);
 
             Span<byte> output = new byte[expected1.Length + expected2.Length];
-            Assert.Equal(OperationStatus.Done, Encoders.Utf16.ToUtf8(input1, output, out int consumed1, out int written1));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf16.ToUtf8(input1, output, out int consumed1, out int written1));
             Assert.Equal(input1.Length, consumed1);
             Assert.Equal(expected1.Length, written1);
 
-            Assert.Equal(OperationStatus.Done, Encoders.Utf16.ToUtf8(input2, output.Slice(written1), out int consumed2, out int written2));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf16.ToUtf8(input2, output.Slice(written1), out int consumed2, out int written2));
             Assert.Equal(input2.Length, consumed2);
             Assert.Equal(expected2.Length, written2);
 
@@ -201,11 +201,11 @@ namespace System.Text.Primitives.Tests.Encoding
             Span<byte> expected2 = Text.Encoding.UTF8.GetBytes(inputString2);
 
             Span<byte> output = new byte[expected1.Length + expected2.Length];
-            Assert.Equal(OperationStatus.Done, Encoders.Utf32.ToUtf8(input1, output, out int consumed1, out int written1));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf32.ToUtf8(input1, output, out int consumed1, out int written1));
             Assert.Equal(input1.Length, consumed1);
             Assert.Equal(expected1.Length, written1);
 
-            Assert.Equal(OperationStatus.Done, Encoders.Utf32.ToUtf8(input2, output.Slice(written1), out int consumed2, out int written2));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf32.ToUtf8(input2, output.Slice(written1), out int consumed2, out int written2));
             Assert.Equal(input2.Length, consumed2);
             Assert.Equal(expected2.Length, written2);
 
@@ -221,12 +221,12 @@ namespace System.Text.Primitives.Tests.Encoding
             Span<byte> output = new byte[16];
 
             ReadOnlySpan<byte> input = inputStringLow.AsReadOnlySpan().AsBytes();
-            Assert.Equal(OperationStatus.InvalidData, Encoders.Utf16.ToUtf8(input, output, out int consumed, out int written));
+            Assert.Equal(OperationStatus.InvalidData, Encodings.Utf16.ToUtf8(input, output, out int consumed, out int written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
 
             input = inputStringHigh.AsReadOnlySpan().AsBytes();
-            Assert.Equal(OperationStatus.InvalidData, Encoders.Utf16.ToUtf8(input, output, out consumed, out written));
+            Assert.Equal(OperationStatus.InvalidData, Encodings.Utf16.ToUtf8(input, output, out consumed, out written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
         }
@@ -238,7 +238,7 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> input = codepoints.AsSpan().AsBytes();
             Span<byte> output = new byte[16];
 
-            Assert.Equal(OperationStatus.InvalidData, Encoders.Utf32.ToUtf8(input, output, out int consumed, out int written));
+            Assert.Equal(OperationStatus.InvalidData, Encodings.Utf32.ToUtf8(input, output, out int consumed, out int written));
             Assert.Equal(0, consumed);
             Assert.Equal(0, written);
         }
@@ -252,7 +252,7 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> expected = Text.Encoding.Convert(Text.Encoding.Unicode, Text.Encoding.UTF8, inputBytes);
             int expectedWritten = TextEncoderTestHelper.GetUtf8ByteCount(inputStringEndsWithLow.AsReadOnlySpan());
             Span<byte> output = new byte[expectedWritten + 10];
-            Assert.Equal(OperationStatus.InvalidData, Encoders.Utf16.ToUtf8(input, output, out int consumed, out int written));
+            Assert.Equal(OperationStatus.InvalidData, Encodings.Utf16.ToUtf8(input, output, out int consumed, out int written));
             Assert.True(consumed < input.Length, "Consumed too many input characters");
             Assert.Equal(expectedWritten, written);
             Assert.True(expected.Slice(0, written).SequenceEqual(output.Slice(0, written)), "Invalid output sequence [ends with low]");
@@ -263,7 +263,7 @@ namespace System.Text.Primitives.Tests.Encoding
             expected = Text.Encoding.Convert(Text.Encoding.Unicode, Text.Encoding.UTF8, inputBytes);
             expectedWritten = TextEncoderTestHelper.GetUtf8ByteCount(inputStringInvalid.AsReadOnlySpan());
             output = new byte[expectedWritten + 10];
-            Assert.Equal(OperationStatus.InvalidData, Encoders.Utf16.ToUtf8(input, output, out consumed, out written));
+            Assert.Equal(OperationStatus.InvalidData, Encodings.Utf16.ToUtf8(input, output, out consumed, out written));
             Assert.True(consumed < input.Length, "Consumed more input than expected");
             Assert.Equal(expectedWritten, written);
             Assert.True(expected.Slice(0, written).SequenceEqual(output.Slice(0, written)), "Invalid output sequence [invalid]");
@@ -278,7 +278,7 @@ namespace System.Text.Primitives.Tests.Encoding
             int expectedWritten = TextEncoderTestHelper.GetUtf8ByteCount(codepoints);
             Span<byte> output = new byte[expectedWritten];
 
-            Assert.Equal(OperationStatus.InvalidData, Encoders.Utf32.ToUtf8(input, output, out int consumed, out int written));
+            Assert.Equal(OperationStatus.InvalidData, Encodings.Utf32.ToUtf8(input, output, out int consumed, out int written));
             Assert.True(consumed < input.Length, "Consumed more input than expected");
             Assert.Equal(expectedWritten, written);
             Assert.True(expected.Slice(0, expectedWritten).SequenceEqual(output));
@@ -300,13 +300,13 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> expected = Text.Encoding.UTF8.GetBytes(inputString1 + inputString2);
             Span<byte> output = new byte[expected.Length];
 
-            Assert.Equal(OperationStatus.NeedMoreSourceData, Encoders.Utf16.ToUtf8(input1, output, out int consumed, out int written));
+            Assert.Equal(OperationStatus.NeedMoreSourceData, Encodings.Utf16.ToUtf8(input1, output, out int consumed, out int written));
             Assert.Equal(input1.Length - 2, consumed);
             Assert.NotEqual(expected.Length, written);
             Assert.True(expected.Slice(0, written).SequenceEqual(output.Slice(0, written)), "Invalid output sequence [first half]");
 
             expected = expected.Slice(written);
-            Assert.Equal(OperationStatus.Done, Encoders.Utf16.ToUtf8(input2, output, out consumed, out written));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf16.ToUtf8(input2, output, out consumed, out written));
             Assert.Equal(input2.Length, consumed);
             Assert.Equal(expected.Length, written);
             Assert.True(expected.SequenceEqual(output.Slice(0, written)), "Invalid output sequence [second half]");
@@ -327,14 +327,14 @@ namespace System.Text.Primitives.Tests.Encoding
 
             ReadOnlySpan<byte> input = inputAll.AsSpan().Slice(0, codepoints1.Length).AsBytes();
             input = input.Slice(0, input.Length - 2); // Strip a couple bytes from last good code point
-            Assert.Equal(OperationStatus.NeedMoreSourceData, Encoders.Utf32.ToUtf8(input, output, out int consumed, out int written));
+            Assert.Equal(OperationStatus.NeedMoreSourceData, Encodings.Utf32.ToUtf8(input, output, out int consumed, out int written));
             Assert.True(input.Length > consumed, "Consumed too many bytes [first half]");
             Assert.NotEqual(expected.Length, written);
             Assert.True(expected.Slice(0, written).SequenceEqual(output.Slice(0, written)), "Invalid output sequence [first half]");
 
             input = inputAll.AsSpan().AsBytes().Slice(consumed);
             expected = expected.Slice(written);
-            Assert.Equal(OperationStatus.Done, Encoders.Utf32.ToUtf8(input, output, out consumed, out written));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf32.ToUtf8(input, output, out consumed, out written));
             Assert.Equal(input.Length, consumed);
             Assert.Equal(expected.Length, written);
             Assert.True(expected.SequenceEqual(output.Slice(0, written)), "Invalid output sequence [second half]");
@@ -369,7 +369,7 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> expected = Text.Encoding.UTF8.GetBytes(inputString);
             Span<byte> output = new byte[expected.Length];
 
-            Assert.Equal(OperationStatus.Done, Encoders.Utf16.ToUtf8(input, output, out int consumed, out int written));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf16.ToUtf8(input, output, out int consumed, out int written));
             Assert.Equal(input.Length, consumed);
             Assert.Equal(expected.Length, written);
             Assert.True(expected.SequenceEqual(output), "Invalid output sequence");
@@ -381,7 +381,7 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> expected = Text.Encoding.UTF8.GetBytes(inputString);
             Span<byte> output = new byte[expected.Length];
 
-            Assert.Equal(OperationStatus.Done, Encoders.Utf32.ToUtf8(input, output, out int consumed, out int written));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf32.ToUtf8(input, output, out int consumed, out int written));
             Assert.Equal(input.Length, consumed);
             Assert.Equal(expected.Length, written);
             Assert.True(expected.SequenceEqual(output), "Invalid output sequence");

--- a/tests/System.Text.Primitives.Tests/Encoding/Performance/PerfTests.Span.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/Performance/PerfTests.Span.cs
@@ -47,7 +47,7 @@ namespace System.Text.Primitives.Tests
             string inputString = GenerateStringData(length, minCodePoint, maxCodePoint, special);
             ReadOnlySpan<byte> utf16 = inputString.AsReadOnlySpan().AsBytes();
 
-            var status = Encoders.Utf16.ToUtf8Length(utf16, out int needed);
+            var status = Encodings.Utf16.ToUtf8Length(utf16, out int needed);
             Assert.Equal(OperationStatus.Done, status);
 
             Span<byte> utf8 = new byte[needed];
@@ -58,7 +58,7 @@ namespace System.Text.Primitives.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        status = Encoders.Utf16.ToUtf8(utf16, utf8, out int consumed, out int written);
+                        status = Encodings.Utf16.ToUtf8(utf16, utf8, out int consumed, out int written);
                         if (status != OperationStatus.Done)
                             throw new Exception();
                     }
@@ -73,7 +73,7 @@ namespace System.Text.Primitives.Tests
             string inputString = GenerateStringData(length, minCodePoint, maxCodePoint, special);
             ReadOnlySpan<byte> utf32 = Text.Encoding.UTF32.GetBytes(inputString);
 
-            var status = Encoders.Utf32.ToUtf8Length(utf32, out int needed);
+            var status = Encodings.Utf32.ToUtf8Length(utf32, out int needed);
             Assert.Equal(OperationStatus.Done, status);
 
             Span<byte> utf8 = new byte[needed];
@@ -84,7 +84,7 @@ namespace System.Text.Primitives.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        status = Encoders.Utf32.ToUtf8(utf32, utf8, out int consumed, out int written);
+                        status = Encodings.Utf32.ToUtf8(utf32, utf8, out int consumed, out int written);
                         if (status != OperationStatus.Done)
                             throw new Exception();
                     }
@@ -99,7 +99,7 @@ namespace System.Text.Primitives.Tests
             string inputString = GenerateStringData(length, minCodePoint, maxCodePoint, special);
             ReadOnlySpan<byte> utf8 = Text.Encoding.UTF8.GetBytes(inputString);
 
-            var status = Encoders.Utf8.ToUtf16Length(utf8, out int needed);
+            var status = Encodings.Utf8.ToUtf16Length(utf8, out int needed);
             Assert.Equal(OperationStatus.Done, status);
 
             Span<byte> utf16 = new byte[needed];
@@ -110,7 +110,7 @@ namespace System.Text.Primitives.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        status = Encoders.Utf8.ToUtf16(utf8, utf16, out int consumed, out int written);
+                        status = Encodings.Utf8.ToUtf16(utf8, utf16, out int consumed, out int written);
                         if (status != OperationStatus.Done)
                             throw new Exception();
                     }
@@ -125,7 +125,7 @@ namespace System.Text.Primitives.Tests
             string inputString = GenerateStringData(length, minCodePoint, maxCodePoint, special);
             ReadOnlySpan<byte> utf32 = Text.Encoding.UTF32.GetBytes(inputString);
 
-            var status = Encoders.Utf32.ToUtf16Length(utf32, out int needed);
+            var status = Encodings.Utf32.ToUtf16Length(utf32, out int needed);
             Assert.Equal(OperationStatus.Done, status);
 
             Span<byte> utf16 = new byte[needed];
@@ -136,7 +136,7 @@ namespace System.Text.Primitives.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        status = Encoders.Utf32.ToUtf16(utf32, utf16, out int consumed, out int written);
+                        status = Encodings.Utf32.ToUtf16(utf32, utf16, out int consumed, out int written);
                         if (status != OperationStatus.Done)
                             throw new Exception();
                     }

--- a/tests/System.Text.Primitives.Tests/Encoding/Utf8EncoderTests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/Utf8EncoderTests.cs
@@ -23,7 +23,7 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> utf16 = new ReadOnlySpan<char>(chars).NonPortableCast<char, byte>();
             Span<byte> buffer = new byte[expectedBytes.Length];
 
-            Assert.Equal(expectedReturnVal, Encoders.Utf16.ToUtf8(utf16, buffer, out int consumed, out int written));
+            Assert.Equal(expectedReturnVal, Encodings.Utf16.ToUtf8(utf16, buffer, out int consumed, out int written));
             Assert.Equal(expectedBytes.Length, written);
 
             if (expectedBytes.Length > 0)
@@ -35,18 +35,18 @@ namespace System.Text.Primitives.Tests.Encoding
 
         public static object[][] TryEncodeFromUnicodeMultipleCodePointsTestData = {
              // empty
-            new object[] { true, new byte[] { }, new uint[] { 0x50 }, Buffers.OperationStatus.DestinationTooSmall },
-            new object[] { false, new byte[] { }, new uint[] { 0x50 }, Buffers.OperationStatus.DestinationTooSmall },
+            new object[] { true, new byte[] { }, new uint[] { 0x50 }, OperationStatus.DestinationTooSmall },
+            new object[] { false, new byte[] { }, new uint[] { 0x50 }, OperationStatus.DestinationTooSmall },
             // multiple bytes
             new object[] { true, new byte[] { 0x50, 0xCF, 0xA8, 0xEA, 0xBF, 0x88, 0xF0, 0xA4, 0xA7, 0xB0 },
-                new uint[] { 0x50, 0x3E8, 0xAFC8, 0x249F0 } , Buffers.OperationStatus.Done },
+                new uint[] { 0x50, 0x3E8, 0xAFC8, 0x249F0 } , OperationStatus.Done },
             new object[] { false, new byte[] { 0x50, 0x00, 0xE8, 0x03, 0xC8, 0xAF, 0x52, 0xD8, 0xF0, 0xDD },
-                new uint[] { 0x50, 0x3E8, 0xAFC8, 0x249F0 } , Buffers.OperationStatus.Done },
+                new uint[] { 0x50, 0x3E8, 0xAFC8, 0x249F0 } , OperationStatus.Done },
             // multiple bytes - buffer too small
             new object[] { true, new byte[] { 0x50 },
-                new uint[] { 0x50, 0x3E8, 0xAFC8, 0x249F0 } , Buffers.OperationStatus.DestinationTooSmall },
+                new uint[] { 0x50, 0x3E8, 0xAFC8, 0x249F0 } , OperationStatus.DestinationTooSmall },
             new object[] { false, new byte[] { 0x50, 0x00 },
-                new uint[] { 0x50, 0x3E8, 0xAFC8, 0x249F0 } , Buffers.OperationStatus.DestinationTooSmall },
+                new uint[] { 0x50, 0x3E8, 0xAFC8, 0x249F0 } , OperationStatus.DestinationTooSmall },
         };
 
         [Theory, MemberData("TryEncodeFromUnicodeMultipleCodePointsTestData")]
@@ -59,9 +59,9 @@ namespace System.Text.Primitives.Tests.Encoding
             Buffers.OperationStatus result;
 
             if (useUtf8Encoder)
-                result = Encoders.Utf32.ToUtf8(codePoints, buffer, out consumed, out written);
+                result = Encodings.Utf32.ToUtf8(codePoints, buffer, out consumed, out written);
             else
-                result = Encoders.Utf32.ToUtf16(codePoints, buffer, out consumed, out written);
+                result = Encodings.Utf32.ToUtf16(codePoints, buffer, out consumed, out written);
 
             Assert.Equal(expectedReturnVal, result);
             Assert.Equal(expectedBytes.Length, written);
@@ -74,29 +74,29 @@ namespace System.Text.Primitives.Tests.Encoding
 
         public static object[][] TryDecodeToUnicodeMultipleCodePointsTestData = {
             //empty
-            new object[] { true, new uint[] {}, new byte[] {}, Buffers.OperationStatus.Done },
-            new object[] { false, new uint[] {}, new byte[] {}, Buffers.OperationStatus.Done },
+            new object[] { true, new uint[] {}, new byte[] {}, OperationStatus.Done },
+            new object[] { false, new uint[] {}, new byte[] {}, OperationStatus.Done },
             // multiple bytes
             new object[] { true,
-                new uint[] { 0x50, 0x3E8, 0xAFC8, 0x249F0 }, new byte[] { 0x50, 0xCF, 0xA8,  0xEA, 0xBF, 0x88, 0xF0, 0xA4, 0xA7, 0xB0 },  Buffers.OperationStatus.Done },
+                new uint[] { 0x50, 0x3E8, 0xAFC8, 0x249F0 }, new byte[] { 0x50, 0xCF, 0xA8,  0xEA, 0xBF, 0x88, 0xF0, 0xA4, 0xA7, 0xB0 },  OperationStatus.Done },
             new object[] { false,
-                new uint[] { 0x50, 0x3E8, 0xAFC8, 0x249F0 }, new byte[] {  0x50, 0x00, 0xE8,  0x03, 0xC8, 0xAF, 0x52, 0xD8, 0xF0, 0xDD },  Buffers.OperationStatus.Done },
+                new uint[] { 0x50, 0x3E8, 0xAFC8, 0x249F0 }, new byte[] {  0x50, 0x00, 0xE8,  0x03, 0xC8, 0xAF, 0x52, 0xD8, 0xF0, 0xDD },  OperationStatus.Done },
         };
 
         [Theory, MemberData("TryDecodeToUnicodeMultipleCodePointsTestData")]
-        public void TryDecodeToUnicodeMultipleCodePoints(bool useUtf8Encoder, uint[] expectedCodePointsArray, byte[] inputBytesArray, Buffers.OperationStatus expectedReturnVal)
+        public void TryDecodeToUnicodeMultipleCodePoints(bool useUtf8Encoder, uint[] expectedCodePointsArray, byte[] inputBytesArray, OperationStatus expectedReturnVal)
         {
             ReadOnlySpan<byte> expectedBytes = expectedCodePointsArray.AsSpan().AsBytes();
             ReadOnlySpan<byte> inputBytes = inputBytesArray;
             Span<byte> codePoints = new byte[expectedBytes.Length];
             int written;
             int consumed;
-            Buffers.OperationStatus result;
+            OperationStatus result;
 
             if (useUtf8Encoder)
-                result = Encoders.Utf8.ToUtf32(inputBytes, codePoints, out consumed, out written);
+                result = Encodings.Utf8.ToUtf32(inputBytes, codePoints, out consumed, out written);
             else
-                result = Encoders.Utf16.ToUtf32(inputBytes, codePoints, out consumed, out written);
+                result = Encodings.Utf16.ToUtf32(inputBytes, codePoints, out consumed, out written);
 
             Assert.Equal(expectedReturnVal, result);
             Assert.Equal(inputBytes.Length, consumed);
@@ -113,7 +113,7 @@ namespace System.Text.Primitives.Tests.Encoding
             uint[] expectedCodePoints = new uint[maximumValidCodePoint + 1];
             for (uint i = 0; i <= maximumValidCodePoint; i++)
             {
-                if (!Encoders.EncodingHelper.IsSupportedCodePoint(i))
+                if (!EncodingHelper.IsSupportedCodePoint(i))
                 {
                     expectedCodePoints[i] = 0; // skip unsupported code points.
                 }
@@ -129,9 +129,9 @@ namespace System.Text.Primitives.Tests.Encoding
             int written;
 
             if (useUtf8Encoder)
-                Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf32.ToUtf8(allCodePoints.AsBytes(), buffer, out consumed, out written));
+                Assert.Equal(OperationStatus.Done, Encodings.Utf32.ToUtf8(allCodePoints.AsBytes(), buffer, out consumed, out written));
             else
-                Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf32.ToUtf16(allCodePoints.AsBytes(), buffer, out consumed, out written));
+                Assert.Equal(OperationStatus.Done, Encodings.Utf32.ToUtf16(allCodePoints.AsBytes(), buffer, out consumed, out written));
 
             Assert.Equal(allCodePoints.AsBytes().Length, consumed);
             buffer = buffer.Slice(0, written);
@@ -139,9 +139,9 @@ namespace System.Text.Primitives.Tests.Encoding
             Span<uint> utf32 = new uint[maximumValidCodePoint + 1];
 
             if (useUtf8Encoder)
-                Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf8.ToUtf32(buffer, utf32.AsBytes(), out consumed, out written));
+                Assert.Equal(OperationStatus.Done, Encodings.Utf8.ToUtf32(buffer, utf32.AsBytes(), out consumed, out written));
             else
-                Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf16.ToUtf32(buffer, utf32.AsBytes(), out consumed, out written));
+                Assert.Equal(OperationStatus.Done, Encodings.Utf16.ToUtf32(buffer, utf32.AsBytes(), out consumed, out written));
 
             Assert.Equal(buffer.Length, consumed);
             Assert.Equal((maximumValidCodePoint + 1) * sizeof(uint), written);
@@ -160,7 +160,7 @@ namespace System.Text.Primitives.Tests.Encoding
             var plainText = new StringBuilder();
             for (int i = 0; i <= maximumValidCodePoint; i++)
             {
-                if (!Encoders.EncodingHelper.IsSupportedCodePoint((uint)i))
+                if (!EncodingHelper.IsSupportedCodePoint((uint)i))
                 {
                     codePoints[i] = 0; // skip unsupported characters
                     plainText.Append((char)0);
@@ -186,9 +186,9 @@ namespace System.Text.Primitives.Tests.Encoding
             int consumed;
 
             if (useUtf8Encoder)
-                Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf32.ToUtf8(allCodePoints.AsBytes(), buffer, out consumed, out written));
+                Assert.Equal(Buffers.OperationStatus.Done, Encodings.Utf32.ToUtf8(allCodePoints.AsBytes(), buffer, out consumed, out written));
             else
-                Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf32.ToUtf16(allCodePoints.AsBytes(), buffer, out consumed, out written));
+                Assert.Equal(Buffers.OperationStatus.Done, Encodings.Utf32.ToUtf16(allCodePoints.AsBytes(), buffer, out consumed, out written));
 
             buffer = buffer.Slice(0, written);
 
@@ -237,14 +237,14 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> input = inputBytes;
             Span<byte> output = new byte[outputSize];
 
-            Assert.Equal(Buffers.OperationStatus.DestinationTooSmall, Encoders.Utf8.ToUtf16(input, output, out consumed, out written));
+            Assert.Equal(Buffers.OperationStatus.DestinationTooSmall, Encodings.Utf8.ToUtf16(input, output, out consumed, out written));
             Assert.Equal(expected1.Length, written);
             Assert.Equal(expectedConsumed, consumed);
             Assert.True(output.Slice(0, written).SequenceEqual(expected1), "Bad first segment of partial sequence");
 
             input = input.Slice(consumed);
             output = new byte[expected2.Length];
-            Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf8.ToUtf16(input, output, out consumed, out written));
+            Assert.Equal(Buffers.OperationStatus.Done, Encodings.Utf8.ToUtf16(input, output, out consumed, out written));
             Assert.Equal(expected2.Length, written);
             Assert.Equal(input.Length, consumed);
             Assert.True(output.Slice(0, written).SequenceEqual(expected2), "Bad second segment of partial sequence");
@@ -284,14 +284,14 @@ namespace System.Text.Primitives.Tests.Encoding
             ReadOnlySpan<byte> input = inputBytes.AsSpan().AsBytes();
             Span<byte> output = new byte[outputSize];
 
-            Assert.Equal(Buffers.OperationStatus.DestinationTooSmall, Encoders.Utf16.ToUtf8(input, output, out consumed, out written));
+            Assert.Equal(Buffers.OperationStatus.DestinationTooSmall, Encodings.Utf16.ToUtf8(input, output, out consumed, out written));
             Assert.Equal(expected1.Length, written);
             Assert.Equal(expectedConsumed, consumed);
             Assert.True(output.Slice(0, written).SequenceEqual(expected1), "Bad first segment of partial sequence");
 
             input = input.Slice(consumed);
             output = new byte[expected2.Length];
-            Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf16.ToUtf8(input, output, out consumed, out written));
+            Assert.Equal(Buffers.OperationStatus.Done, Encodings.Utf16.ToUtf8(input, output, out consumed, out written));
             Assert.Equal(expected2.Length, written);
             Assert.Equal(input.Length, consumed);
             Assert.True(output.Slice(0, written).SequenceEqual(expected2), "Bad second segment of partial sequence");

--- a/tests/System.Text.Primitives.Tests/Encoding/Utf8Utf16ConversionTests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/Utf8Utf16ConversionTests.cs
@@ -140,7 +140,7 @@ namespace System.Text.Primitives.Tests
             int bytesNeeded = (expectedOutput.Length + 10) * sizeof(char);
             Span<byte> actualOutput = new byte[bytesNeeded];
 
-            var result = Encoders.Utf8.ToUtf16(input, actualOutput, out int consumed, out int written);
+            var result = Encodings.Utf8.ToUtf16(input, actualOutput, out int consumed, out int written);
             Assert.Equal(expectedResult, result);
 
             Assert.Equal(expectedConsumed, consumed);
@@ -174,7 +174,7 @@ namespace System.Text.Primitives.Tests
 
             // Encoders.Utf16 version
             Span<byte> encodedData = data;
-            Assert.Equal(OperationStatus.Done, Encoders.Utf8.ToUtf16Length(encodedData, out int neededBytes));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf8.ToUtf16Length(encodedData, out int neededBytes));
 
             // System version
             int expectedBytes = Text.Encoding.UTF8.GetCharCount(data) * sizeof(char);
@@ -206,12 +206,12 @@ namespace System.Text.Primitives.Tests
             byte[] data = GenerateUtf8String(count, minCodePoint, maxCodePoint);
 
             Span<byte> encodedData = data;
-            var result = Encoders.Utf8.ToUtf16Length(encodedData, out int needed);
+            var result = Encodings.Utf8.ToUtf16Length(encodedData, out int needed);
             Assert.Equal(OperationStatus.Done, result);
 
             // Encoders.Utf16 version
             Span<byte> actual = new byte[needed];
-            result = Encoders.Utf8.ToUtf16(encodedData, actual, out int consumed, out int written);
+            result = Encodings.Utf8.ToUtf16(encodedData, actual, out int consumed, out int written);
             Assert.Equal(OperationStatus.Done, result);
 
             // System version

--- a/tests/System.Text.Primitives.Tests/Formatting/GuidTests.cs
+++ b/tests/System.Text.Primitives.Tests/Formatting/GuidTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
+using System.Buffers.Text;
 using Xunit;
 
 namespace System.Text.Primitives.Tests

--- a/tests/System.Text.Primitives.Tests/Formatting/IntegerTests.cs
+++ b/tests/System.Text.Primitives.Tests/Formatting/IntegerTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
+using System.Buffers.Text;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using Xunit;

--- a/tests/System.Text.Primitives.Tests/Formatting/TimeTests.cs
+++ b/tests/System.Text.Primitives.Tests/Formatting/TimeTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
+using System.Buffers.Text;
 using System.Globalization;
 using Xunit;
 

--- a/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserBoolPerfTests.cs
+++ b/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserBoolPerfTests.cs
@@ -4,6 +4,7 @@
 
 using Xunit;
 using Microsoft.Xunit.Performance;
+using System.Buffers;
 
 namespace System.Text.Primitives.Tests
 {
@@ -42,7 +43,7 @@ namespace System.Text.Primitives.Tests
                 {
                     for (int i = 0; i < TestHelper.LoadIterations; i++)
                     {
-                        PrimitiveParser.InvariantUtf8.TryParseBoolean(utf8ByteSpan, out value, out bytesConsumed);
+                        Parsers.Utf8.TryParseBoolean(utf8ByteSpan, out value, out bytesConsumed);
                     }
                 }
             }
@@ -64,7 +65,7 @@ namespace System.Text.Primitives.Tests
                     {
                         for (int i = 0; i < TestHelper.LoadIterations; i++)
                         {
-                            PrimitiveParser.InvariantUtf8.TryParseBoolean(utf8ByteStar, utf8ByteArray.Length, out value, out bytesConsumed);
+                            Parsers.Utf8.TryParseBoolean(utf8ByteStar, utf8ByteArray.Length, out value, out bytesConsumed);
                         }
                     }
                 }

--- a/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserBoolTests.cs
+++ b/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserBoolTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
+using System.Buffers.Text;
 using Xunit;
 
 namespace System.Text.Primitives.Tests
@@ -27,7 +29,7 @@ namespace System.Text.Primitives.Tests
             bool actualValue;
             int actualConsumed;
 
-            result = PrimitiveParser.TryParseBoolean(byteSpan, out actualValue, out actualConsumed, SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseBoolean(byteSpan, out actualValue, out actualConsumed, SymbolTable.InvariantUtf8);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
@@ -35,55 +37,55 @@ namespace System.Text.Primitives.Tests
 
             fixed (byte* bytePointer = byteBuffer)
             {
-                result = PrimitiveParser.InvariantUtf8.TryParseBoolean(bytePointer, length, out actualValue);
+                result = Parsers.Utf8.TryParseBoolean(bytePointer, length, out actualValue);
 
                 Assert.True(result);
                 Assert.Equal(expectedValue, actualValue);
 
-                result = PrimitiveParser.InvariantUtf8.TryParseBoolean(bytePointer, length, out actualValue, out actualConsumed);
+                result = Parsers.Utf8.TryParseBoolean(bytePointer, length, out actualValue, out actualConsumed);
 
                 Assert.True(result);
                 Assert.Equal(expectedValue, actualValue);
                 Assert.Equal(expectedConsumed, actualConsumed);
             }
 
-            result = PrimitiveParser.InvariantUtf8.TryParseBoolean(byteSpan, out actualValue);
+            result = Parsers.Utf8.TryParseBoolean(byteSpan, out actualValue);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseBoolean(byteSpan, out actualValue, out actualConsumed);
+            result = Parsers.Utf8.TryParseBoolean(byteSpan, out actualValue, out actualConsumed);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
             Assert.Equal(expectedConsumed, actualConsumed);
 
             ReadOnlySpan<byte> utf16ByteSpan = charSpan.AsBytes();
-            result = PrimitiveParser.TryParseBoolean(utf16ByteSpan, out actualValue, out actualConsumed, SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseBoolean(utf16ByteSpan, out actualValue, out actualConsumed, SymbolTable.InvariantUtf16);
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
             Assert.Equal(expectedConsumed, actualConsumed / 2);
 
             fixed (char* charPointer = charBuffer)
             {
-                result = PrimitiveParser.InvariantUtf16.TryParseBoolean(charPointer, length, out actualValue);
+                result = Parsers.Utf16.TryParseBoolean(charPointer, length, out actualValue);
 
                 Assert.True(result);
                 Assert.Equal(expectedValue, actualValue);
 
-                result = PrimitiveParser.InvariantUtf16.TryParseBoolean(charPointer, length, out actualValue, out actualConsumed);
+                result = Parsers.Utf16.TryParseBoolean(charPointer, length, out actualValue, out actualConsumed);
 
                 Assert.True(result);
                 Assert.Equal(expectedValue, actualValue);
                 Assert.Equal(expectedConsumed, actualConsumed);
             }
 
-            result = PrimitiveParser.InvariantUtf16.TryParseBoolean(charSpan, out actualValue);
+            result = Parsers.Utf16.TryParseBoolean(charSpan, out actualValue);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseBoolean(charSpan, out actualValue, out actualConsumed);
+            result = Parsers.Utf16.TryParseBoolean(charSpan, out actualValue, out actualConsumed);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);

--- a/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserDecimalTests.cs
+++ b/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserDecimalTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
+using System.Buffers.Text;
 using Xunit;
 
 namespace System.Text.Primitives.Tests
@@ -25,7 +27,7 @@ namespace System.Text.Primitives.Tests
             decimal actualValue;
             int actualConsumed;
 
-            result = PrimitiveParser.TryParseDecimal(byteSpan, out actualValue, out actualConsumed, SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseDecimal(byteSpan, out actualValue, out actualConsumed, SymbolTable.InvariantUtf8);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
@@ -33,55 +35,55 @@ namespace System.Text.Primitives.Tests
 
             fixed (byte* bytePointer = byteBuffer)
             {
-                result = PrimitiveParser.InvariantUtf8.TryParseDecimal(bytePointer, length, out actualValue);
+                result = Parsers.Utf8.TryParseDecimal(bytePointer, length, out actualValue);
 
                 Assert.True(result);
                 Assert.Equal(expectedValue, actualValue);
 
-                result = PrimitiveParser.InvariantUtf8.TryParseDecimal(bytePointer, length, out actualValue, out actualConsumed);
+                result = Parsers.Utf8.TryParseDecimal(bytePointer, length, out actualValue, out actualConsumed);
 
                 Assert.True(result);
                 Assert.Equal(expectedValue, actualValue);
                 Assert.Equal(expectedConsumed, actualConsumed);
             }
 
-            result = PrimitiveParser.InvariantUtf8.TryParseDecimal(byteSpan, out actualValue);
+            result = Parsers.Utf8.TryParseDecimal(byteSpan, out actualValue);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseDecimal(byteSpan, out actualValue, out actualConsumed);
+            result = Parsers.Utf8.TryParseDecimal(byteSpan, out actualValue, out actualConsumed);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
             Assert.Equal(expectedConsumed, actualConsumed);
 
             ReadOnlySpan<byte> utf16ByteSpan = charSpan.AsBytes();
-            result = PrimitiveParser.TryParseDecimal(utf16ByteSpan, out actualValue, out actualConsumed, SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseDecimal(utf16ByteSpan, out actualValue, out actualConsumed, SymbolTable.InvariantUtf16);
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
             Assert.Equal(expectedConsumed, actualConsumed / 2);
 
             fixed (char* charPointer = charBuffer)
             {
-                result = PrimitiveParser.InvariantUtf16.TryParseDecimal(charPointer, length, out actualValue);
+                result = Parsers.Utf16.TryParseDecimal(charPointer, length, out actualValue);
 
                 Assert.True(result);
                 Assert.Equal(expectedValue, actualValue);
 
-                result = PrimitiveParser.InvariantUtf16.TryParseDecimal(charPointer, length, out actualValue, out actualConsumed);
+                result = Parsers.Utf16.TryParseDecimal(charPointer, length, out actualValue, out actualConsumed);
 
                 Assert.True(result);
                 Assert.Equal(expectedValue, actualValue);
                 Assert.Equal(expectedConsumed, actualConsumed);
             }
 
-            result = PrimitiveParser.InvariantUtf16.TryParseDecimal(charSpan, out actualValue);
+            result = Parsers.Utf16.TryParseDecimal(charSpan, out actualValue);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseDecimal(charSpan, out actualValue, out actualConsumed);
+            result = Parsers.Utf16.TryParseDecimal(charSpan, out actualValue, out actualConsumed);
 
             Assert.True(result);
             Assert.Equal(expectedValue, actualValue);

--- a/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserInt16PerfTests.cs
+++ b/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserInt16PerfTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 using Xunit;
 using Microsoft.Xunit.Performance;
+using System.Buffers;
 
 namespace System.Text.Primitives.Tests.Parsing
 {
@@ -43,7 +44,7 @@ namespace System.Text.Primitives.Tests.Parsing
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        PrimitiveParser.InvariantUtf8.TryParseInt16(utf8ByteSpan, out short value);
+                        Parsers.Utf8.TryParseInt16(utf8ByteSpan, out short value);
                         TestHelper.DoNotIgnore(value, 0);
                     }
                 }
@@ -110,7 +111,7 @@ namespace System.Text.Primitives.Tests.Parsing
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        PrimitiveParser.InvariantUtf8.TryParseInt16(utf8ByteSpan, out short value, out int bytesConsumed);
+                        Parsers.Utf8.TryParseInt16(utf8ByteSpan, out short value, out int bytesConsumed);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     }
                 }
@@ -134,7 +135,7 @@ namespace System.Text.Primitives.Tests.Parsing
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
                         ReadOnlySpan<byte> utf8ByteSpan = utf8ByteArray[i % textLength];
-                        PrimitiveParser.InvariantUtf8.TryParseInt16(utf8ByteSpan, out short value, out int bytesConsumed);
+                        Parsers.Utf8.TryParseInt16(utf8ByteSpan, out short value, out int bytesConsumed);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     }
                 }
@@ -272,7 +273,7 @@ namespace System.Text.Primitives.Tests.Parsing
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        PrimitiveParser.TryParseInt16(utf8Span, out short value, out int bytesConsumed, 'G', TestHelper.ThaiTable);
+                        Parsers.Custom.TryParseInt16(utf8Span, out short value, out int bytesConsumed, 'G', TestHelper.ThaiTable);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     }
                 }

--- a/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserInt32PerfTests.cs
+++ b/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserInt32PerfTests.cs
@@ -4,6 +4,7 @@
 
 using Xunit;
 using Microsoft.Xunit.Performance;
+using System.Buffers;
 
 namespace System.Text.Primitives.Tests
 {
@@ -51,7 +52,7 @@ namespace System.Text.Primitives.Tests
                 {
                     for(int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        PrimitiveParser.InvariantUtf8.TryParseInt32(utf8ByteSpan, out int value);
+                        Parsers.Utf8.TryParseInt32(utf8ByteSpan, out int value);
                         TestHelper.DoNotIgnore(value, 0);
                     }
                 }
@@ -75,7 +76,7 @@ namespace System.Text.Primitives.Tests
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
                         ReadOnlySpan<byte> utf8ByteSpan = utf8ByteArray[i % textLength];
-                        PrimitiveParser.InvariantUtf8.TryParseInt32(utf8ByteSpan, out int value);
+                        Parsers.Utf8.TryParseInt32(utf8ByteSpan, out int value);
                         TestHelper.DoNotIgnore(value, 0);
                     }
                 }
@@ -155,7 +156,7 @@ namespace System.Text.Primitives.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        PrimitiveParser.InvariantUtf8.TryParseInt32(utf8ByteSpan, out int value, out int bytesConsumed);
+                        Parsers.Utf8.TryParseInt32(utf8ByteSpan, out int value, out int bytesConsumed);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     }
                 }
@@ -179,7 +180,7 @@ namespace System.Text.Primitives.Tests
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
                         ReadOnlySpan<byte> utf8ByteSpan = utf8ByteArray[i % textLength];
-                        PrimitiveParser.InvariantUtf8.TryParseInt32(utf8ByteSpan, out int value, out int bytesConsumed);
+                        Parsers.Utf8.TryParseInt32(utf8ByteSpan, out int value, out int bytesConsumed);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     }
                 }
@@ -360,7 +361,7 @@ namespace System.Text.Primitives.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        PrimitiveParser.TryParseInt32(utf8Span, out int value, out int bytesConsumed, 'G', TestHelper.ThaiTable);
+                        Parsers.Custom.TryParseInt32(utf8Span, out int value, out int bytesConsumed, 'G', TestHelper.ThaiTable);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     }
                 }

--- a/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserIntegerTests.cs
+++ b/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserIntegerTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
+using System.Buffers.Text;
 using System.Runtime.CompilerServices;
 
 using Xunit;
@@ -32,59 +34,59 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseByte(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseByte(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.TryParseByte(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Custom.TryParseByte(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseByte(utf8Span, out parsedValue);
+            result = Parsers.Utf8.TryParseByte(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseByte(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.TryParseByte(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.TryParseByte(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.TryParseByte(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.TryParseByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.TryParseByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseByte(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseByte(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseByte(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.TryParseByte(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseByte(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.TryParseByte(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.TryParseByte(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.TryParseByte(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.TryParseByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.TryParseByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -110,54 +112,54 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseByte(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseByte(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseByte(utf8Span, out parsedValue);
+            result = Parsers.Utf8.Hex.TryParseByte(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseByte(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.Hex.TryParseByte(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseByte(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.Hex.TryParseByte(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.Hex.TryParseByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseByte(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseByte(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseByte(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.Hex.TryParseByte(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseByte(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.Hex.TryParseByte(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseByte(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.Hex.TryParseByte(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.Hex.TryParseByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -188,59 +190,59 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseUInt16(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseUInt16(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.TryParseUInt16(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Custom.TryParseUInt16(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseUInt16(utf8Span, out parsedValue);
+            result = Parsers.Utf8.TryParseUInt16(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseUInt16(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.TryParseUInt16(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseUInt16(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseUInt16(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseUInt16(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.TryParseUInt16(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseUInt16(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.TryParseUInt16(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -266,54 +268,54 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseUInt16(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseUInt16(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt16(utf8Span, out parsedValue);
+            result = Parsers.Utf8.Hex.TryParseUInt16(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt16(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.Hex.TryParseUInt16(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.Hex.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.Hex.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseUInt16(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseUInt16(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt16(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.Hex.TryParseUInt16(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt16(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.Hex.TryParseUInt16(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.Hex.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.Hex.TryParseUInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -344,59 +346,59 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseUInt32(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseUInt32(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.TryParseUInt32(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Custom.TryParseUInt32(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8Span, out parsedValue);
+            result = Parsers.Utf8.TryParseUInt32(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.TryParseUInt32(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseUInt32(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseUInt32(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseUInt32(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.TryParseUInt32(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseUInt32(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.TryParseUInt32(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -422,54 +424,54 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseUInt32(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseUInt32(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(utf8Span, out parsedValue);
+            result = Parsers.Utf8.Hex.TryParseUInt32(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.Hex.TryParseUInt32(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.Hex.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.Hex.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseUInt32(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseUInt32(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt32(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.Hex.TryParseUInt32(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt32(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.Hex.TryParseUInt32(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.Hex.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.Hex.TryParseUInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -500,59 +502,59 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseUInt64(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseUInt64(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.TryParseUInt64(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Custom.TryParseUInt64(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseUInt64(utf8Span, out parsedValue);
+            result = Parsers.Utf8.TryParseUInt64(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseUInt64(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.TryParseUInt64(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseUInt64(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseUInt64(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseUInt64(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.TryParseUInt64(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseUInt64(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.TryParseUInt64(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -578,54 +580,54 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseUInt64(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseUInt64(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt64(utf8Span, out parsedValue);
+            result = Parsers.Utf8.Hex.TryParseUInt64(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt64(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.Hex.TryParseUInt64(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.Hex.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.Hex.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseUInt64(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseUInt64(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt64(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.Hex.TryParseUInt64(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt64(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.Hex.TryParseUInt64(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.Hex.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.Hex.TryParseUInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -700,59 +702,59 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseSByte(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseSByte(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.TryParseSByte(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Custom.TryParseSByte(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseSByte(utf8Span, out parsedValue);
+            result = Parsers.Utf8.TryParseSByte(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseSByte(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.TryParseSByte(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseSByte(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseSByte(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseSByte(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.TryParseSByte(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseSByte(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.TryParseSByte(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -778,7 +780,7 @@ namespace System.Text.Primitives.Tests
             ReadOnlySpan<byte> utf8Span = TestHelper.UtfEncode(text, false);
             bool result;
 
-            result = PrimitiveParser.TryParseSByte(utf8Span.Slice(index), out parsedValue, out consumed, 'G', TestHelper.ThaiTable);
+            result = Parsers.Custom.TryParseSByte(utf8Span.Slice(index), out parsedValue, out consumed, 'G', TestHelper.ThaiTable);
 
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
@@ -805,54 +807,54 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseSByte(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseSByte(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseSByte(utf8Span, out parsedValue);
+            result = Parsers.Utf8.Hex.TryParseSByte(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseSByte(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.Hex.TryParseSByte(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.Hex.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.Hex.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseSByte(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseSByte(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseSByte(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.Hex.TryParseSByte(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseSByte(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.Hex.TryParseSByte(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.Hex.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.Hex.TryParseSByte(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -923,59 +925,59 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseInt16(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseInt16(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.TryParseInt16(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Custom.TryParseInt16(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseInt16(utf8Span, out parsedValue);
+            result = Parsers.Utf8.TryParseInt16(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseInt16(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.TryParseInt16(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseInt16(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseInt16(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseInt16(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.TryParseInt16(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseInt16(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.TryParseInt16(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -1001,7 +1003,7 @@ namespace System.Text.Primitives.Tests
             ReadOnlySpan<byte> utf8Span = TestHelper.UtfEncode(text, false);
             bool result;
 
-            result = PrimitiveParser.TryParseInt16(utf8Span.Slice(index), out parsedValue, out consumed, 'G', TestHelper.ThaiTable);
+            result = Parsers.Custom.TryParseInt16(utf8Span.Slice(index), out parsedValue, out consumed, 'G', TestHelper.ThaiTable);
 
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
@@ -1028,54 +1030,54 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseInt16(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseInt16(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseInt16(utf8Span, out parsedValue);
+            result = Parsers.Utf8.Hex.TryParseInt16(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseInt16(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.Hex.TryParseInt16(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.Hex.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.Hex.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseInt16(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseInt16(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseInt16(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.Hex.TryParseInt16(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseInt16(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.Hex.TryParseInt16(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.Hex.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.Hex.TryParseInt16(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -1147,59 +1149,59 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseInt32(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseInt32(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.TryParseInt32(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Custom.TryParseInt32(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseInt32(utf8Span, out parsedValue);
+            result = Parsers.Utf8.TryParseInt32(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseInt32(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.TryParseInt32(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseInt32(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseInt32(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseInt32(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.TryParseInt32(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseInt32(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.TryParseInt32(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -1240,7 +1242,7 @@ namespace System.Text.Primitives.Tests
         private void ParseInt32VariableLength(string text, bool expectSuccess, int expectedValue, int expectedConsumed)
         {
             ReadOnlySpan<byte> utf8Span = TestHelper.UtfEncode(text, false);
-            bool result = PrimitiveParser.InvariantUtf8.TryParseInt32(utf8Span, out int parsedValue, out int consumed);
+            bool result = Parsers.Utf8.TryParseInt32(utf8Span, out int parsedValue, out int consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
@@ -1283,7 +1285,7 @@ namespace System.Text.Primitives.Tests
         private void ParseInt32VariableOverflowTests(string text)
         {
             ReadOnlySpan<byte> utf8Span = TestHelper.UtfEncode(text, false);
-            bool result = PrimitiveParser.InvariantUtf8.TryParseInt32(utf8Span, out int parsedValue, out int consumed);
+            bool result = Parsers.Utf8.TryParseInt32(utf8Span, out int parsedValue, out int consumed);
             Assert.Equal(false, result);
             Assert.Equal(0, parsedValue);
             Assert.Equal(0, consumed);
@@ -1329,7 +1331,7 @@ namespace System.Text.Primitives.Tests
                     }
                     utf8Span.CopyTo(span.Slice(TwoGiB - utf8Span.Length));
 
-                    bool result = PrimitiveParser.InvariantUtf8.TryParseInt32(span, out int parsedValue, out int consumed);
+                    bool result = Parsers.Utf8.TryParseInt32(span, out int parsedValue, out int consumed);
                     Assert.Equal(expectSuccess, result);
                     Assert.Equal(expectedValue, parsedValue);
                     Assert.Equal(expectedConsumed, consumed);
@@ -1421,7 +1423,7 @@ namespace System.Text.Primitives.Tests
         public unsafe void ParseInt32Thai(string text, bool expectSuccess, int expectedValue, int expectedConsumed)
         {
             ReadOnlySpan<byte> utf8Span = TestHelper.UtfEncode(text, false);
-            bool result = PrimitiveParser.TryParseInt32(utf8Span, out int parsedValue, out int consumed, 'G', TestHelper.ThaiTable);
+            bool result = Parsers.Custom.TryParseInt32(utf8Span, out int parsedValue, out int consumed, 'G', TestHelper.ThaiTable);
 
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
@@ -1477,7 +1479,7 @@ namespace System.Text.Primitives.Tests
 
                     utf8Span.CopyTo(span.Slice(TwoGiB - utf8Span.Length));
 
-                    bool result = PrimitiveParser.TryParseInt32(span, out int parsedValue, out int consumed, 'G', TestHelper.ThaiTable);
+                    bool result = Parsers.Custom.TryParseInt32(span, out int parsedValue, out int consumed, 'G', TestHelper.ThaiTable);
                     Assert.Equal(expectSuccess, result);
                     Assert.Equal(expectedValue, parsedValue);
                     Assert.Equal(expectedConsumed, consumed);
@@ -1509,54 +1511,54 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseInt32(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseInt32(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseInt32(utf8Span, out parsedValue);
+            result = Parsers.Utf8.Hex.TryParseInt32(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseInt32(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.Hex.TryParseInt32(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.Hex.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.Hex.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseInt32(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseInt32(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseInt32(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.Hex.TryParseInt32(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseInt32(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.Hex.TryParseInt32(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.Hex.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.Hex.TryParseInt32(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -1589,59 +1591,59 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseInt64(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseInt64(utf8Span, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.TryParseInt64(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Custom.TryParseInt64(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseInt64(utf8Span, out parsedValue);
+            result = Parsers.Utf8.TryParseInt64(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.TryParseInt64(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.TryParseInt64(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseInt64(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseInt64(utf16ByteSpan, out parsedValue, out consumed, 'G', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseInt64(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.TryParseInt64(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.TryParseInt64(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.TryParseInt64(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
@@ -1667,7 +1669,7 @@ namespace System.Text.Primitives.Tests
             ReadOnlySpan<byte> utf8Span = TestHelper.UtfEncode(text, false);
             bool result;
 
-            result = PrimitiveParser.TryParseInt64(utf8Span.Slice(index), out parsedValue, out consumed, 'G', TestHelper.ThaiTable);
+            result = Parsers.Custom.TryParseInt64(utf8Span.Slice(index), out parsedValue, out consumed, 'G', TestHelper.ThaiTable);
 
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
@@ -1694,54 +1696,54 @@ namespace System.Text.Primitives.Tests
             char[] textChars = utf16CharSpan.ToArray();
             bool result;
 
-            result = PrimitiveParser.TryParseInt64(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
+            result = Parsers.Custom.TryParseInt64(utf8Span, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf8);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseInt64(utf8Span, out parsedValue);
+            result = Parsers.Utf8.Hex.TryParseInt64(utf8Span, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf8.Hex.TryParseInt64(utf8Span, out parsedValue, out consumed);
+            result = Parsers.Utf8.Hex.TryParseInt64(utf8Span, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (byte* arrayPointer = textBytes)
             {
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf8.Hex.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue);
 
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf8.Hex.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf8.Hex.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);
             }
 
-            result = PrimitiveParser.TryParseInt64(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
+            result = Parsers.Custom.TryParseInt64(utf16ByteSpan, out parsedValue, out consumed, 'X', SymbolTable.InvariantUtf16);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed * sizeof(char), consumed);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseInt64(utf16CharSpan, out parsedValue);
+            result = Parsers.Utf16.Hex.TryParseInt64(utf16CharSpan, out parsedValue);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
 
-            result = PrimitiveParser.InvariantUtf16.Hex.TryParseInt64(utf16CharSpan, out parsedValue, out consumed);
+            result = Parsers.Utf16.Hex.TryParseInt64(utf16CharSpan, out parsedValue, out consumed);
             Assert.Equal(expectSuccess, result);
             Assert.Equal(expectedValue, parsedValue);
             Assert.Equal(expectedConsumed, consumed);
 
             fixed (char* arrayPointer = textChars)
             {
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue);
+                result = Parsers.Utf16.Hex.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
 
-                result = PrimitiveParser.InvariantUtf16.Hex.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
+                result = Parsers.Utf16.Hex.TryParseInt64(arrayPointer, textBytes.Length, out parsedValue, out consumed);
                 Assert.Equal(expectSuccess, result);
                 Assert.Equal(expectedValue, parsedValue);
                 Assert.Equal(expectedConsumed, consumed);

--- a/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserSBytePerfTests.cs
+++ b/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserSBytePerfTests.cs
@@ -4,6 +4,7 @@
 
 using Xunit;
 using Microsoft.Xunit.Performance;
+using System.Buffers;
 
 namespace System.Text.Primitives.Tests
 {
@@ -71,7 +72,7 @@ namespace System.Text.Primitives.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        PrimitiveParser.InvariantUtf8.TryParseSByte(utf8ByteSpan, out sbyte value, out int bytesConsumed);
+                        Parsers.Utf8.TryParseSByte(utf8ByteSpan, out sbyte value, out int bytesConsumed);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     }
                 }
@@ -95,7 +96,7 @@ namespace System.Text.Primitives.Tests
                     for (int i = 0; i<Benchmark.InnerIterationCount; i++) 
                     {
                         ReadOnlySpan<byte> utf8ByteSpan = utf8ByteArray[i % textLength];
-                        PrimitiveParser.InvariantUtf8.TryParseSByte(utf8ByteSpan, out sbyte value, out int bytesConsumed);
+                        Parsers.Utf8.TryParseSByte(utf8ByteSpan, out sbyte value, out int bytesConsumed);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     } 
                 } 
@@ -200,7 +201,7 @@ namespace System.Text.Primitives.Tests
                 {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                     {
-                        PrimitiveParser.TryParseSByte(utf8Span, out sbyte value, out int bytesConsumed, 'G', TestHelper.ThaiTable);
+                        Parsers.Custom.TryParseSByte(utf8Span, out sbyte value, out int bytesConsumed, 'G', TestHelper.ThaiTable);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     }
                 }

--- a/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserUInt32PerfTests.cs
+++ b/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserUInt32PerfTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using Xunit;
 using Microsoft.Xunit.Performance;
+using System.Buffers;
 
 namespace System.Text.Primitives.Tests
 {
@@ -165,7 +166,7 @@ namespace System.Text.Primitives.Tests
                         for (int i = 0; i < TestHelper.LoadIterations; i++)
                         {
                             uint value;
-                            PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteStar, length, out value);
+                            Parsers.Utf8.TryParseUInt32(utf8ByteStar, length, out value);
                             TestHelper.DoNotIgnore(value, 0);
                         }
                     }
@@ -192,7 +193,7 @@ namespace System.Text.Primitives.Tests
                         fixed (byte* utf8ByteStar = utf8ByteArray)
                         {
                             uint value;
-                            PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteStar, utf8ByteArray.Length, out value);
+                            Parsers.Utf8.TryParseUInt32(utf8ByteStar, utf8ByteArray.Length, out value);
                             TestHelper.DoNotIgnore(value, 0);
                         }
                     }
@@ -218,7 +219,7 @@ namespace System.Text.Primitives.Tests
                         {
                             uint value;
                             int bytesConsumed;
-                            PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteStar, length, out value, out bytesConsumed);
+                            Parsers.Utf8.TryParseUInt32(utf8ByteStar, length, out value, out bytesConsumed);
                             TestHelper.DoNotIgnore(value, bytesConsumed);
                         }
                     }
@@ -246,7 +247,7 @@ namespace System.Text.Primitives.Tests
                         {
                             uint value;
                             int bytesConsumed;
-                            PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteStar, utf8ByteArray.Length, out value, out bytesConsumed);
+                            Parsers.Utf8.TryParseUInt32(utf8ByteStar, utf8ByteArray.Length, out value, out bytesConsumed);
                             TestHelper.DoNotIgnore(value, bytesConsumed);
                         }
                     }
@@ -269,7 +270,7 @@ namespace System.Text.Primitives.Tests
                     for (int i = 0; i < TestHelper.LoadIterations; i++)
                     {
                         uint value;
-                        PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteSpan, out value);
+                        Parsers.Utf8.TryParseUInt32(utf8ByteSpan, out value);
                         TestHelper.DoNotIgnore(value, 0);
                     }
                 }
@@ -294,7 +295,7 @@ namespace System.Text.Primitives.Tests
                     {
                         ReadOnlySpan<byte> utf8ByteSpan = utf8ByteArray[i % textLength];
                         uint value;
-                        PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteSpan, out value);
+                        Parsers.Utf8.TryParseUInt32(utf8ByteSpan, out value);
                         TestHelper.DoNotIgnore(value, 0);
                     }
                 }
@@ -317,7 +318,7 @@ namespace System.Text.Primitives.Tests
                     {
                         uint value;
                         int bytesConsumed;
-                        PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);
+                        Parsers.Utf8.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     }
                 }
@@ -342,7 +343,7 @@ namespace System.Text.Primitives.Tests
                         ReadOnlySpan<byte> utf8ByteSpan = utf8ByteArray[i % textLength];
                         uint value;
                         int bytesConsumed;
-                        PrimitiveParser.InvariantUtf8.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);
+                        Parsers.Utf8.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     }
                 }
@@ -366,7 +367,7 @@ namespace System.Text.Primitives.Tests
                         for (int i = 0; i < TestHelper.LoadIterations; i++)
                         {
                             uint value;
-                            PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(utf8ByteStar, length, out value);
+                            Parsers.Utf8.Hex.TryParseUInt32(utf8ByteStar, length, out value);
                             TestHelper.DoNotIgnore(value, 0);
                         }
                     }
@@ -393,7 +394,7 @@ namespace System.Text.Primitives.Tests
                         fixed (byte* utf8ByteStar = utf8ByteArray)
                         {
                             uint value;
-                            PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(utf8ByteStar, utf8ByteArray.Length, out value);
+                            Parsers.Utf8.Hex.TryParseUInt32(utf8ByteStar, utf8ByteArray.Length, out value);
                             TestHelper.DoNotIgnore(value, 0);
                         }
                     }
@@ -419,7 +420,7 @@ namespace System.Text.Primitives.Tests
                         {
                             uint value;
                             int bytesConsumed;
-                            PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(utf8ByteStar, length, out value, out bytesConsumed);
+                            Parsers.Utf8.Hex.TryParseUInt32(utf8ByteStar, length, out value, out bytesConsumed);
                             TestHelper.DoNotIgnore(value, bytesConsumed);
                         }
                     }
@@ -447,7 +448,7 @@ namespace System.Text.Primitives.Tests
                         {
                             uint value;
                             int bytesConsumed;
-                            PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(utf8ByteStar, utf8ByteArray.Length, out value, out bytesConsumed);
+                            Parsers.Utf8.Hex.TryParseUInt32(utf8ByteStar, utf8ByteArray.Length, out value, out bytesConsumed);
                             TestHelper.DoNotIgnore(value, bytesConsumed);
                         }
                     }
@@ -470,7 +471,7 @@ namespace System.Text.Primitives.Tests
                     for (int i = 0; i < TestHelper.LoadIterations; i++)
                     {
                         uint value;
-                        PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(utf8ByteSpan, out value);
+                        Parsers.Utf8.Hex.TryParseUInt32(utf8ByteSpan, out value);
                         TestHelper.DoNotIgnore(value, 0);
                     }
                 }
@@ -494,7 +495,7 @@ namespace System.Text.Primitives.Tests
                     {
                         ReadOnlySpan<byte> utf8ByteSpan = utf8ByteArray[i % textLength];
                         uint value;
-                        PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(utf8ByteSpan, out value);
+                        Parsers.Utf8.Hex.TryParseUInt32(utf8ByteSpan, out value);
                         TestHelper.DoNotIgnore(value, 0);
                     }
                 }
@@ -517,7 +518,7 @@ namespace System.Text.Primitives.Tests
                     {
                         uint value;
                         int bytesConsumed;
-                        PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);
+                        Parsers.Utf8.Hex.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     }
                 }
@@ -542,7 +543,7 @@ namespace System.Text.Primitives.Tests
                         ReadOnlySpan<byte> utf8ByteSpan = utf8ByteArray[i % textLength];
                         uint value;
                         int bytesConsumed;
-                        PrimitiveParser.InvariantUtf8.Hex.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);
+                        Parsers.Utf8.Hex.TryParseUInt32(utf8ByteSpan, out value, out bytesConsumed);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     }
                 }

--- a/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserUInt64PerfTests.cs
+++ b/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserUInt64PerfTests.cs
@@ -5,6 +5,7 @@
 using System.Globalization;
 using Xunit;
 using Microsoft.Xunit.Performance;
+using System.Buffers;
 
 namespace System.Text.Primitives.Tests
 {
@@ -87,7 +88,7 @@ namespace System.Text.Primitives.Tests
                         for (int i = 0; i < TestHelper.LoadIterations; i++)
                         {
                             ulong value;
-                            PrimitiveParser.InvariantUtf8.TryParseUInt64(utf8ByteStar, length, out value);
+                            Parsers.Utf8.TryParseUInt64(utf8ByteStar, length, out value);
                             TestHelper.DoNotIgnore(value, 0);
                         }
                     }
@@ -113,7 +114,7 @@ namespace System.Text.Primitives.Tests
                         {
                             ulong value;
                             int bytesConsumed;
-                            PrimitiveParser.InvariantUtf8.TryParseUInt64(utf8ByteStar, length, out value, out bytesConsumed);
+                            Parsers.Utf8.TryParseUInt64(utf8ByteStar, length, out value, out bytesConsumed);
                             TestHelper.DoNotIgnore(value, bytesConsumed);
                         }
                     }
@@ -136,7 +137,7 @@ namespace System.Text.Primitives.Tests
                     for (int i = 0; i < TestHelper.LoadIterations; i++)
                     {
                         ulong value;
-                        PrimitiveParser.InvariantUtf8.TryParseUInt64(utf8ByteSpan, out value);
+                        Parsers.Utf8.TryParseUInt64(utf8ByteSpan, out value);
                         TestHelper.DoNotIgnore(value, 0);
                     }
                 }
@@ -159,7 +160,7 @@ namespace System.Text.Primitives.Tests
                     {
                         ulong value;
                         int bytesConsumed;
-                        PrimitiveParser.InvariantUtf8.TryParseUInt64(utf8ByteSpan, out value, out bytesConsumed);
+                        Parsers.Utf8.TryParseUInt64(utf8ByteSpan, out value, out bytesConsumed);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     }
                 }
@@ -183,7 +184,7 @@ namespace System.Text.Primitives.Tests
                         for (int i = 0; i < TestHelper.LoadIterations; i++)
                         {
                             ulong value;
-                            PrimitiveParser.InvariantUtf8.Hex.TryParseUInt64(utf8ByteStar, length, out value);
+                            Parsers.Utf8.Hex.TryParseUInt64(utf8ByteStar, length, out value);
                             TestHelper.DoNotIgnore(value, 0);
                         }
                     }
@@ -209,7 +210,7 @@ namespace System.Text.Primitives.Tests
                         {
                             ulong value;
                             int bytesConsumed;
-                            PrimitiveParser.InvariantUtf8.Hex.TryParseUInt64(utf8ByteStar, length, out value, out bytesConsumed);
+                            Parsers.Utf8.Hex.TryParseUInt64(utf8ByteStar, length, out value, out bytesConsumed);
                             TestHelper.DoNotIgnore(value, bytesConsumed);
                         }
                     }
@@ -232,7 +233,7 @@ namespace System.Text.Primitives.Tests
                     for (int i = 0; i < TestHelper.LoadIterations; i++)
                     {
                         ulong value;
-                        PrimitiveParser.InvariantUtf8.Hex.TryParseUInt64(utf8ByteSpan, out value);
+                        Parsers.Utf8.Hex.TryParseUInt64(utf8ByteSpan, out value);
                         TestHelper.DoNotIgnore(value, 0);
                     }
                 }
@@ -255,7 +256,7 @@ namespace System.Text.Primitives.Tests
                     {
                         ulong value;
                         int bytesConsumed;
-                        PrimitiveParser.InvariantUtf8.Hex.TryParseUInt64(utf8ByteSpan, out value, out bytesConsumed);
+                        Parsers.Utf8.Hex.TryParseUInt64(utf8ByteSpan, out value, out bytesConsumed);
                         TestHelper.DoNotIgnore(value, bytesConsumed);
                     }
                 }

--- a/tests/System.Text.Primitives.Tests/PrimitiveEncoderTests_ascii.cs
+++ b/tests/System.Text.Primitives.Tests/PrimitiveEncoderTests_ascii.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Text.Encoders;
 using Xunit;
 
@@ -14,8 +15,8 @@ namespace System.Text.Encoders.Tests
         [InlineData("Hello World")]
         public void AsciiToUtf16StringBasics(string original)
         {
-            var encoded = (Span<byte>)Text.Encoding.ASCII.GetBytes(original);
-            var decoded = Ascii.ToUtf16String(encoded);
+            var encoded = (Span<byte>)Encoding.ASCII.GetBytes(original);
+            var decoded = Encodings.Ascii.ToUtf16String(encoded);
             Assert.Equal(original, decoded);
         }
 
@@ -26,7 +27,7 @@ namespace System.Text.Encoders.Tests
                 var encoded = (Span<byte>)new byte[100];
                 for (int encodedByte = 0; encodedByte < 128; encodedByte++) {
                     encoded[index] = (byte)encodedByte;
-                    var result = Ascii.ToUtf16String(encoded);
+                    var result = Encodings.Ascii.ToUtf16String(encoded);
                 }
             }
         }
@@ -40,7 +41,7 @@ namespace System.Text.Encoders.Tests
                     encoded[0] = (byte)encodedByte;
                     bool exception = false;
                     try {
-                        var result = Ascii.ToUtf16String(encoded);
+                        var result = Encodings.Ascii.ToUtf16String(encoded);
                     }
                     catch(ArgumentException) {
                         exception = true;

--- a/tests/System.Text.Primitives.Tests/RandomTests.cs
+++ b/tests/System.Text.Primitives.Tests/RandomTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -34,17 +35,17 @@ namespace System.Text.Primitives.Tests
             int actual;
 
             // test via string input
-            Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf16.ToUtf8Length(value.AsReadOnlySpan().AsBytes(), out actual));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf16.ToUtf8Length(value.AsReadOnlySpan().AsBytes(), out actual));
             Assert.Equal(expectedBytes, actual);
 
             // test via utf16 input
             ReadOnlySpan<byte> bytes = Text.Encoding.Unicode.GetBytes(value);
-            Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf16.ToUtf8Length(bytes, out actual));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf16.ToUtf8Length(bytes, out actual));
             Assert.Equal(expectedBytes, actual);
 
             // test via utf32 input
             bytes = Text.Encoding.UTF32.GetBytes(value);
-            Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf32.ToUtf8Length(bytes, out actual));
+            Assert.Equal(OperationStatus.Done, Encodings.Utf32.ToUtf8Length(bytes, out actual));
             Assert.Equal(expectedBytes, actual);
         }
 
@@ -57,12 +58,12 @@ namespace System.Text.Primitives.Tests
 
             // test via utf8 input
             ReadOnlySpan<byte> bytes = Text.Encoding.UTF8.GetBytes(value);
-            Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf8.ToUtf16Length(bytes, out actual));
+            Assert.Equal(Buffers.OperationStatus.Done, Encodings.Utf8.ToUtf16Length(bytes, out actual));
             Assert.Equal(expectedBytes, actual);
 
             // test via utf32 input
             bytes = Text.Encoding.UTF32.GetBytes(value);
-            Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf32.ToUtf16Length(bytes, out actual));
+            Assert.Equal(Buffers.OperationStatus.Done, Encodings.Utf32.ToUtf16Length(bytes, out actual));
             Assert.Equal(expectedBytes, actual);
         }
 
@@ -70,7 +71,7 @@ namespace System.Text.Primitives.Tests
         public void TryComputeEncodedBytesIllegal_Utf8()
         {
             string text = Encoding.TextEncoderTestHelper.GenerateOnlyInvalidString(20);
-            Assert.Equal(Buffers.OperationStatus.InvalidData, Encoders.Utf16.ToUtf8Length(text.AsReadOnlySpan().AsBytes(), out int needed));
+            Assert.Equal(Buffers.OperationStatus.InvalidData, Encodings.Utf16.ToUtf8Length(text.AsReadOnlySpan().AsBytes(), out int needed));
         }
     }
 }

--- a/tests/System.Text.Primitives.Tests/TestHelper.cs
+++ b/tests/System.Text.Primitives.Tests/TestHelper.cs
@@ -7,6 +7,7 @@ using Xunit;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Runtime.CompilerServices;
+using System.Buffers.Text;
 
 namespace System.Text.Primitives.Tests
 {
@@ -45,9 +46,9 @@ namespace System.Text.Primitives.Tests
         {
             if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
             {
-                Assert.Equal(OperationStatus.Done, Encoders.Utf8.ToUtf16Length(span, out int needed));
+                Assert.Equal(OperationStatus.Done, Encodings.Utf8.ToUtf16Length(span, out int needed));
                 Span<byte> output = new byte[needed];
-                Assert.Equal(OperationStatus.Done, Encoders.Utf8.ToUtf16(span, output, out int consumed, out int written));
+                Assert.Equal(OperationStatus.Done, Encodings.Utf8.ToUtf16(span, output, out int consumed, out int written));
                 return new string(output.NonPortableCast<byte, char>().ToArray());
             }
             else if (symbolTable == SymbolTable.InvariantUtf16)

--- a/tests/System.Text.Utf8String.Tests/RandomTests.cs
+++ b/tests/System.Text.Utf8String.Tests/RandomTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Utf16;
@@ -347,10 +348,10 @@ namespace System.Text.Utf8.Tests
         private byte[] GetUtf8BytesFromCodePoints(List<uint> codePoints)
         {
             ReadOnlySpan<byte> utf32 = codePoints.ToArray().AsSpan().AsBytes();
-            Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf32.ToUtf8Length(utf32, out int needed));
+            Assert.Equal(Buffers.OperationStatus.Done, Encodings.Utf32.ToUtf8Length(utf32, out int needed));
 
             byte[] utf8 = new byte[needed];
-            Assert.Equal(Buffers.OperationStatus.Done, Encoders.Utf32.ToUtf8(utf32, utf8, out int consumed, out int written));
+            Assert.Equal(Buffers.OperationStatus.Done, Encodings.Utf32.ToUtf8(utf32, utf8, out int consumed, out int written));
             Assert.Equal(needed, written);
 
             return utf8;


### PR DESCRIPTION
We cannot have multiple types called e.g. Utf8, even if they are in different namespaces. Our ecosystem of tools gets confused with such APIs). This moves Utf8, Utf16, and Custom encoders, parsers, formatters to be nested types in Encodings, Parsers, Formatters outer classes.

Also, I moved all the APIs into System.Buffers* namesapces in preparation for the move to System.Buffers.dll

cc: @ahsonkhan, @shiftylogic, @joshfree 