### PR TITLE
Fix errors on selfcontained publish on HttpParser tests.

### DIFF
--- a/tests/System.Text.Http.Parser.Tests/System.Text.Http.Parser.Tests.csproj
+++ b/tests/System.Text.Http.Parser.Tests/System.Text.Http.Parser.Tests.csproj
@@ -19,6 +19,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="System.IO.FileSystem" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Runtime.Extensions" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Runtime.Handles" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="$(CoreFxVersion)" />
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>


### PR DESCRIPTION
Since nuget apparently needs me to do its job for it,
I'll add the package references to humor it so I can
do a --self-contained "dotnet publish" without the
scads of NU1605 errors.