### PR TITLE
Added SpanWriter

### DIFF
--- a/scripts/PerfHarness/run.bat
+++ b/scripts/PerfHarness/run.bat
@@ -1,1 +1,1 @@
-..\..\dotnet\dotnet.exe run -c Release -- --perf:outputdir results --perf:typenames %1
+..\..\dotnetcli\dotnet.exe run -c Release -- --perf:outputdir results --perf:typenames %1

--- a/src/System.Azure.Experimental/System.Azure.Experimental.csproj
+++ b/src/System.Azure.Experimental/System.Azure.Experimental.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Binary.Base64\System.Binary.Base64.csproj" />
+    <ProjectReference Include="..\System.Buffers.Experimental\System.Buffers.Experimental.csproj" />
     <ProjectReference Include="..\System.Text.Encodings.Web.Utf8\System.Text.Encodings.Web.Utf8.csproj" />
   </ItemGroup>
 </Project>

--- a/src/System.Azure.Experimental/System/Azure/CosmosDbAuthorizationHeader.cs
+++ b/src/System.Azure.Experimental/System/Azure/CosmosDbAuthorizationHeader.cs
@@ -7,6 +7,7 @@ using System.Buffers.Cryptography;
 using System.Buffers.Text;
 using System.Text;
 using System.Text.Encodings.Web.Utf8;
