### PR TITLE
Switching to the new toolset compiler - 2.6.0-beta2-62211-02

### DIFF
--- a/src/System.Text.Http.Parser/HttpParser.cs
+++ b/src/System.Text.Http.Parser/HttpParser.cs
@@ -35,7 +35,7 @@ namespace System.Text.Http.Parser
             _showErrorDetails = showErrorDetails;
         }
 
-        public unsafe bool ParseRequestLine<T>(T handler, ref readonly ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined) where T : IHttpRequestLineHandler
+        public unsafe bool ParseRequestLine<T>(T handler, in ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined) where T : IHttpRequestLineHandler
         {
             consumed = buffer.Start;
             examined = buffer.End;
@@ -77,7 +77,7 @@ namespace System.Text.Http.Parser
         }
 
         static readonly byte[] s_Eol = Encoding.UTF8.GetBytes("\r\n");
-        public unsafe bool ParseRequestLine<T>(ref T handler, ref readonly ReadOnlyBytes buffer, out int consumed) where T : IHttpRequestLineHandler
+        public unsafe bool ParseRequestLine<T>(ref T handler, in ReadOnlyBytes buffer, out int consumed) where T : IHttpRequestLineHandler
         {
             // Prepare the first span
             var span = buffer.First.Span;
@@ -227,7 +227,7 @@ namespace System.Text.Http.Parser
             handler.OnStartLine(method, httpVersion, targetBuffer, pathBuffer, query, customMethod, pathEncoded);
         }
 
-        public unsafe bool ParseHeaders<T>(T handler, ref readonly ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes) where T : IHttpHeadersHandler
+        public unsafe bool ParseHeaders<T>(T handler, in ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes) where T : IHttpHeadersHandler
         {
             consumed = buffer.Start;
             examined = buffer.End;
@@ -604,7 +604,7 @@ namespace System.Text.Http.Parser
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static bool TryGetNewLineSpan(ref readonly ReadableBuffer buffer, out ReadCursor found)
+        private static bool TryGetNewLineSpan(in ReadableBuffer buffer, out ReadCursor found)
         {
             var start = buffer.Start;
             if (ReadCursorOperations.Seek(start, buffer.End, out found, ByteLF) != -1)

--- a/src/System.Text.Http.Parser/IHttpParser.cs
+++ b/src/System.Text.Http.Parser/IHttpParser.cs
@@ -7,9 +7,9 @@ namespace System.Text.Http.Parser
 {
     public interface IHttpParser
     {
-        bool ParseRequestLine<T>(T handler, ref readonly ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined) where T : IHttpRequestLineHandler;
+        bool ParseRequestLine<T>(T handler, in ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined) where T : IHttpRequestLineHandler;
 
-        bool ParseHeaders<T>(T handler, ref readonly ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes) where T : IHttpHeadersHandler;
+        bool ParseHeaders<T>(T handler, in ReadableBuffer buffer, out ReadCursor consumed, out ReadCursor examined, out int consumedBytes) where T : IHttpHeadersHandler;
 
         void Reset();
     }

--- a/src/System.Text.Json/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonReader.cs
@@ -800,7 +800,7 @@ namespace System.Text.Json
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int GetNextCharAscii(ref readonly JsonReader reader, ref byte src, int length, out char ch)
+        private static int GetNextCharAscii(in JsonReader reader, ref byte src, int length, out char ch)
         {
             if (reader.UseFastUtf8)
             {

--- a/src/System.Text.Utf8String/System/Text/Utf8String.cs
+++ b/src/System.Text.Utf8String/System/Text/Utf8String.cs
@@ -12,7 +12,7 @@ using System.Text.Utf16;
 namespace System.Text.Utf8
 {
     [DebuggerDisplay("{ToString()}u8")]
-    public partial ref struct Utf8String
+    public ref partial struct Utf8String
     {
         private readonly ReadOnlySpan<byte> _buffer;
 
@@ -534,15 +534,12 @@ namespace System.Text.Utf8
 
         public override bool Equals(object obj)
         {
-            if (obj is Utf8String)
-            {
-                return Equals((Utf8String)obj);
-            }
             if (obj is string)
             {
                 return Equals((string)obj);
             }
 
+            // obj cannot be Utf8String since it cannot be boxed
             return false;
         }
 

--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <CoreFxStableVersion>4.3.0</CoreFxStableVersion>
-    <RoslynVersion>2.6.0-beta1-62126-01</RoslynVersion>
+    <RoslynVersion>2.6.0-beta2-62211-02</RoslynVersion>
     <SystemMemoryVersion>4.5.0-preview1-25813-01</SystemMemoryVersion>
     <SystemCompilerServicesUnsafeVersion>4.5.0-preview1-25813-01</SystemCompilerServicesUnsafeVersion>
     <LibuvVersion>1.9.1</LibuvVersion>


### PR DESCRIPTION
This brings support for the final syntax of "ref readonly" and some bug fixes.
Noticeable changes:
- use `in` at declaration of "in" parameters, not `ref readonly`
- `ref` comes before `partial` when declaring partial ref structs.
- unboxing conversions for ref-like types are statically rejected as impossible to succeed

The corresponding VSIX to match these compiler bits with IDE experience is -
https://dotnet.myget.org/F/roslyn/vsix/0b48e25b-9903-4d8b-ad39-d4cca196e3c7-2.6.0.6221102.vsix