### PR TITLE
Add compressed sparse tensor layout

### DIFF
--- a/src/System.Numerics.Tensors/System.Numerics.Tensors.csproj
+++ b/src/System.Numerics.Tensors/System.Numerics.Tensors.csproj
@@ -12,6 +12,7 @@
     <Compile Include="System\Numerics\ArrayUtilities.cs" />
     <Compile Include="System\Numerics\DenseTensor.cs" />
     <Compile Include="System\Numerics\RefUtilities.cs" />
+    <Compile Include="System\Numerics\CompressedSparseTensor.cs" />
     <Compile Include="System\Numerics\SparseTensor.cs" />
     <Compile Include="System\Numerics\Tensor.cs" />
     <Compile Include="System\Numerics\TensorArithmetic.cs">

--- a/src/System.Numerics.Tensors/System/Numerics/CompressedSparseTensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/CompressedSparseTensor.cs
@@ -1,0 +1,351 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+
+namespace System.Numerics
+{
+    /// <summary>
+    /// Represents a tensor using compressed sparse format
+    /// For a two dimensional tensor this is referred to as compressed sparse row (CSR), compressed sparse column (CSR)
+    /// 
+    /// In this format, data that is in the same value for the compressed dimension has locality
+    /// 
+    /// In standard layout of a dense tensor, data with the same value for first dimensions has locality.
+    /// As such we'll use reverseStride = false (default) to mean that the first dimension is compressed (CSR)
+    /// and reverseStride = true to mean that the last dimension is compressed (CSC)
+    /// 
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class CompressedSparseTensor<T> : Tensor<T>
+    {
+        private T[] values;
+        private int[] compressedCounts;
+        private int[] indices;
+
+        private int valueCount;
+
+        private readonly int[] nonCompressedStrides;
+        private readonly int compressedDimension;
+
+        private const int defaultCapacity = 64;
+
+
+        public CompressedSparseTensor(int[] dimensions, bool reverseStride = false) : this(dimensions, defaultCapacity, reverseStride)
+        { }
+
+        public CompressedSparseTensor(int[] dimensions, int capacity, bool reverseStride = false) : base(dimensions, reverseStride)
+        {
+            valueCount = 0;
+            compressedDimension = reverseStride ? Rank - 1 : 0;
+            nonCompressedStrides = (int[])strides.Clone();
+            nonCompressedStrides[compressedDimension] = 0;
+            var compressedDimensionLength = dimensions[compressedDimension];
+            compressedCounts = new int[compressedDimensionLength + 1];
+            EnsureCapacity(capacity);
+        }
+
+        public CompressedSparseTensor(T[] values, int[] compressedCounts, int[] indices, int valueCount, int[] dimensions, bool reverseStride = false) : base(dimensions, reverseStride)
+        {
+            compressedDimension = reverseStride ? Rank - 1 : 0;
+            nonCompressedStrides = (int[])strides.Clone();
+            nonCompressedStrides[compressedDimension] = 0;
+            this.values = values;
+            this.compressedCounts = compressedCounts;
+            this.indices = indices;
+            this.valueCount = valueCount;
+        }
+
+        public CompressedSparseTensor(Array fromArray, bool reverseStride = false) : base(GetDimensionsFromArray(fromArray), reverseStride)
+        {
+            valueCount = 0;
+            compressedDimension = reverseStride ? Rank - 1 : 0;
+            nonCompressedStrides = (int[])strides.Clone();
+            nonCompressedStrides[compressedDimension] = 0;
+            var compressedDimensionLength = dimensions[compressedDimension];
+            compressedCounts = new int[compressedDimensionLength + 1];
+
+            int index = 0;
+            if (reverseStride)
+            {
+                // Array is always row-major
+                var sourceStrides = ArrayUtilities.GetStrides(dimensions);
+
+                foreach (T item in fromArray)
+                {
+                    if (!item.Equals(arithmetic.Zero))
+                    {
+                        var destIndex = ArrayUtilities.TransformIndexByStrides(index, sourceStrides, false, strides);
+                        var compressedIndex = destIndex / strides[compressedDimension];
+                        var nonCompressedIndex = destIndex % strides[compressedDimension];
+
+                        SetAt(item, compressedIndex, nonCompressedIndex);
+                    }
+                    
+                    index++;
+                }
+            }
+            else
+            {
+                foreach (T item in fromArray)
+                {
+                    if (!item.Equals(arithmetic.Zero))
+                    {
+                        var compressedIndex = index / strides[compressedDimension];
+                        var nonCompressedIndex = index % strides[compressedDimension];
+
+                        SetAt(item, compressedIndex, nonCompressedIndex);
+                    }
+
+                    index++;
+                }
+            }
+        }
+
+        public override T this[Span<int> indices]
+        {
+            get
+            {
+                var compressedIndex = indices[compressedDimension];
+                var nonCompressedIndex = ArrayUtilities.GetIndex(nonCompressedStrides, indices);
+
+                var valueIndex = 0;
+
+                if (TryFindIndex(compressedIndex, nonCompressedIndex, out valueIndex))
+                {
+                    return values[valueIndex];
+                }
+
+                return arithmetic.Zero;
+            }
+
+            set
+            {
+                var compressedIndex = indices[compressedDimension];
+                var nonCompressedIndex = ArrayUtilities.GetIndex(nonCompressedStrides, indices);
+
+                SetAt(value, compressedIndex, nonCompressedIndex);
+            }
+        }
+
+        // unsafe accessors
+        public T[] Values => values;
+        public int ValueCount => valueCount;
+        public int[] CompressedCounts => compressedCounts;
+        public int[] Indices => indices;
+
+        private void EnsureCapacity(int min, int allocateIndex = -1)
+        {
+            if (values == null || values.Length < min)
+            {
+                var newCapacity = (values == null || values.Length == 0) ? defaultCapacity : values.Length * 2;
+
+                if (newCapacity > Length)
+                {
+                    newCapacity = (int)Length;
+                }
+
+                if (newCapacity < min)
+                {
+                    newCapacity = min;
+                }
+
+                T[] newValues = new T[newCapacity];
+                int[] newIndices = new int[newCapacity];
+
+                if (valueCount > 0)
+                {
+                    if (allocateIndex == -1)
+                    {
+                        Array.Copy(values, newValues, valueCount);
+                        Array.Copy(indices, newIndices, valueCount);
+                    }
+                    else
+                    {
+                        Debug.Assert(allocateIndex <= valueCount);
+                        // leave a gap at allocateIndex
+
+                        // copy range before allocateIndex
+                        if (allocateIndex > 0)
+                        {
+                            Array.Copy(values, newValues, allocateIndex);
+                            Array.Copy(indices, newIndices, allocateIndex);
+                        }
+
+                        if (allocateIndex < valueCount)
+                        {
+                            Array.Copy(values, allocateIndex, newValues, allocateIndex + 1, valueCount - allocateIndex);
+                            Array.Copy(indices, allocateIndex, newIndices, allocateIndex + 1, valueCount - allocateIndex);
+                        }
+                    }
+                }
+
+                values = newValues;
+                indices = newIndices;
+            }
+        }
+
+        private void InsertAt(int valueIndex, T value, int compressedIndex, int nonCompressedIndex)
+        {
+            Debug.Assert(valueIndex <= valueCount);
+            Debug.Assert(compressedIndex < compressedCounts.Length - 1);
+
+            if (values == null || values.Length <= valueIndex)
+            {
+                // allocate a new array, leaving a gap
+                EnsureCapacity(valueIndex + 1, valueIndex);
+
+                // insert into the gap
+                values[valueIndex] = value;
+                indices[valueIndex] = nonCompressedIndex;
+            }
+            else if (valueCount != valueIndex)
+            {
+                // shift values to make a gap
+                Array.Copy(values, valueIndex, values, valueIndex + 1, valueCount - valueIndex);
+                Array.Copy(indices, valueIndex, indices, valueIndex + 1, valueCount - valueIndex);
+            }
+
+            values[valueIndex] = value;
+            indices[valueIndex] = nonCompressedIndex;
+
+            for (int i = compressedIndex + 1; i < compressedCounts.Length; i++)
+            {
+                compressedCounts[i]++;
+            }
+            valueCount++;
+        }
+
+        private void RemoveAt(int valueIndex, int compressedIndex)
+        {
+            Debug.Assert(valueIndex < valueCount);
+            Debug.Assert(compressedIndex < compressedCounts.Length - 1);
+
+            // shift values to close the gap
+            Array.Copy(values, valueIndex + 1, values, valueIndex, valueCount - valueIndex - 1);
+            Array.Copy(indices, valueIndex + 1, indices, valueIndex, valueCount - valueIndex - 1);
+
+            for (int i = compressedIndex + 1; i < compressedCounts.Length; i++)
+            {
+                compressedCounts[i]--;
+            }
+            valueCount--;
+        }
+
+        private void SetAt(T value, int compressedIndex, int nonCompressedIndex)
+        {
+            var valueIndex = 0;
+            bool isZero = value.Equals(arithmetic.Zero);
+
+            if (TryFindIndex(compressedIndex, nonCompressedIndex, out valueIndex))
+            {
+                if (isZero)
+                {
+                    RemoveAt(valueIndex, compressedIndex);
+                }
+                else
+                {
+                    values[valueIndex] = value;
+                    indices[valueIndex] = nonCompressedIndex;
+                }
+            }
+            else if (!isZero)
+            {
+                InsertAt(valueIndex, value, compressedIndex, nonCompressedIndex);
+            }
+        }
+
+        /// <summary>
+        /// Trys to find the place to store a value
+        /// </summary>
+        /// <param name="compressedIndex"></param>
+        /// <param name="nonCompressedIndex"></param>
+        /// <param name="valueIndex"></param>
+        /// <returns>True if element is found at specific index, false if no specific index is found and insertion point is returned</returns>
+        private bool TryFindIndex(int compressedIndex, int nonCompressedIndex, out int valueIndex)
+        {
+            if (valueCount == 0)
+            {
+                valueIndex = 0;
+                return false;
+            }
+
+            Debug.Assert(compressedIndex < compressedCounts.Length - 1);
+
+            var lowerValueIndex = compressedCounts[compressedIndex];
+            var upperValueIndex = compressedCounts[compressedIndex + 1];
+
+            // could be a faster search
+
+            for (valueIndex = lowerValueIndex; valueIndex < upperValueIndex; valueIndex++)
+            {
+                if (indices[valueIndex] == nonCompressedIndex)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static int[] GetDimensionsFromArray(Array fromArray)
+        {
+            if (fromArray == null)
+            {
+                throw new ArgumentNullException(nameof(fromArray));
+            }
+
+            var dimensions = new int[fromArray.Rank];
+            for (int i = 0; i < dimensions.Length; i++)
+            {
+                dimensions[i] = fromArray.GetLength(i);
+            }
+
+            return dimensions;
+        }
+
+        public override Tensor<T> Clone()
+        {
+            return new CompressedSparseTensor<T>((T[])values.Clone(), (int[])compressedCounts.Clone(), (int[])indices.Clone(), valueCount, dimensions, IsReversedStride);
+        }
+
+        public override Tensor<TResult> CloneEmpty<TResult>(int[] dimensions)
+        {
+            return new CompressedSparseTensor<TResult>(dimensions, IsReversedStride);
+        }
+
+        public override Tensor<T> Reshape(params int[] dimensions)
+        {
+            // reshape currently has shallow semantics which are not compatible with the backing storage for CompressedSparseTensor
+            // which bakes in information about dimensions (compressedCounts and indices)
+
+            var newCompressedDimension = IsReversedStride ? dimensions.Length - 1 : 0;
+            var newCompressedDimensionLength = dimensions[newCompressedDimension];
+            var newCompressedDimensionStride = (int)(Length / newCompressedDimensionLength);
+            
+
+            var newValues = (T[])values.Clone();
+            var newCompressedCounts = new int[newCompressedDimensionLength + 1];
+            var newIndices = new int[indices.Length];
+
+            var compressedIndex = 0;
+
+            for (int valueIndex = 0; valueIndex < valueCount; valueIndex++)
+            {
+                while (valueIndex >= compressedCounts[compressedIndex + 1])
+                {
+                    compressedIndex++;
+                }
+
+                var currentIndex = indices[valueIndex] + compressedIndex * strides[compressedDimension];
+
+                newIndices[valueIndex] = currentIndex % newCompressedDimensionStride;
+
+                var newCompressedIndex = currentIndex / newCompressedDimensionStride;
+                newCompressedCounts[newCompressedIndex + 1] = valueIndex + 1;
+            }
+
+            return new CompressedSparseTensor<T>(newValues, newCompressedCounts, newIndices, valueCount, dimensions, IsReversedStride);
+        }
+    }
+}

--- a/src/System.Numerics.Tensors/System/Numerics/DenseTensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/DenseTensor.cs
@@ -102,41 +102,6 @@
             return dimensions;
         }
 
-        private int GetOffset(int index0, int index1)
-        {
-            if (Rank != 2)
-            {
-                throw new ArgumentOutOfRangeException($"Cannot use 2 dimension indexer on {nameof(Tensor<T>)} with {Rank} dimensions.");
-            }
-
-            if (index0 < 0 || index0 >= dimensions[0])
-            {
-                throw new ArgumentOutOfRangeException(nameof(index0));
-            }
-
-            if (index1 < 0 || index1 >= dimensions[1])
-            {
-                throw new ArgumentOutOfRangeException(nameof(index1));
-            }
-
-            return index0 * strides[0] + index1 * strides[1];
-        }
-
-        private int GetOffsetFromIndices(int[] indices)
-        {
-            if (indices == null)
-            {
-                throw new ArgumentNullException(nameof(indices));
-            }
-
-            if (indices.Length != dimensions?.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(indices));
-            }
-
-            return ArrayUtilities.GetIndex(strides, indices);
-        }
-
         public override Tensor<T> Reshape(params int[] dimensions)
         {
             if (dimensions == null)

--- a/src/System.Numerics.Tensors/System/Numerics/SparseTensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/SparseTensor.cs
@@ -16,6 +16,7 @@ namespace System.Numerics
             this.values = values;
         }
 
