### PR TITLE
Remove obsolete Base64 APIs and use new BenchmarkDotNet attribute

### DIFF
--- a/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
@@ -290,25 +290,5 @@ namespace System.Binary.Base64
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         };
-
-        [Obsolete("Use Base64.Utf8ToBytesLength")]
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int ComputeDecodedUtf8Length(ReadOnlySpan<byte> source)
-            => Utf8ToBytesLength(source);
-
-        [Obsolete("Use Base64.Utf8ToBytes")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static OperationStatus Decode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-            => Utf8ToBytes(source, destination, out bytesConsumed, out bytesWritten);
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="buffer"></param>
-        /// <returns>Number of bytes written to the buffer.</returns>
-        [Obsolete("Use Base64.Utf8ToBytesInPlace")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static OperationStatus DecodeInPlace(Span<byte> buffer, out int bytesConsumed, out int bytesWritten)
-            => Utf8ToBytesInPlace(buffer, out bytesConsumed, out bytesWritten);
     }
 }

--- a/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
@@ -107,10 +107,10 @@ namespace System.Binary.Base64
         sealed class ToBase64Utf8 : BufferEncoder
         {
             public override OperationStatus Encode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-                => Base64.Encode(source, destination, out bytesConsumed, out bytesWritten);
+                => BytesToUtf8(source, destination, out bytesConsumed, out bytesWritten);
 
             public override OperationStatus EncodeInPlace(Span<byte> buffer, int inputLength, out int written)
-                => Base64.EncodeInPlace(buffer, inputLength, out written) ? OperationStatus.Done : OperationStatus.DestinationTooSmall;
+                => BytesToUtf8InPlace(buffer, inputLength, out written);
 
             public override bool IsEncodeInPlaceSupported => true;
         }
@@ -196,31 +196,5 @@ namespace System.Binary.Base64
         };
 
         const byte s_encodingPad = (byte)'='; // '=', for padding
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [Obsolete("Use Base64.BytesToUtf8Length")]
-        public static int ComputeEncodedUtf8Length(int sourceLength) => BytesToUtf8Length(sourceLength);
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="source"></param>
-        /// <param name="destination"></param>
-        /// <returns>Number of bytes written to the destination.</returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        [Obsolete("Use Base64.BytesToUtf8InPlace")]
-        public static OperationStatus Encode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
-            => BytesToUtf8(source, destination, out bytesConsumed, out bytesWritten);
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="buffer">Buffer containing source bytes and empty space for the encoded bytes</param>
-        /// <param name="sourceLength">Number of bytes to encode.</param>
-        /// <returns>Number of bytes written to the buffer.</returns>
-        [Obsolete("Use Base64.BytesToUtf8InPlace")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static bool EncodeInPlace(Span<byte> buffer, int sourceLength, out int bytesWritten)
-            => BytesToUtf8InPlace(buffer, sourceLength, out bytesWritten) == OperationStatus.Done;
     }
 }

--- a/tests/System.IO.Pipelines.Performance.Tests/Enumerators.cs
+++ b/tests/System.IO.Pipelines.Performance.Tests/Enumerators.cs
@@ -11,7 +11,7 @@ namespace System.IO.Pipelines.Performance.Tests
 
         private ReadableBuffer _readableBuffer;
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             _readableBuffer = BufferUtilities.CreateBuffer(Enumerable.Range(100, 200).ToArray());

--- a/tests/System.IO.Pipelines.Performance.Tests/PipeThroughput.cs
+++ b/tests/System.IO.Pipelines.Performance.Tests/PipeThroughput.cs
@@ -28,7 +28,7 @@ namespace System.IO.Pipelines.Performance.Tests
         private IPipe _pipe;
         private MemoryPool _memoryPool;
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             _memoryPool = new MemoryPool();

--- a/tests/System.IO.Pipelines.Performance.Tests/ReadCursorOperationsThroughput.cs
+++ b/tests/System.IO.Pipelines.Performance.Tests/ReadCursorOperationsThroughput.cs
@@ -29,7 +29,7 @@ namespace System.IO.Pipelines.Performance.Tests
         private ReadableBuffer _liveAspNetBuffer;
         private ReadableBuffer _liveAspNetMultiBuffer;
 
-        [Setup]
+        [GlobalSetup]
         public void Setup()
         {
             var liveaspnetRequestBytes = Encoding.UTF8.GetBytes(liveaspnetRequest);


### PR DESCRIPTION
cc @pakrym, @dotnet/corefxlab-contrib 