### PR TITLE
Installing 2.0.0 version of the shared framework for update dependencies

### DIFF
--- a/scripts/update-dependencies.ps1
+++ b/scripts/update-dependencies.ps1
@@ -38,6 +38,12 @@ if (!(Test-Path "dotnet\dotnet.exe")) {
         Write-Error "Failed to install dotnet.exe, exit code [$lastexitcode], aborting build."
         exit -1
     }
+
+    Invoke-Expression -Command "$PSScriptRoot\install-dotnet.ps1 -Version 2.0.0 -InstallDir $PSScriptRoot\..\dotnet"
+    if ($lastexitcode -ne $null -and $lastexitcode -ne 0) {
+        Write-Error "Failed to install framework version 2.0.0, exit code [$lastexitcode], aborting build."
+        exit -1
+    }
 }
 
 # Restore the app


### PR DESCRIPTION
The update-dependencies project requires Microsoft.NETCore.App 2.0.0.

The build task that creates PRs to update our dependencies was failing otherwise.

Alternatively, we could target netcoreapp2.1 instead:
https://github.com/dotnet/corefxlab/blob/master/scripts/update-dependencies/update-dependencies.csproj#L5

2017-09-18T18:41:21.9077388Z   Restore completed in 3.07 sec for E:\A\_work\1261\s\scripts\update-dependencies\update-dependencies.csproj.
2017-09-18T18:41:21.9546151Z Invoking App E:\A\_work\1261\s\scripts\update-dependencies\update-dependencies.csproj...
2017-09-18T18:41:26.4553981Z It was not possible to find any compatible framework version
2017-09-18T18:41:26.4553981Z The specified framework 'Microsoft.NETCore.App', version '2.0.0' was not found.
2017-09-18T18:41:26.4553981Z   - Check application dependencies and target a framework version installed at:
2017-09-18T18:41:26.4553981Z       \
2017-09-18T18:41:26.4553981Z   - Alternatively, install the framework version '2.0.0'.
2017-09-18T18:41:26.5491506Z Build failed


cc @dotnet/corefxlab-contrib 