+using static System.Buffers.Text.Encodings;
 
 namespace System.Azure.Authentication
 {   
@@ -18,6 +19,38 @@ namespace System.Azure.Authentication
         public string ResourceType;
         public string Version;
         public DateTime Time;
+
+        public static bool TryWrite2(Span<byte> output, Sha256 hash, string keyType, string verb, string resourceId, string resourceType, string tokenVersion, DateTime utc, out int bytesWritten)
+        {
+            Span<byte> buffer = stackalloc byte[AuthenticationHeaderBufferSize];
+            var writer = new SpanWriter(buffer);
+            writer.Enlarge = (minumumSize) => { return new byte[minumumSize * 2]; };
+
+            // compute signature hash
+            writer.WriteLine(verb, Ascii.ToLowercase);
+            writer.WriteLine(resourceType, Ascii.ToLowercase);
+            writer.WriteLine(resourceId, Ascii.ToLowercase);
+            writer.WriteLine(utc, 'l');
+            writer.Write('\n');
+            hash.Append(writer.Written);
+
+            // combine token
+            writer.Index = 0; // reuse writer and buffer
+            writer.Write("type=");
+            writer.Write(keyType);
+            writer.Write("&ver=");
+            writer.Write(tokenVersion);
+            writer.Write("&sig=");
+
+            writer.WriteBytes(hash, Base64.BytesToUtf8Encoder);
+
+            if (UrlEncoder.Utf8.Encode(writer.Written, output, out var consumed, out bytesWritten) != OperationStatus.Done)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+            return true;
+        }
 
         public bool TryFormat(Span<byte> buffer, out int written, ParsedFormat format = default(ParsedFormat), SymbolTable symbolTable = null)
         {

--- a/src/System.Buffers.Experimental/System/Buffers/SpanWriter.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/SpanWriter.cs
@@ -1,0 +1,207 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers.Text;
+using System.Diagnostics;
+using System.Text;
+
+namespace System.Buffers
+{
+    public ref struct SpanWriter
+    {
+        Span<byte> _buffer;
+        int _written;
+        SymbolTable _symbols;
+
+        public ReadOnlyMemory<byte> Newline;
+        public Func<int, Memory<byte>> Enlarge;
+
+        static ReadOnlyMemory<byte> s_defaultNewline = new byte[] { (byte)'\n' };
+
+        public SpanWriter(Span<byte> buffer, SymbolTable symbols = default(SymbolTable))
+        {
+            _buffer = buffer;
+            _written = 0;
+            _symbols = symbols == default(SymbolTable) ? SymbolTable.InvariantUtf8 : symbols;
+            Newline = s_defaultNewline;
+            Enlarge = null;
+        }
+
+        public void WriteBytes<T>(T value, IBufferTransformation transformation = null) where T : IWritable
+        {
+            var start = Index;
+            int written;
+            while (!value.TryWrite(Free, out written, default(ParsedFormat)))
+            {
+                Resize();
+            }
+
+            if (transformation != null)
+            {
+                var status = transformation.Transform(Buffer.Slice(start), written, out written);
+                if (status == OperationStatus.Done)
+                {
+                    _written += written;
+                    return;
+                }
+
+                if (status == OperationStatus.InvalidData || status == OperationStatus.NeedMoreData) throw new Exception("invalid value or transformation");
+                // if OperationStatus.DestinationTooSmall
+                Resize();
+                WriteBytes(value, transformation);
+            }
+        }
+
+        public void WriteText<T>(T value, IBufferTransformation transformation = null) where T : IBufferFormattable
+        {
+            var start = Index;
+            int written;
+            while (!value.TryFormat(Free, out written, default(ParsedFormat), _symbols))
+            {
+                Resize();
+            }
+
+            if (transformation != null)
+            {
+                var status = transformation.Transform(Buffer.Slice(start), written, out written);
+                if (status == OperationStatus.Done)
+                {
+                    _written += written;
+                    return;
+                }
+
+                if (status == OperationStatus.InvalidData || status == OperationStatus.NeedMoreData) throw new Exception("invalid value or transformation");
+                // if OperationStatus.DestinationTooSmall
+                Resize();
+                WriteText(value, transformation);
+            }
+        }
+
+        public void WriteLine(string text, IBufferTransformation transformation = null)
+        {
+            int start = Index;
+            int encoded;
+            while (true)
+            {
+                var status = Buffers.Text.Encodings.Utf16.ToUtf8(text.AsReadOnlySpan().AsBytes(), Free, out var consumed, out encoded);
+                if (status == OperationStatus.Done) { _written += encoded; break; }
+                if (status == OperationStatus.DestinationTooSmall) { Resize(); continue; }
+                if (status == OperationStatus.InvalidData) throw new ArgumentOutOfRangeException(nameof(text));
+                Debug.Assert(false, "this (NeedMoreData) should never happen");
+            }
+            WriteBytes(Newline);
+
+            if (transformation != null)
+            {
+                encoded = Index - start;
+                var status = transformation.Transform(Buffer.Slice(start), encoded, out int transformed);
+                if (status == OperationStatus.Done)
+                {
+                    _written += transformed - encoded; // as this was an in-place transform;
+                    return;
+                }
+
+                if (status == OperationStatus.InvalidData || status == OperationStatus.NeedMoreData) throw new Exception("invalid value or transformation");
+
+                // if OperationStatus.DestinationTooSmall
+                Resize();
+                WriteLine(text, transformation);
+            }
+        }
+
+        public void Write(string text, IBufferTransformation transformation = null)
+        {
+            int start = Index;
+            int encoded;
+            while (true)
+            {
+                var status = Buffers.Text.Encodings.Utf16.ToUtf8(text.AsReadOnlySpan().AsBytes(), Free, out var consumed, out encoded);
+                if (status == OperationStatus.Done) { _written += encoded; break; }
+                if (status == OperationStatus.DestinationTooSmall) { Resize(); continue; }
+                if (status == OperationStatus.InvalidData) throw new ArgumentOutOfRangeException(nameof(text));
+                Debug.Assert(false, "this (NeedMoreData) should never happen");
+            }
+
+            if (transformation != null)
+            {
+                var status = transformation.Transform(Buffer.Slice(start), encoded, out int transformed);
+                if (status == OperationStatus.Done)
+                {
+                    _written += transformed - encoded; // as this was an in-place transform;
+                    return;
+                }
+
+                if (status == OperationStatus.InvalidData || status == OperationStatus.NeedMoreData) throw new Exception("invalid value or transformation");
+
+                // if OperationStatus.DestinationTooSmall
+                Resize();
+                WriteLine(text, transformation);
+            }
+        }
+
+        public void Write(char character)
+        {
+            if (character > 127) throw new NotImplementedException();
+            if (Free.Length < 1) Resize();
+            Free[0] = (byte)character;
+            _written++;
+        }
+
+        public void Write(DateTime date, ParsedFormat format)
+        {
+            int written;
+            while (!date.TryFormat(Free, out written, format, _symbols)) Resize();
+            _written += written;
+        }
+        public void WriteLine(DateTime date, ParsedFormat format)
+        {
+            int written;
+            while (!date.TryFormat(Free, out written, format, _symbols)) Resize();
+            _written += written;
+            WriteBytes(Newline);
+        }
+
+        public void WriteBytes(ReadOnlySpan<byte> value)
+        {
+            if (value.Length == 0) return;
+            while (Free.Length < value.Length) Resize();
+            value.CopyTo(Free);
+            _written += value.Length;
+        }
+
+        public void WriteBytes(ReadOnlyMemory<byte> value)
+        {
+            if (value.Length == 0) return;
+            while (Free.Length < value.Length) Resize();
+            value.Span.CopyTo(Free);
+            _written += value.Length;
+        }
+
+        public Span<byte> Free => _buffer.Slice(_written);
+        public Span<byte> Written => _buffer.Slice(0, _written);
+        public Span<byte> Buffer => _buffer;
+
+        public int Index
+        {
+            get { return _written; }
+            set {
+                while (value > _buffer.Length) Resize();
+                _written = value;
+            }
+        }
+
+        private void Resize()
+        {
+            if (Enlarge == null) throw new Exception("buffer too small");
+            var newBuffer = Enlarge(_buffer.Length + 1);
+            if (newBuffer.Length <= _buffer.Length) throw new Exception("Enlarge delegate created too small buffer");
+            _buffer.CopyTo(newBuffer.Span);
+            _buffer = newBuffer.Span;
+        }
+
+        public override string ToString()
+        {
+            return Encoding.UTF8.GetString(_buffer.Slice(0, _written).ToArray(), 0, _written);
+        }
+    }
+}

--- a/src/System.Text.Primitives/System/Text/Encoders/Ascii/Ascii_casing.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Ascii/Ascii_casing.cs
@@ -12,6 +12,8 @@ namespace System.Buffers.Text
             static readonly byte[] s_toLower = new byte[128];
             static readonly byte[] s_toUpper = new byte[128];
 
+            public static readonly IBufferTransformation ToLowercase = new ToLowerTransformation();
+
             static Ascii()
             {
                 for (int i = 0; i < s_toLower.Length; i++)
@@ -68,6 +70,21 @@ namespace System.Buffers.Text
                     output[processedBytes] = s_toUpper[next];
                 }
                 return OperationStatus.Done;
+            }
+
+            internal class ToLowerTransformation : IBufferTransformation
+            {
+                OperationStatus IBufferOperation.Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written)
+                {
+                    var result = Ascii.ToLower(input, output, out written);
+                    consumed = written;
+                    return result;
+                }
+
+                OperationStatus IBufferTransformation.Transform(Span<byte> buffer, int dataLength, out int written)
+                {
+                    return Ascii.ToLowerInPlace(buffer.Slice(0, dataLength), out written);
+                }
             }
         }
     }

