### PR TITLE
Skipping the packaging (and hence pushing) of BrotliNative.

### DIFF
--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -33,10 +33,17 @@ Ensure-Nuget-Exists
 Write-Host "** Creating NuGet packages from nuspec. **"
 foreach ($file in [System.IO.Directory]::EnumerateFiles("$repoRoot\external", "*.nuspec", "AllDirectories")) {
     Write-Host "Creating NuGet package for $file..."
-    Invoke-Expression "$nugetPath pack $file -o $packagesPath"
+    if (!$file.contains("Brotli")) {
+        Invoke-Expression "$nugetPath pack $file -o $packagesPath"
+    }
+    else {
+        # Update this if a new version of Brotli Native needs to be published.
+        # Version 0.0.1 already exists and overwriting packages is forbidden.
+        Write-Host "Skipping creation of package from $file"
+    }
     
     if (!$?) {
-        Write-Error "Failed to create NuGet package for project $brotliExternalFile"
+        Write-Error "Failed to create NuGet package for project $file"
     }
 }
 


### PR DESCRIPTION
This fix resolves the recent nightly build failures due to error in pushing packages  of the same version.
> Response status code does not indicate success: 409 (The package could not be uploaded. The package "BrotliNative 0.0.1" already exists. Overwriting existing packages is forbidden according to the package retention settings for this feed.).

The rest of the packages get published as expected.

For now, the "Creating NuGet packages from nuspec." step is unnecessary (since we only have Brotli nuspec in the external directory), but I decided to keep the scaffolding for future additions.

cc @dotnet/corefxlab-contrib 