### PR TITLE
Removed Generic ReadLE/BE methods

### DIFF
--- a/src/System.Binary/System/Binary/BufferReader.cs
+++ b/src/System.Binary/System/Binary/BufferReader.cs
@@ -16,6 +16,66 @@ namespace System.Buffers
     public static partial class Binary
     {
         /// <summary>
+        /// Reverses a primitive value - performs an endianness swap
+        /// </summary> 
+        public static unsafe T Reverse<[Primitive]T>(T value) where T : struct
+        {
+            // note: relying on JIT goodness here!
+            if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
+            {
+                return value;
+            }
+            else if (typeof(T) == typeof(ushort) || typeof(T) == typeof(short))
+            {
+                ushort val = 0;
+                Unsafe.Write(&val, value);
+                val = (ushort)((val >> 8) | (val << 8));
+                return Unsafe.Read<T>(&val);
+            }
+            else if (typeof(T) == typeof(uint) || typeof(T) == typeof(int)
+                || typeof(T) == typeof(float))
+            {
+                uint val = 0;
+                Unsafe.Write(&val, value);
+                val = (val << 24)
+                    | ((val & 0xFF00) << 8)
+                    | ((val & 0xFF0000) >> 8)
+                    | (val >> 24);
+                return Unsafe.Read<T>(&val);
+            }
+            else if (typeof(T) == typeof(ulong) || typeof(T) == typeof(long)
+                || typeof(T) == typeof(double))
+            {
+                ulong val = 0;
+                Unsafe.Write(&val, value);
+                val = (val << 56)
+                    | ((val & 0xFF00) << 40)
+                    | ((val & 0xFF0000) << 24)
+                    | ((val & 0xFF000000) << 8)
+                    | ((val & 0xFF00000000) >> 8)
+                    | ((val & 0xFF0000000000) >> 24)
+                    | ((val & 0xFF000000000000) >> 40)
+                    | (val >> 56);
+                return Unsafe.Read<T>(&val);
+            }
+            else
+            {
+                // default implementation
+                int len = Unsafe.SizeOf<T>();
+                var val = stackalloc byte[len];
+                Unsafe.Write(val, value);
+                int to = len >> 1, dest = len - 1;
+                for (int i = 0; i < to; i++)
+                {
+                    var tmp = val[i];
+                    val[i] = val[dest];
+                    val[dest--] = tmp;
+                }
+                return Unsafe.Read<T>(val);
+            }
+        }
+
+        /// <summary>
         /// Reads a structure of type T out of a slice of bytes.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Binary/System/Binary/BufferReader_BE.cs
+++ b/src/System.Binary/System/Binary/BufferReader_BE.cs
@@ -8,20 +8,6 @@ namespace System.Buffers
 {
     public static partial class Binary
     {
-        /// <summary>
-        /// Reads a structure of type <typeparamref name="T"/> out of a span of bytes.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T ReadBigEndian<[Primitive]T>(this ReadOnlySpan<byte> buffer) where T : struct
-            => BitConverter.IsLittleEndian ? UnsafeUtilities.Reverse(buffer.Read<T>()) : buffer.Read<T>();
-
-        /// <summary>
-        /// Reads a structure of type <typeparamref name="T"/> out of a span of bytes.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T ReadBigEndian<[Primitive]T>(this Span<byte> buffer) where T : struct
-            => BitConverter.IsLittleEndian ? UnsafeUtilities.Reverse(buffer.Read<T>()) : buffer.Read<T>();
-
         #region ReadBigEndianROSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short ReadInt16BigEndian(this ReadOnlySpan<byte> buffer)

--- a/src/System.Binary/System/Binary/BufferReader_LE.cs
+++ b/src/System.Binary/System/Binary/BufferReader_LE.cs
@@ -8,20 +8,6 @@ namespace System.Buffers
 {
     public static partial class Binary
     {
-        /// <summary>
-        /// Reads a structure of type <typeparamref name="T"/> out of a span of bytes.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T ReadLittleEndian<[Primitive]T>(this ReadOnlySpan<byte> buffer) where T : struct
-            => BitConverter.IsLittleEndian ? buffer.Read<T>() : UnsafeUtilities.Reverse(buffer.Read<T>());
-
-        /// <summary>
-        /// Reads a structure of type <typeparamref name="T"/> out of a span of bytes.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T ReadLittleEndian<[Primitive]T>(this Span<byte> buffer) where T : struct
-            => BitConverter.IsLittleEndian ? buffer.Read<T>() : UnsafeUtilities.Reverse(buffer.Read<T>());
-
         #region ReadLittleEndianROSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static short ReadInt16LittleEndian(this ReadOnlySpan<byte> buffer)

--- a/src/System.Binary/System/Binary/BufferWriter.cs
+++ b/src/System.Binary/System/Binary/BufferWriter.cs
@@ -43,20 +43,6 @@ namespace System.Buffers
             return true;
         }
 
-        /// <summary>
-        /// Writes a structure of type T to a span of bytes.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteBigEndian<[Primitive]T>(this Span<byte> buffer, T value) where T : struct
-            => buffer.Write(BitConverter.IsLittleEndian ? UnsafeUtilities.Reverse(value) : value);
-
-        /// <summary>
-        /// Writes a structure of type T to a span of bytes.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void WriteLittleEndian<[Primitive]T>(this Span<byte> buffer, T value) where T : struct
-            => buffer.Write(BitConverter.IsLittleEndian ? value : UnsafeUtilities.Reverse(value));
-
         #region WriteBigEndianSpan
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteInt16BigEndian(this Span<byte> buffer, short value)

--- a/src/System.Binary/System/Binary/UnsafeUtilities.cs
+++ b/src/System.Binary/System/Binary/UnsafeUtilities.cs
@@ -11,60 +11,6 @@ namespace System.Runtime
     /// </summary>
     internal static class UnsafeUtilities
     {
-        /// <summary>
-        /// Reverses a primitive value - performs an endianness swap
-        /// </summary> 
-        public static unsafe T Reverse<[Primitive]T>(T value) where T : struct
-        {
-            // note: relying on JIT goodness here!
-            if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte)) {
-                return value;
-            }
-            else if (typeof(T) == typeof(ushort) || typeof(T) == typeof(short)) {
-                ushort val = 0;
-                Unsafe.Write(&val, value);
-                val = (ushort)((val >> 8) | (val << 8));
-                return Unsafe.Read<T>(&val);
-            }
-            else if (typeof(T) == typeof(uint) || typeof(T) == typeof(int)
-                || typeof(T) == typeof(float)) {
-                uint val = 0;
-                Unsafe.Write(&val, value);
-                val = (val << 24)
-                    | ((val & 0xFF00) << 8)
-                    | ((val & 0xFF0000) >> 8)
-                    | (val >> 24);
-                return Unsafe.Read<T>(&val);
-            }
-            else if (typeof(T) == typeof(ulong) || typeof(T) == typeof(long)
-                || typeof(T) == typeof(double)) {
-                ulong val = 0;
-                Unsafe.Write(&val, value);
-                val = (val << 56)
-                    | ((val & 0xFF00) << 40)
-                    | ((val & 0xFF0000) << 24)
-                    | ((val & 0xFF000000) << 8)
-                    | ((val & 0xFF00000000) >> 8)
-                    | ((val & 0xFF0000000000) >> 24)
-                    | ((val & 0xFF000000000000) >> 40)
-                    | (val >> 56);
-                return Unsafe.Read<T>(&val);
-            }
-            else {
-                // default implementation
-                int len = Unsafe.SizeOf<T>();
-                var val = stackalloc byte[len];
-                Unsafe.Write(val, value);
-                int to = len >> 1, dest = len - 1;
-                for (int i = 0; i < to; i++) {
-                    var tmp = val[i];
-                    val[i] = val[dest];
-                    val[dest--] = tmp;
-                }
-                return Unsafe.Read<T>(val);
-            }
-        }
-
         public static short ReverseEndianness(short value)
         {
             return (short)((value & 0x00FF) << 8 | (value & 0xFF00) >> 8);

--- a/src/System.IO.Pipelines.Extensions/ReadWriteExtensions.cs
+++ b/src/System.IO.Pipelines.Extensions/ReadWriteExtensions.cs
@@ -10,6 +10,25 @@ namespace System.IO.Pipelines
 {
     public static class ReadWriteExtensions
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static T ReadBigEndian<[Primitive]T>(this Span<byte> buffer) where T : struct
+            => BitConverter.IsLittleEndian ? Binary.Reverse(buffer.Read<T>()) : buffer.Read<T>();
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static T ReadLittleEndian<[Primitive]T>(this Span<byte> buffer) where T : struct
+            => BitConverter.IsLittleEndian ? buffer.Read<T>() : Binary.Reverse(buffer.Read<T>());
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void WriteBigEndian<[Primitive]T>(this Span<byte> buffer, T value) where T : struct
+            => buffer.Write(BitConverter.IsLittleEndian ? Binary.Reverse(value) : value);
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static void WriteLittleEndian<[Primitive]T>(this Span<byte> buffer, T value) where T : struct
+            => buffer.Write(BitConverter.IsLittleEndian ? value : Binary.Reverse(value));
+
         public static async Task<ReadableBuffer> ReadToEndAsync(this IPipeReader input)
         {
             while (true)


### PR DESCRIPTION
The generic reads don't work for types other than basic ints. For example, it does not make sense to reverse a multi field struct.

Also, I added public Reverse per API review suggestion from @stephentoub 

@ahsonkhan, @joshfree, @shiftylogic, @stephentoub, @davidfowl 