### PR TITLE
New toolset compiler - 2.6.0-beta1-62126-01

### DIFF
--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <CoreFxVersion>4.3.0</CoreFxVersion>
-    <RoslynVersion>2.6.0-rdonly-ref-62111-06</RoslynVersion>
+    <RoslynVersion>2.6.0-beta1-62126-01</RoslynVersion>
     <SystemMemoryVersion>4.5.0-preview1-25728-02</SystemMemoryVersion>
     <SystemCompilerServicesUnsafeVersion>4.5.0-preview1-25728-02</SystemCompilerServicesUnsafeVersion>
     <SystemNumericsVectorsVersion>4.5.0-preview1-25728-02</SystemNumericsVectorsVersion>


### PR DESCRIPTION
new toolset compiler - 2.6.0-beta1-62126-01

This was a "special" build, so there is no public VSIX for this.
The old one should be ok, for most scenarios.

When `VS 15.5 preview1` is available it will match this compiler feature-wise by default. 