### PR TITLE
Documentation naming fixes, spelling fixes, line length standardization.

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # High-Performance Data Pipelines
 
-Our goal is to optimize .NET much more for scenarios in which inefficiences are
+Our goal is to optimize .NET much more for scenarios in which inefficiencies are
 directly tied to your monthly billing. With ASP.NET Core, we've already
 [improved significantly][TechEmpower13] and are now in the top 10 for the plain
 text benchmark. But we believe there is still a lot more potential that we could
@@ -18,8 +18,8 @@ Consider an example for a typical web request:
 
 ![](./img/pipeline.png)
 
-Most cloud apps are parellelized by running multiple requests at the same time
-while each requests is often executed as a single chain. This results in the
+Most cloud apps are parallelized by running multiple requests at the same time
+while each request is often executed as a single chain. This results in the
 picture above where all components are daisy-chained. That means slowing down
 one component will slow down the entire request.
 
@@ -63,10 +63,10 @@ we're seeking to improve is scalability:
 >
 > --- [Wikipedia](https://en.wikipedia.org/wiki/Scalability)
 
-Many areas affect scale but an efficient request/response pipeline is key as
+Many areas affect scale, but an efficient request/response pipeline is key as
 it's the backbone for all cloud solutions.
 
-Other investments (faster GC, better JIT, AOT) aren't a replacement but will
+Other investments (faster GC, better JIT, AOT) aren't a replacement, but will
 provide additional benefits.
 
 ## Current areas of concerns

--- a/docs/specs/encoding.md
+++ b/docs/specs/encoding.md
@@ -1,18 +1,24 @@
 # Encoding
 
-The existing .NET encoding APIs (System.Text.Encoding) don't work super well in non-allocating data pipelines:
+The existing .NET encoding APIs (System.Text.Encoding) don't work super well in
+non-allocating data pipelines:
 
-1. They allocate output arrays (as opposed to taking output buffers are parameters).
+1. They allocate output arrays (as opposed to taking output buffers are
+  parameters).
 2. They don't work with Span\<T\>
-3. They have the overhead of virtual calls (which might be significant to transcoding small slices)
+3. They have the overhead of virtual calls (which might be significant to
+  transcoding small slices)
 
 The requirements for the new APIs are as follows:
 
 1. Transcode bytes contained in ReadOnlySpan<byte> into a passed in Span<byte>
-2. The API needs to handle running out of space in the output buffer and then continuing when an additional output buffer is passed in.
+2. The API needs to handle running out of space in the output buffer and then
+continuing when an additional output buffer is passed in.
 3. The API needs to be fast (on par with native code implementations)
 4. Needs to do this with zero GC allocations
 5. Needs to be stateless (multithreaded)
-6. We need to support transcoding between UTF8, UTF16LE, ISO8859-1, and be able to support other encodings in the future.
+6. We need to support transcoding between UTF8, UTF16LE, ISO8859-1, and be able
+ to support other encodings in the future.
 
-This document will describe these issues in detail and propose new APIs better suited for data pipelines.
+This document will describe these issues in detail and propose new APIs better
+suited for data pipelines.

--- a/docs/specs/parsing.md
+++ b/docs/specs/parsing.md
@@ -1,6 +1,7 @@
 # Parsing
 
-The current .NET Framework parsing APIs (e.g. int.TryParse) can parse text represented by System.String (UTF16).
+The current .NET Framework parsing APIs (e.g. int.TryParse) can parse text
+represented by System.String (UTF16).
 ```c#
 string text = ...
 int value;
@@ -8,56 +9,71 @@ if(int.TryParse(text, out value)){
    ...
 }
 ```
-These APIs work great in many scenarios, e.g. parsing text contained in GUI application's text boxes. They are not suitable for processing modern network protocols, which are often text (e.g. JSON, HTTP headers), but encoded with UTF8/ASCII, not UTF16, and contained in byte buffers, not strings. Because of this, all modern web servers written for the .NET platform either don't use the current BCL parsing APIs or take a performance hit to transcode from UTF8 to UTF16, and to copy from buffers to strings.
+These APIs work great in many scenarios, e.g. parsing text contained in GUI
+application's text boxes. They are not suitable for processing modern network
+protocols, which are often text (e.g. JSON, HTTP headers), but encoded with
+UTF8/ASCII, not UTF16, and contained in byte buffers, not strings. Because of
+this, all modern web servers written for the .NET platform either don't use the
+current BCL parsing APIs or take a performance hit to transcode from UTF8 to
+UTF16, and to copy from buffers to strings.
 ```c#
 byte[] json = ...
-string text = Encoding.UTF8.GetString(json); // this is very expensive: copy, transformation, object allocations
+string text = Encoding.UTF8.GetString(json); // this is very expensive: copy,
+                                             // transformation, object
+                                             // allocations
 int value;
 if(int.TryParse(text, out value)){
    ...
 }
 ```
-To address modern networking scenarios beter, we will provide parsing APIs that:
+To address modern networking scenarios better, we will provide parsing APIs
+that:
 
-a) Can parse byte buffers, with out the need to have a string to parse
+a) Can parse byte buffers without the need to have a string to parse
 b) Can parse text encoded as UTF8 (and possibly other encodings)
 c) Can parse without any GC heap allocations
 
 This document spells out the details of the project.
 
 ## API Design
