### PR TITLE
Rename System.IO.Channels to System.Threading.Channels

### DIFF
--- a/src/System.Threading.Tasks.Channels/README.md
+++ b/src/System.Threading.Tasks.Channels/README.md
@@ -1,9 +1,9 @@
-# System.Threading.Tasks.Channels
+# System.Threading.Channels
 
-The System.Threading.Tasks.Channels library provides a set of synchronization data structures 
+The System.Threading.Channels library provides a set of synchronization data structures 
 for passing data between producers and consumers.  Whereas the existing System.Threading.Tasks.Dataflow 
 library is focused on pipelining and connecting together dataflow "blocks" which encapsulate both storage and 
-processing,  System.Threading.Tasks.Channels is focused purely on the storage aspect, with data structures used
+processing,  System.Threading.Channels is focused purely on the storage aspect, with data structures used
 to provide the hand-offs between participants explicitly coded to use the storage. The library is designed to be 
 used with async/await in C#.
 
@@ -306,7 +306,7 @@ for that scenario, further expanding on the kinds of such buffers available and 
 consumption models.
 
 When these Channel abstract classes become part of corefx, System.Threading.Tasks.Dataflow may take a dependency on 
-System.Threading.Tasks.Channels as a lower-level set of abstractions, replacing internal implementation details with these channels.
+System.Threading.Channels as a lower-level set of abstractions, replacing internal implementation details with these channels.
 It's also possible that several of the blocks in System.Threading.Tasks.Dataflow could be modified to relate to channels in the public API,
 enabling direct integration between the libraries.  For example, ```BufferBlock<T>```  could derive from ```Channel<T>```,
 ```ActionBlock<T>``` could derive from ```WritableChannel<T>```, etc., and/or methods could be added to support linking dataflow blocks

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/BoundedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/BoundedChannel.cs
@@ -4,10 +4,9 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
 
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     /// <summary>Provides a channel with a bounded capacity.</summary>
     [DebuggerDisplay("Items={ItemsCountForDebugger}, Capacity={_bufferedCapacity}")]

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/BoundedChannelFullMode.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/BoundedChannelFullMode.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     /// <summary>Specifies the behavior to use when writing to a bounded channel that is already full.</summary>
     public enum BoundedChannelFullMode

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/Channel.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/Channel.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     /// <summary>Provides static methods for creating channels.</summary>
     public static class Channel

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/ChannelClosedException.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/ChannelClosedException.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     /// <summary>Exception thrown when a channel is used after it's been closed.</summary>
     public class ChannelClosedException : InvalidOperationException

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/ChannelOptions.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/ChannelOptions.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     /// <summary>Provides options that control the behavior of channel instances.</summary>
     public abstract class ChannelOptions

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/ChannelReader.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/ChannelReader.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
 using System.Threading.Tasks;
 
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     /// <summary>
     /// Provides a base class for reading from a channel.

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/ChannelUtilities.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/ChannelUtilities.cs
@@ -4,10 +4,9 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
 
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     /// <summary>Provides internal helper methods for implementing channels.</summary>
     internal static class ChannelUtilities

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/ChannelWriter.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/ChannelWriter.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
 using System.Threading.Tasks;
 
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     /// <summary>
     /// Provides a base class for writing to a channel.

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/Channel_1.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/Channel_1.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     /// <summary>Provides a base class for channels that support reading and writing elements of type <typeparamref name="T"/>.</summary>
     /// <typeparam name="T">Specifies the type of data readable and writable in the channel.</typeparam>

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/Channel_2.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/Channel_2.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     /// <summary>
     /// Provides a base class for channels that support reading elements of type <typeparamref name="TRead"/>

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/IDebugEnumerator.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/IDebugEnumerator.cs
@@ -5,7 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     interface IDebugEnumerable<T>
     {

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/Interactor.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/Interactor.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
 using System.Threading.Tasks;
 
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     internal abstract class Interactor<T> : TaskCompletionSource<T>
     {

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/SingleConsumerUnboundedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/SingleConsumerUnboundedChannel.cs
@@ -5,10 +5,9 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
 
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     /// <summary>
     /// Provides a buffered channel of unbounded capacity for use by any number

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/UnboundedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/UnboundedChannel.cs
@@ -5,10 +5,9 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
 
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     /// <summary>Provides a buffered channel of unbounded capacity.</summary>
     [DebuggerDisplay("Items={ItemsCountForDebugger}")]

--- a/src/System.Threading.Tasks.Channels/System/IO/Channels/UnbufferedChannel.cs
+++ b/src/System.Threading.Tasks.Channels/System/IO/Channels/UnbufferedChannel.cs
@@ -4,10 +4,9 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
 
-namespace System.IO.Channels
+namespace System.Threading.Channels
 {
     /// <summary>Provides an unbuffered channel, such that a reader and a writer must rendezvous to succeed.</summary>
     [DebuggerDisplay("Blocked Writers: {BlockedWritersCountForDebugger}, Waiting Readers: {WaitingReadersForDebugger}")]

--- a/tests/System.Threading.Tasks.Channels.Tests/BoundedChannelTests.cs
+++ b/tests/System.Threading.Tasks.Channels.Tests/BoundedChannelTests.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.Channels.Tests
+namespace System.Threading.Channels.Tests
 {
     public class BoundedChannelTests : ChannelTestBase
     {

--- a/tests/System.Threading.Tasks.Channels.Tests/ChannelClosedExceptionTests.cs
+++ b/tests/System.Threading.Tasks.Channels.Tests/ChannelClosedExceptionTests.cs
@@ -3,7 +3,7 @@
 
 using Xunit;
 
-namespace System.IO.Channels.Tests
+namespace System.Threading.Channels.Tests
 {
     public class ChannelClosedExceptionTests
     {

--- a/tests/System.Threading.Tasks.Channels.Tests/ChannelTestBase.cs
+++ b/tests/System.Threading.Tasks.Channels.Tests/ChannelTestBase.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.Channels.Tests
+namespace System.Threading.Channels.Tests
 {
     public abstract class ChannelTestBase : TestBase
     {

--- a/tests/System.Threading.Tasks.Channels.Tests/ChannelTests.cs
+++ b/tests/System.Threading.Tasks.Channels.Tests/ChannelTests.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.Channels.Tests
+namespace System.Threading.Channels.Tests
 {
     public class ChannelTests
     {

--- a/tests/System.Threading.Tasks.Channels.Tests/TestBase.cs
+++ b/tests/System.Threading.Tasks.Channels.Tests/TestBase.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 #pragma warning disable 0649 // unused fields there for future testing needs
 
-namespace System.IO.Channels.Tests
+namespace System.Threading.Channels.Tests
 {
     public abstract class TestBase
     {

--- a/tests/System.Threading.Tasks.Channels.Tests/TestExtensions.cs
+++ b/tests/System.Threading.Tasks.Channels.Tests/TestExtensions.cs
@@ -5,7 +5,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace System.IO.Channels.Tests
+namespace System.Threading.Channels.Tests
 {
     internal static class TestExtensions
     {

--- a/tests/System.Threading.Tasks.Channels.Tests/UnboundedChannelTests.cs
+++ b/tests/System.Threading.Tasks.Channels.Tests/UnboundedChannelTests.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.Channels.Tests
+namespace System.Threading.Channels.Tests
 {
     public abstract class UnboundedChannelTests : ChannelTestBase
     {

--- a/tests/System.Threading.Tasks.Channels.Tests/UnbufferedChannelTests.cs
+++ b/tests/System.Threading.Tasks.Channels.Tests/UnbufferedChannelTests.cs
@@ -7,7 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace System.IO.Channels.Tests
+namespace System.Threading.Channels.Tests
 {
     public class UnbufferedChannelTests : ChannelTestBase
     {


### PR DESCRIPTION
Just changing the namespace (again).