### PR TITLE
Trying to use Binary Reader on struct with new Reverse Endian method.

### DIFF
--- a/src/System.Binary/System/Binary/BufferReader.cs
+++ b/src/System.Binary/System/Binary/BufferReader.cs
@@ -105,5 +105,33 @@ namespace System.Binary
                 throw new ArgumentOutOfRangeException();
             }
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe static int ReverseEndianness(this int num)
+        {
+            uint val = 0;
+            Unsafe.Write(&val, num);
+            val = (val << 24)
+                | ((val & 0xFF00) << 8)
+                | ((val & 0xFF0000) >> 8)
+                | (val >> 24);
+            return Unsafe.Read<int>(&val);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public unsafe static long ReverseEndianness(this long num)
+        {
+            ulong val = 0;
+            Unsafe.Write(&val, num);
+            val = (val << 56)
+                | ((val & 0xFF00) << 40)
+                | ((val & 0xFF0000) << 24)
+                | ((val & 0xFF000000) << 8)
+                | ((val & 0xFF00000000) >> 8)
+                | ((val & 0xFF0000000000) >> 24)
+                | ((val & 0xFF000000000000) >> 40)
+                | (val >> 56);
+            return Unsafe.Read<long>(&val);
+        }
     }
 }

--- a/tests/System.Binary.Tests/BufferReaderTests.cs
+++ b/tests/System.Binary.Tests/BufferReaderTests.cs
@@ -51,7 +51,7 @@ namespace System.Binary.Tests
             var myStruct = new HomogenousTestStruct
             {
                 I0 = 12345, // 00 00 48 57 => BE => 959447040
-                I1 = 5316513, // 00 81 31 161 => BE => 2703184128
+                I1 = 5316513, // 00 81 31 161 => BE => 2703184128 => (integer overflow) -1591783168
                 I2 = 790 // 00 00 03 22 => BE => 369295360
             };
 

--- a/tests/System.Binary.Tests/BufferReaderTests.cs
+++ b/tests/System.Binary.Tests/BufferReaderTests.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Binary.Tests
@@ -14,7 +16,8 @@ namespace System.Binary.Tests
 
             ulong value = 0x8877665544332211; // [11 22 33 44 55 66 77 88]
             Span<byte> span;
