### PR TITLE
Rename dotnet folder to dotnet cli to workaround corefx #24402

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,7 +246,7 @@ tools/
 *.ncrunchsolution
 
 #dotnet cli
-[Dd]otnet/
+[Dd]otnetcli/
 
 # Nuget.exe
 nuget.exe

--- a/build.sh
+++ b/build.sh
@@ -57,7 +57,7 @@ if [ ! -d "dotnetcli" ]; then
   fi
 fi
 
-dotnetExePath="dotnet/dotnetcli"
+dotnetExePath="dotnetcli/dotnet"
 
 myFile="corefxlab.sln"
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 # adding dotnet to the path. it is needed to run toolset csc.
 parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-dotnet_path=$parent_path/dotnet
+dotnet_path=$parent_path/dotnetcli
 export PATH=$PATH:$dotnet_path
 
 usage()
@@ -30,26 +30,26 @@ echo "Restore=$Restore."
 echo "Version=$Version."
 echo "BuildVersion=$BuildVersion."
 
-if [ ! -d "dotnet" ]; then
+if [ ! -d "dotnetcli" ]; then
   echo "dotnet.exe not installed, downloading and installing."
   if [ "$Version" = "<default>" ]; then
     Version=$(head -n 1 "DotnetCLIVersion.txt")
   fi
-  ./scripts/install-dotnet.sh -Channel master -Version "$Version" -InstallDir "dotnet"
+  ./scripts/install-dotnet.sh -Channel master -Version "$Version" -InstallDir "dotnetcli"
   ret=$?
   if [ $ret -ne 0 ]; then
     echo "Failed to install latest dotnet.exe, exit code $ret, aborting build."
     exit -1
   fi
 
-  ./scripts/install-dotnet.sh -Version 1.0.0 -InstallDir "dotnet"
+  ./scripts/install-dotnet.sh -Version 1.0.0 -InstallDir "dotnetcli"
   ret=$?
   if [ $ret -ne 0 ]; then
     echo "Failed to install framework version 1.0.0, exit code $ret, aborting build."
     exit -1
   fi
 
-  ./scripts/install-dotnet.sh -Version 2.0.0 -InstallDir "dotnet"
+  ./scripts/install-dotnet.sh -Version 2.0.0 -InstallDir "dotnetcli"
   ret=$?
   if [ $ret -ne 0 ]; then
     echo "Failed to install framework version 2.0.0, exit code $ret, aborting build."
@@ -57,7 +57,7 @@ if [ ! -d "dotnet" ]; then
   fi
 fi
 
-dotnetExePath="dotnet/dotnet"
+dotnetExePath="dotnet/dotnetcli"
 
 myFile="corefxlab.sln"
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -12,24 +12,24 @@ Write-Host "Version=$Version."
 Write-Host "BuildVersion=$BuildVersion."
 Write-Host "SkipTests=$SkipTests."
 
