### PR TITLE
Add missing PackageReference to System.Text.Primitives.Tests

### DIFF
--- a/tests/System.Text.Primitives.Tests/System.Text.Primitives.Tests.csproj
+++ b/tests/System.Text.Primitives.Tests/System.Text.Primitives.Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.performance.core" Version="$(XunitPerformanceVersion)" />
+    <PackageReference Include="xunit.performance.execution" Version="$(XunitPerformanceVersion)" />
     <PackageReference Include="System.IO.FileSystem" Version="$(CoreFxVersion)" />
   </ItemGroup>
   <!-- Project references -->


### PR DESCRIPTION
At least nuget has an excuse for missing this one - this
is an assembly that's loaded by Reflection inside the bowels
of xunit. Not that I plan to run benchmarks in the self-contained
setup but without this, you can't even skip the benchmark
tests since xunit.performance.execution.dll is the one
that contains the Discoverer class that tells you
that [Benchmark] is a "Benchmark" trait.