+
         public SparseTensor(Array fromArray, bool reverseStride = false) : base(GetDimensionsFromArray(fromArray), reverseStride)
         {
             values = new Dictionary<int, T>();
@@ -112,41 +113,6 @@ namespace System.Numerics
         public override Tensor<T> Reshape(params int[] dimensions)
         {
             return new SparseTensor<T>(values, dimensions, IsReversedStride);
-        }
-
-        private int GetOffset(int index0, int index1)
-        {
-            if (Rank != 2)
-            {
-                throw new ArgumentOutOfRangeException($"Cannot use 2 dimension indexer on {nameof(Tensor<T>)} with {Rank} dimensions.");
-            }
-
-            if (index0 < 0 || index0 >= dimensions[0])
-            {
-                throw new ArgumentOutOfRangeException(nameof(index0));
-            }
-
-            if (index1 < 0 || index1 >= dimensions[1])
-            {
-                throw new ArgumentOutOfRangeException(nameof(index1));
-            }
-
-            return index0 * strides[0] + index1 * strides[1];
-        }
-
-        private int GetOffsetFromIndices(int[] indices)
-        {
-            if (indices == null)
-            {
-                throw new ArgumentNullException(nameof(indices));
-            }
-
-            if (indices.Length != dimensions?.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(indices));
-            }
-
-            return ArrayUtilities.GetIndex(strides, indices);
         }
     }
 }