-if (!(Test-Path "dotnet\dotnet.exe")) {
+if (!(Test-Path "dotnetcli\dotnet.exe")) {
     Write-Host "dotnet.exe not installed, downloading and installing."
     if ($Version -eq "<default>") {
         $Version = (Get-Content "$PSScriptRoot\..\DotnetCLIVersion.txt" -Raw).Trim()
     }
-    Invoke-Expression -Command "$PSScriptRoot\install-dotnet.ps1 -Channel master -Version $Version -InstallDir $PSScriptRoot\..\dotnet"
+    Invoke-Expression -Command "$PSScriptRoot\install-dotnet.ps1 -Channel master -Version $Version -InstallDir $PSScriptRoot\..\dotnetcli"
     if ($lastexitcode -ne $null -and $lastexitcode -ne 0) {
         Write-Error "Failed to install latest dotnet.exe, exit code [$lastexitcode], aborting build."
         exit -1
     }
 
-    Invoke-Expression -Command "$PSScriptRoot\install-dotnet.ps1 -Version 1.0.0 -InstallDir $PSScriptRoot\..\dotnet"
+    Invoke-Expression -Command "$PSScriptRoot\install-dotnet.ps1 -Version 1.0.0 -InstallDir $PSScriptRoot\..\dotnetcli"
     if ($lastexitcode -ne $null -and $lastexitcode -ne 0) {
         Write-Error "Failed to install framework version 1.0.0, exit code [$lastexitcode], aborting build."
         exit -1
     }
 
-    Invoke-Expression -Command "$PSScriptRoot\install-dotnet.ps1 -Version 2.0.0 -InstallDir $PSScriptRoot\..\dotnet"
+    Invoke-Expression -Command "$PSScriptRoot\install-dotnet.ps1 -Version 2.0.0 -InstallDir $PSScriptRoot\..\dotnetcli"
     if ($lastexitcode -ne $null -and $lastexitcode -ne 0) {
         Write-Error "Failed to install framework version 2.0.0, exit code [$lastexitcode], aborting build."
         exit -1
@@ -38,7 +38,7 @@ if (!(Test-Path "dotnet\dotnet.exe")) {
 
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
 
-$dotnetExePath="$PSScriptRoot\..\dotnet\dotnet.exe"
+$dotnetExePath="$PSScriptRoot\..\dotnetcli\dotnet.exe"
 
 $file = "corefxlab.sln"
 

--- a/scripts/update-dependencies.ps1
+++ b/scripts/update-dependencies.ps1
@@ -21,7 +21,7 @@ if($Help)
 
 $ProjectPath = "$PSScriptRoot\update-dependencies\update-dependencies.csproj"
 $ProjectArgs = ""
-$DotNetExePath = "$PSScriptRoot\..\dotnet\dotnet.exe"
+$DotNetExePath = "$PSScriptRoot\..\dotnetcli\dotnet.exe"
 
 if ($Update)
 {
@@ -31,15 +31,15 @@ if ($Update)
 $Version = (Get-Content "$PSScriptRoot\..\DotnetCLIVersion.txt" -Raw).Trim()
 
 # Ensure dotnet is installed
-if (!(Test-Path "dotnet\dotnet.exe")) {
+if (!(Test-Path "dotnetcli\dotnet.exe")) {
     Write-Host "dotnet.exe not installed, downloading and installing."
-    Invoke-Expression -Command "$PSScriptRoot\install-dotnet.ps1 -Version $Version -InstallDir $PSScriptRoot\..\dotnet"
+    Invoke-Expression -Command "$PSScriptRoot\install-dotnet.ps1 -Version $Version -InstallDir $PSScriptRoot\..\dotnetcli"
     if ($lastexitcode -ne $null -and $lastexitcode -ne 0) {
         Write-Error "Failed to install dotnet.exe, exit code [$lastexitcode], aborting build."
         exit -1
     }
 
-    Invoke-Expression -Command "$PSScriptRoot\install-dotnet.ps1 -Version 2.0.0 -InstallDir $PSScriptRoot\..\dotnet"
+    Invoke-Expression -Command "$PSScriptRoot\install-dotnet.ps1 -Version 2.0.0 -InstallDir $PSScriptRoot\..\dotnetcli"
     if ($lastexitcode -ne $null -and $lastexitcode -ne 0) {
         Write-Error "Failed to install framework version 2.0.0, exit code [$lastexitcode], aborting build."
         exit -1

--- a/src/System.IO.Pipelines.Extensions/ReadWriteExtensions.cs
+++ b/src/System.IO.Pipelines.Extensions/ReadWriteExtensions.cs
@@ -13,7 +13,7 @@ namespace System.IO.Pipelines
         /// <summary>
         /// Reverses a primitive value - performs an endianness swap
         /// </summary> 
-        public static unsafe T Reverse<[Primitive]T>(T value) where T : struct
+        private static unsafe T Reverse<[Primitive]T>(T value) where T : struct
         {
             // note: relying on JIT goodness here!
             if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))


### PR DESCRIPTION
Temporary workaround for https://github.com/dotnet/corefx/issues/24402 (related: https://github.com/dotnet/cli/issues/7726)

- Renaming the folder from dotnet to dotnetcli (following corefx).
- Making generic Reverse API private (since it is not used anywhere else).

This will unblock:
https://github.com/dotnet/corefxlab/pull/1787
> Failure to restore a package: Failed to restore packages.

@dotnet/corefxlab-contrib 