--- a/tests/Benchmarks/AzureBench.cs
+++ b/tests/Benchmarks/AzureBench.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Xunit.Performance;
+using System;
+using System.Azure.Authentication;
+using System.Buffers;
+using System.Buffers.Cryptography;
+using System.Buffers.Text;
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+
+public class AzureBench
+{
+    static DateTime utc = DateTime.UtcNow;
+    static string fakeKey = "TjW7xr4kKR67qgt2y3fAAMxvC2neMHT6cKawiliGCsDkxSS34V0EnwL8GKrA6ZTIfNrXK91t1Ey3RmEKQLrrCA==";
+    static string keyType = "master";
+    static string resourceType = "dbs";
+    static string version = "1.0";
+    static string resourceId = "";
+    static byte[] output = new byte[256];
+    static Sha256 sha;
+
+    static AzureBench()
+    {
+        var keyBytes = Key.ComputeKeyBytes(fakeKey);
+        sha = Sha256.Create(keyBytes);
+    }
+
+    [Benchmark]
+    static void Msdn()
+    {
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement()) {
+                CosmosDbBaselineFromMsdn(fakeKey, keyType, "GET", resourceId, resourceType, version, utc);
+            }
+        }
+    }
+
+    [Benchmark]
+    static void Raw()
+    {
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement()) {
+                CosmosDbAuthorizationHeader.TryWrite(output, sha, keyType, "GET", resourceId, resourceType, version, utc, out int bytesWritten);
+            }
+        }
+    }
+
+    [Benchmark]
+    static void Writer()
+    {
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement()) {
+                CosmosDbAuthorizationHeader.TryWrite2(output, sha, keyType, "GET", resourceId, resourceType, version, utc, out int bytesWritten);
+            }
+        }
+    }
+
+    static string CosmosDbBaselineFromMsdn(string key, string keyType, string verb, string resourceId, string resourceType, string tokenVersion, DateTime utc)
+    {
+        var keyBytes = Convert.FromBase64String(key);
+        var hmacSha256 = new HMACSHA256 { Key = keyBytes };
+        string utc_date = utc.ToString("r");
+
+        string payLoad = string.Format(CultureInfo.InvariantCulture, "{0}\n{1}\n{2}\n{3}\n{4}\n",
+                verb.ToLowerInvariant(),
+                resourceType.ToLowerInvariant(),
+                resourceId,
+                utc_date.ToLowerInvariant(),
+                ""
+        );
+
+        byte[] hashPayLoad = hmacSha256.ComputeHash(Encoding.UTF8.GetBytes(payLoad));
+        string signature = Convert.ToBase64String(hashPayLoad);
+
+        var full = String.Format(CultureInfo.InvariantCulture, "type={0}&ver={1}&sig={2}",
+            keyType,
+            tokenVersion,
+            signature);
+
+        var result = System.Text.Encodings.Web.UrlEncoder.Default.Encode(full);
+
+        return result;
+    }
+}
+

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -20,6 +20,7 @@
     <NoWarn>$(NoWarn);CS0618</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(CoreFxStableVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
@@ -27,6 +28,7 @@
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Azure.Experimental\System.Azure.Experimental.csproj" />
     <ProjectReference Include="..\..\src\System.IO.Pipelines.Extensions\System.IO.Pipelines.Extensions.csproj" />
     <ProjectReference Include="..\..\src\System.Text.Http.Parser\System.Text.Http.Parser.csproj" />
     <ProjectReference Include="..\..\src\System.Text.Http\System.Text.Http.csproj" />

--- a/tests/System.Azure.Experimental.Tests/AuthenticationTests.cs
+++ b/tests/System.Azure.Experimental.Tests/AuthenticationTests.cs
@@ -37,7 +37,23 @@ namespace System.Azure.Tests
             Assert.Equal(expected, signatureAsString);
         }
 