-            unsafe {
+            unsafe
+            {
                 span = new Span<byte>(&value, 8);
             }
 
@@ -38,6 +41,144 @@ namespace System.Binary.Tests
             Assert.Equal<long>(0x1122334455667788, span.ReadBigEndian<long>());
             Assert.Equal<long>(unchecked((long)0x8877665544332211), span.ReadLittleEndian<long>());
 
+        }
+
+        [Fact]
+        public void BufferReaderReadHomogenousStruct()
+        {
+            Assert.True(BitConverter.IsLittleEndian);
+
+            var myStruct = new HomogenousTestStruct
+            {
+                I0 = 12345, // 00 00 48 57 => BE => 959447040
+                I1 = 5316513, // 00 81 31 161 => BE => 2703184128
+                I2 = 790 // 00 00 03 22 => BE => 369295360
+            };
+
+            Span<byte> spanBE = new byte[Unsafe.SizeOf<HomogenousTestStruct>()];
+
+            spanBE.WriteBigEndian(myStruct.I0);
+            spanBE.Slice(4).WriteBigEndian(myStruct.I1);
+            spanBE.Slice(8).WriteBigEndian(myStruct.I2);
+
+            HomogenousTestStruct readStruct = spanBE.Read<HomogenousTestStruct>();
+
+            if (BitConverter.IsLittleEndian)
+            {
+                readStruct.I0 = readStruct.I0.ReverseEndianness();
+                readStruct.I1 = readStruct.I1.ReverseEndianness();
+                readStruct.I2 = readStruct.I2.ReverseEndianness();
+            }
+
+            Assert.Equal(myStruct.I0, readStruct.I0);
+            Assert.Equal(myStruct.I1, readStruct.I1);
+            Assert.Equal(myStruct.I2, readStruct.I2);
+        }
+
+        [Fact]
+        public void BufferReaderReadHeterogeneousStructWILLFAIL()
+        {
+            Assert.True(BitConverter.IsLittleEndian);
+
+            var myStruct = new HeterogenousTestStruct
+            {
+                I0 = 12345, // 00 00 48 57 => BE => 959447040
+                L1 = 4147483647,
+                I2 = int.MaxValue,
+                L3 = long.MinValue,
+                I4 = int.MinValue,
+                L5 = long.MaxValue
+            };
+
+            Span<byte> spanBE = new byte[Unsafe.SizeOf<HeterogenousTestStruct>()];
+
+            spanBE.WriteBigEndian(myStruct.I0);
+            spanBE.Slice(4).WriteBigEndian(myStruct.L1);
+            spanBE.Slice(12).WriteBigEndian(myStruct.I2);
+            spanBE.Slice(16).WriteBigEndian(myStruct.L3);
+            spanBE.Slice(24).WriteBigEndian(myStruct.I4);
+            spanBE.Slice(28).WriteBigEndian(myStruct.L5);
+
+            HeterogenousTestStruct readStruct = spanBE.Read<HeterogenousTestStruct>();
+
+            // This does not work!
+            if (BitConverter.IsLittleEndian)
+            {
+                readStruct.I0 = readStruct.I0.ReverseEndianness();
+                readStruct.L1 = readStruct.L1.ReverseEndianness();
+                readStruct.I2 = readStruct.I2.ReverseEndianness();
+                readStruct.L3 = readStruct.L3.ReverseEndianness();
+                readStruct.I4 = readStruct.I4.ReverseEndianness();
+                readStruct.L5 = readStruct.L5.ReverseEndianness();
+            }
+
+            Assert.Equal(myStruct.I0, readStruct.I0);
+            Assert.Equal(myStruct.L1, readStruct.L1);
+            Assert.Equal(myStruct.I2, readStruct.I2);
+            Assert.Equal(myStruct.L3, readStruct.L3);
+            Assert.Equal(myStruct.I4, readStruct.I4);
+            Assert.Equal(myStruct.L5, readStruct.L5);
+        }
+
+        [Fact]
+        public void BufferReaderReadHeterogeneousStruct()
+        {
+            Assert.True(BitConverter.IsLittleEndian);
+
+            var myStruct = new HeterogenousTestStruct
+            {
+                I0 = 12345, // 00 00 48 57 => BE => 959447040
+                L1 = 4147483647,
+                I2 = int.MaxValue,
+                L3 = long.MinValue,
+                I4 = int.MinValue,
+                L5 = long.MaxValue
+            };
+
+            Span<byte> spanBE = new byte[Unsafe.SizeOf<HeterogenousTestStruct>()];
+
+            spanBE.WriteBigEndian(myStruct.I0);
+            spanBE.Slice(4).WriteBigEndian(myStruct.L1);
+            spanBE.Slice(12).WriteBigEndian(myStruct.I2);
+            spanBE.Slice(16).WriteBigEndian(myStruct.L3);
+            spanBE.Slice(24).WriteBigEndian(myStruct.I4);
+            spanBE.Slice(28).WriteBigEndian(myStruct.L5);
+
+            HeterogenousTestStruct readStruct = new HeterogenousTestStruct
+            {
+                I0 = spanBE.ReadBigEndian<int>(),
+                L1 = spanBE.Slice(4).ReadBigEndian<long>(),
+                I2 = spanBE.Slice(12).ReadBigEndian<int>(),
+                L3 = spanBE.Slice(16).ReadBigEndian<long>(),
+                I4 = spanBE.Slice(24).ReadBigEndian<int>(),
+                L5 = spanBE.Slice(28).ReadBigEndian<long>()
+            };
+
+            Assert.Equal(myStruct.I0, readStruct.I0);
+            Assert.Equal(myStruct.L1, readStruct.L1);
+            Assert.Equal(myStruct.I2, readStruct.I2);
+            Assert.Equal(myStruct.L3, readStruct.L3);
+            Assert.Equal(myStruct.I4, readStruct.I4);
+            Assert.Equal(myStruct.L5, readStruct.L5);
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct HeterogenousTestStruct
+        {
+            public int I0;
+            public long L1;
+            public int I2;
+            public long L3;
+            public int I4;
+            public long L5;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct HomogenousTestStruct
+        {
+            public int I0;
+            public int I1;
+            public int I2;
         }
     }
 }


### PR DESCRIPTION
Related to: https://github.com/dotnet/corefx/issues/24144#issuecomment-330638602
> - Consider making the Read/Write Apis use the default endianness and just have a flip endianness method for just the single value primitives. 

For structs containing types of of varying lengths, is the above suggestion possible? I don't know how we can call Read and then correctly set the struct values by calling primitive type ReverseEndianness methods.

This is experimental (and won't work as is) and hence **do not merge**.

```C#
int ReverseEndianness(this int num)
long ReverseEndianness(this long num)
```

Note that the test BufferReaderReadHeterogeneousStructWILLFAIL() will fail.
```C#
            HeterogenousTestStruct readStruct = spanBE.Read<HeterogenousTestStruct>();

            // This does not work!
            if (BitConverter.IsLittleEndian)
            {
                readStruct.I0 = readStruct.I0.ReverseEndianness();
                readStruct.L1 = readStruct.L1.ReverseEndianness();
                readStruct.I2 = readStruct.I2.ReverseEndianness();
                readStruct.L3 = readStruct.L3.ReverseEndianness();
                readStruct.I4 = readStruct.I4.ReverseEndianness();
                readStruct.L5 = readStruct.L5.ReverseEndianness();
            }
```

cc @KrzysztofCwalina