### PR TITLE
Port over fix for ParseRequestLineSplit...DoesNotUpdateConsumed() test

### DIFF
--- a/tests/System.Text.Http.Parser.Tests/HttpParserTests.cs
+++ b/tests/System.Text.Http.Parser.Tests/HttpParserTests.cs
@@ -7,6 +7,8 @@ using System.IO.Pipelines;
 using System.Linq;
 using Xunit;
 
+using BufferUtilities = System.IO.Pipelines.Testing.BufferUtilities;
+
 namespace System.Text.Http.Parser.Tests
 {
     public class HttpParserTests
@@ -300,6 +302,20 @@ namespace System.Text.Http.Parser.Tests
 
             //Assert.Equal(expectedExceptionMessage, exception.Message);
             //Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);
+        }
+
+        [Fact]
+        public void ParseRequestLineSplitBufferWithoutNewLineDoesNotUpdateConsumed()
+        {
+            HttpParser parser = new HttpParser();
+
+            ReadableBuffer buffer = BufferUtilities.CreateBuffer("GET ", "/");
+            RequestHandler requestHandler = new RequestHandler();
+
+            bool result = parser.ParseRequestLine(requestHandler, buffer, out ReadCursor consumed, out ReadCursor examined);
+            Assert.False(result);
+            Assert.Equal(buffer.Start, consumed);
+            Assert.Equal(buffer.End, examined);
         }
 
         //[Fact]

--- a/tests/System.Text.Http.Parser.Tests/System.Text.Http.Parser.Tests.csproj
+++ b/tests/System.Text.Http.Parser.Tests/System.Text.Http.Parser.Tests.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Text.Http.Parser\System.Text.Http.Parser.csproj" />
     <ProjectReference Include="..\..\src\System.IO.Pipelines\System.IO.Pipelines.csproj" />
+    <ProjectReference Include="..\..\src\System.IO.Pipelines.Testing\System.IO.Pipelines.Testing.csproj" />
   </ItemGroup>
   <!-- register for test discovery in Visual Studio -->
   <ItemGroup>


### PR DESCRIPTION
This migrates over this fix here:

  https://github.com/aspnet/KestrelHttpServer/commit/547ad80a272c94861453ae50daaa5f9addb0cc8f

and addresses the last test failure from the Kestrel ingestion
experiment:

  ParseRequestLineSplitBufferWithoutNewLineDoesNotUpdateConsumed()