-        
+        [Fact]
+        public void CosmosDbAuthenticationHeaderTryWrite2()
+        {
+            var keyBytes = Key.ComputeKeyBytes(fakeKey);
+            var sha = Sha256.Create(keyBytes);
+
+            // Generate using non-allocating APIs
+            var buffer = new byte[256];
+            Assert.True(CosmosDbAuthorizationHeader.TryWrite2(buffer, sha, keyType, "get", resourceId, resourceType, version, utc, out int bytesWritten));
+            var signatureAsString = Encoding.UTF8.GetString(buffer, 0, bytesWritten);
+
+            // Generate using existing .NET APIs (sample from Asure documentation)
+            var expected = CosmosDbBaselineFromMsdn(fakeKey, keyType, "GET", resourceId, resourceType, version, utc);
+
+            Assert.Equal(expected, signatureAsString);
+        }
+
         [Fact]
         public void CosmosDbAuthenticationHeaderTryFormat()
         { 


### PR DESCRIPTION
Added a prototype of byref SpanWriter and rewrote CosmosDB authentication token generation routine using the new writer (see CosmosDbAuthorizationHeader.TryWrite2). The rewritten routine is much much simpler and the perfromance regression is pretty much insignificant (2% in instructions retired; no detectable change in time elapsed). 

Note that CosmosDbAuthorizationHeader.TryWrite2 is 3x faster than the [MSDN prescribed way of generating the header](https://docs.microsoft.com/en-us/rest/api/documentdb/access-control-on-documentdb-resources). Also, it does not allocate any GC heap memory; MSDN routine allocates 2KB per header.

See the following benchmark results. "Raw" is [the complicated generation routine using low level primitive APIs](https://github.com/dotnet/corefxlab/blob/master/src/System.Azure.Experimental/System/Azure/CosmosDbAuthorizationHeader.cs#L33), "Writer" is the routine using the new SpanWriter, and "Msdn" is an MSDN sample using allocating classic APIs.



 Test Name         | Metric                                        |  AVERAGE 
:----------------- |:--------------------------------------------- |:---------: 
 AzureBench.Msdn   | Duration                                      |     0.008 
 AzureBench.Msdn   | Instructions Retired                          | 56800 
 AzureBench.Msdn   | Branch Mispredictions                         |    24.576 
 AzureBench.Msdn   | Cache Misses                                  |    81.920 
 AzureBench.Msdn   | Allocation Size on Benchmark Execution Thread |  1920 
 AzureBench.Raw    | Duration                                      |     0.003 
 AzureBench.Raw    | Instructions Retired                          | 19300 
 AzureBench.Raw    | Branch Mispredictions                         |     0 
 AzureBench.Raw    | Cache Misses                                  |    12.288 
 AzureBench.Raw    | Allocation Size on Benchmark Execution Thread |     0 
 AzureBench.Writer | Duration                                      |     0.003 
 AzureBench.Writer | Instructions Retired                          | 19800
 AzureBench.Writer | Branch Mispredictions                         |     8.192 
 AzureBench.Writer | Cache Misses                                  |    16.384 
 AzureBench.Writer | Allocation Size on Benchmark Execution Thread |     0 

cc: @ahsonkhan, @GrabYourPitchforks, @joshfree, @ianhays, @jkotas

