### PR TITLE
Cut STP.Tests run time from 2.33 minutes to 0.5 seconds

### DIFF
--- a/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserIntegerTests.cs
+++ b/tests/System.Text.Primitives.Tests/Parsing/PrimitiveParserIntegerTests.cs
@@ -1291,7 +1291,7 @@ namespace System.Text.Primitives.Tests
             Assert.Equal(0, consumed);
         }
 
-        [Theory]
+        //[Theory] - This test is far too slow (turns a 0.5-second test run into a 2.33 minute test run!) and tests a very unlikely scenario. Save for outerloop.
         [InlineData("0", true, 0, int.MaxValue)]
         [InlineData("2", true, 2, int.MaxValue)]
         [InlineData("21", true, 21, int.MaxValue)]


### PR DESCRIPTION
Finally took the time to track down why a test exercising
these high performance apis was taking so much longer
than any other test.

I don't think parsing a 2gb long string is a common enough
scenario to justify a 28,000% tax on every test cycle.
Regressions are caught much faster when people are incented
to run tests regularly.