### PR TITLE
Revert "Add missing PackageReference to System.Text.Primitives.Tests …

### DIFF
--- a/tests/System.Text.Primitives.Tests/System.Text.Primitives.Tests.csproj
+++ b/tests/System.Text.Primitives.Tests/System.Text.Primitives.Tests.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.performance.core" Version="$(XunitPerformanceVersion)" />
-    <PackageReference Include="xunit.performance.execution" Version="$(XunitPerformanceVersion)" />
     <PackageReference Include="System.IO.FileSystem" Version="$(CoreFxVersion)" />
   </ItemGroup>
   <!-- Project references -->


### PR DESCRIPTION
…(#1795)"

This reverts commit a3f169bee007646c91dc090469b6b0d64cfb59bd.

The previous PR broke the build (confirmed by running the tests locally):
https://github.com/dotnet/corefxlab/pull/1795#issuecomment-333010223

cc @KrzysztofCwalina 