### PR TITLE
Add Utf8Decoder and tests

### DIFF
--- a/src/System.Text.Primitives/System/Text/Encoders/Utf8Decoder.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Utf8Decoder.cs
@@ -1,0 +1,264 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Text.Primitives.System.Text.Encoders
+{
+    /// <summary>
+    /// Contains facilities for validating and extracting Unicode scalar values from UTF8 byte sequences.
+    /// </summary>
+    internal static class Utf8Decoder
+    {
+        // Assumption: bytesAvailable > 0
+        /// <summary>
+        /// Reads a Unicode scalar value from the provided UTF8 sequence.
+        /// </summary>
+        /// <param name="data">A reference to the first byte of the UTF8 sequence from which to read the scalar value.</param>
+        /// <param name="bytesAvailable">The number of elements available in the buffer referenced by <paramref name="data"/>.</param>
+        /// <param name="bytesConsumed">When this method returns, contains the number of bytes
+        /// from <paramref name="data"/> which were consumed while reading the scalar value.</param>
+        /// <returns>On success, a non-negative integer which represents a Unicode scalar value.
+        /// On failure, a negative integer which represents an <see cref="ErrorStatus"/> failure code.</returns>
+        /// <remarks>
+        /// The caller must use extreme caution to avoid passing a value for <paramref name="bytesAvailable"/> that is
+        /// larger than the actual buffer referenced by <paramref name="data"/>, else a buffer overrun could occur.
+        /// See http://www.unicode.org/glossary/#unicode_scalar_value for the definition of Unicode scalar value.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int DangerousReadUnicodeScalarValue(ref byte data, int bytesAvailable, out int bytesConsumed)
+        {
+            if (bytesAvailable == 0)
+            {
+                // Quick check: no data to consume
+                bytesConsumed = 0;
+                return ErrorStatus.InsufficientData;
+            }
+            else
+            {
+                return DangerousReadUnicodeScalarValueWithoutNullCheck(ref data, bytesAvailable, out bytesConsumed);
+            }
+        }
+
+        // Assumption: bytesAvailable > 0
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int DangerousReadUnicodeScalarValueWithoutNullCheck(ref byte data, int bytesAvailable, out int bytesConsumed)
+        {
+            Debug.Assert(bytesAvailable > 0);
+
+            if ((data & 0x80) == 0)
+            {
+                // Fast case: ASCII character => the code point is the byte itself
+                bytesConsumed = 1;
+                return data;
+            }
+            else
+            {
+                // Slow case: multi-byte sequence
+                bytesConsumed = 0;
+                return ReadUnicodeScalarValueFromNonAscii(ref data, bytesAvailable, ref bytesConsumed);
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the index of the first invalid byte in the data, i.e., the index of the
+        /// first invalid UTF8 subsequence within the data.
+        /// </summary>
+        /// <param name="data">The data to check.</param>
+        /// <returns>The index into <paramref name="data"/> where the first invalid byte appears, or -1
+        /// if <paramref name="data"/> represents a well-formed UTF8 string.</returns>
+        /// <remarks>An invalid subsequence could occur because of the presence of an illegal byte
+        /// (such as 0xFF) or because <paramref name="data"/> begins or ends in the middle of a subsequence.</remarks>
+        public static int GetIndexOfFirstInvalidUtf8Byte(ReadOnlySpan<byte> data)
+        {
+            // TODO: Can this be optimized, perhaps by performing a clever "is ASCII?" bitwise check
+            // and consuming entire ASCII sequences one natural word length at a time?
+
+            int numValidBytesSoFar = 0;
+
+            while (numValidBytesSoFar < data.Length)
+            {
+                if (DangerousReadUnicodeScalarValueWithoutNullCheck(ref Unsafe.Add(ref data.DangerousGetPinnableReference(), numValidBytesSoFar), data.Length - numValidBytesSoFar, out int thisIterBytesConsumed) < 0)
+                {
+                    return numValidBytesSoFar; // error (not enough data or malformed sequence seen)
+                }
+                else
+                {
+                    numValidBytesSoFar += thisIterBytesConsumed; // success (read a valid code point from the sequence)
+                }
+            }
+
+            return -1; // no invalid bytes
+        }
+
+        /// <summary>
+        /// Given the first byte of a UTF8 multi-byte sequence, returns the number of expected trailing
+        /// bytes and the minimum allowed code point value which is encoded by this sequence. Returns
+        /// 0 on invalid leading byte.
+        /// </summary>
+        private static int GetNumberOfTrailingBytes(byte firstByte, out int minAllowedCodePointValue)
+        {
+            // Logic below is from http://www.unicode.org/versions/Unicode10.0.0/ch03.pdf, Tables 3.6 and 3.7.
+
+            if ((firstByte & 0b1110_0000) == 0b1100_0000)
+            {
+                // [ 110yyyyy 10xxxxxx ]
+                minAllowedCodePointValue = 0x80;
+                return 1;
+            }
+            else if ((firstByte & 0b1111_0000) == 0b1110_0000)
+            {
+                // [ 1110zzzz 10yyyyyy 10xxxxxx ]
+                minAllowedCodePointValue = 0x800;
+                return 2;
+            }
+            else if ((firstByte & 0b1111_1000) == 0b1111_0000)
+            {
+                // [ 11110uuu 10uuzzzz 10yyyyyy 10xxxxxx ]
+                minAllowedCodePointValue = 0x10000;
+                return 3;
+            }
+            else
+            {
+                minAllowedCodePointValue = 0;
+                return 0;
+            }
+        }
+
+        /// <summary>
+        /// Returns true iff the specified code point is a UTF16 surrogate.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsSurrogate(int codePoint)
+        {
+            Debug.Assert(0 <= codePoint && codePoint <= 0x10FFFF);
+
+            // See http://www.unicode.org/versions/Unicode10.0.0/ch03.pdf, Sec. 3.8.
+            // Surrogates are in the range U+D800..U+DFFF, so we can perform a simple
+            // bit mask check to see if the requested code point is within this range.
+            return ((codePoint & 0b1111_1111_1111_1000_0000_0000) == 0b1101_1000_0000_0000);
+        }
+
+        /// <summary>
+        /// Returns true iff the specified byte is a valid UTF8 trailing byte.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsValidTrailingByte(byte value)
+        {
+            // See http://www.unicode.org/versions/Unicode10.0.0/ch03.pdf, Table 3-6.
+            return ((value & 0b1100_0000) == 0b1000_0000);
+        }
+
+        /// <summary>
+        /// Determines whether the provided data represents a well-formed UTF8 string.
+        /// </summary>
+        /// <param name="data">The data to check for well-formedness.</param>
+        /// <returns>True if the data is a well-formed UTF8 string; false otherwise.</returns>
+        public static bool IsWellFormedUtf8String(ReadOnlySpan<byte> data)
+        {
+            return (GetIndexOfFirstInvalidUtf8Byte(data) < 0);
+        }
+
+        /// <summary>
+        /// Reads a Unicode scalar value from the provided UTF8 sequence.
+        /// </summary>
+        /// <param name="data">The UTF8 sequence from which to read the scalar value.</param>
+        /// <param name="bytesConsumed">When this method returns, contains the number of bytes
+        /// from <paramref name="data"/> which were consumed while reading the scalar value.</param>
+        /// <returns>On success, a non-negative integer which represents a Unicode scalar value.
+        /// On failure, a negative integer which represents an <see cref="ErrorStatus"/> failure code.</returns>
+        /// <remarks>See http://www.unicode.org/glossary/#unicode_scalar_value for the definition of Unicode scalar value.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ReadUnicodeScalarValue(ReadOnlySpan<byte> data, out int bytesConsumed)
+        {
+            return DangerousReadUnicodeScalarValue(ref data.DangerousGetPinnableReference(), data.Length, out bytesConsumed);
+        }
+
+        // Assumption: bytesAvailable > 0
+        // Assumption: bytesConsumed = 0
+        private static int ReadUnicodeScalarValueFromNonAscii(ref byte data, int bytesAvailable, ref int bytesConsumed)
+        {
+            Debug.Assert(bytesAvailable > 0);
+            Debug.Assert(bytesConsumed == 0);
+
+            // n.b. For most of this method bytesConsumed has a value of *one fewer* than the actual number of
+            // bytes consumed so far. This is required for error handling, where if we need to report back to
+            // our caller that there's a problem we don't want to mark the byte that caused the error as consumed.
+            // See http://www.unicode.org/versions/Unicode10.0.0/ch03.pdf, "Constraints on Conversion Process",
+            // and http://www.unicode.org/reports/tr36/, Sec. 3.6.1, for more info.
+
+            // First, determine how many bytes are required to read the entire code point.
+
+            int minAllowedCodePointValue;
+            int numTrailingBytes = GetNumberOfTrailingBytes(data, out minAllowedCodePointValue);
+
+            if (numTrailingBytes == 0)
+            {
+                return ErrorStatus.BadCharacter; // not a valid leading byte
+            }
+            else if (numTrailingBytes >= bytesAvailable)
+            {
+                return ErrorStatus.InsufficientData; // not enough trailing bytes (n.b. bytesAvailable includes leading byte)
+            }
+
+            // Next, fold the leading byte and all trailing bytes into the code point.
+
+            int constructedCodePoint = data & (0x3F >> numTrailingBytes);
+
+            Debug.Assert(numTrailingBytes > 0);
+            do
+            {
+                byte nextTrailingByte = Unsafe.Add(ref data, ++bytesConsumed);
+                if (IsValidTrailingByte(nextTrailingByte))
+                {
+                    constructedCodePoint = (constructedCodePoint << 6) | (nextTrailingByte & 0b0011_1111);
+                }
+                else
+                {
+                    // We don't want to mark this byte as consumed, as it may begin a new valid sequence,
+                    // and the Unicode Standard (Sec. 3.9, "Constraints on Conversion Processes") forbids
+                    // us from consuming potentially such bytes while processing multibyte sequences.
+                    // It's possible that the new byte is itself part of an invalid sequence, but if this
+                    // is the case we'll just report that to the caller on the next iteration. The Standard
+                    // gives us considerable leeway to report multiple errors as part of a single invalid
+                    // sequence.
+                    return ErrorStatus.BadCharacter;
+                }
+            } while (--numTrailingBytes != 0);
+
+            // We've completed reconstruction of the code point. Now all that's left to check is that the code point
+            // is in shortest form and is not a surrogate. If the sequence is valid, we can return the value as-is.
+            // If the sequence is invalid, we can return a single error because we checked earlier in the method
+            // that no individual byte within this sequence (apart from the first byte) could possibly be the start
+            // of a new valid UTF8 subsequence. In either case we consumed all bytes so must perform one final fixup
+            // to the bytesConsumed variable.
+
+            bytesConsumed++;
+            Debug.Assert(bytesConsumed <= bytesAvailable);
+
+            return ((constructedCodePoint < minAllowedCodePointValue) || IsSurrogate(constructedCodePoint))
+                ? ErrorStatus.BadCharacter : constructedCodePoint;
+        }
+
+        /// <summary>
+        /// Contains error codes that may be returned when attempting to read Unicode scalar values.
+        /// </summary>
+        /// <remarks>
+        /// All error codes are negative integers.
+        /// </remarks>
+        public static class ErrorStatus
+        {
+            /// <summary>
+            /// The subsequence was malformed or contained an illegal byte.
+            /// </summary>
+            public const int BadCharacter = -1;
+
+            /// <summary>
+            /// The end of the buffer was reached while trying to decode a subsequence.
+            /// </summary>
+            public const int InsufficientData = -2;
+        }
+    }
+}

--- a/tests/System.Text.Primitives.Tests/Encoding/Utf8DecoderTests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/Utf8DecoderTests.cs
@@ -1,0 +1,172 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Text.Primitives.System.Text.Encoders;
+using Xunit;
+
+namespace System.Text.Primitives.Tests.Encoding
+{
+    public class Utf8DecoderTests
+    {
+        private static readonly UTF8Encoding _strictEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+        [Fact]
+        public void IsWellFormedUtf8String_WithSequenceOfAllValidChars_ReturnsOk()
+        {
+            // Arrange - build up a buffer of all possible valid sequences
+
+            MemoryStream buffer = new MemoryStream();
+            for (int i = 0; i <= 0x10FFFF; i++)
+            {
+                if (!IsSurrogateCodePoint(i))
+                {
+                    byte[] thisSequence = GetUtf8SequenceForCodePoint(i);
+                    buffer.Write(thisSequence, 0, thisSequence.Length);
+                }
+            }
+
+            // Act & assert
+
+            Assert.True(Utf8Decoder.IsWellFormedUtf8String(buffer.ToArray()));
+        }
+
+        [Theory]
+        [InlineData(new byte[] { }, -1)] // valid, empty string
+        [InlineData(new byte[] { 0b0000_0000 }, -1)] // valid, ASCII character
+        [InlineData(new byte[] { 0b1000_0000 }, 0)] // invalid, begins with trailing char
+        [InlineData(new byte[] { 0b0000_0000, 0b1111_1111 }, 1)] // invalid, contains illegal char
+        [InlineData(new byte[] { 0b1101_1111, 0b1011_1111, 0b0000_0000, 0b1110_1111, 0b1000_0000 }, 3)] // invalid, ends in middle of multi-byte sequence
+        public void GetIndexOfFirstInvalidUtf8Byte_Tests(byte[] data, int expectedFirstIndex)
+        {
+            // Act & assert - 1
+
+            Assert.Equal(expectedFirstIndex, Utf8Decoder.GetIndexOfFirstInvalidUtf8Byte(data));
+
+            // Act & assert - 2
+
+            Assert.Equal((expectedFirstIndex == -1), Utf8Decoder.IsWellFormedUtf8String(data));
+        }
+
+        [Theory]
+        [InlineData((byte)0b1000_0000)]
+        [InlineData((byte)0b1111_1000)]
+        [InlineData((byte)0b1111_1111)]
+        public void ReadUnicodeScalarValue_InputHasMalformedLeadingByte_ReturnsBadDataError(byte input)
+        {
+            // Act
+
+            int retVal = Utf8Decoder.ReadUnicodeScalarValue(new byte[] { input }, out int numBytesConsumed);
+
+            // Assert
+
+            Assert.Equal(Utf8Decoder.ErrorStatus.BadCharacter, retVal);
+            Assert.Equal(0, numBytesConsumed);
+        }
+
+        [Theory]
+        [InlineData(new byte[] { 0b1100_0000, 0xFF }, 1)]
+        [InlineData(new byte[] { 0b1110_0000, 0xFF, 0xFF }, 1)]
+        [InlineData(new byte[] { 0b1110_0000, 0b1000_0000, 0xFF }, 2)]
+        [InlineData(new byte[] { 0b1111_0000, 0xFF, 0xFF, 0xFF }, 1)]
+        [InlineData(new byte[] { 0b1111_0000, 0b1000_0000, 0xFF, 0xFF }, 2)]
+        [InlineData(new byte[] { 0b1111_0000, 0b1000_0000, 0b1000_0000, 0xFF }, 3)]
+        public void ReadUnicodeScalarValue_InputHasMalformedTrailingByte_ReturnsBadDataError(byte[] data, int expectedNumBytesConsumed)
+        {
+            // Act
+
+            int retVal = Utf8Decoder.ReadUnicodeScalarValue(data, out int actualNumBytesConsumed);
+
+            // Assert
+
+            Assert.Equal(Utf8Decoder.ErrorStatus.BadCharacter, retVal);
+            Assert.Equal(expectedNumBytesConsumed, actualNumBytesConsumed);
+        }
+
+        [Fact]
+        public void ReadUnicodeScalarValue_ReadsAllValidSequencesCorrectly()
+        {
+            for (int i = 0; i <= 0x10FFFF; i++)
+            {
+                if (!IsSurrogateCodePoint(i))
+                {
+                    ReadUnicodeScalarValue_ReadsAllValidSequencesCorrectly_Core(i);
+                }
+            }
+        }
+
+        private static void ReadUnicodeScalarValue_ReadsAllValidSequencesCorrectly_Core(int codePoint)
+        {
+            // Arrange
+
+            byte[] codePointAsUtf8 = GetUtf8SequenceForCodePoint(codePoint);
+
+            // Act & assert 1 - buffer contains just this single code point
+
+            int retVal1 = Utf8Decoder.ReadUnicodeScalarValue(codePointAsUtf8, out int bytesConsumed1);
+            Assert.Equal(codePoint, retVal1);
+            Assert.Equal(codePointAsUtf8.Length, bytesConsumed1);
+
+            // Act & assert 2 - buffer contains extra unused chars
+
+            byte[] codePointAsUtf8WithExtraChars = new byte[codePointAsUtf8.Length + 1];
+            Buffer.BlockCopy(codePointAsUtf8, 0, codePointAsUtf8WithExtraChars, 0, codePointAsUtf8.Length);
+            codePointAsUtf8WithExtraChars[codePointAsUtf8WithExtraChars.Length - 1] = 0x80; // invalid byte
+
+            int retVal2 = Utf8Decoder.ReadUnicodeScalarValue(codePointAsUtf8WithExtraChars, out int bytesConsumed2);
+            Assert.Equal(codePoint, retVal2);
+            Assert.Equal(codePointAsUtf8.Length, bytesConsumed2);
+        }
+
+        [Theory]
+        [InlineData(new byte[] { 0b1100_0001, 0b1011_1111 })] // U+007F should be encoded as [ 01111111 ]
+        [InlineData(new byte[] { 0b1110_0000, 0b1001_1111, 0b1011_1111 })] // U+07FF should be encoded as [ 11011111 10111111 ]
+        [InlineData(new byte[] { 0b1111_0000, 0b1000_1111, 0b1011_1111, 0b1011_1111 })] // U+FFFF should be encoded as [ 11101111 10111111 10111111 ]
+        public void ReadUnicodeScalarValue_InputIsNotInShortestForm_ReturnsBadDataError(byte[] input) => RunDecoder_ExpectBadDataError(input);
+
+        [Theory]
+        [InlineData(new byte[] { 0b1110_1101, 0b1010_0000, 0b1000_0000 })] // U+D800, minimally encoded
+        [InlineData(new byte[] { 0b1110_1101, 0b1011_1111, 0b1011_1111 })] // U+DFFF, minimally encoded
+        public void ReadUnicodeScalarValue_InputIsSurrogate_ReturnsBadDataError(byte[] input) => RunDecoder_ExpectBadDataError(input);
+
+        [Theory]
+        [InlineData(new byte[] { })] // zero-length buffer
+        [InlineData(new byte[] { 0b1100_0000 })] // marker begins a two-byte sequence
+        [InlineData(new byte[] { 0b1110_0000, 0b1000_0000 })] // marker begins a three-byte sequence
+        [InlineData(new byte[] { 0b1111_0000, 0b1000_0000, 0b1000_0000 })] // marker begins a four-byte sequence
+        private static void ReadUnicodeScalarValue_WithTooShortBuffer_ReturnsInsufficientDataError(byte[] input)
+        {
+            // Act
+
+            int retVal = Utf8Decoder.ReadUnicodeScalarValue(input, out int bytesConsumed);
+
+            // Assert
+
+            Assert.Equal(Utf8Decoder.ErrorStatus.InsufficientData, retVal);
+            Assert.Equal(0, bytesConsumed);
+        }
+
+        private static bool IsSurrogateCodePoint(int i)
+        {
+            return (0xD800 <= i && i <= 0xDFFF);
+        }
+
+        private static void RunDecoder_ExpectBadDataError(byte[] input)
+        {
+            // Act
+
+            int retVal = Utf8Decoder.ReadUnicodeScalarValue(input, out int bytesConsumed);
+
+            // Assert
+
+            Assert.Equal(Utf8Decoder.ErrorStatus.BadCharacter, retVal);
+            Assert.Equal(input.Length, bytesConsumed);
+        }
+
+        private static byte[] GetUtf8SequenceForCodePoint(int codePoint)
+        {
+            return _strictEncoding.GetBytes(Char.ConvertFromUtf32(codePoint));
+        }
+    }
+}


### PR DESCRIPTION
This is basic functionality to perform UTF8 sequence validation and to extract Unicode scalar values from a UTF8 sequence. This class meets the requirements as specified in the [Unicode Standard 10.0, Sec. 3.9](http://www.unicode.org/versions/Unicode10.0.0/ch03.pdf), and [Unicode TR 36](http://www.unicode.org/reports/tr36/). The purpose of this class is to provide a single secure decoding component that can consumed by our web encoders, Utf8String, and other types.

Seeking feedback on the API shape and whether this type should be made public. Among the open questions: should this use the existing `OperationStatus` type? This would make APIs like "read next scalar" have yet another _out_ parameter, but maybe the consistency is worth it. We can also nix the `ErrorStatus` type entirely if needed since we really only need to return -1 to indicate error.

One other issue is that running unit tests takes 2 minutes from the command line but only seconds from within VS. Still investigating this.