### PR TITLE
Removing the generic Reverse API and adding no-op byte overloads.

### DIFF
--- a/src/System.Binary/System/Binary/BufferReader.cs
+++ b/src/System.Binary/System/Binary/BufferReader.cs
@@ -18,7 +18,7 @@ namespace System.Buffers
         /// <summary>
         /// This is a no-op and added only for consistency.
         /// This allows the caller to read a struct of numeric primitives and reverse each field
-        /// rather than having to skip byte & sbyte fields.
+        /// rather than having to skip sbyte fields.
         /// </summary> 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static sbyte Reverse(this sbyte value)
@@ -50,7 +50,7 @@ namespace System.Buffers
         /// <summary>
         /// This is a no-op and added only for consistency.
         /// This allows the caller to read a struct of numeric primitives and reverse each field
-        /// rather than having to skip byte & sbyte fields.
+        /// rather than having to skip byte fields.
         /// </summary> 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static byte Reverse(this byte value)

--- a/src/System.IO.Pipelines.Extensions/ReadWriteExtensions.cs
+++ b/src/System.IO.Pipelines.Extensions/ReadWriteExtensions.cs
@@ -10,24 +10,84 @@ namespace System.IO.Pipelines
 {
     public static class ReadWriteExtensions
     {
+        /// <summary>
+        /// Reverses a primitive value - performs an endianness swap
+        /// </summary> 
+        public static unsafe T Reverse<[Primitive]T>(T value) where T : struct
+        {
+            // note: relying on JIT goodness here!
+            if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
+            {
+                return value;
+            }
+            else if (typeof(T) == typeof(ushort) || typeof(T) == typeof(short))
+            {
+                ushort val = 0;
+                Unsafe.Write(&val, value);
+                val = (ushort)((val >> 8) | (val << 8));
+                return Unsafe.Read<T>(&val);
+            }
+            else if (typeof(T) == typeof(uint) || typeof(T) == typeof(int)
+                || typeof(T) == typeof(float))
+            {
+                uint val = 0;
+                Unsafe.Write(&val, value);
+                val = (val << 24)
+                    | ((val & 0xFF00) << 8)
+                    | ((val & 0xFF0000) >> 8)
+                    | (val >> 24);
+                return Unsafe.Read<T>(&val);
+            }
+            else if (typeof(T) == typeof(ulong) || typeof(T) == typeof(long)
+                || typeof(T) == typeof(double))
+            {
+                ulong val = 0;
+                Unsafe.Write(&val, value);
+                val = (val << 56)
+                    | ((val & 0xFF00) << 40)
+                    | ((val & 0xFF0000) << 24)
+                    | ((val & 0xFF000000) << 8)
+                    | ((val & 0xFF00000000) >> 8)
+                    | ((val & 0xFF0000000000) >> 24)
+                    | ((val & 0xFF000000000000) >> 40)
+                    | (val >> 56);
+                return Unsafe.Read<T>(&val);
+            }
+            else
+            {
+                // default implementation
+                int len = Unsafe.SizeOf<T>();
+                var val = stackalloc byte[len];
+                Unsafe.Write(val, value);
+                int to = len >> 1, dest = len - 1;
+                for (int i = 0; i < to; i++)
+                {
+                    var tmp = val[i];
+                    val[i] = val[dest];
+                    val[dest--] = tmp;
+                }
+                return Unsafe.Read<T>(val);
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static T ReadBigEndian<[Primitive]T>(this Span<byte> buffer) where T : struct
-            => BitConverter.IsLittleEndian ? Binary.Reverse(buffer.Read<T>()) : buffer.Read<T>();
+            => BitConverter.IsLittleEndian ? Reverse(buffer.Read<T>()) : buffer.Read<T>();
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static T ReadLittleEndian<[Primitive]T>(this Span<byte> buffer) where T : struct
-            => BitConverter.IsLittleEndian ? buffer.Read<T>() : Binary.Reverse(buffer.Read<T>());
+            => BitConverter.IsLittleEndian ? buffer.Read<T>() : Reverse(buffer.Read<T>());
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void WriteBigEndian<[Primitive]T>(this Span<byte> buffer, T value) where T : struct
-            => buffer.Write(BitConverter.IsLittleEndian ? Binary.Reverse(value) : value);
+            => buffer.Write(BitConverter.IsLittleEndian ? Reverse(value) : value);
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static void WriteLittleEndian<[Primitive]T>(this Span<byte> buffer, T value) where T : struct
-            => buffer.Write(BitConverter.IsLittleEndian ? value : Binary.Reverse(value));
+            => buffer.Write(BitConverter.IsLittleEndian ? value : Reverse(value));
 
         public static async Task<ReadableBuffer> ReadToEndAsync(this IPipeReader input)
         {


### PR DESCRIPTION
Notes from System.Binary API review:

1)	Add Reverse overload for byte & sbyte (which is a no-op).
    - This is a no-op and added only for consistency. This allows the caller to read a struct of numeric primitives and reverse each field rather than having to skip byte/sbyte fields.
2)	Remove the generic Reverse API. **Edit**: Moved to Pipelines ReadWriteExtensions
3)	The rest of the APIs are fine to move to corefx as is to System.Buffers dll (and namespace)

cc @dotnet/corefxlab-contrib, @pakrym, @davidfowl 