### PR TITLE
Update to new nuget.exe and add logging and process exit code check.

### DIFF
--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -15,7 +15,7 @@ Function Ensure-Nuget-Exists {
             New-Item -ItemType directory -Path "$repoRoot\nuget"
         }
         Write-Host "nuget.exe not found. Downloading to $nugetPath"
-        Invoke-WebRequest "https://nuget.org/nuget.exe" -OutFile $nugetPath
+        Invoke-WebRequest "https://dist.nuget.org/win-x86-commandline/v4.3.0/nuget.exe" -OutFile $nugetPath
     }
 }
 
@@ -51,8 +51,14 @@ if ($ApiKey)
             else { 
                 $arguments = "push $file $apiKey -Source https://dotnet.myget.org/F/dotnet-corefxlab/api/v2/package"
             }
-            Start-Process -FilePath $nugetPath -ArgumentList $arguments -Wait -PassThru
-            Write-Host "done"
+            $process = Start-Process -FilePath $nugetPath -ArgumentList $arguments -Wait -PassThru -NoNewWindow
+            $RetVal = $process.ExitCode
+            if($RetVal -eq 0) {
+                Write-Host "done"
+            }
+            else {
+                Write-Error "Failed to push nuget package $file with error code $RetVal"
+            }
         } catch [System.Exception] {
             Write-Host "Failed to push nuget package $file with error $_.Exception.Message"
         }


### PR DESCRIPTION
The nuget.exe at the previous url is really old (2.8.60717.93) and package publishing is failing incorrectly due to "File contains corrupted data." error.

This updates the nuget.exe to a newer version.
Also added an exit code check and the -NoNewWindow flag so that logs can be visible and the CI will catch the failures in the future.

cc @dagood, @shiftylogic, @KrzysztofCwalina 