### PR TITLE
Set the DOTNET_MULTILEVEL_LOOKUP env variable in the build script.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -57,6 +57,9 @@ if [ ! -d "dotnetcli" ]; then
   fi
 fi
 
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_MULTILEVEL_LOOKUP=0
+
 dotnetExePath="dotnetcli/dotnet"
 
 myFile="corefxlab.sln"

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -37,6 +37,7 @@ if (!(Test-Path "dotnetcli\dotnet.exe")) {
 }
 
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
+$env:DOTNET_MULTILEVEL_LOOKUP = 0
 
 $dotnetExePath="$PSScriptRoot\..\dotnetcli\dotnet.exe"
 


### PR DESCRIPTION
This will override the global install of the dotnet cli and use the repo-specific version.

See https://github.com/dotnet/corefx/issues/24698#issuecomment-337794414 for more info.

cc @dotnet/corefxlab-contrib 