### PR TITLE
Added an abstraction for in-place transformations

### DIFF
--- a/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
@@ -228,13 +228,13 @@ namespace System.Binary.Base64
             }
         }
 
-        sealed class FromBase64Utf8 : BufferDecoder
+        sealed class FromBase64Utf8 : BufferDecoder, IBufferTransformation
         {
             public override OperationStatus Decode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
                 => Utf8ToBytes(source, destination, out bytesConsumed, out bytesWritten);
 
-            public override OperationStatus DecodeInPlace(Span<byte> buffer, int inputLength, out int written)
-                => Utf8ToBytesInPlace(buffer.Slice(0, inputLength), out var consumed, out written);
+            public override OperationStatus Transform(Span<byte> buffer, int dataLength, out int written)
+                => Utf8ToBytesInPlace(buffer.Slice(0, dataLength), out var consumed, out written);
 
             public override bool IsDecodeInPlaceSupported => true;
         }

--- a/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
@@ -201,13 +201,13 @@ namespace System.Binary.Base64
             return OperationStatus.DestinationTooSmall;
         }
 
-        sealed class ToBase64Utf8 : BufferEncoder
+        sealed class ToBase64Utf8 : BufferEncoder, IBufferTransformation
         {
             public override OperationStatus Encode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
                 => BytesToUtf8(source, destination, out bytesConsumed, out bytesWritten);
 
-            public override OperationStatus EncodeInPlace(Span<byte> buffer, int inputLength, out int written)
-                => BytesToUtf8InPlace(buffer, inputLength, out written);
+            public override OperationStatus Transform(Span<byte> buffer, int dataLength, out int written)
+                => BytesToUtf8InPlace(buffer, dataLength, out written);
 
             public override bool IsEncodeInPlaceSupported => true;
         }

--- a/src/System.Buffers.Primitives/System/Buffers/BufferDecoder.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/BufferDecoder.cs
@@ -10,7 +10,7 @@ namespace System.Buffers
     {
         public abstract OperationStatus Decode(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written);
 
-        public virtual OperationStatus DecodeInPlace(Span<byte> buffer, int inputLength, out int written)
+        public virtual OperationStatus Transform(Span<byte> buffer, int inputLength, out int written)
         {
             throw new NotSupportedException();
         }

--- a/src/System.Buffers.Primitives/System/Buffers/BufferEncoder.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/BufferEncoder.cs
@@ -10,7 +10,7 @@ namespace System.Buffers
     {
         public abstract OperationStatus Encode(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written);
 
-        public virtual OperationStatus EncodeInPlace(Span<byte> buffer, int inputLength, out int written)
+        public virtual OperationStatus Transform(Span<byte> buffer, int inputLength, out int written)
         {
             throw new NotSupportedException();
         }

--- a/src/System.Buffers.Primitives/System/Buffers/Transformation.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Transformation.cs
@@ -8,6 +8,10 @@ namespace System.Buffers
     {
         OperationStatus Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written);
     }
+    public interface IBufferTransformation
+    {
+        OperationStatus Transform(Span<byte> buffer, int dataLength, out int written);
+    }
 
     public enum OperationStatus
     {

--- a/src/System.Text.Encodings.Web.Utf8/Utf8BufferEncoder.cs
+++ b/src/System.Text.Encodings.Web.Utf8/Utf8BufferEncoder.cs
@@ -30,7 +30,7 @@ namespace System.Text.Encodings.Web.Internal
             return OperationStatus.Done;
         }
 
-        public override OperationStatus DecodeInPlace(Span<byte> buffer, int length, out int written)
+        public override OperationStatus Transform(Span<byte> buffer, int length, out int written)
         {
             written = Utf8.UrlEncoder.DecodeInPlace(buffer.Slice(0, length));
             return OperationStatus.Done;

--- a/tests/System.Text.Encodings.Web.Utf8.Tests/UnescapeUrlPathInPlaceTests.cs
+++ b/tests/System.Text.Encodings.Web.Utf8.Tests/UnescapeUrlPathInPlaceTests.cs
@@ -43,7 +43,7 @@ namespace System.Text.Encodings.Web.Utf8.Tests
         protected override void TestCore(string encoded, string decoded)
         {
             var input = GetBytes(encoded).ToArray();
-            Assert.Equal(OperationStatus.Done, UrlDecoder.Utf8.DecodeInPlace(input, input.Length, out int written));
+            Assert.Equal(OperationStatus.Done, UrlDecoder.Utf8.Transform(input, input.Length, out int written));
             Assert.True(written <= input.Length);
 
             var decodedString = Encoding.UTF8.GetString(input, 0, written);


### PR DESCRIPTION
The idea is that Writer.Write method can take in IBufferTransformation to additional transform the date being written.  For example, the following code writes Base64 encoded hash to a buffer:
```c#
Span<byte> buffer = stackalloc byte[256];
var writer = new Utf8SpanWriter(buffer);

Sha256 hash = Sha256.Create(key, data);
writer.Write(hash, Base64.Encoder); // the encoder implements IBufferTransformation
```

CC: @joshfree, @ahsonkhan, @GrabYourPitchforks 