### PR TITLE
Reapply selfcontained publishing fixes.

### DIFF
--- a/tests/System.Text.Http.Parser.Tests/System.Text.Http.Parser.Tests.csproj
+++ b/tests/System.Text.Http.Parser.Tests/System.Text.Http.Parser.Tests.csproj
@@ -19,6 +19,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="System.IO.FileSystem" Version="$(CoreFxStableVersion)" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" Version="$(CoreFxStableVersion)" />
+    <PackageReference Include="System.Runtime.Extensions" Version="$(CoreFxStableVersion)" />
+    <PackageReference Include="System.Runtime.Handles" Version="$(CoreFxStableVersion)" />
+    <PackageReference Include="System.Runtime.InteropServices" Version="$(CoreFxStableVersion)" />
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>

--- a/tests/System.Text.Primitives.Tests/System.Text.Primitives.Tests.csproj
+++ b/tests/System.Text.Primitives.Tests/System.Text.Primitives.Tests.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.performance.core" Version="$(XunitPerformanceVersion)" />
+    <PackageReference Include="System.IO.FileSystem" Version="$(CoreFxStableVersion)" />
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>

--- a/tests/System.Threading.Tasks.Channels.Tests/System.Threading.Tasks.Channels.Tests.csproj
+++ b/tests/System.Threading.Tasks.Channels.Tests/System.Threading.Tasks.Channels.Tests.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+    <PackageReference Include="System.IO.FileSystem" Version="$(CoreFxStableVersion)" />
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>


### PR DESCRIPTION
Correct was to update the property name to reflect
the rename in 0d8bd06a84a0d1987cc6e3a229042a356564a3cf.