### PR TITLE
Fixing NU1701 and NU1604 build warnings caused by recent changes

### DIFF
--- a/tests/System.Text.Http.Parser.Tests/System.Text.Http.Parser.Tests.csproj
+++ b/tests/System.Text.Http.Parser.Tests/System.Text.Http.Parser.Tests.csproj
@@ -19,11 +19,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
-    <PackageReference Include="System.IO.FileSystem" Version="$(CoreFxVersion)" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="$(CoreFxVersion)" />
-    <PackageReference Include="System.Runtime.Extensions" Version="$(CoreFxVersion)" />
-    <PackageReference Include="System.Runtime.Handles" Version="$(CoreFxVersion)" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="$(CoreFxVersion)" />
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>

--- a/tests/System.Text.Primitives.Tests/System.Text.Primitives.Tests.csproj
+++ b/tests/System.Text.Primitives.Tests/System.Text.Primitives.Tests.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.performance.core" Version="$(XunitPerformanceVersion)" />
-    <PackageReference Include="System.IO.FileSystem" Version="$(CoreFxVersion)" />
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>


### PR DESCRIPTION
Reverting https://github.com/dotnet/corefxlab/pull/1780 & https://github.com/dotnet/corefxlab/pull/1788.

These recent changes are causing NuGet warnings during build:


D:\GitHub\Fork\corefxlab\tests\System.Text.Primitives.Tests\System.Text.Primitives.Tests.csproj : warning NU1604: Project dependency System.IO.FileSystem does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results.
D:\GitHub\Fork\corefxlab\tests\System.Text.Primitives.Tests\System.Text.Primitives.Tests.csproj : warning NU1701: Package 'System.IO.FileSystem 4.0.0' was restored using '.NETFramework,Version=v4.6.1' instead of the project target framework '.NETCoreApp,Version=v2.1'. This package may not be fully compatible with your project.

D:\GitHub\Fork\corefxlab\tests\System.Text.Http.Parser.Tests\System.Text.Http.Parser.Tests.csproj : warning NU1604: Project dependency System.Runtime.InteropServices does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results. [D:\GitHub\Fork\corefxlab\corefxlab.sln]
D:\GitHub\Fork\corefxlab\tests\System.Text.Http.Parser.Tests\System.Text.Http.Parser.Tests.csproj : warning NU1701: Package 'System.IO.FileSystem 4.0.0' was restored using '.NETFramework,Version=v4.6.1' instead of the project target framework '.NETCoreApp,Version=v2.1'. This package may not be fully compatible with your project. [D:\GitHub\Fork\corefxlab\corefxlab.sln]