--- a/src/System.Numerics.Tensors/System/Numerics/Tensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/Tensor.cs
@@ -4,6 +4,8 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Text;
 
 namespace System.Numerics
 {
@@ -218,6 +220,7 @@ namespace System.Numerics
         }
     }
 
+    [DebuggerDisplay("{GetArrayString(false)}")]
     // When we cross-compile for frameworks that expose ICloneable this must implement ICloneable as well.
     public abstract class Tensor<T> : IList, ICollection, IEnumerable, IStructuralComparable, IStructuralEquatable
     {
@@ -1094,6 +1097,94 @@ namespace System.Numerics
             return hashCode;
         }
         #endregion
+        public string GetArrayString(bool includeWhitespace = true)
+        {
+            var builder = new StringBuilder();
 
+            var strides = ArrayUtilities.GetStrides(dimensions);
+            var indices = new int[Rank];
+            var innerDimension = Rank - 1;
+            var innerLength = dimensions[innerDimension];
+            var outerLength = Length / innerLength;
+
+            int indent = 0;
+            for (int outerIndex = 0; outerIndex < Length; outerIndex += innerLength)
+            {
+                ArrayUtilities.GetIndices(strides, false, outerIndex, indices);
+
+                while ((indent < innerDimension) && (indices[indent] == 0))
+                {
+                    // start up
+                    if (includeWhitespace)
+                    {
+                        Indent(builder, indent);
+                    }
+                    indent++;
+                    builder.Append('{');
+                    if (includeWhitespace)
+                    {
+                        builder.AppendLine();
+                    }
+                }
+
+                for(int innerIndex = 0; innerIndex < innerLength; innerIndex++)
+                {
+                    indices[innerDimension] = innerIndex;
+
+                    if ((innerIndex == 0))
+                    {
+                        if (includeWhitespace)
+                        {
+                            Indent(builder, indent);
+                        }
+                        builder.Append('{');
+                    }
+                    else
+                    {
+                        builder.Append(',');
+                    }
+                    builder.Append(this[indices]);
+                }
+                builder.Append('}');
+
+                for(int i = Rank - 2; i >= 0; i--)
+                {
+                    var lastIndex = dimensions[i] - 1;
+                    if (indices[i] == lastIndex)
+                    {
+                        // close out
+                        --indent;
+                        if (includeWhitespace)
+                        {
+                            builder.AppendLine();
+                            Indent(builder, indent);
+                        }
+                        builder.Append('}');
+                    }
+                    else
+                    {
+                        builder.Append(',');
+                        if (includeWhitespace)
+                        {
+                            builder.AppendLine();
+                        }
+                        break;
+                    }
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private static void Indent(StringBuilder builder, int tabs, int spacesPerTab = 4)
+        {
+            for(int tab = 0; tab < tabs; tab++)
+            {
+                for(int space = 0; space < spacesPerTab; space++)
+                {
+                    builder.Append(' ');
+                }
+            }
+        }
     }
 }

--- a/src/System.Numerics.Tensors/System/Numerics/TensorArithmetic.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/TensorArithmetic.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-
 namespace System.Numerics
 {
     internal interface ITensorArithmetic<T>

--- a/src/System.Numerics.Tensors/System/Numerics/TensorArithmetic.tt
+++ b/src/System.Numerics.Tensors/System/Numerics/TensorArithmetic.tt
@@ -4,10 +4,6 @@
 <#@ include file="TensorTemplate.ttinclude" #>// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace System.Numerics
 {
     internal interface ITensorArithmetic<T>

--- a/tests/System.Numerics.Tensors.Tests/TensorTests.cs
+++ b/tests/System.Numerics.Tensors.Tests/TensorTests.cs
@@ -1862,5 +1862,64 @@ namespace tests
             var actual = Tensor.Contract(leftReshaped, right, new[] { 0 }, new[] { 1 });
             Assert.Equal(true, StructuralComparisons.StructuralEqualityComparer.Equals(actual, expected));
         }
+
+        [Theory]
+        [MemberData(nameof(GetSingleTensorConstructors))]
+        public void GetArrayString(TensorConstructor constructor)
+        {
+            var tensor = constructor.CreateFromArray<int>(
+                new[, ,]
+                {
+                    {
+                        {0, 1},
+                        {2, 3},
+                        {4, 5}
+                    },
+                    {
+                        {6, 7},
+                        {8, 9},
+                        {10, 11}
+                    },
+                    {
+                        {12, 13},
+                        {14, 15},
+                        {16, 17}
+                    },
+                    {
+                        {18, 19},
+                        {20, 21},
+                        {22, 23}
+                    }
+                });
+
+            var expected =
+@"{
+    {
+        {0,1},
+        {2,3},
+        {4,5}
+    },
+    {
+        {6,7},
+        {8,9},
+        {10,11}
+    },
+    {
+        {12,13},
+        {14,15},
+        {16,17}
+    },
+    {
+        {18,19},
+        {20,21},
+        {22,23}
+    }
+}";
+
+            Assert.Equal(expected, tensor.GetArrayString());
+
+            var expectedNoSpace = expected.Replace(Environment.NewLine, "").Replace(" ", "");
+            Assert.Equal(expectedNoSpace, tensor.GetArrayString(false));
+        }
     }
 }

