### PR TITLE
Update Base64 impl to support isFinalBlock = false

### DIFF
--- a/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
@@ -213,13 +213,13 @@ namespace System.Binary.Base64
 
         public sealed class Utf8Decoder : IBufferOperation, IBufferTransformation
         {
-            public OperationStatus Decode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten/*, bool isFinalBlock*/)
+            public OperationStatus Decode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
                 => DecodeFromUtf8(source, destination, out bytesConsumed, out bytesWritten);
 
             public OperationStatus DecodeInPlace(Span<byte> buffer, int dataLength, out int written)
                 => DecodeFromUtf8InPlace(buffer, dataLength, out written);
 
-            OperationStatus IBufferOperation.Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written/*, bool isFinalBlock*/)
+            OperationStatus IBufferOperation.Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written)
                 => Decode(input, output, out consumed, out written);
 
             OperationStatus IBufferTransformation.Transform(Span<byte> buffer, int dataLength, out int written)

--- a/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Decoder.cs
@@ -12,7 +12,7 @@ namespace System.Binary.Base64
     {
         public static readonly Utf8Decoder Utf8ToBytesDecoder = new Utf8Decoder();
 
-        public static OperationStatus DecodeFromUtf8(ReadOnlySpan<byte> utf8, Span<byte> bytes, out int consumed, out int written)
+        public static OperationStatus DecodeFromUtf8(ReadOnlySpan<byte> utf8, Span<byte> bytes, out int consumed, out int written, bool isFinalBlock = true)
         {
             ref byte srcBytes = ref utf8.DangerousGetPinnableReference();
             ref byte destBytes = ref bytes.DangerousGetPinnableReference();
@@ -27,7 +27,9 @@ namespace System.Binary.Base64
 
             ref sbyte decodingMap = ref s_decodingMap[0];
 
-            while (sourceIndex < srcLength - 4)
+            int skipLastChunk = isFinalBlock ? 4 : 0;
+
+            while (sourceIndex < srcLength - skipLastChunk)
             {
                 int result = Decode(ref Unsafe.Add(ref srcBytes, sourceIndex), ref decodingMap);
                 if (result < 0) goto InvalidExit;
@@ -37,7 +39,11 @@ namespace System.Binary.Base64
                 sourceIndex += 4;
             }
 
-            if (sourceIndex >= srcLength) goto NeedMoreExit;
+            if (sourceIndex >= srcLength)
+            {
+                if (isFinalBlock) goto InvalidExit;
+                goto NeedMoreExit;
+            }
 
             int i0 = Unsafe.Add(ref srcBytes, srcLength - 4);
             int i1 = Unsafe.Add(ref srcBytes, srcLength - 3);
@@ -91,7 +97,11 @@ namespace System.Binary.Base64
 
             sourceIndex += 4;
 
-            if (srcLength != utf8.Length) goto NeedMoreExit;
+            if (srcLength != utf8.Length)
+            {
+                if (isFinalBlock) goto InvalidExit;
+                goto NeedMoreExit;
+            }
 
             DoneExit:
             consumed = sourceIndex;
@@ -114,20 +124,22 @@ namespace System.Binary.Base64
             return OperationStatus.InvalidData;
         }
 
-        public static OperationStatus DecodeFromUtf8InPlace(Span<byte> buffer, out int consumed, out int written)
+        public static OperationStatus DecodeFromUtf8InPlace(Span<byte> buffer, int dataLength, out int written)
         {
-            ref byte bufferBytes = ref buffer.DangerousGetPinnableReference();
-
-            int bufferLength = buffer.Length & ~0x3;  // only decode input up to the closest multiple of 4.
+            buffer = buffer.Slice(0, dataLength);
 
             int sourceIndex = 0;
             int destIndex = 0;
 
+            // only decode input if it is a multiple of 4
+            if (buffer.Length % 4 != 0) goto InvalidExit;
             if (buffer.Length == 0) goto DoneExit;
+
+            ref byte bufferBytes = ref buffer.DangerousGetPinnableReference();
 
             ref sbyte decodingMap = ref s_decodingMap[0];
 
-            while (sourceIndex < bufferLength - 4)
+            while (sourceIndex < buffer.Length - 4)
             {
                 int result = Decode(ref Unsafe.Add(ref bufferBytes, sourceIndex), ref decodingMap);
                 if (result < 0) goto InvalidExit;
@@ -136,12 +148,10 @@ namespace System.Binary.Base64
                 sourceIndex += 4;
             }
 
-            if (sourceIndex >= bufferLength) goto NeedMoreExit;
-
-            int i0 = Unsafe.Add(ref bufferBytes, bufferLength - 4);
-            int i1 = Unsafe.Add(ref bufferBytes, bufferLength - 3);
-            int i2 = Unsafe.Add(ref bufferBytes, bufferLength - 2);
-            int i3 = Unsafe.Add(ref bufferBytes, bufferLength - 1);
+            int i0 = Unsafe.Add(ref bufferBytes, buffer.Length - 4);
+            int i1 = Unsafe.Add(ref bufferBytes, buffer.Length - 3);
+            int i2 = Unsafe.Add(ref bufferBytes, buffer.Length - 2);
+            int i3 = Unsafe.Add(ref bufferBytes, buffer.Length - 1);
 
             i0 = Unsafe.Add(ref decodingMap, i0);
             i1 = Unsafe.Add(ref decodingMap, i1);
@@ -185,23 +195,12 @@ namespace System.Binary.Base64
                 destIndex += 1;
             }
 
-            sourceIndex += 4;
-
-            if (bufferLength != buffer.Length) goto NeedMoreExit;
-
             DoneExit:
-            consumed = sourceIndex;
             written = destIndex;
             return OperationStatus.Done;
 
-            NeedMoreExit:
-            consumed = sourceIndex;
-            written = destIndex;
-            return OperationStatus.NeedMoreData;
-
             InvalidExit:
-            consumed = sourceIndex;
-            written = destIndex;
+            written = 0;
             return OperationStatus.InvalidData;
         }
 
