### PR TITLE
Don't remove observer when the channel is completed

### DIFF
--- a/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/ReadableChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/Threading/Tasks/Channels/ReadableChannel.cs
@@ -215,8 +215,11 @@ namespace System.Threading.Tasks.Channels
                     {
                         if (_observer != null)
                         {
-                            bool removed = _observable._observers.Remove(_observer);
-                            Debug.Assert(removed);
+                            if (!_observable._channel.Completion.IsCompleted)
+                            {
+                                bool removed = _observable._observers.Remove(_observer);
+                                Debug.Assert(removed);
+                            }
                             _observer = null;
                         }
                     }


### PR DESCRIPTION
Fix for issue #1761
Avoid removing the observer when channel is being completed.