### PR TITLE
Adding non-generic {Try}Read/Write BE & LE methods

### DIFF
--- a/scripts/PerfHarness/PerfHarness.csproj
+++ b/scripts/PerfHarness/PerfHarness.csproj
@@ -7,7 +7,6 @@
     <AssemblyName>PerfHarness</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>PerfHarness</PackageId>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/System.Binary/System/Binary/BufferReader_BE.cs
+++ b/src/System.Binary/System/Binary/BufferReader_BE.cs
@@ -22,8 +22,280 @@ namespace System.Buffers
         public static T ReadBigEndian<[Primitive]T>(this Span<byte> buffer) where T : struct
             => BitConverter.IsLittleEndian ? UnsafeUtilities.Reverse(buffer.Read<T>()) : buffer.Read<T>();
 
+        #region ReadBigEndianROSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndiann<[Primitive]T>(this ReadOnlySpan<byte> buffer, out T value) where T : struct
+        public static short ReadBigEndianInt16(this ReadOnlySpan<byte> buffer)
+        {
+            short result = buffer.Read<short>();
+            if (BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ReadBigEndianInt32(this ReadOnlySpan<byte> buffer)
+        {
+            int result = buffer.Read<int>();
+            if (BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long ReadBigEndianInt64(this ReadOnlySpan<byte> buffer)
+        {
+            long result = buffer.Read<long>();
+            if (BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ushort ReadBigEndianUInt16(this ReadOnlySpan<byte> buffer)
+        {
+            ushort result = buffer.Read<ushort>();
+            if (BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint ReadBigEndianUInt32(this ReadOnlySpan<byte> buffer)
+        {
+            uint result = buffer.Read<uint>();
+            if (BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong ReadBigEndianUInt64(this ReadOnlySpan<byte> buffer)
+        {
+            ulong result = buffer.Read<ulong>();
+            if (BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+        #endregion
+
+        #region ReadBigEndianSpan
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static short ReadBigEndianInt16(this Span<byte> buffer)
+        {
+            short result = buffer.Read<short>();
+            if (BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ReadBigEndianInt32(this Span<byte> buffer)
+        {
+            int result = buffer.Read<int>();
+            if (BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long ReadBigEndianInt64(this Span<byte> buffer)
+        {
+            long result = buffer.Read<long>();
+            if (BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ushort ReadBigEndianUInt16(this Span<byte> buffer)
+        {
+            ushort result = buffer.Read<ushort>();
+            if (BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint ReadBigEndianUInt32(this Span<byte> buffer)
+        {
+            uint result = buffer.Read<uint>();
+            if (BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong ReadBigEndianUInt64(this Span<byte> buffer)
+        {
+            ulong result = buffer.Read<ulong>();
+            if (BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+        #endregion
+
+        #region TryReadBigEndianSpan
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadBigEndianInt16(this Span<byte> buffer, out short value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadBigEndianInt32(this Span<byte> buffer, out int value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadBigEndianInt64(this Span<byte> buffer, out long value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadBigEndianUInt16(this Span<byte> buffer, out ushort value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadBigEndianUInt32(this Span<byte> buffer, out uint value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadBigEndianUInt64(this Span<byte> buffer, out ulong value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+        #endregion
+
+        #region TryReadBigEndianROSpan
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadBigEndianInt16(this ReadOnlySpan<byte> buffer, out short value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadBigEndianInt32(this ReadOnlySpan<byte> buffer, out int value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadBigEndianInt64(this ReadOnlySpan<byte> buffer, out long value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadBigEndianUInt16(this ReadOnlySpan<byte> buffer, out ushort value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadBigEndianUInt32(this ReadOnlySpan<byte> buffer, out uint value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadBigEndianUInt64(this ReadOnlySpan<byte> buffer, out ulong value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+        #endregion
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadBigEndian<[Primitive]T>(this ReadOnlySpan<byte> buffer, out T value) where T : struct
         {
             if (!BitConverter.IsLittleEndian) return buffer.TryRead(out value);
             if (!buffer.TryRead(out value)) return false;

--- a/src/System.Binary/System/Binary/BufferReader_BE.cs
+++ b/src/System.Binary/System/Binary/BufferReader_BE.cs
@@ -24,7 +24,7 @@ namespace System.Buffers
 
         #region ReadBigEndianROSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static short ReadBigEndianInt16(this ReadOnlySpan<byte> buffer)
+        public static short ReadInt16BigEndian(this ReadOnlySpan<byte> buffer)
         {
             short result = buffer.Read<short>();
             if (BitConverter.IsLittleEndian)
@@ -35,7 +35,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ReadBigEndianInt32(this ReadOnlySpan<byte> buffer)
+        public static int ReadInt32BigEndian(this ReadOnlySpan<byte> buffer)
         {
             int result = buffer.Read<int>();
             if (BitConverter.IsLittleEndian)
@@ -46,7 +46,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long ReadBigEndianInt64(this ReadOnlySpan<byte> buffer)
+        public static long ReadInt64BigEndian(this ReadOnlySpan<byte> buffer)
         {
             long result = buffer.Read<long>();
             if (BitConverter.IsLittleEndian)
@@ -57,7 +57,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort ReadBigEndianUInt16(this ReadOnlySpan<byte> buffer)
+        public static ushort ReadUInt16BigEndian(this ReadOnlySpan<byte> buffer)
         {
             ushort result = buffer.Read<ushort>();
             if (BitConverter.IsLittleEndian)
@@ -68,7 +68,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint ReadBigEndianUInt32(this ReadOnlySpan<byte> buffer)
+        public static uint ReadUInt32BigEndian(this ReadOnlySpan<byte> buffer)
         {
             uint result = buffer.Read<uint>();
             if (BitConverter.IsLittleEndian)
@@ -79,7 +79,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong ReadBigEndianUInt64(this ReadOnlySpan<byte> buffer)
+        public static ulong ReadUInt64BigEndian(this ReadOnlySpan<byte> buffer)
         {
             ulong result = buffer.Read<ulong>();
             if (BitConverter.IsLittleEndian)
@@ -92,7 +92,7 @@ namespace System.Buffers
 
         #region ReadBigEndianSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static short ReadBigEndianInt16(this Span<byte> buffer)
+        public static short ReadInt16BigEndian(this Span<byte> buffer)
         {
             short result = buffer.Read<short>();
             if (BitConverter.IsLittleEndian)
@@ -103,7 +103,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ReadBigEndianInt32(this Span<byte> buffer)
+        public static int ReadInt32BigEndian(this Span<byte> buffer)
         {
             int result = buffer.Read<int>();
             if (BitConverter.IsLittleEndian)
@@ -114,7 +114,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long ReadBigEndianInt64(this Span<byte> buffer)
+        public static long ReadInt64BigEndian(this Span<byte> buffer)
         {
             long result = buffer.Read<long>();
             if (BitConverter.IsLittleEndian)
@@ -125,7 +125,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort ReadBigEndianUInt16(this Span<byte> buffer)
+        public static ushort ReadUInt16BigEndian(this Span<byte> buffer)
         {
             ushort result = buffer.Read<ushort>();
             if (BitConverter.IsLittleEndian)
@@ -136,7 +136,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint ReadBigEndianUInt32(this Span<byte> buffer)
+        public static uint ReadUInt32BigEndian(this Span<byte> buffer)
         {
             uint result = buffer.Read<uint>();
             if (BitConverter.IsLittleEndian)
@@ -147,7 +147,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong ReadBigEndianUInt64(this Span<byte> buffer)
+        public static ulong ReadUInt64BigEndian(this Span<byte> buffer)
         {
             ulong result = buffer.Read<ulong>();
             if (BitConverter.IsLittleEndian)
@@ -160,7 +160,7 @@ namespace System.Buffers
 
         #region TryReadBigEndianSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndianInt16(this Span<byte> buffer, out short value)
+        public static bool TryReadInt16BigEndian(this Span<byte> buffer, out short value)
         {
             bool success = buffer.TryRead(out value);
             if (BitConverter.IsLittleEndian)
@@ -171,7 +171,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndianInt32(this Span<byte> buffer, out int value)
+        public static bool TryReadInt32BigEndian(this Span<byte> buffer, out int value)
         {
             bool success = buffer.TryRead(out value);
             if (BitConverter.IsLittleEndian)
@@ -182,7 +182,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndianInt64(this Span<byte> buffer, out long value)
+        public static bool TryReadInt64BigEndian(this Span<byte> buffer, out long value)
         {
             bool success = buffer.TryRead(out value);
             if (BitConverter.IsLittleEndian)
@@ -193,7 +193,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndianUInt16(this Span<byte> buffer, out ushort value)
+        public static bool TryReadUInt16BigEndian(this Span<byte> buffer, out ushort value)
         {
             bool success = buffer.TryRead(out value);
             if (BitConverter.IsLittleEndian)
@@ -204,7 +204,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndianUInt32(this Span<byte> buffer, out uint value)
+        public static bool TryReadUInt32BigEndian(this Span<byte> buffer, out uint value)
         {
             bool success = buffer.TryRead(out value);
             if (BitConverter.IsLittleEndian)
@@ -215,7 +215,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndianUInt64(this Span<byte> buffer, out ulong value)
+        public static bool TryReadUInt64BigEndian(this Span<byte> buffer, out ulong value)
         {
             bool success = buffer.TryRead(out value);
             if (BitConverter.IsLittleEndian)
@@ -228,7 +228,7 @@ namespace System.Buffers
 
         #region TryReadBigEndianROSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndianInt16(this ReadOnlySpan<byte> buffer, out short value)
+        public static bool TryReadInt16BigEndian(this ReadOnlySpan<byte> buffer, out short value)
         {
             bool success = buffer.TryRead(out value);
             if (BitConverter.IsLittleEndian)
@@ -239,7 +239,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndianInt32(this ReadOnlySpan<byte> buffer, out int value)
+        public static bool TryReadInt32BigEndian(this ReadOnlySpan<byte> buffer, out int value)
         {
             bool success = buffer.TryRead(out value);
             if (BitConverter.IsLittleEndian)
@@ -250,7 +250,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndianInt64(this ReadOnlySpan<byte> buffer, out long value)
+        public static bool TryReadInt64BigEndian(this ReadOnlySpan<byte> buffer, out long value)
         {
             bool success = buffer.TryRead(out value);
             if (BitConverter.IsLittleEndian)
@@ -261,7 +261,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndianUInt16(this ReadOnlySpan<byte> buffer, out ushort value)
+        public static bool TryReadUInt16BigEndian(this ReadOnlySpan<byte> buffer, out ushort value)
         {
             bool success = buffer.TryRead(out value);
             if (BitConverter.IsLittleEndian)
@@ -272,7 +272,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndianUInt32(this ReadOnlySpan<byte> buffer, out uint value)
+        public static bool TryReadUInt32BigEndian(this ReadOnlySpan<byte> buffer, out uint value)
         {
             bool success = buffer.TryRead(out value);
             if (BitConverter.IsLittleEndian)
@@ -283,7 +283,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndianUInt64(this ReadOnlySpan<byte> buffer, out ulong value)
+        public static bool TryReadUInt64BigEndian(this ReadOnlySpan<byte> buffer, out ulong value)
         {
             bool success = buffer.TryRead(out value);
             if (BitConverter.IsLittleEndian)

--- a/src/System.Binary/System/Binary/BufferReader_BE.cs
+++ b/src/System.Binary/System/Binary/BufferReader_BE.cs
@@ -293,23 +293,5 @@ namespace System.Buffers
             return success;
         }
         #endregion
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndian<[Primitive]T>(this ReadOnlySpan<byte> buffer, out T value) where T : struct
-        {
-            if (!BitConverter.IsLittleEndian) return buffer.TryRead(out value);
-            if (!buffer.TryRead(out value)) return false;
-            value = UnsafeUtilities.Reverse(value);
-            return true;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadBigEndian<[Primitive]T>(this Span<byte> buffer, out T value) where T : struct
-        {
-            if (!BitConverter.IsLittleEndian) return buffer.TryRead(out value);
-            if (!buffer.TryRead(out value)) return false;
-            value = UnsafeUtilities.Reverse(value);
-            return true;
-        }
     }
 }

--- a/src/System.Binary/System/Binary/BufferReader_LE.cs
+++ b/src/System.Binary/System/Binary/BufferReader_LE.cs
@@ -22,22 +22,276 @@ namespace System.Buffers
         public static T ReadLittleEndian<[Primitive]T>(this Span<byte> buffer) where T : struct
             => BitConverter.IsLittleEndian ? buffer.Read<T>() : UnsafeUtilities.Reverse(buffer.Read<T>());
 
+        #region ReadLittleEndianROSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadLittleEndian<[Primitive]T>(this ReadOnlySpan<byte> buffer, out T value) where T : struct
+        public static short ReadLittleEndianInt16(this ReadOnlySpan<byte> buffer)
         {
-            if (BitConverter.IsLittleEndian) return buffer.TryRead(out value);           
-            if (!buffer.TryRead<T>(out value)) return false;
-            value = UnsafeUtilities.Reverse(value);
-            return true;
+            short result = buffer.Read<short>();
+            if (!BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadLittleEndian<[Primitive]T>(this Span<byte> buffer, out T value) where T : struct
+        public static int ReadLittleEndianInt32(this ReadOnlySpan<byte> buffer)
         {
-            if (BitConverter.IsLittleEndian) return buffer.TryRead(out value);
-            if (!buffer.TryRead(out value)) return false;
-            value = UnsafeUtilities.Reverse(value);
-            return true;
+            int result = buffer.Read<int>();
+            if (!BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long ReadLittleEndianInt64(this ReadOnlySpan<byte> buffer)
+        {
+            long result = buffer.Read<long>();
+            if (!BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ushort ReadLittleEndianUInt16(this ReadOnlySpan<byte> buffer)
+        {
+            ushort result = buffer.Read<ushort>();
+            if (!BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint ReadLittleEndianUInt32(this ReadOnlySpan<byte> buffer)
+        {
+            uint result = buffer.Read<uint>();
+            if (!BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong ReadLittleEndianUInt64(this ReadOnlySpan<byte> buffer)
+        {
+            ulong result = buffer.Read<ulong>();
+            if (!BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+        #endregion
+
+        #region ReadLittleEndianSpan
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static short ReadLittleEndianInt16(this Span<byte> buffer)
+        {
+            short result = buffer.Read<short>();
+            if (!BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ReadLittleEndianInt32(this Span<byte> buffer)
+        {
+            int result = buffer.Read<int>();
+            if (!BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long ReadLittleEndianInt64(this Span<byte> buffer)
+        {
+            long result = buffer.Read<long>();
+            if (!BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ushort ReadLittleEndianUInt16(this Span<byte> buffer)
+        {
+            ushort result = buffer.Read<ushort>();
+            if (!BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint ReadLittleEndianUInt32(this Span<byte> buffer)
+        {
+            uint result = buffer.Read<uint>();
+            if (!BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ulong ReadLittleEndianUInt64(this Span<byte> buffer)
+        {
+            ulong result = buffer.Read<ulong>();
+            if (!BitConverter.IsLittleEndian)
+            {
+                result = UnsafeUtilities.ReverseEndianness(result);
+            }
+            return result;
+        }
+        #endregion
+
+        #region TryReadLittleEndianSpan
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadLittleEndianInt16(this Span<byte> buffer, out short value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadLittleEndianInt32(this Span<byte> buffer, out int value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadLittleEndianInt64(this Span<byte> buffer, out long value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadLittleEndianUInt16(this Span<byte> buffer, out ushort value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadLittleEndianUInt32(this Span<byte> buffer, out uint value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadLittleEndianUInt64(this Span<byte> buffer, out ulong value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+        #endregion
+
+        #region TryReadLittleEndianROSpan
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadLittleEndianInt16(this ReadOnlySpan<byte> buffer, out short value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadLittleEndianInt32(this ReadOnlySpan<byte> buffer, out int value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadLittleEndianInt64(this ReadOnlySpan<byte> buffer, out long value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadLittleEndianUInt16(this ReadOnlySpan<byte> buffer, out ushort value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadLittleEndianUInt32(this ReadOnlySpan<byte> buffer, out uint value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadLittleEndianUInt64(this ReadOnlySpan<byte> buffer, out ulong value)
+        {
+            bool success = buffer.TryRead(out value);
+            if (!BitConverter.IsLittleEndian)
+            {
+                value = UnsafeUtilities.ReverseEndianness(value);
+            }
+            return success;
+        }
+        #endregion
     }
 }

--- a/src/System.Binary/System/Binary/BufferReader_LE.cs
+++ b/src/System.Binary/System/Binary/BufferReader_LE.cs
@@ -24,7 +24,7 @@ namespace System.Buffers
 
         #region ReadLittleEndianROSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static short ReadLittleEndianInt16(this ReadOnlySpan<byte> buffer)
+        public static short ReadInt16LittleEndian(this ReadOnlySpan<byte> buffer)
         {
             short result = buffer.Read<short>();
             if (!BitConverter.IsLittleEndian)
@@ -35,7 +35,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ReadLittleEndianInt32(this ReadOnlySpan<byte> buffer)
+        public static int ReadInt32LittleEndian(this ReadOnlySpan<byte> buffer)
         {
             int result = buffer.Read<int>();
             if (!BitConverter.IsLittleEndian)
@@ -46,7 +46,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long ReadLittleEndianInt64(this ReadOnlySpan<byte> buffer)
+        public static long ReadInt64LittleEndian(this ReadOnlySpan<byte> buffer)
         {
             long result = buffer.Read<long>();
             if (!BitConverter.IsLittleEndian)
@@ -57,7 +57,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort ReadLittleEndianUInt16(this ReadOnlySpan<byte> buffer)
+        public static ushort ReadUInt16LittleEndian(this ReadOnlySpan<byte> buffer)
         {
             ushort result = buffer.Read<ushort>();
             if (!BitConverter.IsLittleEndian)
@@ -68,7 +68,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint ReadLittleEndianUInt32(this ReadOnlySpan<byte> buffer)
+        public static uint ReadUInt32LittleEndian(this ReadOnlySpan<byte> buffer)
         {
             uint result = buffer.Read<uint>();
             if (!BitConverter.IsLittleEndian)
@@ -79,7 +79,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong ReadLittleEndianUInt64(this ReadOnlySpan<byte> buffer)
+        public static ulong ReadUInt64LittleEndian(this ReadOnlySpan<byte> buffer)
         {
             ulong result = buffer.Read<ulong>();
             if (!BitConverter.IsLittleEndian)
@@ -92,7 +92,7 @@ namespace System.Buffers
 
         #region ReadLittleEndianSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static short ReadLittleEndianInt16(this Span<byte> buffer)
+        public static short ReadInt16LittleEndian(this Span<byte> buffer)
         {
             short result = buffer.Read<short>();
             if (!BitConverter.IsLittleEndian)
@@ -103,7 +103,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ReadLittleEndianInt32(this Span<byte> buffer)
+        public static int ReadInt32LittleEndian(this Span<byte> buffer)
         {
             int result = buffer.Read<int>();
             if (!BitConverter.IsLittleEndian)
@@ -114,7 +114,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long ReadLittleEndianInt64(this Span<byte> buffer)
+        public static long ReadInt64LittleEndian(this Span<byte> buffer)
         {
             long result = buffer.Read<long>();
             if (!BitConverter.IsLittleEndian)
@@ -125,7 +125,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ushort ReadLittleEndianUInt16(this Span<byte> buffer)
+        public static ushort ReadUInt16LittleEndian(this Span<byte> buffer)
         {
             ushort result = buffer.Read<ushort>();
             if (!BitConverter.IsLittleEndian)
@@ -136,7 +136,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static uint ReadLittleEndianUInt32(this Span<byte> buffer)
+        public static uint ReadUInt32LittleEndian(this Span<byte> buffer)
         {
             uint result = buffer.Read<uint>();
             if (!BitConverter.IsLittleEndian)
@@ -147,7 +147,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong ReadLittleEndianUInt64(this Span<byte> buffer)
+        public static ulong ReadUInt64LittleEndian(this Span<byte> buffer)
         {
             ulong result = buffer.Read<ulong>();
             if (!BitConverter.IsLittleEndian)
@@ -160,7 +160,7 @@ namespace System.Buffers
 
         #region TryReadLittleEndianSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadLittleEndianInt16(this Span<byte> buffer, out short value)
+        public static bool TryReadInt16LittleEndian(this Span<byte> buffer, out short value)
         {
             bool success = buffer.TryRead(out value);
             if (!BitConverter.IsLittleEndian)
@@ -171,7 +171,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadLittleEndianInt32(this Span<byte> buffer, out int value)
+        public static bool TryReadInt32LittleEndian(this Span<byte> buffer, out int value)
         {
             bool success = buffer.TryRead(out value);
             if (!BitConverter.IsLittleEndian)
@@ -182,7 +182,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadLittleEndianInt64(this Span<byte> buffer, out long value)
+        public static bool TryReadInt64LittleEndian(this Span<byte> buffer, out long value)
         {
             bool success = buffer.TryRead(out value);
             if (!BitConverter.IsLittleEndian)
@@ -193,7 +193,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadLittleEndianUInt16(this Span<byte> buffer, out ushort value)
+        public static bool TryReadUInt16LittleEndian(this Span<byte> buffer, out ushort value)
         {
             bool success = buffer.TryRead(out value);
             if (!BitConverter.IsLittleEndian)
@@ -204,7 +204,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadLittleEndianUInt32(this Span<byte> buffer, out uint value)
+        public static bool TryReadUInt32LittleEndian(this Span<byte> buffer, out uint value)
         {
             bool success = buffer.TryRead(out value);
             if (!BitConverter.IsLittleEndian)
@@ -215,7 +215,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadLittleEndianUInt64(this Span<byte> buffer, out ulong value)
+        public static bool TryReadUInt64LittleEndian(this Span<byte> buffer, out ulong value)
         {
             bool success = buffer.TryRead(out value);
             if (!BitConverter.IsLittleEndian)
@@ -228,7 +228,7 @@ namespace System.Buffers
 
         #region TryReadLittleEndianROSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadLittleEndianInt16(this ReadOnlySpan<byte> buffer, out short value)
+        public static bool TryReadInt16LittleEndian(this ReadOnlySpan<byte> buffer, out short value)
         {
             bool success = buffer.TryRead(out value);
             if (!BitConverter.IsLittleEndian)
@@ -239,7 +239,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadLittleEndianInt32(this ReadOnlySpan<byte> buffer, out int value)
+        public static bool TryReadInt32LittleEndian(this ReadOnlySpan<byte> buffer, out int value)
         {
             bool success = buffer.TryRead(out value);
             if (!BitConverter.IsLittleEndian)
@@ -250,7 +250,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadLittleEndianInt64(this ReadOnlySpan<byte> buffer, out long value)
+        public static bool TryReadInt64LittleEndian(this ReadOnlySpan<byte> buffer, out long value)
         {
             bool success = buffer.TryRead(out value);
             if (!BitConverter.IsLittleEndian)
@@ -261,7 +261,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadLittleEndianUInt16(this ReadOnlySpan<byte> buffer, out ushort value)
+        public static bool TryReadUInt16LittleEndian(this ReadOnlySpan<byte> buffer, out ushort value)
         {
             bool success = buffer.TryRead(out value);
             if (!BitConverter.IsLittleEndian)
@@ -272,7 +272,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadLittleEndianUInt32(this ReadOnlySpan<byte> buffer, out uint value)
+        public static bool TryReadUInt32LittleEndian(this ReadOnlySpan<byte> buffer, out uint value)
         {
             bool success = buffer.TryRead(out value);
             if (!BitConverter.IsLittleEndian)
@@ -283,7 +283,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryReadLittleEndianUInt64(this ReadOnlySpan<byte> buffer, out ulong value)
+        public static bool TryReadUInt64LittleEndian(this ReadOnlySpan<byte> buffer, out ulong value)
         {
             bool success = buffer.TryRead(out value);
             if (!BitConverter.IsLittleEndian)

--- a/src/System.Binary/System/Binary/BufferWriter.cs
+++ b/src/System.Binary/System/Binary/BufferWriter.cs
@@ -59,37 +59,37 @@ namespace System.Buffers
 
         #region WriteBigEndianSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteBigEndianInt16(this Span<byte> buffer, short value)
+        public static void WriteInt16BigEndian(this Span<byte> buffer, short value)
         {
             buffer.Write(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteBigEndianInt32(this Span<byte> buffer, int value)
+        public static void WriteInt32BigEndian(this Span<byte> buffer, int value)
         {
             buffer.Write(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteBigEndianInt64(this Span<byte> buffer, long value)
+        public static void WriteInt64BigEndian(this Span<byte> buffer, long value)
         {
             buffer.Write(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteBigEndianUInt16(this Span<byte> buffer, ushort value)
+        public static void WriteUInt16BigEndian(this Span<byte> buffer, ushort value)
         {
             buffer.Write(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteBigEndianUInt32(this Span<byte> buffer, uint value)
+        public static void WriteUInt32BigEndian(this Span<byte> buffer, uint value)
         {
             buffer.Write(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteBigEndianUInt64(this Span<byte> buffer, ulong value)
+        public static void WriteUInt64BigEndian(this Span<byte> buffer, ulong value)
         {
             buffer.Write(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
         }
@@ -97,37 +97,37 @@ namespace System.Buffers
 
         #region WriteLittleEndianSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteLittleEndianInt16(this Span<byte> buffer, short value)
+        public static void WriteInt16LittleEndian(this Span<byte> buffer, short value)
         {
             buffer.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteLittleEndianInt32(this Span<byte> buffer, int value)
+        public static void WriteInt32LittleEndian(this Span<byte> buffer, int value)
         {
             buffer.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteLittleEndianInt64(this Span<byte> buffer, long value)
+        public static void WriteInt64LittleEndian(this Span<byte> buffer, long value)
         {
             buffer.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteLittleEndianUInt16(this Span<byte> buffer, ushort value)
+        public static void WriteUInt16LittleEndian(this Span<byte> buffer, ushort value)
         {
             buffer.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteLittleEndianUInt32(this Span<byte> buffer, uint value)
+        public static void WriteUInt32LittleEndian(this Span<byte> buffer, uint value)
         {
             buffer.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteLittleEndianUInt64(this Span<byte> buffer, ulong value)
+        public static void WriteUInt64LittleEndian(this Span<byte> buffer, ulong value)
         {
             buffer.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
         }
@@ -135,37 +135,37 @@ namespace System.Buffers
 
         #region TryWriteBigEndianSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteBigEndianInt16(this Span<byte> buffer, short value)
+        public static bool TryWriteInt16BigEndian(this Span<byte> buffer, short value)
         {
             return buffer.TryWrite(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteBigEndianInt32(this Span<byte> buffer, int value)
+        public static bool TryWriteInt32BigEndian(this Span<byte> buffer, int value)
         {
             return buffer.TryWrite(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteBigEndianInt64(this Span<byte> buffer, long value)
+        public static bool TryWriteInt64BigEndian(this Span<byte> buffer, long value)
         {
             return buffer.TryWrite(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteBigEndianUInt16(this Span<byte> buffer, ushort value)
+        public static bool TryWriteUInt16BigEndian(this Span<byte> buffer, ushort value)
         {
             return buffer.TryWrite(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteBigEndianUInt32(this Span<byte> buffer, uint value)
+        public static bool TryWriteUInt32BigEndian(this Span<byte> buffer, uint value)
         {
             return buffer.TryWrite(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteBigEndianUInt64(this Span<byte> buffer, ulong value)
+        public static bool TryWriteUInt64BigEndian(this Span<byte> buffer, ulong value)
         {
             return buffer.TryWrite(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
         }
@@ -173,37 +173,37 @@ namespace System.Buffers
 
         #region TryWriteLittleEndianSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteLittleEndianInt16(this Span<byte> buffer, short value)
+        public static bool TryWriteInt16LittleEndian(this Span<byte> buffer, short value)
         {
             return buffer.TryWrite(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteLittleEndianInt32(this Span<byte> buffer, int value)
+        public static bool TryWriteInt32LittleEndian(this Span<byte> buffer, int value)
         {
             return buffer.TryWrite(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteLittleEndianInt64(this Span<byte> buffer, long value)
+        public static bool TryWriteInt64LittleEndian(this Span<byte> buffer, long value)
         {
             return buffer.TryWrite(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteLittleEndianUInt16(this Span<byte> buffer, ushort value)
+        public static bool TryWriteUInt16LittleEndian(this Span<byte> buffer, ushort value)
         {
             return buffer.TryWrite(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteLittleEndianUInt32(this Span<byte> buffer, uint value)
+        public static bool TryWriteUInt32LittleEndian(this Span<byte> buffer, uint value)
         {
             return buffer.TryWrite(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteLittleEndianUInt64(this Span<byte> buffer, ulong value)
+        public static bool TryWriteUInt64LittleEndian(this Span<byte> buffer, ulong value)
         {
             return buffer.TryWrite(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
         }

--- a/src/System.Binary/System/Binary/BufferWriter.cs
+++ b/src/System.Binary/System/Binary/BufferWriter.cs
@@ -57,17 +57,156 @@ namespace System.Buffers
         public static void WriteLittleEndian<[Primitive]T>(this Span<byte> buffer, T value) where T : struct
             => buffer.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.Reverse(value));
 
-
+        #region WriteBigEndianSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteLittleEndian<[Primitive]T>(this Span<byte> buffer, T value) where T : struct
+        public static void WriteBigEndianInt16(this Span<byte> buffer, short value)
         {
-            return BitConverter.IsLittleEndian ? TryWrite(buffer, value) : TryWrite(buffer, UnsafeUtilities.Reverse(value));
+            buffer.Write(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryWriteBigEndian<[Primitive]T>(this Span<byte> buffer, T value) where T : struct
+        public static void WriteBigEndianInt32(this Span<byte> buffer, int value)
         {
-            return BitConverter.IsLittleEndian ? TryWrite(buffer, UnsafeUtilities.Reverse(value)) : TryWrite(buffer, value);
+            buffer.Write(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteBigEndianInt64(this Span<byte> buffer, long value)
+        {
+            buffer.Write(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteBigEndianUInt16(this Span<byte> buffer, ushort value)
+        {
+            buffer.Write(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteBigEndianUInt32(this Span<byte> buffer, uint value)
+        {
+            buffer.Write(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteBigEndianUInt64(this Span<byte> buffer, ulong value)
+        {
+            buffer.Write(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
+        }
+        #endregion
+
+        #region WriteLittleEndianSpan
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteLittleEndianInt16(this Span<byte> buffer, short value)
+        {
+            buffer.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteLittleEndianInt32(this Span<byte> buffer, int value)
+        {
+            buffer.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteLittleEndianInt64(this Span<byte> buffer, long value)
+        {
+            buffer.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteLittleEndianUInt16(this Span<byte> buffer, ushort value)
+        {
+            buffer.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteLittleEndianUInt32(this Span<byte> buffer, uint value)
+        {
+            buffer.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteLittleEndianUInt64(this Span<byte> buffer, ulong value)
+        {
+            buffer.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
+        }
+        #endregion
+
+        #region TryWriteBigEndianSpan
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBigEndianInt16(this Span<byte> buffer, short value)
+        {
+            return buffer.TryWrite(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBigEndianInt32(this Span<byte> buffer, int value)
+        {
+            return buffer.TryWrite(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBigEndianInt64(this Span<byte> buffer, long value)
+        {
+            return buffer.TryWrite(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBigEndianUInt16(this Span<byte> buffer, ushort value)
+        {
+            return buffer.TryWrite(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBigEndianUInt32(this Span<byte> buffer, uint value)
+        {
+            return buffer.TryWrite(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteBigEndianUInt64(this Span<byte> buffer, ulong value)
+        {
+            return buffer.TryWrite(BitConverter.IsLittleEndian ? UnsafeUtilities.ReverseEndianness(value) : value);
+        }
+        #endregion
+
+        #region TryWriteLittleEndianSpan
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteLittleEndianInt16(this Span<byte> buffer, short value)
+        {
+            return buffer.TryWrite(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteLittleEndianInt32(this Span<byte> buffer, int value)
+        {
+            return buffer.TryWrite(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteLittleEndianInt64(this Span<byte> buffer, long value)
+        {
+            return buffer.TryWrite(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteLittleEndianUInt16(this Span<byte> buffer, ushort value)
+        {
+            return buffer.TryWrite(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteLittleEndianUInt32(this Span<byte> buffer, uint value)
+        {
+            return buffer.TryWrite(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryWriteLittleEndianUInt64(this Span<byte> buffer, ulong value)
+        {
+            return buffer.TryWrite(BitConverter.IsLittleEndian ? value : UnsafeUtilities.ReverseEndianness(value));
+        }
+        #endregion
     }
 }

--- a/src/System.Binary/System/Binary/UnsafeUtilities.cs
+++ b/src/System.Binary/System/Binary/UnsafeUtilities.cs
@@ -64,5 +64,57 @@ namespace System.Runtime
                 return Unsafe.Read<T>(val);
             }
         }
+
+        public static short ReverseEndianness(short value)
+        {
+            return (short)((value & 0xFF) << 8 | 
+                (short)(((ushort)value & 0xFF00) >> 8));
+        }
+
+        public static int ReverseEndianness(int value)
+        {
+            return (value & 0x000000FF) << 24 |
+                (value & 0x0000FF00) << 8 |
+                (value & 0x00FF0000) >> 8 |
+                (int)(((uint)value & 0xFF000000) >> 24);
+        }
+
+        public static long ReverseEndianness(long value)
+        {
+            return (value & 0x00000000000000FFL) << 56 |
+                (value & 0x000000000000FF00L) << 40 |
+                (value & 0x0000000000FF0000L) << 24 |
+                (value & 0x00000000FF000000L) << 8 |
+                (value & 0x000000FF00000000L) >> 8 |
+                (value & 0x0000FF0000000000L) >> 24 |
+                (value & 0x00FF000000000000L) >> 40 |
+                (long)(((ulong)value & 0xFF00000000000000L) >> 56);
+        }
+
+        public static ushort ReverseEndianness(ushort value)
+        {
+            return (ushort)((value & 0xFFU) << 8 |
+                (value & 0xFF00U) >> 8);
+        }
+
+        public static uint ReverseEndianness(uint value)
+        {
+            return (value & 0x000000FFU) << 24 |
+                (value & 0x0000FF00U) << 8 |
+                (value & 0x00FF0000U) >> 8 |
+                (value & 0xFF000000U) >> 24;
+        }
+
+        public static ulong ReverseEndianness(ulong value)
+        {
+            return (value & 0x00000000000000FFUL) << 56 |
+                (value & 0x000000000000FF00UL) << 40 |
+                (value & 0x0000000000FF0000UL) << 24 |
+                (value & 0x00000000FF000000UL) << 8 |
+                (value & 0x000000FF00000000UL) >> 8 |
+                (value & 0x0000FF0000000000UL) >> 24 |
+                (value & 0x00FF000000000000UL) >> 40 |
+                (value & 0xFF00000000000000UL) >> 56;
+        }
     }
 }

--- a/src/System.Binary/System/Binary/UnsafeUtilities.cs
+++ b/src/System.Binary/System/Binary/UnsafeUtilities.cs
@@ -67,8 +67,7 @@ namespace System.Runtime
 
         public static short ReverseEndianness(short value)
         {
-            return (short)((value & 0xFF) << 8 | 
-                (short)(((ushort)value & 0xFF00) >> 8));
+            return (short)(value << 8 | value >> 8);
         }
 
         public static int ReverseEndianness(int value)
@@ -93,8 +92,7 @@ namespace System.Runtime
 
         public static ushort ReverseEndianness(ushort value)
         {
-            return (ushort)((value & 0xFFU) << 8 |
-                (value & 0xFF00U) >> 8);
+            return (ushort)(value << 8 | value >> 8);
         }
 
         public static uint ReverseEndianness(uint value)

--- a/src/System.Binary/System/Binary/UnsafeUtilities.cs
+++ b/src/System.Binary/System/Binary/UnsafeUtilities.cs
@@ -67,7 +67,7 @@ namespace System.Runtime
 
         public static short ReverseEndianness(short value)
         {
-            return (short)(value << 8 | value >> 8);
+            return (short)((value & 0x00FF) << 8 | (value & 0xFF00) >> 8);
         }
 
         public static int ReverseEndianness(int value)
@@ -92,7 +92,7 @@ namespace System.Runtime
 
         public static ushort ReverseEndianness(ushort value)
         {
-            return (ushort)(value << 8 | value >> 8);
+            return (ushort)((value & 0x00FFU) << 8 | (value & 0xFF00U) >> 8);
         }
 
         public static uint ReverseEndianness(uint value)

--- a/tests/System.Binary.Tests/BufferReaderTests.cs
+++ b/tests/System.Binary.Tests/BufferReaderTests.cs
@@ -89,26 +89,44 @@ namespace System.Buffers.Tests
                 L0 = long.MaxValue,
                 US0 = ushort.MaxValue,
                 UI0 = uint.MaxValue,
-                UL0 = ulong.MaxValue
+                UL0 = ulong.MaxValue,
+                S1 = short.MinValue,
+                I1 = int.MinValue,
+                L1 = long.MinValue,
+                US1 = ushort.MinValue,
+                UI1 = uint.MinValue,
+                UL1 = ulong.MinValue
             };
 
             Span<byte> spanBE = new byte[Unsafe.SizeOf<TestStruct>()];
 
             spanBE.WriteBigEndianInt16(myStruct.S0);
             spanBE.Slice(2).WriteBigEndianInt32(myStruct.I0);
-            spanBE.Slice(2 + 4).WriteBigEndianInt64(myStruct.L0);
-            spanBE.Slice(2 + 4 + 8).WriteBigEndianUInt16(myStruct.US0);
-            spanBE.Slice(2 + 4 + 8 + 2).WriteBigEndianUInt32(myStruct.UI0);
-            spanBE.Slice(2 + 4 + 8 + 2 + 4).WriteBigEndianUInt64(myStruct.UL0);
+            spanBE.Slice(6).WriteBigEndianInt64(myStruct.L0);
+            spanBE.Slice(14).WriteBigEndianUInt16(myStruct.US0);
+            spanBE.Slice(16).WriteBigEndianUInt32(myStruct.UI0);
+            spanBE.Slice(20).WriteBigEndianUInt64(myStruct.UL0);
+            spanBE.Slice(28).WriteBigEndianInt16(myStruct.S1);
+            spanBE.Slice(30).WriteBigEndianInt32(myStruct.I1);
+            spanBE.Slice(34).WriteBigEndianInt64(myStruct.L1);
+            spanBE.Slice(42).WriteBigEndianUInt16(myStruct.US1);
+            spanBE.Slice(44).WriteBigEndianUInt32(myStruct.UI1);
+            spanBE.Slice(48).WriteBigEndianUInt64(myStruct.UL1);
 
             var readStruct = new TestStruct
             {
                 S0 = spanBE.ReadBigEndianInt16(),
                 I0 = spanBE.Slice(2).ReadBigEndianInt32(),
-                L0 = spanBE.Slice(2 + 4).ReadBigEndianInt64(),
-                US0 = spanBE.Slice(2 + 4 + 8).ReadBigEndianUInt16(),
-                UI0 = spanBE.Slice(2 + 4 + 8 + 2).ReadBigEndianUInt32(),
-                UL0 = spanBE.Slice(2 + 4 + 8 + 2 + 4).ReadBigEndianUInt64(),
+                L0 = spanBE.Slice(6).ReadBigEndianInt64(),
+                US0 = spanBE.Slice(14).ReadBigEndianUInt16(),
+                UI0 = spanBE.Slice(16).ReadBigEndianUInt32(),
+                UL0 = spanBE.Slice(20).ReadBigEndianUInt64(),
+                S1 = spanBE.Slice(28).ReadBigEndianInt16(),
+                I1 = spanBE.Slice(30).ReadBigEndianInt32(),
+                L1 = spanBE.Slice(34).ReadBigEndianInt64(),
+                US1 = spanBE.Slice(42).ReadBigEndianUInt16(),
+                UI1 = spanBE.Slice(44).ReadBigEndianUInt32(),
+                UL1 = spanBE.Slice(48).ReadBigEndianUInt64()
             };
 
             Assert.Equal(myStruct.S0, readStruct.S0);
@@ -117,6 +135,12 @@ namespace System.Buffers.Tests
             Assert.Equal(myStruct.US0, readStruct.US0);
             Assert.Equal(myStruct.UI0, readStruct.UI0);
             Assert.Equal(myStruct.UL0, readStruct.UL0);
+            Assert.Equal(myStruct.S1, readStruct.S1);
+            Assert.Equal(myStruct.I1, readStruct.I1);
+            Assert.Equal(myStruct.L1, readStruct.L1);
+            Assert.Equal(myStruct.US1, readStruct.US1);
+            Assert.Equal(myStruct.UI1, readStruct.UI1);
+            Assert.Equal(myStruct.UL1, readStruct.UL1);
         }
 
         [Fact]
@@ -131,26 +155,44 @@ namespace System.Buffers.Tests
                 L0 = long.MaxValue,
                 US0 = ushort.MaxValue,
                 UI0 = uint.MaxValue,
-                UL0 = ulong.MaxValue
+                UL0 = ulong.MaxValue,
+                S1 = short.MinValue,
+                I1 = int.MinValue,
+                L1 = long.MinValue,
+                US1 = ushort.MinValue,
+                UI1 = uint.MinValue,
+                UL1 = ulong.MinValue
             };
 
             Span<byte> spanLE = new byte[Unsafe.SizeOf<TestStruct>()];
 
             spanLE.WriteLittleEndianInt16(myStruct.S0);
             spanLE.Slice(2).WriteLittleEndianInt32(myStruct.I0);
-            spanLE.Slice(2 + 4).WriteLittleEndianInt64(myStruct.L0);
-            spanLE.Slice(2 + 4 + 8).WriteLittleEndianUInt16(myStruct.US0);
-            spanLE.Slice(2 + 4 + 8 + 2).WriteLittleEndianUInt32(myStruct.UI0);
-            spanLE.Slice(2 + 4 + 8 + 2 + 4).WriteLittleEndianUInt64(myStruct.UL0);
+            spanLE.Slice(6).WriteLittleEndianInt64(myStruct.L0);
+            spanLE.Slice(14).WriteLittleEndianUInt16(myStruct.US0);
+            spanLE.Slice(16).WriteLittleEndianUInt32(myStruct.UI0);
+            spanLE.Slice(20).WriteLittleEndianUInt64(myStruct.UL0);
+            spanLE.Slice(28).WriteLittleEndianInt16(myStruct.S1);
+            spanLE.Slice(30).WriteLittleEndianInt32(myStruct.I1);
+            spanLE.Slice(34).WriteLittleEndianInt64(myStruct.L1);
+            spanLE.Slice(42).WriteLittleEndianUInt16(myStruct.US1);
+            spanLE.Slice(44).WriteLittleEndianUInt32(myStruct.UI1);
+            spanLE.Slice(48).WriteLittleEndianUInt64(myStruct.UL1);
 
             var readStruct = new TestStruct
             {
                 S0 = spanLE.ReadLittleEndianInt16(),
                 I0 = spanLE.Slice(2).ReadLittleEndianInt32(),
-                L0 = spanLE.Slice(2 + 4).ReadLittleEndianInt64(),
-                US0 = spanLE.Slice(2 + 4 + 8).ReadLittleEndianUInt16(),
-                UI0 = spanLE.Slice(2 + 4 + 8 + 2).ReadLittleEndianUInt32(),
-                UL0 = spanLE.Slice(2 + 4 + 8 + 2 + 4).ReadLittleEndianUInt64(),
+                L0 = spanLE.Slice(6).ReadLittleEndianInt64(),
+                US0 = spanLE.Slice(14).ReadLittleEndianUInt16(),
+                UI0 = spanLE.Slice(16).ReadLittleEndianUInt32(),
+                UL0 = spanLE.Slice(20).ReadLittleEndianUInt64(),
+                S1 = spanLE.Slice(28).ReadLittleEndianInt16(),
+                I1 = spanLE.Slice(30).ReadLittleEndianInt32(),
+                L1 = spanLE.Slice(34).ReadLittleEndianInt64(),
+                US1 = spanLE.Slice(42).ReadLittleEndianUInt16(),
+                UI1 = spanLE.Slice(44).ReadLittleEndianUInt32(),
+                UL1 = spanLE.Slice(48).ReadLittleEndianUInt64()
             };
 
             Assert.Equal(myStruct.S0, readStruct.S0);
@@ -159,6 +201,12 @@ namespace System.Buffers.Tests
             Assert.Equal(myStruct.US0, readStruct.US0);
             Assert.Equal(myStruct.UI0, readStruct.UI0);
             Assert.Equal(myStruct.UL0, readStruct.UL0);
+            Assert.Equal(myStruct.S1, readStruct.S1);
+            Assert.Equal(myStruct.I1, readStruct.I1);
+            Assert.Equal(myStruct.L1, readStruct.L1);
+            Assert.Equal(myStruct.US1, readStruct.US1);
+            Assert.Equal(myStruct.UI1, readStruct.UI1);
+            Assert.Equal(myStruct.UL1, readStruct.UL1);
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -170,6 +218,12 @@ namespace System.Buffers.Tests
             public ushort US0;
             public uint UI0;
             public ulong UL0;
+            public short S1;
+            public int I1;
+            public long L1;
+            public ushort US1;
+            public uint UI1;
+            public ulong UL1;
         }
     }
 }

--- a/tests/System.Binary.Tests/BufferReaderTests.cs
+++ b/tests/System.Binary.Tests/BufferReaderTests.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Buffers.Tests
@@ -18,69 +20,156 @@ namespace System.Buffers.Tests
                 span = new Span<byte>(&value, 8);
             }
 
-            Assert.Equal<byte>(0x11, span.ReadBigEndian<byte>());
-            Assert.True(span.TryReadBigEndian(out byte byteValue));
+            Assert.Equal<byte>(0x11, span.Read<byte>());
+            Assert.True(span.TryRead(out byte byteValue));
             Assert.Equal(0x11, byteValue);
 
-            Assert.Equal<byte>(0x11, span.ReadLittleEndian<byte>());
-            Assert.True(span.TryReadLittleEndian(out byteValue));
+            Assert.Equal<sbyte>(0x11, span.Read<sbyte>());
+            Assert.True(span.TryRead(out byte sbyteValue));
             Assert.Equal(0x11, byteValue);
 
-            Assert.Equal<sbyte>(0x11, span.ReadBigEndian<sbyte>());
-            Assert.True(span.TryReadBigEndian(out byte sbyteValue));
-            Assert.Equal(0x11, byteValue);
-
-            Assert.Equal<sbyte>(0x11, span.ReadLittleEndian<sbyte>());
-            Assert.True(span.TryReadLittleEndian(out byteValue));
-            Assert.Equal(0x11, sbyteValue);
-
-            Assert.Equal<ushort>(0x1122, span.ReadBigEndian<ushort>());
-            Assert.True(span.TryReadBigEndian(out ushort ushortValue));
+            Assert.Equal<ushort>(0x1122, span.ReadBigEndianUInt16());
+            Assert.True(span.TryReadBigEndianUInt16(out ushort ushortValue));
             Assert.Equal(0x1122, ushortValue);
 
-            Assert.Equal<ushort>(0x2211, span.ReadLittleEndian<ushort>());
-            Assert.True(span.TryReadLittleEndian(out ushortValue));
+            Assert.Equal<ushort>(0x2211, span.ReadLittleEndianUInt16());
+            Assert.True(span.TryReadLittleEndianUInt16(out ushortValue));
             Assert.Equal(0x2211, ushortValue);
 
-            Assert.Equal<short>(0x1122, span.ReadBigEndian<short>());
-            Assert.True(span.TryReadBigEndian(out short shortValue));
+            Assert.Equal<short>(0x1122, span.ReadBigEndianInt16());
+            Assert.True(span.TryReadBigEndianInt16(out short shortValue));
             Assert.Equal(0x1122, shortValue);
 
-            Assert.Equal<short>(0x2211, span.ReadLittleEndian<short>());
-            Assert.True(span.TryReadLittleEndian(out shortValue));
+            Assert.Equal<short>(0x2211, span.ReadLittleEndianInt16());
+            Assert.True(span.TryReadLittleEndianInt16(out shortValue));
             Assert.Equal(0x2211, ushortValue);
 
-            Assert.Equal<uint>(0x11223344, span.ReadBigEndian<uint>());
-            Assert.True(span.TryReadBigEndian(out uint uintValue));
+            Assert.Equal<uint>(0x11223344, span.ReadBigEndianUInt32());
+            Assert.True(span.TryReadBigEndianUInt32(out uint uintValue));
             Assert.Equal<uint>(0x11223344, uintValue);
 
-            Assert.Equal<uint>(0x44332211, span.ReadLittleEndian<uint>());
-            Assert.True(span.TryReadLittleEndian(out uintValue));
+            Assert.Equal<uint>(0x44332211, span.ReadLittleEndianUInt32());
+            Assert.True(span.TryReadLittleEndianUInt32(out uintValue));
             Assert.Equal<uint>(0x44332211, uintValue);
 
-            Assert.Equal<int>(0x11223344, span.ReadBigEndian<int>());
-            Assert.True(span.TryReadBigEndian(out int intValue));
+            Assert.Equal<int>(0x11223344, span.ReadBigEndianInt32());
+            Assert.True(span.TryReadBigEndianInt32(out int intValue));
             Assert.Equal<int>(0x11223344, intValue);
 
-            Assert.Equal<int>(0x44332211, span.ReadLittleEndian<int>());
-            Assert.True(span.TryReadLittleEndian(out intValue));
+            Assert.Equal<int>(0x44332211, span.ReadLittleEndianInt32());
+            Assert.True(span.TryReadLittleEndianInt32(out intValue));
             Assert.Equal<int>(0x44332211, intValue);
 
-            Assert.Equal<ulong>(0x1122334455667788, span.ReadBigEndian<ulong>());
-            Assert.True(span.TryReadBigEndian(out ulong ulongValue));
+            Assert.Equal<ulong>(0x1122334455667788, span.ReadBigEndianUInt64());
+            Assert.True(span.TryReadBigEndianUInt64(out ulong ulongValue));
             Assert.Equal<ulong>(0x1122334455667788, ulongValue);
 
-            Assert.Equal<ulong>(0x8877665544332211, span.ReadLittleEndian<ulong>());
-            Assert.True(span.TryReadLittleEndian(out ulongValue));
+            Assert.Equal<ulong>(0x8877665544332211, span.ReadLittleEndianUInt64());
+            Assert.True(span.TryReadLittleEndianUInt64(out ulongValue));
             Assert.Equal<ulong>(0x8877665544332211, ulongValue);
 
-            Assert.Equal<long>(0x1122334455667788, span.ReadBigEndian<long>());
-            Assert.True(span.TryReadBigEndian(out long longValue));
+            Assert.Equal<long>(0x1122334455667788, span.ReadBigEndianInt64());
+            Assert.True(span.TryReadBigEndianInt64(out long longValue));
             Assert.Equal<long>(0x1122334455667788, longValue);
 
-            Assert.Equal<long>(unchecked((long)0x8877665544332211), span.ReadLittleEndian<long>());
-            Assert.True(span.TryReadLittleEndian(out longValue));
+            Assert.Equal<long>(unchecked((long)0x8877665544332211), span.ReadLittleEndianInt64());
+            Assert.True(span.TryReadLittleEndianInt64(out longValue));
             Assert.Equal<long>(unchecked((long)0x8877665544332211), longValue);
+        }
+
+        [Fact]
+        public void BufferWriteReadBigEndianHeterogeneousStruct()
+        {
+            Assert.True(BitConverter.IsLittleEndian);
+
+            var myStruct = new TestStruct
+            {
+                S0 = short.MaxValue,
+                I0 = int.MaxValue,
+                L0 = long.MaxValue,
+                US0 = ushort.MaxValue,
+                UI0 = uint.MaxValue,
+                UL0 = ulong.MaxValue
+            };
+
+            Span<byte> spanBE = new byte[Unsafe.SizeOf<TestStruct>()];
+
+            spanBE.WriteBigEndianInt16(myStruct.S0);
+            spanBE.Slice(2).WriteBigEndianInt32(myStruct.I0);
+            spanBE.Slice(2 + 4).WriteBigEndianInt64(myStruct.L0);
+            spanBE.Slice(2 + 4 + 8).WriteBigEndianUInt16(myStruct.US0);
+            spanBE.Slice(2 + 4 + 8 + 2).WriteBigEndianUInt32(myStruct.UI0);
+            spanBE.Slice(2 + 4 + 8 + 2 + 4).WriteBigEndianUInt64(myStruct.UL0);
+
+            var readStruct = new TestStruct
+            {
+                S0 = spanBE.ReadBigEndianInt16(),
+                I0 = spanBE.Slice(2).ReadBigEndianInt32(),
+                L0 = spanBE.Slice(2 + 4).ReadBigEndianInt64(),
+                US0 = spanBE.Slice(2 + 4 + 8).ReadBigEndianUInt16(),
+                UI0 = spanBE.Slice(2 + 4 + 8 + 2).ReadBigEndianUInt32(),
+                UL0 = spanBE.Slice(2 + 4 + 8 + 2 + 4).ReadBigEndianUInt64(),
+            };
+
+            Assert.Equal(myStruct.S0, readStruct.S0);
+            Assert.Equal(myStruct.I0, readStruct.I0);
+            Assert.Equal(myStruct.L0, readStruct.L0);
+            Assert.Equal(myStruct.US0, readStruct.US0);
+            Assert.Equal(myStruct.UI0, readStruct.UI0);
+            Assert.Equal(myStruct.UL0, readStruct.UL0);
+        }
+
+        [Fact]
+        public void BufferWriteReadLittleEndianHeterogeneousStruct()
+        {
+            Assert.True(BitConverter.IsLittleEndian);
+
+            var myStruct = new TestStruct
+            {
+                S0 = short.MaxValue,
+                I0 = int.MaxValue,
+                L0 = long.MaxValue,
+                US0 = ushort.MaxValue,
+                UI0 = uint.MaxValue,
+                UL0 = ulong.MaxValue
+            };
+
+            Span<byte> spanLE = new byte[Unsafe.SizeOf<TestStruct>()];
+
+            spanLE.WriteLittleEndianInt16(myStruct.S0);
+            spanLE.Slice(2).WriteLittleEndianInt32(myStruct.I0);
+            spanLE.Slice(2 + 4).WriteLittleEndianInt64(myStruct.L0);
+            spanLE.Slice(2 + 4 + 8).WriteLittleEndianUInt16(myStruct.US0);
+            spanLE.Slice(2 + 4 + 8 + 2).WriteLittleEndianUInt32(myStruct.UI0);
+            spanLE.Slice(2 + 4 + 8 + 2 + 4).WriteLittleEndianUInt64(myStruct.UL0);
+
+            var readStruct = new TestStruct
+            {
+                S0 = spanLE.ReadLittleEndianInt16(),
+                I0 = spanLE.Slice(2).ReadLittleEndianInt32(),
+                L0 = spanLE.Slice(2 + 4).ReadLittleEndianInt64(),
+                US0 = spanLE.Slice(2 + 4 + 8).ReadLittleEndianUInt16(),
+                UI0 = spanLE.Slice(2 + 4 + 8 + 2).ReadLittleEndianUInt32(),
+                UL0 = spanLE.Slice(2 + 4 + 8 + 2 + 4).ReadLittleEndianUInt64(),
+            };
+
+            Assert.Equal(myStruct.S0, readStruct.S0);
+            Assert.Equal(myStruct.I0, readStruct.I0);
+            Assert.Equal(myStruct.L0, readStruct.L0);
+            Assert.Equal(myStruct.US0, readStruct.US0);
+            Assert.Equal(myStruct.UI0, readStruct.UI0);
+            Assert.Equal(myStruct.UL0, readStruct.UL0);
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct TestStruct
+        {
+            public short S0;
+            public int I0;
+            public long L0;
+            public ushort US0;
+            public uint UI0;
+            public ulong UL0;
         }
     }
 }

--- a/tests/System.Binary.Tests/BufferReaderTests.cs
+++ b/tests/System.Binary.Tests/BufferReaderTests.cs
@@ -28,52 +28,52 @@ namespace System.Buffers.Tests
             Assert.True(span.TryRead(out byte sbyteValue));
             Assert.Equal(0x11, byteValue);
 
-            Assert.Equal<ushort>(0x1122, span.ReadBigEndianUInt16());
-            Assert.True(span.TryReadBigEndianUInt16(out ushort ushortValue));
+            Assert.Equal<ushort>(0x1122, span.ReadUInt16BigEndian());
+            Assert.True(span.TryReadUInt16BigEndian(out ushort ushortValue));
             Assert.Equal(0x1122, ushortValue);
 
-            Assert.Equal<ushort>(0x2211, span.ReadLittleEndianUInt16());
-            Assert.True(span.TryReadLittleEndianUInt16(out ushortValue));
+            Assert.Equal<ushort>(0x2211, span.ReadUInt16LittleEndian());
+            Assert.True(span.TryReadUInt16LittleEndian(out ushortValue));
             Assert.Equal(0x2211, ushortValue);
 
-            Assert.Equal<short>(0x1122, span.ReadBigEndianInt16());
-            Assert.True(span.TryReadBigEndianInt16(out short shortValue));
+            Assert.Equal<short>(0x1122, span.ReadInt16BigEndian());
+            Assert.True(span.TryReadInt16BigEndian(out short shortValue));
             Assert.Equal(0x1122, shortValue);
 
-            Assert.Equal<short>(0x2211, span.ReadLittleEndianInt16());
-            Assert.True(span.TryReadLittleEndianInt16(out shortValue));
+            Assert.Equal<short>(0x2211, span.ReadInt16LittleEndian());
+            Assert.True(span.TryReadInt16LittleEndian(out shortValue));
             Assert.Equal(0x2211, ushortValue);
 
-            Assert.Equal<uint>(0x11223344, span.ReadBigEndianUInt32());
-            Assert.True(span.TryReadBigEndianUInt32(out uint uintValue));
+            Assert.Equal<uint>(0x11223344, span.ReadUInt32BigEndian());
+            Assert.True(span.TryReadUInt32BigEndian(out uint uintValue));
             Assert.Equal<uint>(0x11223344, uintValue);
 
-            Assert.Equal<uint>(0x44332211, span.ReadLittleEndianUInt32());
-            Assert.True(span.TryReadLittleEndianUInt32(out uintValue));
+            Assert.Equal<uint>(0x44332211, span.ReadUInt32LittleEndian());
+            Assert.True(span.TryReadUInt32LittleEndian(out uintValue));
             Assert.Equal<uint>(0x44332211, uintValue);
 
-            Assert.Equal<int>(0x11223344, span.ReadBigEndianInt32());
-            Assert.True(span.TryReadBigEndianInt32(out int intValue));
+            Assert.Equal<int>(0x11223344, span.ReadInt32BigEndian());
+            Assert.True(span.TryReadInt32BigEndian(out int intValue));
             Assert.Equal<int>(0x11223344, intValue);
 
-            Assert.Equal<int>(0x44332211, span.ReadLittleEndianInt32());
-            Assert.True(span.TryReadLittleEndianInt32(out intValue));
+            Assert.Equal<int>(0x44332211, span.ReadInt32LittleEndian());
+            Assert.True(span.TryReadInt32LittleEndian(out intValue));
             Assert.Equal<int>(0x44332211, intValue);
 
-            Assert.Equal<ulong>(0x1122334455667788, span.ReadBigEndianUInt64());
-            Assert.True(span.TryReadBigEndianUInt64(out ulong ulongValue));
+            Assert.Equal<ulong>(0x1122334455667788, span.ReadUInt64BigEndian());
+            Assert.True(span.TryReadUInt64BigEndian(out ulong ulongValue));
             Assert.Equal<ulong>(0x1122334455667788, ulongValue);
 
-            Assert.Equal<ulong>(0x8877665544332211, span.ReadLittleEndianUInt64());
-            Assert.True(span.TryReadLittleEndianUInt64(out ulongValue));
+            Assert.Equal<ulong>(0x8877665544332211, span.ReadUInt64LittleEndian());
+            Assert.True(span.TryReadUInt64LittleEndian(out ulongValue));
             Assert.Equal<ulong>(0x8877665544332211, ulongValue);
 
-            Assert.Equal<long>(0x1122334455667788, span.ReadBigEndianInt64());
-            Assert.True(span.TryReadBigEndianInt64(out long longValue));
+            Assert.Equal<long>(0x1122334455667788, span.ReadInt64BigEndian());
+            Assert.True(span.TryReadInt64BigEndian(out long longValue));
             Assert.Equal<long>(0x1122334455667788, longValue);
 
-            Assert.Equal<long>(unchecked((long)0x8877665544332211), span.ReadLittleEndianInt64());
-            Assert.True(span.TryReadLittleEndianInt64(out longValue));
+            Assert.Equal<long>(unchecked((long)0x8877665544332211), span.ReadInt64LittleEndian());
+            Assert.True(span.TryReadInt64LittleEndian(out longValue));
             Assert.Equal<long>(unchecked((long)0x8877665544332211), longValue);
         }
 
@@ -100,33 +100,33 @@ namespace System.Buffers.Tests
 
             Span<byte> spanBE = new byte[Unsafe.SizeOf<TestStruct>()];
 
-            spanBE.WriteBigEndianInt16(myStruct.S0);
-            spanBE.Slice(2).WriteBigEndianInt32(myStruct.I0);
-            spanBE.Slice(6).WriteBigEndianInt64(myStruct.L0);
-            spanBE.Slice(14).WriteBigEndianUInt16(myStruct.US0);
-            spanBE.Slice(16).WriteBigEndianUInt32(myStruct.UI0);
-            spanBE.Slice(20).WriteBigEndianUInt64(myStruct.UL0);
-            spanBE.Slice(28).WriteBigEndianInt16(myStruct.S1);
-            spanBE.Slice(30).WriteBigEndianInt32(myStruct.I1);
-            spanBE.Slice(34).WriteBigEndianInt64(myStruct.L1);
-            spanBE.Slice(42).WriteBigEndianUInt16(myStruct.US1);
-            spanBE.Slice(44).WriteBigEndianUInt32(myStruct.UI1);
-            spanBE.Slice(48).WriteBigEndianUInt64(myStruct.UL1);
+            spanBE.WriteInt16BigEndian(myStruct.S0);
+            spanBE.Slice(2).WriteInt32BigEndian(myStruct.I0);
+            spanBE.Slice(6).WriteInt64BigEndian(myStruct.L0);
+            spanBE.Slice(14).WriteUInt16BigEndian(myStruct.US0);
+            spanBE.Slice(16).WriteUInt32BigEndian(myStruct.UI0);
+            spanBE.Slice(20).WriteUInt64BigEndian(myStruct.UL0);
+            spanBE.Slice(28).WriteInt16BigEndian(myStruct.S1);
+            spanBE.Slice(30).WriteInt32BigEndian(myStruct.I1);
+            spanBE.Slice(34).WriteInt64BigEndian(myStruct.L1);
+            spanBE.Slice(42).WriteUInt16BigEndian(myStruct.US1);
+            spanBE.Slice(44).WriteUInt32BigEndian(myStruct.UI1);
+            spanBE.Slice(48).WriteUInt64BigEndian(myStruct.UL1);
 
             var readStruct = new TestStruct
             {
-                S0 = spanBE.ReadBigEndianInt16(),
-                I0 = spanBE.Slice(2).ReadBigEndianInt32(),
-                L0 = spanBE.Slice(6).ReadBigEndianInt64(),
-                US0 = spanBE.Slice(14).ReadBigEndianUInt16(),
-                UI0 = spanBE.Slice(16).ReadBigEndianUInt32(),
-                UL0 = spanBE.Slice(20).ReadBigEndianUInt64(),
-                S1 = spanBE.Slice(28).ReadBigEndianInt16(),
-                I1 = spanBE.Slice(30).ReadBigEndianInt32(),
-                L1 = spanBE.Slice(34).ReadBigEndianInt64(),
-                US1 = spanBE.Slice(42).ReadBigEndianUInt16(),
-                UI1 = spanBE.Slice(44).ReadBigEndianUInt32(),
-                UL1 = spanBE.Slice(48).ReadBigEndianUInt64()
+                S0 = spanBE.ReadInt16BigEndian(),
+                I0 = spanBE.Slice(2).ReadInt32BigEndian(),
+                L0 = spanBE.Slice(6).ReadInt64BigEndian(),
+                US0 = spanBE.Slice(14).ReadUInt16BigEndian(),
+                UI0 = spanBE.Slice(16).ReadUInt32BigEndian(),
+                UL0 = spanBE.Slice(20).ReadUInt64BigEndian(),
+                S1 = spanBE.Slice(28).ReadInt16BigEndian(),
+                I1 = spanBE.Slice(30).ReadInt32BigEndian(),
+                L1 = spanBE.Slice(34).ReadInt64BigEndian(),
+                US1 = spanBE.Slice(42).ReadUInt16BigEndian(),
+                UI1 = spanBE.Slice(44).ReadUInt32BigEndian(),
+                UL1 = spanBE.Slice(48).ReadUInt64BigEndian()
             };
 
             Assert.Equal(myStruct.S0, readStruct.S0);
@@ -166,33 +166,33 @@ namespace System.Buffers.Tests
 
             Span<byte> spanLE = new byte[Unsafe.SizeOf<TestStruct>()];
 
-            spanLE.WriteLittleEndianInt16(myStruct.S0);
-            spanLE.Slice(2).WriteLittleEndianInt32(myStruct.I0);
-            spanLE.Slice(6).WriteLittleEndianInt64(myStruct.L0);
-            spanLE.Slice(14).WriteLittleEndianUInt16(myStruct.US0);
-            spanLE.Slice(16).WriteLittleEndianUInt32(myStruct.UI0);
-            spanLE.Slice(20).WriteLittleEndianUInt64(myStruct.UL0);
-            spanLE.Slice(28).WriteLittleEndianInt16(myStruct.S1);
-            spanLE.Slice(30).WriteLittleEndianInt32(myStruct.I1);
-            spanLE.Slice(34).WriteLittleEndianInt64(myStruct.L1);
-            spanLE.Slice(42).WriteLittleEndianUInt16(myStruct.US1);
-            spanLE.Slice(44).WriteLittleEndianUInt32(myStruct.UI1);
-            spanLE.Slice(48).WriteLittleEndianUInt64(myStruct.UL1);
+            spanLE.WriteInt16LittleEndian(myStruct.S0);
+            spanLE.Slice(2).WriteInt32LittleEndian(myStruct.I0);
+            spanLE.Slice(6).WriteInt64LittleEndian(myStruct.L0);
+            spanLE.Slice(14).WriteUInt16LittleEndian(myStruct.US0);
+            spanLE.Slice(16).WriteUInt32LittleEndian(myStruct.UI0);
+            spanLE.Slice(20).WriteUInt64LittleEndian(myStruct.UL0);
+            spanLE.Slice(28).WriteInt16LittleEndian(myStruct.S1);
+            spanLE.Slice(30).WriteInt32LittleEndian(myStruct.I1);
+            spanLE.Slice(34).WriteInt64LittleEndian(myStruct.L1);
+            spanLE.Slice(42).WriteUInt16LittleEndian(myStruct.US1);
+            spanLE.Slice(44).WriteUInt32LittleEndian(myStruct.UI1);
+            spanLE.Slice(48).WriteUInt64LittleEndian(myStruct.UL1);
 
             var readStruct = new TestStruct
             {
-                S0 = spanLE.ReadLittleEndianInt16(),
-                I0 = spanLE.Slice(2).ReadLittleEndianInt32(),
-                L0 = spanLE.Slice(6).ReadLittleEndianInt64(),
-                US0 = spanLE.Slice(14).ReadLittleEndianUInt16(),
-                UI0 = spanLE.Slice(16).ReadLittleEndianUInt32(),
-                UL0 = spanLE.Slice(20).ReadLittleEndianUInt64(),
-                S1 = spanLE.Slice(28).ReadLittleEndianInt16(),
-                I1 = spanLE.Slice(30).ReadLittleEndianInt32(),
-                L1 = spanLE.Slice(34).ReadLittleEndianInt64(),
-                US1 = spanLE.Slice(42).ReadLittleEndianUInt16(),
-                UI1 = spanLE.Slice(44).ReadLittleEndianUInt32(),
-                UL1 = spanLE.Slice(48).ReadLittleEndianUInt64()
+                S0 = spanLE.ReadInt16LittleEndian(),
+                I0 = spanLE.Slice(2).ReadInt32LittleEndian(),
+                L0 = spanLE.Slice(6).ReadInt64LittleEndian(),
+                US0 = spanLE.Slice(14).ReadUInt16LittleEndian(),
+                UI0 = spanLE.Slice(16).ReadUInt32LittleEndian(),
+                UL0 = spanLE.Slice(20).ReadUInt64LittleEndian(),
+                S1 = spanLE.Slice(28).ReadInt16LittleEndian(),
+                I1 = spanLE.Slice(30).ReadInt32LittleEndian(),
+                L1 = spanLE.Slice(34).ReadInt64LittleEndian(),
+                US1 = spanLE.Slice(42).ReadUInt16LittleEndian(),
+                UI1 = spanLE.Slice(44).ReadUInt32LittleEndian(),
+                UL1 = spanLE.Slice(48).ReadUInt64LittleEndian()
             };
 
             Assert.Equal(myStruct.S0, readStruct.S0);

--- a/tests/System.Binary.Tests/BufferWriterTests.cs
+++ b/tests/System.Binary.Tests/BufferWriterTests.cs
@@ -16,23 +16,23 @@ namespace System.Buffers.Tests
         public void WriteUInt32(uint value)
         {
             var span = new Span<byte>(new byte[4]);
-            span.WriteBigEndian(value);
-            uint read = span.ReadBigEndian<uint>();
+            span.WriteBigEndianUInt32(value);
+            uint read = span.ReadBigEndianUInt32();
             Assert.Equal(value, read);
 
             span.Clear();
-            Assert.True(span.TryWriteBigEndian(value));
-            read = span.ReadBigEndian<uint>();
+            Assert.True(span.TryWriteBigEndianUInt32(value));
+            read = span.ReadBigEndianUInt32();
             Assert.Equal(value,read);
 
             span.Clear();
-            span.WriteLittleEndian(value);
-            read = span.ReadLittleEndian<uint>();
+            span.WriteLittleEndianUInt32(value);
+            read = span.ReadLittleEndianUInt32();
             Assert.Equal(value, read);
 
             span.Clear();
-            Assert.True(span.TryWriteLittleEndian(value));
-            read = span.ReadLittleEndian<uint>();
+            Assert.True(span.TryWriteLittleEndianUInt32(value));
+            read = span.ReadLittleEndianUInt32();
             Assert.Equal(value, read);
         }
     }

--- a/tests/System.Binary.Tests/BufferWriterTests.cs
+++ b/tests/System.Binary.Tests/BufferWriterTests.cs
@@ -16,23 +16,23 @@ namespace System.Buffers.Tests
         public void WriteUInt32(uint value)
         {
             var span = new Span<byte>(new byte[4]);
-            span.WriteBigEndianUInt32(value);
-            uint read = span.ReadBigEndianUInt32();
+            span.WriteUInt32BigEndian(value);
+            uint read = span.ReadUInt32BigEndian();
             Assert.Equal(value, read);
 
             span.Clear();
-            Assert.True(span.TryWriteBigEndianUInt32(value));
-            read = span.ReadBigEndianUInt32();
+            Assert.True(span.TryWriteUInt32BigEndian(value));
+            read = span.ReadUInt32BigEndian();
             Assert.Equal(value,read);
 
             span.Clear();
-            span.WriteLittleEndianUInt32(value);
-            read = span.ReadLittleEndianUInt32();
+            span.WriteUInt32LittleEndian(value);
+            read = span.ReadUInt32LittleEndian();
             Assert.Equal(value, read);
 
             span.Clear();
-            Assert.True(span.TryWriteLittleEndianUInt32(value));
-            read = span.ReadLittleEndianUInt32();
+            Assert.True(span.TryWriteUInt32LittleEndian(value));
+            read = span.ReadUInt32LittleEndian();
             Assert.Equal(value, read);
         }
     }


### PR DESCRIPTION
Related to: https://github.com/dotnet/corefx/issues/24144#issuecomment-330638602
> - BigEndian/LittleEndian the T should be constrained to our single value primitive types, perhaps just use an overload for each of those instead of a T. 

- Adding safe ReverseEndianness primitive APIs to UnsafeUtilities (should move to helper class)
- Adding non-generic {Try}ReadBE & LE and {Try}WriteBE & LE
- Removed generic TryReadBE & LE and TryWriteBE & LE

- Fixed implementation of ReverseEndianness to no longer use Unsafe.Write and Unsafe.Read which improves performance significantly:
![image](https://user-images.githubusercontent.com/6527137/30629828-c05b9f30-9d92-11e7-812b-a6592dde914f.png)

**Note:** Piplines uses the generic [ReadBE & LE and WriteBE & LE](https://github.com/dotnet/corefxlab/blob/master/src/System.IO.Pipelines.Extensions/ReadWriteExtensions.cs#L39). Should we move them there?
cc @davidfowl 

cc @KrzysztofCwalina 