@@ -214,13 +213,13 @@ namespace System.Binary.Base64
 
         public sealed class Utf8Decoder : IBufferOperation, IBufferTransformation
         {
-            public OperationStatus Decode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+            public OperationStatus Decode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten/*, bool isFinalBlock*/)
                 => DecodeFromUtf8(source, destination, out bytesConsumed, out bytesWritten);
 
             public OperationStatus DecodeInPlace(Span<byte> buffer, int dataLength, out int written)
-                => DecodeFromUtf8InPlace(buffer.Slice(0, dataLength), out _, out written);
+                => DecodeFromUtf8InPlace(buffer, dataLength, out written);
 
-            OperationStatus IBufferOperation.Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written)
+            OperationStatus IBufferOperation.Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written/*, bool isFinalBlock*/)
                 => Decode(input, output, out consumed, out written);
 
             OperationStatus IBufferTransformation.Transform(Span<byte> buffer, int dataLength, out int written)

--- a/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
@@ -35,9 +35,8 @@ namespace System.Binary.Base64
                 destIndex += 4;
                 sourceIndex += 3;
             }
-
-            // TODO: Implement logic for when isFinalBlock is false
-            if (isFinalBlock != true) throw new NotImplementedException();
+            
+            if (isFinalBlock != true) goto NeedMoreDataExit;
 
             if (sourceIndex == srcLength - 1)
             {
@@ -59,6 +58,11 @@ namespace System.Binary.Base64
             consumed = sourceIndex;
             written = destIndex;
             return OperationStatus.Done;
+
+            NeedMoreDataExit:
+            consumed = sourceIndex;
+            written = destIndex;
+            return OperationStatus.NeedMoreData;
 
             DestinationSmallExit:
             consumed = sourceIndex;
@@ -163,15 +167,15 @@ namespace System.Binary.Base64
             utf8.Slice(0, utf8.Length - num).CopyTo(utf8.Slice(num));
         }
 
