### PR TITLE
Add Base64 encoder with ParsedFormat and isFinalBlock bool

### DIFF
--- a/src/System.Binary.Base64/System.Binary.Base64.csproj
+++ b/src/System.Binary.Base64/System.Binary.Base64.csproj
@@ -9,5 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Buffers.Primitives\System.Buffers.Primitives.csproj" />
+    <ProjectReference Include="..\System.Text.Primitives\System.Text.Primitives.csproj" />
   </ItemGroup>
 </Project>

--- a/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -13,7 +14,9 @@ namespace System.Binary.Base64
     {
         public static readonly BufferEncoder BytesToUtf8Encoder = new ToBase64Utf8();
 
-        public static OperationStatus BytesToUtf8(ReadOnlySpan<byte> bytes, Span<byte> utf8, out int consumed, out int written)
+        private const int MaxLineLength = 76;
+
+        public static OperationStatus BytesToUtf8(ReadOnlySpan<byte> bytes, Span<byte> utf8, out int consumed, out int written, bool isFinalBlock = true)
         {
             ref byte srcBytes = ref bytes.DangerousGetPinnableReference();
             ref byte destBytes = ref utf8.DangerousGetPinnableReference();
@@ -33,6 +36,8 @@ namespace System.Binary.Base64
                 destIndex += 4;
                 sourceIndex += 3;
             }
+
+            if (isFinalBlock != true) throw new NotImplementedException();
 
             if (sourceIndex == srcLength - 1)
             {
@@ -61,10 +66,185 @@ namespace System.Binary.Base64
             return OperationStatus.DestinationTooSmall;
         }
 
+        private static ParsedFormat ValidateFormat(ParsedFormat format)
+        {
+            char symbol = format.Symbol;
+
+            if (symbol == 'M')  // M (for MIME) == N76
+            {
+                symbol = 'N';
+                return new ParsedFormat(symbol, MaxLineLength);
+            }
+
+            if (symbol == 'N')
+            {
+                if (format.Precision > MaxLineLength || format.Precision % 4 != 0 || format.Precision == 0)
+                {
+                    throw new FormatException($"Format {format.Symbol}:{format.Precision} not supported for Base64 Encoding.");
+                }
+                return format;
+            }
+
+            throw new FormatException($"Format {format.Symbol}:{format.Precision} not supported for Base64 Encoding.");
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int BytesToUtf8Length(int bytesLength)
         {
             Debug.Assert(bytesLength >= 0);
-            return ((bytesLength + 2) / 3) << 2;
+            checked
+            {
+                return (((bytesLength + 2) / 3) * 4);
+            }
+        }
+
+        public static int BytesToUtf8Length(int bytesLength, ParsedFormat format)
+        {
+            Debug.Assert(bytesLength >= 0);
+
+            int length = BytesToUtf8Length(bytesLength);
+            if (format.IsDefault) return length;
+
+            format = ValidateFormat(format);
+
+            int bytesInOneLine = (format.Precision >> 2) * 3;
+            int extra = ((bytesLength - 1) / bytesInOneLine) * 2;
+            checked
+            {
+                return length + extra;
+            }
+        }
+
+        public static OperationStatus BytesToUtf8Alternate(ReadOnlySpan<byte> bytes, Span<byte> utf8, out int consumed, out int written, ParsedFormat format)
+        {
+            if (format.IsDefault) return BytesToUtf8(bytes, utf8, out consumed, out written);
+
+            format = ValidateFormat(format);
+
+            int inputLength = bytes.Length;
+            int lineLength = format.Precision;
+            int bytesInOneLine = (format.Precision >> 2) * 3;
+            consumed = 0;
+            written = 0;
+            OperationStatus status = OperationStatus.Done;
+            
+            int numLineBreaks = utf8.Length / (lineLength + 2);
+            if ((utf8.Length % (lineLength + 2)) == (lineLength + 1))
+            {
+                numLineBreaks++;
+            }
+
+            for (int i = 0; i < numLineBreaks; i++)
+            {
+                status = BytesToUtf8(bytes.Slice(0, bytesInOneLine), utf8.Slice(0, lineLength), out int bytesConsumedLoop, out int bytesWrittenLoop);
+                utf8[lineLength] = (byte)'\r';
+                utf8[lineLength + 1] = (byte)'\n';
+                bytesWrittenLoop += 2;
+                bytes = bytes.Slice(bytesConsumedLoop);
+                utf8 = utf8.Slice(bytesWrittenLoop);
+                consumed += bytesConsumedLoop;
+                written += bytesWrittenLoop;
+            }
+            status = BytesToUtf8(bytes, utf8, out int leftOverbytesConsumed, out int leftOverbytesWritten);
+            consumed += leftOverbytesConsumed;
+            written += leftOverbytesWritten;
+            return status;
+        }
+
+        public static OperationStatus BytesToUtf8Alt2(ReadOnlySpan<byte> bytes, Span<byte> utf8, out int consumed, out int written, ParsedFormat format)
+        {
+            if (format.IsDefault) return BytesToUtf8(bytes, utf8, out consumed, out written);
+
+            format = ValidateFormat(format);
+
+            int lineLength = format.Precision;
+            int numLineBreaks = utf8.Length / (lineLength + 2);
+            if ((utf8.Length % (lineLength + 2)) == (lineLength + 1))
+            {
+                numLineBreaks++;
+            }
+
+            OperationStatus status = BytesToUtf8(bytes, utf8.Slice(0, utf8.Length - numLineBreaks * 2), out consumed, out written);
+
+            AddLineBreaks(utf8, lineLength, numLineBreaks);
+            written += numLineBreaks * 2;
+            return status;
+        }
+
+        public static OperationStatus BytesToUtf8(ReadOnlySpan<byte> bytes, Span<byte> utf8, out int consumed, out int written, ParsedFormat format, bool isFinalBlock = true)
+        {
+            if (format.IsDefault) return BytesToUtf8(bytes, utf8, out consumed, out written, isFinalBlock);
+
+            format = ValidateFormat(format);
+
+            int inputLength = bytes.Length;
+            int lineLength = format.Precision;
+            int bytesInOneLine = (format.Precision >> 2) * 3;
+            consumed = 0;
+            written = 0;
+            OperationStatus status = OperationStatus.Done;
+
+            int numLineBreaks = utf8.Length / (lineLength + 2);
+            if ((utf8.Length % (lineLength + 2)) == (lineLength + 1))
+            {
+                numLineBreaks++;
+            }
+
+            for (int i = 0; i < numLineBreaks; i++)
+            {
+                status = BytesToUtf8(bytes.Slice(0, bytesInOneLine), utf8.Slice(0, lineLength), out int bytesConsumedLoop, out int bytesWrittenLoop);
+                utf8[lineLength] = (byte)'\r';
+                utf8[lineLength + 1] = (byte)'\n';
+                bytesWrittenLoop += 2;
+                bytes = bytes.Slice(bytesConsumedLoop);
+                utf8 = utf8.Slice(bytesWrittenLoop);
+                consumed += bytesConsumedLoop;
+                written += bytesWrittenLoop;
+            }
+
+            if (isFinalBlock)
+            {
+                status = BytesToUtf8(bytes, utf8, out int leftOverbytesConsumed, out int leftOverbytesWritten);
+                consumed += leftOverbytesConsumed;
+                written += leftOverbytesWritten;
+                return status;
+            }
+
+            return (bytes.Length > bytesInOneLine) ? OperationStatus.DestinationTooSmall : OperationStatus.NeedMoreData;
+        }
+
+
+        private static void AddLineBreaks(Span<byte> utf8, int lineLength, int numLineBreaks)
+        {
+            //VerifyZero(utf8, numLineBreaks * 2);
+            int previousInsert = utf8.Length;
+            for (int i = 0; i < numLineBreaks; i++)
+            {
+                int startOfSlice = lineLength * (numLineBreaks - i);
+                int shiftNum = 2 * (numLineBreaks - i);
+                ShiftByN(utf8.Slice(startOfSlice, previousInsert - startOfSlice), shiftNum);
+
+                int indextoInsert = startOfSlice + shiftNum;
+                utf8[indextoInsert - 2] = (byte)'\r';
+                utf8[indextoInsert - 1] = (byte)'\n';
+                previousInsert = indextoInsert - 2;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void VerifyZero(Span<byte> utf8, int numZeroes)
+        {
+            int end = utf8.Length - 1;
+            for (int i = 0; i < numZeroes; i++)
+            {
+                if (utf8[end - i] != 0) throw new Exception();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ShiftByN(Span<byte> utf8, int num)
+        {
+            utf8.Slice(0, utf8.Length - num).CopyTo(utf8.Slice(num));
         }
 
         public static OperationStatus BytesToUtf8InPlace(Span<byte> buffer, int bytesLength, out int written)

--- a/tests/System.Binary.Base64.Tests/PerformanceTests.cs
+++ b/tests/System.Binary.Base64.Tests/PerformanceTests.cs
@@ -64,56 +64,6 @@ namespace System.Binary.Base64.Tests
         [InlineData(100)]
         [InlineData(1000)]
         [InlineData(1000 * 1000)]
-        private static void Base64EncodeWithLineBreaksAlternate(int numberOfBytes)
-        {
-            Span<byte> source = new byte[numberOfBytes];
-            Base64TestHelper.InitalizeBytes(source);
-            Span<byte> destination = new byte[Base64.BytesToUtf8Length(numberOfBytes, format)];
-
-            foreach (var iteration in Benchmark.Iterations)
-            {
-                using (iteration.StartMeasurement())
-                {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                        Base64.BytesToUtf8Alternate(source, destination, out int consumed, out int written, format);
-                }
-            }
-
-            string encodedText = Text.Encoding.ASCII.GetString(destination.ToArray());
-            string expectedText = Convert.ToBase64String(source.ToArray(), Base64FormattingOptions.InsertLineBreaks);
-            Assert.Equal(expectedText, encodedText);
-        }
-
-        [Benchmark(InnerIterationCount = InnerCount)]
-        [InlineData(10)]
-        [InlineData(100)]
-        [InlineData(1000)]
-        [InlineData(1000 * 1000)]
-        private static void Base64EncodeWithLineBreaksAlternate2(int numberOfBytes)
-        {
-            Span<byte> source = new byte[numberOfBytes];
-            Base64TestHelper.InitalizeBytes(source);
-            Span<byte> destination = new byte[Base64.BytesToUtf8Length(numberOfBytes, format)];
-
-            foreach (var iteration in Benchmark.Iterations)
-            {
-                using (iteration.StartMeasurement())
-                {
-                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
-                        Base64.BytesToUtf8Alt2(source, destination, out int consumed, out int written, format);
-                }
-            }
-
-            string encodedText = Text.Encoding.ASCII.GetString(destination.ToArray());
-            string expectedText = Convert.ToBase64String(source.ToArray(), Base64FormattingOptions.InsertLineBreaks);
-            Assert.Equal(expectedText, encodedText);
-        }
-
-        [Benchmark(InnerIterationCount = InnerCount)]
-        [InlineData(10)]
-        [InlineData(100)]
-        [InlineData(1000)]
-        [InlineData(1000 * 1000)]
         private static void Base64EncodeWithLineBreaksBaseline(int numberOfBytes)
         {
             var source = new byte[numberOfBytes];

--- a/tests/System.Binary.Base64.Tests/PerformanceTests.cs
+++ b/tests/System.Binary.Base64.Tests/PerformanceTests.cs
@@ -4,12 +4,15 @@
 
 using Xunit;
 using Microsoft.Xunit.Performance;
+using System.Buffers.Text;
 
 namespace System.Binary.Base64.Tests
 {
     public class Base64PerformanceTests
     {
         private const int InnerCount = 1000;
+
+        private static readonly ParsedFormat format = new ParsedFormat('M');
 
         [Benchmark(InnerIterationCount = InnerCount)]
         [InlineData(10)]
@@ -26,6 +29,103 @@ namespace System.Binary.Base64.Tests
                 using (iteration.StartMeasurement()) {
                     for (int i = 0; i < Benchmark.InnerIterationCount; i++)
                         Base64.BytesToUtf8(source, destination, out int consumed, out int written);
+                }
+            }
+        }
+
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(1000 * 1000)]
+        private static void Base64EncodeWithLineBreaks(int numberOfBytes)
+        {
+            Span<byte> source = new byte[numberOfBytes];
+            Base64TestHelper.InitalizeBytes(source);
+            Span<byte> destination = new byte[Base64.BytesToUtf8Length(numberOfBytes, format)];
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        Base64.BytesToUtf8(source, destination, out int consumed, out int written, format);
+                }
+            }
+
+            string encodedText = Text.Encoding.ASCII.GetString(destination.ToArray());
+            string expectedText = Convert.ToBase64String(source.ToArray(), Base64FormattingOptions.InsertLineBreaks);
+            Assert.Equal(expectedText, encodedText);
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(1000 * 1000)]
+        private static void Base64EncodeWithLineBreaksAlternate(int numberOfBytes)
+        {
+            Span<byte> source = new byte[numberOfBytes];
+            Base64TestHelper.InitalizeBytes(source);
+            Span<byte> destination = new byte[Base64.BytesToUtf8Length(numberOfBytes, format)];
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        Base64.BytesToUtf8Alternate(source, destination, out int consumed, out int written, format);
+                }
+            }
+
+            string encodedText = Text.Encoding.ASCII.GetString(destination.ToArray());
+            string expectedText = Convert.ToBase64String(source.ToArray(), Base64FormattingOptions.InsertLineBreaks);
+            Assert.Equal(expectedText, encodedText);
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(1000 * 1000)]
+        private static void Base64EncodeWithLineBreaksAlternate2(int numberOfBytes)
+        {
+            Span<byte> source = new byte[numberOfBytes];
+            Base64TestHelper.InitalizeBytes(source);
+            Span<byte> destination = new byte[Base64.BytesToUtf8Length(numberOfBytes, format)];
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        Base64.BytesToUtf8Alt2(source, destination, out int consumed, out int written, format);
+                }
+            }
+
+            string encodedText = Text.Encoding.ASCII.GetString(destination.ToArray());
+            string expectedText = Convert.ToBase64String(source.ToArray(), Base64FormattingOptions.InsertLineBreaks);
+            Assert.Equal(expectedText, encodedText);
+        }
+
+        [Benchmark(InnerIterationCount = InnerCount)]
+        [InlineData(10)]
+        [InlineData(100)]
+        [InlineData(1000)]
+        [InlineData(1000 * 1000)]
+        private static void Base64EncodeWithLineBreaksBaseline(int numberOfBytes)
+        {
+            var source = new byte[numberOfBytes];
+            Base64TestHelper.InitalizeBytes(source.AsSpan());
+            var destination = new char[Base64.BytesToUtf8Length(numberOfBytes, format)];
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                        Convert.ToBase64CharArray(source, 0, source.Length, destination, 0, Base64FormattingOptions.InsertLineBreaks);
                 }
             }
         }


### PR DESCRIPTION
Related to https://github.com/dotnet/corefx/issues/24568

The new BytesToUtf8 API that takes in a ParsedFormat was added as a proof of concept to showcase that an encoder with line break capabilities can be built on top of the existing API.

cc @dotnet/corefxlab-contrib 