### PR TITLE
Preparing APIs for Span ReaderWriter

### DIFF
--- a/src/System.Azure.Experimental/System/Azure/CosmosDbAuthorizationHeader.cs
+++ b/src/System.Azure.Experimental/System/Azure/CosmosDbAuthorizationHeader.cs
@@ -132,8 +132,10 @@ namespace System.Azure.Authentication
             totalWritten += 1;
 
             hash.Append(buffer.Slice(front.Length, totalWritten));
-            hash.GetHash(buffer.Slice(front.Length, hash.OutputSize));
-            if (Base64.BytesToUtf8InPlace(buffer.Slice(front.Length), hash.OutputSize, out written) != OperationStatus.Done)
+            if(!hash.TryWrite(buffer.Slice(front.Length), out written)){
+                throw new NotImplementedException("need to resize buffer");
+            }
+            if (Base64.BytesToUtf8InPlace(buffer.Slice(front.Length), written, out written) != OperationStatus.Done)
             {
                 throw new NotImplementedException("need to resize buffer");
             }

--- a/src/System.Azure.Experimental/System/Azure/StorageAccessSignature.cs
+++ b/src/System.Azure.Experimental/System/Azure/StorageAccessSignature.cs
@@ -62,9 +62,11 @@ namespace System.Azure.Authentication
             var formatted = output.Slice(0, bytesWritten);
 
             hash.Append(formatted);
-            hash.GetHash(output.Slice(0, hash.OutputSize));
+            if(!hash.TryWrite(output, out written)){
+                throw new NotImplementedException("need to resize buffer");
+            }
 
-            if (Base64.BytesToUtf8InPlace(output, hash.OutputSize, out written) != OperationStatus.Done)
+            if (Base64.BytesToUtf8InPlace(output, written, out written) != OperationStatus.Done)
             {
                 bytesWritten = 0;
                 return false;

--- a/src/System.Text.Primitives/System/Buffers/IWritable.cs
+++ b/src/System.Text.Primitives/System/Buffers/IWritable.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Buffers.Text;
+
+namespace System.Buffers
+{
+    public interface IWritable
+    {
+        bool TryWrite(Span<byte> buffer, out int written, ParsedFormat format = default);
+    }
+}


### PR DESCRIPTION
I am working on a prototype of self-advancing reader/writer APIs. 

This is just a preparatory work:
1. Adds IWritable interface similar to IBufferFormattable that allows custom types to write themselves to buffers as binary data.
2. Sha256 is an example of such self-writable type.
3. Changed Sha256 so it can write to buffers of equal or larger size. Before this PR the buffer had to be exact size.

CC: @ahsonkhan, @GrabYourPitchforks, @joshfree 