-        public static OperationStatus EncodeToUtf8InPlace(Span<byte> buffer, int bytesLength, out int written)
+        public static OperationStatus EncodeToUtf8InPlace(Span<byte> buffer, int dataLength, out int written)
         {
-            var encodedLength = GetMaxEncodedToUtf8Length(bytesLength);
+            var encodedLength = GetMaxEncodedToUtf8Length(dataLength);
             if (buffer.Length < encodedLength) goto FalseExit;
 
-            var leftover = bytesLength - bytesLength / 3 * 3; // how many bytes after packs of 3
+            var leftover = dataLength - dataLength / 3 * 3; // how many bytes after packs of 3
 
             var destinationIndex = encodedLength - 4;
-            var sourceIndex = bytesLength - leftover;
+            var sourceIndex = dataLength - leftover;
 
             // encode last pack to avoid conditional in the main loop
             if (leftover != 0)
@@ -202,13 +206,13 @@ namespace System.Binary.Base64
 
         public sealed class Utf8Encoder : IBufferOperation, IBufferTransformation
         {
-            public OperationStatus Encode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
+            public OperationStatus Encode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten/*, bool isFinalBlock*/)
                 => EncodeToUtf8(source, destination, out bytesConsumed, out bytesWritten);
 
             public OperationStatus EncodeInPlace(Span<byte> buffer, int dataLength, out int written)
                 => EncodeToUtf8InPlace(buffer, dataLength, out written);
 
-            OperationStatus IBufferOperation.Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written)
+            OperationStatus IBufferOperation.Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written/*, bool isFinalBlock*/)
                 => Encode(input, output, out consumed, out written);
 
             OperationStatus IBufferTransformation.Transform(Span<byte> buffer, int dataLength, out int written)

--- a/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
+++ b/src/System.Binary.Base64/System/Binary/Base64Encoder.cs
@@ -206,13 +206,13 @@ namespace System.Binary.Base64
 
         public sealed class Utf8Encoder : IBufferOperation, IBufferTransformation
         {
-            public OperationStatus Encode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten/*, bool isFinalBlock*/)
+            public OperationStatus Encode(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
                 => EncodeToUtf8(source, destination, out bytesConsumed, out bytesWritten);
 
             public OperationStatus EncodeInPlace(Span<byte> buffer, int dataLength, out int written)
                 => EncodeToUtf8InPlace(buffer, dataLength, out written);
 
-            OperationStatus IBufferOperation.Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written/*, bool isFinalBlock*/)
+            OperationStatus IBufferOperation.Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written)
                 => Encode(input, output, out consumed, out written);
 
             OperationStatus IBufferTransformation.Transform(Span<byte> buffer, int dataLength, out int written)

--- a/src/System.Buffers.Primitives/System/Buffers/Transformation.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Transformation.cs
@@ -6,7 +6,7 @@ namespace System.Buffers
 {
     public interface IBufferOperation
     {
-        OperationStatus Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written/*, bool isFinalBlock*/);
+        OperationStatus Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written);
     }
     public interface IBufferTransformation : IBufferOperation
     {

--- a/src/System.Buffers.Primitives/System/Buffers/Transformation.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Transformation.cs
@@ -6,7 +6,7 @@ namespace System.Buffers
 {
     public interface IBufferOperation
     {
-        OperationStatus Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written);
+        OperationStatus Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written/*, bool isFinalBlock*/);
     }
     public interface IBufferTransformation : IBufferOperation
     {

--- a/tests/System.Binary.Base64.Tests/PerformanceTests.cs
+++ b/tests/System.Binary.Base64.Tests/PerformanceTests.cs
@@ -157,7 +157,7 @@ namespace System.Binary.Base64.Tests
                     {
                         Span<byte> encodedSpan = new byte[length];
                         Base64.EncodeToUtf8(source, encodedSpan, out int consumed, out int written);
-                        Base64.DecodeFromUtf8InPlace(encodedSpan, out int bytesConsumed, out int bytesWritten);
+                        Base64.DecodeFromUtf8InPlace(encodedSpan, encodedSpan.Length, out int bytesWritten);
                     }
                 }
             }


### PR DESCRIPTION
Made some changes to the Base64 APIs based on https://github.com/dotnet/corefx/issues/24568#issuecomment-338833370.

Also updated DecodeFromUtf8InPlace to take in `dataLength` as arg and no longer return `out consumed`. This also means it will never return NeedsMoreData.

**Note:**
Since our IBufferOperation hasn't been updated to include isFinalBlock (along with the encoder/decoders that implement it), I have disabled the Pipe test.

cc @KrzysztofCwalina, @GrabYourPitchforks