-We will provide low level APIs that can parse byte\* and ReadOnlySpan\<byte\> buffers (moral equivalent of int.TryParse), and higher level APIs to parse sequences of such buffers (similar to BinaryReader for encoded text streams). 
+We will provide low level APIs that can parse byte\* and ReadOnlySpan\<byte\>
+buffers (moral equivalent of int.TryParse), and higher level APIs to parse
+sequences of such buffers (similar to BinaryReader for encoded text streams).
 
-To familiarize yourself with ReadOnlySpan\<T\> refer to: https://github.com/dotnet/corefxlab/blob/master/docs/specs/span.md
+To familiarize yourself with ReadOnlySpan\<T\> refer to:
+https://github.com/dotnet/corefxlab/blob/master/docs/specs/span.md
 
 ### Low Level APIs
 
-The low level APIs are policy free (not specific to scenarios, higher level frameworks, etc.) and optimized for speed, and will look like the following (per data type being parsed; the sample shows Int32 APIs):
+The low level APIs are policy free (not specific to scenarios, higher level
+frameworks, etc.) and optimized for speed, and will look like the following
+(per data type being parsed; the sample shows Int32 APIs):
 ```c#
 public static class PrimitiveParser {
     // most general "overload"
     public static bool TryParseInt32(ReadOnlySpan<byte> text, out int value, out int bytesConsumed, EncodingData encoding=null, TextFormat format=null);
-    
+
     // UTF8-invariant overloads
     public static class InvariantUtf8 {
-       
-        // We did some preliminary measurements, and the shorter overload is non-trivially faster. We should double check though.
+
+        // We did some preliminary measurements, and the shorter overload is
+        // non-trivially faster. We should double check though.
         public static bool TryParseInt32(ReadOnlySpan<byte> text, out int value);
         public static bool TryParseInt32(ReadOnlySpan<byte> text, out int value, out int bytesConsumed);
-            
+
         public unsafe static bool TryParseInt32(byte* text, int length, out int value);
         public unsafe static bool TryParseInt32(byte* text, int length, out int value, out int bytesConsumed);
-        
+
         // overloads optimized for hexadecimal numbers
         public static class Hex {
             public static bool TryParseInt32(ReadOnlySpan<byte> text, out int value);
             public static bool TryParseInt32(ReadOnlySpan<byte> text, out int value, out int bytesConsumed);
-            
+
             public unsafe static bool TryParseInt32(byte* text, int length, out int value);
             public unsafe static bool TryParseInt32(byte* text, int length, out int value, out int bytesConsumed);
         }
     }
-    
+
     // UTF16-invariant overloads
     public static class InvariantUtf16 {
         // same as InvariantUtf8, but using char* and ReadOnlySpan<char>
@@ -65,32 +81,34 @@ public static class PrimitiveParser {
     }
 }
 ```
