### PR TITLE
replace "in" with "ref readonly"

### DIFF
--- a/src/System.Text.Http.Parser/HttpParser.cs
+++ b/src/System.Text.Http.Parser/HttpParser.cs
@@ -35,7 +35,7 @@ namespace System.Text.Http.Parser
             _showErrorDetails = showErrorDetails;
         }
 
-        public unsafe bool ParseRequestLine<T>(T handler, in ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined) where T : IHttpRequestLineHandler
+        public unsafe bool ParseRequestLine<T>(T handler, ref readonly ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined) where T : IHttpRequestLineHandler
         {
             consumed = buffer.Start;
             examined = buffer.End;
@@ -77,7 +77,7 @@ namespace System.Text.Http.Parser
         }
 
         static readonly byte[] s_Eol = Encoding.UTF8.GetBytes("\r\n");
-        public unsafe bool ParseRequestLine<T>(ref T handler, in ReadOnlyBytes buffer, out int consumed) where T : IHttpRequestLineHandler
+        public unsafe bool ParseRequestLine<T>(ref T handler, ref readonly ReadOnlyBytes buffer, out int consumed) where T : IHttpRequestLineHandler
         {
             // Prepare the first span
             var span = buffer.First.Span;
@@ -227,7 +227,7 @@ namespace System.Text.Http.Parser
             handler.OnStartLine(method, httpVersion, targetBuffer, pathBuffer, query, customMethod, pathEncoded);
         }
 
-        public unsafe bool ParseHeaders<T>(T handler, in ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes) where T : IHttpHeadersHandler
+        public unsafe bool ParseHeaders<T>(T handler, ref readonly ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes) where T : IHttpHeadersHandler
         {
             consumed = buffer.Start;
             examined = buffer.End;
@@ -604,7 +604,7 @@ namespace System.Text.Http.Parser
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static bool TryGetNewLineSpan(in ReadableBuffer buffer, out ReadCursor found)
+        private static bool TryGetNewLineSpan(ref readonly ReadableBuffer buffer, out ReadCursor found)
         {
             var start = buffer.Start;
             if (ReadCursorOperations.Seek(start, buffer.End, out found, ByteLF) != -1)

--- a/src/System.Text.Http.Parser/IHttpParser.cs
+++ b/src/System.Text.Http.Parser/IHttpParser.cs
@@ -7,9 +7,9 @@ namespace System.Text.Http.Parser
 {
     public interface IHttpParser
     {
-        bool ParseRequestLine<T>(T handler, in ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined) where T : IHttpRequestLineHandler;
+        bool ParseRequestLine<T>(T handler, ref readonly ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined) where T : IHttpRequestLineHandler;
 
-        bool ParseHeaders<T>(T handler, in ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes) where T : IHttpHeadersHandler;
+        bool ParseHeaders<T>(T handler, ref readonly ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes) where T : IHttpHeadersHandler;
 
         void Reset();
     }

--- a/src/System.Text.Json/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonReader.cs
@@ -800,7 +800,7 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int GetNextCharAscii(in JsonReader reader, ref byte src, int length, out char ch)
+        private static int GetNextCharAscii(ref readonly JsonReader reader, ref byte src, int length, out char ch)
         {
             if (reader.UseFastUtf8)
             {


### PR DESCRIPTION
"ref readonly" is the only variant that will be supported once we switch to the new toolset compiler.

We had two ways to express the same thing, some people find it confusing, so support for "in" is being removed.