--- a/tests/System.Numerics.Tensors.Tests/TensorTests.cs
+++ b/tests/System.Numerics.Tensors.Tests/TensorTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using Xunit;
 
@@ -14,7 +15,8 @@ namespace tests
         public enum TensorType
         {
             Dense,
-            Sparse
+            Sparse,
+            CompressedSparse
         };
 
         public class TensorConstructor
@@ -31,6 +33,8 @@ namespace tests
                         return new DenseTensor<T>(array, IsReversedStride);
                     case TensorType.Sparse:
                         return new SparseTensor<T>(array, IsReversedStride);
+                    case TensorType.CompressedSparse:
+                        return new CompressedSparseTensor<T>(array, IsReversedStride);
                 }
 
                 throw new ArgumentException(nameof(TensorType));
@@ -43,6 +47,8 @@ namespace tests
                         return new DenseTensor<T>(dimensions, IsReversedStride);
                     case TensorType.Sparse:
                         return new SparseTensor<T>(dimensions, IsReversedStride);
+                    case TensorType.CompressedSparse:
+                        return new CompressedSparseTensor<T>(dimensions, IsReversedStride);
                 }
 
                 throw new ArgumentException(nameof(TensorType));
@@ -57,7 +63,8 @@ namespace tests
         private static TensorType[] s_tensorTypes = new[]
         {
             TensorType.Dense,
-            TensorType.Sparse
+            TensorType.Sparse,
+            TensorType.CompressedSparse
         };
 
         private static bool[] s_reverseStrideValues = new[]