-The most general (and the slowest) overload allows callers to specify [format](https://msdn.microsoft.com/en-us/library/dwhawy9k(v=vs.110).aspx) of the text (`TextFormat`), and its encoding and culture (`EncodingData`).
+The most general (and the slowest) overload allows callers to specify [format](https://msdn.microsoft.com/en-us/library/dwhawy9k(v=vs.110).aspx) of
+the text (`TextFormat`), and its encoding and culture (`EncodingData`).
 
-`TextFormat` is an efficient (non allocating, preparsed) representation of format strings. It's used in both parsing and formatting APIs.
+`TextFormat` is an efficient (non allocating, preparsed) representation of
+format strings. It's used in both parsing and formatting APIs.
 ```c#
     public struct TextFormat : IEquatable<TextFormat> {
-        
+
         public static TextFormat Parse(char format);
         public static TextFormat Parse(ReadOnlySpan<char> format);
         public static TextFormat Parse(string format);
-        
+
         public static implicit operator TextFormat (char symbol);
-        
+
         public TextFormat(char symbol, byte precision=(byte)255);
-        
-        public byte Precision { get; } 
+
+        public byte Precision { get; }
         public char Symbol { get; set; }
-        
+
         // less interesting members follow:    
         public bool HasPrecision { get; }
         public bool IsDefault { get; }
         public bool IsHexadecimal { get; }
-        
+
         public const byte NoPrecision = (byte)255;
         public static TextFormat HexLowercase;
         public static TextFormat HexUppercase;
-        
+
         public static bool operator ==(TextFormat left, TextFormat right);      
         public static bool operator !=(TextFormat left, TextFormat right);
         public override bool Equals(object obj);
@@ -99,21 +117,22 @@ The most general (and the slowest) overload allows callers to specify [format](h
         public override string ToString();
     }
 ```
-`EncodingData` providing encoding and culture data used by parsing and formatting routines:
+`EncodingData` providing encoding and culture data used by parsing and
+formatting routines:
 ```c#
     public struct EncodingData : IEquatable<EncodingData> {
-    
+
         public EncodingData(byte[][] symbols, TextEncoding encoding);
-        
+
         public static EncodingData InvariantUtf16 { get; }
         public static EncodingData InvariantUtf8 { get; }
-                
+
         // parsers call this
         public bool TryParseSymbol(ReadOnlySpan<byte> buffer, out Symbol symbol, out int bytesConsumed);
-        
+
         // formatters call this
         public bool TryEncode(Symbol symbol, Span<byte> buffer, out int bytesWritten);
-                
+
         // less interesting members follow:  
         public bool IsInvariantUtf16 { get; }
         public bool IsInvariantUtf8 { get; }
@@ -239,14 +258,20 @@ Frequency=3328121 Hz, Resolution=300.4698 ns, Timer=TSC
 And these should get much better once we start using the [fast span](span.md#designrepresentation).
 
 ### Higher Level APIs
-The low level APIs can parse text residing in a single contiguous memory buffer. We will need higher level APIs to make it easier to parse text out of "streams" of data. The details of these APIs are not yet clear, but the following method illustrates early thinking: https://github.com/dotnet/corefxlab/blob/master/src/System.Text.Formatting/System/Text/Parsing/SequenceParser.cs#L15
+The low level APIs can parse text residing in a single contiguous memory buffer.
+We will need higher level APIs to make it easier to parse text out of "streams"
+of data. The details of these APIs are not yet clear, but the following method
+illustrates early thinking: https://github.com/dotnet/corefxlab/blob/master/src/System.Text.Formatting/System/Text/Parsing/SequenceParser.cs#L15
 
-NOTE: we should explore changing the API from a stateless static method to a TextReader like API that can traverse sequences of buffers while remembering its current position.
+NOTE: We should explore changing the API from a stateless static method to a
+TextReader like API that can traverse sequences of buffers while remembering its
+current position.
 
 ## Requirements
 ### Priority 1
 - Parse text contained in byte buffers
-- Support types commonly used in network protocols: integers, DateTimeOffset/DateTime (HTTP Format), URI, GUID, Boolean, BigInteger
+- Support types commonly used in network protocols: integers,
+DateTimeOffset/DateTime (HTTP Format), URI, GUID, Boolean, BigInteger
 - No GC heap allocations
 - UTF8 and ISO-8859-1 (required by networking protocols)
 - Invariant culture
@@ -254,32 +279,39 @@ NOTE: we should explore changing the API from a stateless static method to a Tex
 - Round trip text output by [formatting](formatting.md) APIs
 - Support 'G', 'D', 'R', and 'X' formats
 - Compatible with .NET Framework APIs, where possible
-- Parse without knowing up-front how many bytes encode the value (i.e. see bytesConsumed parameters)
-- Performance comparable to pinvoking to hand written C++ parsers, and 2x faster than the existing .NET APIs (e.g. int.TryParse)
+- Parse without knowing up-front how many bytes encode the value (i.e. see
+bytesConsumed parameters)
+- Performance comparable to pinvoking to hand written C++ parsers, and 2x faster
+than the existing .NET APIs (e.g. int.TryParse)
 
 ### Priority 2
-* Parse the following types with minimal allocations: `Single`, `Double`, `Decimal`, `TimeSpan`
+* Parse the following types with minimal allocations: `Single`, `Double`,
+`Decimal`, `TimeSpan`
 * Parses different cultures, e.g. English and German
 * Parse from these additional encodings: ASCII, UTF16-BE, UTF16-LE
 
 ### Note on Encodings
 
-While we generally need to handle parsing for more than just UTF8 we believe it's
-beneficial to optimize for UTF8 (both in speed and in project schedule).
+While we generally need to handle parsing for more than just UTF8 we believe
+it's beneficial to optimize for UTF8 (both in speed and in project schedule).
 
 That's because UTF8 is the dominant encoding for cloud-based apps. We'd support
 other encodings by either converting them to the UTF8 before or by having an
 implementation that can parse different encodings through an abstraction.
 
-Having said that, when we design the APIs, we need to ensure that they will scale to 
-arbitrary encodings. And the best way to validate that is to implement (possibly not ship)
-other encodings.
+Having said that, when we design the APIs, we need to ensure that they will
+scale to arbitrary encodings. And the best way to validate that is to implement
+(possibly not ship) other encodings.
 
 ## ISSUES/QUESTIONS:
-1. How are we going to support ISO-8859-1? Is it just validation? Or we need specific EncodingData?
-2. We need to measure if it's worth having overloads that don't take bytesConsumed
+1. How are we going to support ISO-8859-1? Is it just validation? Or we need
+specific EncodingData?
+2. We need to measure if it's worth having overloads that don't take
+bytesConsumed
 3. We need detailed design of the higher level APIs (parsing multi-spans)
-4. How do people add support for buffer parsing to their types? Is there an abstraction "IParsable" so that high level reader can read 3rd party types?
+4. How do people add support for buffer parsing to their types? Is there an
+abstraction "IParseable" so that high level reader can read 3rd party types?
 
 ## Workitems
-Workitems related to this design document are traced in issue https://github.com/dotnet/corefxlab/issues/1070
+Workitems related to this design document are traced in issue
+https://github.com/dotnet/corefxlab/issues/1070

--- a/docs/specs/priority-queue.md
+++ b/docs/specs/priority-queue.md
@@ -11,22 +11,28 @@ We want to be able to support all of the following configurations:
 1. User data *is separate* from the priority (two physical instances).
 2. User data *contains* the priority (as one or more properties).
 3. User data *is* the priority (implements `IComparable<T>`).
-4. Rare case: priority is obtainable via some other logic (resides in an object different from the user data).
+4. Rare case: priority is obtainable via some other logic (resides in an object
+different from the user data).
 
-In this entire document, I will refer to the cases above with **(1)**, **(2)**, **(3)**, and **(4)**.
+In this entire document, I will refer to the cases above with **(1)**, **(2)**,
+**(3)**, and **(4)**.
 
 ### Ideal solution
 
 Obviously, our solution should be flexible enough to (respectively):
 
-1. Simply accept two separate instances. The user should not be forced to create a wrapper class for the two types only because of our API limitations.
-2. Accept an element that already has the priority in it, without duplication (no copying).
+1. Simply accept two separate instances. The user should not be forced to create
+a wrapper class for the two types only because of our API limitations.
+2. Accept an element that already has the priority in it, without duplication
+(no copying).
 3. Be able to use `IComparable<T>` and don't expect an additional priority.
-4. Be able to execute some additional logic that retrieves the priority for a given element.
+4. Be able to execute some additional logic that retrieves the priority for a
+given element.
 
 ### Our approach
 
-In order to be able to consume all of that, we need two types of priority queues:
+In order to be able to consume all of that, we need two types of priority
+queues:
 
 * `PriorityQueue<T>`,
 * `PriorityQueue<TElement, TPriority>`.
@@ -59,7 +65,7 @@ public class PriorityQueue<T> : IQueue<T>
 
     public IEnumerator<T> GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator();
-  
+
     public struct Enumerator : IEnumerator<T>
     {
         public T Current { get; }
@@ -120,7 +126,9 @@ var queue = new PriorityQueue<MyClass>();
 
 #### (4)
 
-Priority for `MyClass` is obtainable from some other objects, for example a dictionary. It is done analogically to **(2)**, simply by some custom logic in the comparer.
+Priority for `MyClass` is obtainable from some other objects, for example a
+dictionary. It is done analogically to **(2)**, simply by some custom logic in
+the comparer.
 
 ## `PriorityQueue<TElement, TPriority>`
 
@@ -161,7 +169,7 @@ public class PriorityQueue<TElement, TPriority> :
 
     public IEnumerable<TElement> Elements { get; }
     public IEnumerable<TPriority> Priorities { get; }
-      
+
     public struct Enumerator : IEnumerator<(TElement element, TPriority priority)>
     {
         public (TElement element, TPriority priority) Current { get; }
@@ -202,7 +210,8 @@ To both priority queues:
 
 ## `IQueue<T>`
 
-With the design above, we can address some voices regarding the introduction of `IQueue<T>`:
+With the design above, we can address some voices regarding the introduction of
+`IQueue<T>`:
 
 ```csharp
 public interface IQueue<T> :
@@ -234,8 +243,13 @@ public interface IQueue<T> :
 ## Open questions
 
 1. Do we really need `IQueue<T>`?
-2. In priority queues, we have `Peek`, and `TryPeek`. There is `Dequeue` and `TryDequeue`. Should there also be `Remove` and `TryRemove` following the same pattern or only `bool Remove(T)` (as it is now)?
-3. Do we want to be able to remove and update priorities of elements in O(log n) instead of O(n)? Also, to be able to do conduct such operations on unique nodes (instead of *whichever is found first*)? This would require us to use some sort of a handle:
+2. In priority queues, we have `Peek`, and `TryPeek`. There is `Dequeue` and
+`TryDequeue`. Should there also be `Remove` and `TryRemove` following the same
+pattern or only `bool Remove(T)` (as it is now)?
+3. Do we want to be able to remove and update priorities of elements in O(log n)
+instead of O(n)? Also, to be able to do conduct such operations on unique nodes
+(instead of *whichever is found first*)? This would require us to use some sort
+of a handle:
 
 ```csharp
 void Enqueue(TElement element, TPriority priority, out object handle);
@@ -245,8 +259,23 @@ void Update(object handle, TPriority priority);
 void Remove(object handle);
 ```
 
-4. Do we want to provide an interface for priority queues in the future? If we release two `PriorityQueue` classes, it may be hard to create an interface for them.
-5. If we don't want to add the concept of handles in our priority queues, we are basically locking our solution on less efficient and less correct support for updating / removing arbitrary elements from the collection (problem in Java). It is additionally more problematic if we don't add a proper interface. A solution could be to add a proper support for the heaps family (`IHeap` + possibility of various implementations) in `System.Collections.Specialized`.
-   * Developers could write their third-party solutions based on a single, standardized interface. Their code can depend on an interface rather than an implementation (`PriorityQueue<T>` or `PriorityQueue<T, U>` — which to choose as an argument?).
-   * If such a functionality is added to `CoreFXExtensions`, there would be no common ground for third-party libraries.
-   * Decision where this would eventually land (`CoreFX` or not) directly impacts whether missing features in our support for priority queues are an issue or not. If we add heaps to `System.Collections.Specialized`, priority queues can be lacking more power and enhanceability. If we don't, there is an issue.
+4. Do we want to provide an interface for priority queues in the future? If we
+release two `PriorityQueue` classes, it may be hard to create an interface for
+them.
+5. If we don't want to add the concept of handles in our priority queues, we are
+basically locking our solution on less efficient and less correct support for
+updating / removing arbitrary elements from the collection (problem in Java).
+It is additionally more problematic if we don't add a proper interface. A
+solution could be to add a proper support for the heaps family (`IHeap` +
+possibility of various implementations) in `System.Collections.Specialized`.
+   * Developers could write their third-party solutions based on a single,
+   standardized interface. Their code can depend on an interface rather than an
+   implementation (`PriorityQueue<T>` or `PriorityQueue<T, U>` — which to choose
+   as an argument?).
+   * If such a functionality is added to `CoreFXExtensions`, there would be no
+   common ground for third-party libraries.
+   * Decision where this would eventually land (`CoreFX` or not) directly
+   impacts whether missing features in our support for priority queues are an
+   issue or not. If we add heaps to `System.Collections.Specialized`, priority
+   queues can be lacking more power and enhanceability. If we don't, there is an
+   issue.

--- a/docs/workitems.md
+++ b/docs/workitems.md
@@ -1,109 +1,127 @@
-# Work Items
+# High-Performance Data Pipelines
 
-## Span
+Our goal is to optimize .NET much more for scenarios in which inefficiencies are
+directly tied to your monthly billing. With ASP.NET Core, we've already
+[improved significantly][TechEmpower13] and are now in the top 10 for the plain
+text benchmark. But we believe there is still a lot more potential that we could
+tap into.
 
-* [done] Remove Span<T> and ReadOnlySpan<T> from corefxlab
-* (pri 0) Find APIs that we added in `Span<T>` in CoreFxLab we haven't reviewed and/or
-  scrutinized.
-* (pri 0) Create adaptive package for System.Memory (i.e. fast and slow span)
-* (pri 0) support bulk copy
-* (pri 1) copyto should work for overlapping ranges
-* (pri 1) review SpanExtensions and move some to System.Memory
+![](./img/techempower.png)
 
-## Parsing
+## Roadmap
 
-* (pri 0) performance tests and improvement
-* (pri 0) support fast lower case and upper case hexadecimal parsing
-* (pri 1) remove old APIs
-* (pri 1) remove `EncodingData(byte[][] symbols, TextEncoding encoding, Tuple<byte, int>[] parsingTrie)`
-* (pri 1) add all primitive parser to PrimitiveParser (e.g. GUID, URI, date
-  time, etc.)
-* (pri 1) add support for multi-span parsing
-* (pri 2) support ASCII
-* (pri 2) clean up code
-* (pri 2) full test coverage
-* (pri 2) support all formats
-* (pri 2) provide EncodingData.InvariantUtf16BE
-* (pri 2) write custom EncodingData generation tool
+For the next six to twelve months our primary area of focus for CoreFxLab will be
+to improve performance for data pipeline oriented apps. This is pretty much any
+cloud app as the request-response pattern is fundamentally a data pipeline.
 
-## Formatting
+Consider an example for a typical web request:
 
-* (pri 0) fast path formatting APIs for default and hex formats and for UTF8
-* (pri 0) rearrange TryFormat parameters to match TryParse order
-* (pri 0) performance tests and improvement
-* (pri 2) support ASCII
-* (pri 2) do API cleanup (e.g. rename formattingData to encodingData)
-* (pri 2) clean up code
-* (pri 2) full test coverage
+![](./img/pipeline.png)
 
-## UTF8
+Most cloud apps are parallelized by running multiple requests at the same time
+while each request is often executed as a single chain. This results in the
+picture above where all components are daisy-chained. That means slowing down
+one component will slow down the entire request.
 
-* (pri 0) design proper encoding APIs
-* (pri 0) performance tests and improvement
-* [done] (pri 1) move encoding APIs from System.Text.Utf8 to System.Text.Primitives
-* (pri 2) full test coverage
+An important metric for a cloud app is how many requests per second (RPS) it can
+handle. That's important because the load is (usually) outside the control of
+the app author. So the fewer requests your app can handle, the more instances of
+your app you need in order to satisfy the demand, which basically means the more
+machines you need to pay for.
 
-## Binary Reader/Writer
+Also, consider the role of the framework. For the most part, your app code is
+represented by the green box above, while the blue and red parts are usually
+components provided by the framework. While you can optimize your app code, your
+ability to reduce the overhead in the framework provided pieces is limited.
 
-* (pri 0) performance tests and improvement
-* (pri 1) design binary reader/writer
+That's why many people rely on benchmarks to assess the potential of a given web
+framework. It's important to keep in mind that benchmarks are by definition
+gross simplifications of real-world workloads; but they are often considered to
+be good at providing an indicator for the theoretical best a given framework can
+do for you if you remove virtually all overhead that is specific to your app.
 
-## JSON
+A widely referred to benchmark is [TechEmpower]. Here is how they
+[describe][TechEmpower-Quote] why performance considerations for frameworks are
+important:
 
-* (pri 0) design reader/writer API operating on multi-spans
-* (pri 0) performance tests and improvement
-* (pri 1) cleanup DOM API
-* (pri 1) design and implement UTF8 JSON serializer
-* (pri 2) full test coverage
+> Application performance can be directly mapped to hosting dollars, and for
+> companies both large and small, hosting costs can be a pain point.
+>
+> What if building an application on one framework meant that at the very best
+> your hardware is suitable for one tenth as much load as it would be had you
+> chosen a different framework?
+>
+> --- [TechEmpower][TechEmpower-Quote]
 
-## HTTP Reader/Writer
+## What does high-performance mean?
 
-* (pri 0) design reader/writer API operating on multi-spans
-* (pri 0) performance tests and improvement
-* (pri 2) full test coverage
+It might not be the best term, but for the context of cloud apps the property
+we're seeking to improve is scalability:
 
-## Memory
+> Scalability is the capability of a system, network, or process to handle a
+> growing amount of work.
+>
+> --- [Wikipedia](https://en.wikipedia.org/wiki/Scalability)
 
-* (pri 0) Finish design and prototype of `Memory<T>`
-* (pri 0) Unify buffer pooling abstractions
+Many areas affect scale, but an efficient request/response pipeline is key as
+it's the backbone for all cloud solutions.
 
-## Infrastructure
+Other investments (faster GC, better JIT, AOT) aren't a replacement, but will
+provide additional benefits.
 
-* [done] (pri 0) Enable performance test runs
-* (pri 0) Remove IL rewriting from corefxlab
-* (pri 1) Enable allocation tests and gates
-* (pri 1) Enable C#7
+## Current areas of concerns
 
-## Architecture/Design/Other
+If we look at the .NET Stack, in particular the BCL, there are a few areas where
+we could do much better:
 
-* Remove `System.IO.Pipeline.Text.Primitives`
-* Prototype `TextReader`-like APIs
-* Refactor `System.IO.Pipeline.File` into low level and pipleline-specific APIs
-* Refactor `System.IO.Pipeline.Compression` into low level and pipeline-specific APIs
-* Design proper Web.Encoding APIs
-* Drive language integration for spans
-* Write programming guides/docs
-* Write solid set of benchmarks
-* Explore consumedBytes to be passed by-ref
-* Can we return `Span<T>` from `IOutput` (and other APIs)
-* Make sure `EndocingData` supports currency and date time formatting
-* Decide what to do with Sequences
-* How does memory relate to MSR project
-* UTF8 string representation
-* UTF8 literals
+1. Many primitive operations require allocations, causing GC pressure
+2. `String` is UTF16 but networking is UTF8, forcing translations
+3. Buffers are often defensively copied, slowing down operations and increasing
+   allocations
+4. Buffers are often not pooled, causing fragmentation and GC pressure
+5. Interop with native code often creates additional buffers to avoid passing
+   around raw pointers
+6. Async streaming forces pre-allocation of buffers, causing excessive memory
+   usage
+7. ...
 
-## Other to think about
+Our goal is to reduce the number of allocations for the basic operations, such
+as parsing and encoding, having a more efficient buffer management that can
+handle managed and native memory uniformly, and providing a programming model
+that makes the result easy to use while not losing efficiency.
 
-* Refactor networking channels
-* Productize Base64 encoding
-* SLL
-* Non-allocating compression
-* Built-in cultures
-* UtcDateTime
-* SSL
+Other components of the .NET stack (such as MVC and Serialization) will rewire
+their implementation in order to take advantage of the efficiency gains provided
+by these new APIs.
 
-## Later
+![](./img/areas.png)
 
-* XML
-* OData
-* HTML
+## New APIs
+
+Not all components of this stack are fully designed yet. The key components we
+have spiked so far are:
+
+* **Primitives**
+  - [Span\<T>][span-speclet]
+      + Represents contiguous regions of arbitrary memory (managed & native)
+      + Performance on par with `T[]`, understood by runtime and code gen
+      + Can only live on the stack
+  - [Memory\<T>][memory-speclet]
+      + Provides longer lifetime semantics to a `Span<T>`
+      + Allows storing a reference to a `Span<T>` on the heap
+* **Low-Alloc Transforms**
+  - [Parsing][parsing-speclet]
+  - [Formatting][formatting-speclet]
+* **[Pipelines][pipelines-speclet]**
+  - Leverages the primitives (`Span<T>` and `Memory<T>`) and low-allocation APIs
+  - Provides an efficient programming model while freeing the developers from
+    having to manage buffers
+
+[TechEmpower]: https://www.techempower.com/benchmarks
+[TechEmpower-Quote]: https://www.techempower.com/benchmarks/#section=motivation
+[TechEmpower13]: https://www.techempower.com/blog/2016/11/16/framework-benchmarks-round-13/
+[span-speclet]: ./specs/span.md
+[memory-speclet]: ./specs/memory.md
+[pipelines-speclet]: ./specs/pipelines.md
+[parsing-speclet]: ./specs/parsing.md
+[formatting-speclet]: ./specs/formatting.md


### PR DESCRIPTION
I was reading through the documentation and noticed a few misspelled words.  Fixed them as I noticed them.  Thanks for the great documentation.  Please let me know if I can help in any other way.