@@ -198,6 +205,71 @@ namespace tests
             Assert.Equal(21, tensor[3, 1, 0]);
             Assert.Equal(22, tensor[3, 1, 1]);
             Assert.Equal(23, tensor[3, 1, 2]);
+        }
+        [Theory()]
+        [MemberData(nameof(GetSingleTensorConstructors))]
+        public void ConstructSparseTensor(TensorConstructor tensorConstructor)
+        {
+            var tensor = tensorConstructor.CreateFromArray<int>(new[,]
+            {
+                {0, 0, 0, 0},
+                {5, 8, 0, 0},
+                {0, 0, 3, 0},
+                {0, 6, 0, 0}
+            });
+
+            Assert.Equal(tensorConstructor.IsReversedStride, tensor.IsReversedStride);
+
+
+            Assert.Equal(0, tensor[0, 0]);
+            Assert.Equal(0, tensor[0, 1]);
+            Assert.Equal(0, tensor[0, 2]);
+            Assert.Equal(0, tensor[0, 3]);
+
+
+            Assert.Equal(5, tensor[1, 0]);
+            Assert.Equal(8, tensor[1, 1]);
+            Assert.Equal(0, tensor[1, 2]);
+            Assert.Equal(0, tensor[1, 3]);
+
+
+            Assert.Equal(0, tensor[2, 0]);
+            Assert.Equal(0, tensor[2, 1]);
+            Assert.Equal(3, tensor[2, 2]);
+            Assert.Equal(0, tensor[2, 3]);
+
+
+            Assert.Equal(0, tensor[3, 0]);
+            Assert.Equal(6, tensor[3, 1]);
+            Assert.Equal(0, tensor[3, 2]);
+            Assert.Equal(0, tensor[3, 3]);
+
+            if (tensorConstructor.TensorType == TensorType.CompressedSparse)
+            {
+                var compressedSparseTensor = (CompressedSparseTensor<int>)tensor;
+
+                Assert.Equal(4, compressedSparseTensor.ValueCount);
+
+                int[] expectedValues, expectedCompressedCounts, expectedIndices;
+
+                if (compressedSparseTensor.IsReversedStride)
+                {
+                    // csc
+                    expectedValues = new[] { 5, 8, 6, 3 };
+                    expectedCompressedCounts = new[] { 0, 1, 3, 4, 4 };
+                    expectedIndices = new[] { 1, 1, 3, 2 };
+                }
+                else
+                {
+                    // csr
+                    expectedValues = new[] { 5, 8, 3, 6 };
+                    expectedCompressedCounts = new[] { 0, 0, 2, 3, 4 };
+                    expectedIndices = new[] { 0, 1, 2, 1 };
+                }
+                Assert.Equal(expectedValues, compressedSparseTensor.Values.Take(compressedSparseTensor.ValueCount));
+                Assert.Equal(expectedCompressedCounts, compressedSparseTensor.CompressedCounts);
+                Assert.Equal(expectedIndices, compressedSparseTensor.Indices.Take(compressedSparseTensor.ValueCount));
+            }
         }
 
         [Theory()]


### PR DESCRIPTION
Adds a layout for CompressedSparseTensors supporting both CSR and CSC formats.

/cc @mellinoe 