### PR TITLE
More Utf8Span/String cleanup

### DIFF
--- a/samples/QotdService/Program.cs
+++ b/samples/QotdService/Program.cs
@@ -12,7 +12,7 @@ namespace QotdService
         public static void Main(string[] args)
         {
             var buffer = new byte[1024];
-            var quoteBytes = new Utf8Span("Insanity: doing the same thing over and over again and expecting different results. - Albert Einstein").CopyBytes();
+            var quote = new Utf8String("Insanity: doing the same thing over and over again and expecting different results. - Albert Einstein");
 
             var loop = new UVLoop();
 
@@ -22,9 +22,8 @@ namespace QotdService
             {
                 connection.ReadCompleted += (data) =>
                 {
-                    var quote = new Utf8String(quoteBytes);
-                    quote.CopyTo(buffer);
-                    connection.TryWrite(buffer, quote.Length);
+                    quote.Bytes.CopyTo(buffer);
+                    connection.TryWrite(buffer, quote.Bytes.Length);
                 };
 
                 connection.ReadStart();

--- a/src/System.Text.Http/System/Text/Http/Obsolete/HttpHeaders.cs
+++ b/src/System.Text.Http/System/Text/Http/Obsolete/HttpHeaders.cs
@@ -74,7 +74,7 @@ namespace System.Text.Http.SingleSegment
             }
 
             headerString.TrySubstringFrom((byte) ':', out headerString);
-            if (headerString.Length > 0)
+            if (!headerString.IsEmpty)
             {
                 headerString = headerString.Substring(1);
             }
@@ -85,7 +85,7 @@ namespace System.Text.Http.SingleSegment
             }
 
             headerString.TrySubstringFrom((byte)'\n', out headerString);
-            if (headerString.Length > 0)
+            if (!headerString.IsEmpty)
             {
                 headerString = headerString.Substring(1);
             }            
@@ -110,7 +110,7 @@ namespace System.Text.Http.SingleSegment
 
             public bool MoveNext()
             {
-                if (_headerString.Length == 0)
+                if (_headerString.IsEmpty)
                 {
                     return false;
                 }

--- a/src/System.Text.Http/System/Text/Http/Obsolete/HttpRequestParser.cs
+++ b/src/System.Text.Http/System/Text/Http/Obsolete/HttpRequestParser.cs
@@ -68,9 +68,9 @@ namespace System.Text.Http.SingleSegment
 
     public ref struct HttpRequestReader
     {
-        static readonly byte[] b_Http1_0 = new Utf8Span("HTTP/1.0").CopyBytes();
-        static readonly byte[] b_Http1_1 = new Utf8Span("HTTP/1.1").CopyBytes();
-        static readonly byte[] b_Http2_0 = new Utf8Span("HTTP/2.0").CopyBytes();
+        static readonly byte[] b_Http1_0 = Encoding.UTF8.GetBytes("HTTP/1.0");
+        static readonly byte[] b_Http1_1 = Encoding.UTF8.GetBytes("HTTP/1.1");
+        static readonly byte[] b_Http2_0 = Encoding.UTF8.GetBytes("HTTP/2.0");
 
         static Utf8Span s_Http1_0 => new Utf8Span(b_Http1_0);
         static Utf8Span s_Http1_1 => new Utf8Span(b_Http1_1);
@@ -177,10 +177,10 @@ namespace System.Text.Http.SingleSegment
     static class HttpRequestParser
     {
         // TODO: these copies should be eliminated
-        static readonly byte[] b_Get = new Utf8Span("GET ").CopyBytes();
-        static readonly byte[] b_Post = new Utf8Span("POST ").CopyBytes();
-        static readonly byte[] b_Put = new Utf8Span("PUT ").CopyBytes();
-        static readonly byte[] b_Delete = new Utf8Span("DELETE ").CopyBytes();
+        static readonly byte[] b_Get = Encoding.UTF8.GetBytes("GET ");
+        static readonly byte[] b_Post = Encoding.UTF8.GetBytes("POST ");
+        static readonly byte[] b_Put = Encoding.UTF8.GetBytes("PUT ");
+        static readonly byte[] b_Delete = Encoding.UTF8.GetBytes("DELETE ");
 
         static Utf8Span s_Get => new Utf8Span(b_Get);
         static Utf8Span s_Post => new Utf8Span(b_Post);
@@ -214,28 +214,28 @@ namespace System.Text.Http.SingleSegment
             if(bufferString.StartsWith(s_Get))
             {
                 method = HttpMethod.Get;
-                parsedBytes = s_Get.Length;
+                parsedBytes = s_Get.Bytes.Length;
                 return true;
             }
 
             if (bufferString.StartsWith(s_Post))
             {
                 method = HttpMethod.Post;
-                parsedBytes = s_Post.Length;
+                parsedBytes = s_Post.Bytes.Length;
                 return true;
             }
 
             if (bufferString.StartsWith(s_Put))
             {
                 method = HttpMethod.Put;
-                parsedBytes = s_Put.Length;
+                parsedBytes = s_Put.Bytes.Length;
                 return true;
             }
 
             if (bufferString.StartsWith(s_Delete))
             {
                 method = HttpMethod.Delete;
-                parsedBytes = s_Delete.Length;
+                parsedBytes = s_Delete.Bytes.Length;
                 return true;
             }
 

--- a/src/System.Text.Json.Dynamic/System/Text/Json/JsonDynamicObject.cs
+++ b/src/System.Text.Json.Dynamic/System/Text/Json/JsonDynamicObject.cs
@@ -330,15 +330,7 @@ namespace System.Text.Json
                 return false;
             }
 
-            public override int GetHashCode()
-            {
-                int result = Object.GetHashCode();
-                ReadOnlySpan<byte> nameBytes = _name.Bytes;
-                result = result * 19 + nameBytes[0];
-                result = result * 19 + nameBytes[_name.Length - 1];
-                result = result * 19 + nameBytes[_name.Length>>2];
-                return result;
-            }
+            public override int GetHashCode() => _name.GetHashCode();
 
             public bool TryFormat(Span<byte> buffer, out int written, ParsedFormat format, SymbolTable symbolTable)
             {

--- a/src/System.Text.Json/System/Text/Json/JsonParser.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonParser.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Buffers.Text;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Utf8;
@@ -423,7 +424,7 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SkipWhitespace()
         {
-            while (Utf8Helper.IsWhitespace(_values[_valuesIndex])) {
+            while (Unicode.IsWhitespace(_values[_valuesIndex])) {
                 _valuesIndex++;
             }
         }

--- a/src/System.Text.Primitives/System/Text/Encoders/Unicode/Unicode.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Unicode/Unicode.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace System.Buffers.Text
+{
+    public static class Unicode
+    {
+        // TODO: Make this immutable and let them be strong typed
+        // http://unicode.org/cldr/utility/list-unicodeset.jsp?a=\p{whitespace}&g=&i=
+        private static readonly uint[] SortedWhitespaceCodePoints = new uint[]
+        {
+            0x0009, 0x000A, 0x000B, 0x000C, 0x000D,
+            0x0020,
+            0x0085,
+            0x00A0,
+            0x1680,
+            0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006,
+            0x2007,
+            0x2008, 0x2009, 0x200A,
+            0x2028, 0x2029,
+            0x202F,
+            0x205F,
+            0x3000
+        };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsWhitespace(uint codePoint)
+        {
+            return Array.BinarySearch<uint>(SortedWhitespaceCodePoints, codePoint) >= 0;
+        }
+    }
+}

--- a/src/System.Text.Utf8String/System/Text/Utf8Helper.cs
+++ b/src/System.Text.Utf8String/System/Text/Utf8Helper.cs
@@ -5,28 +5,9 @@ using System.Runtime.CompilerServices;
 
 namespace System.Text
 {
-    public static class Utf8Helper
+    internal static class Utf8Helper
     {
         #region Constants
-
-        // TODO: Make this immutable and let them be strong typed
-        // http://unicode.org/cldr/utility/list-unicodeset.jsp?a=\p{whitespace}&g=&i=
-        private static readonly uint[] SortedWhitespaceCodePoints = new uint[]
-        {
-            0x0009, 0x000A, 0x000B, 0x000C, 0x000D,
-            0x0020,
-            0x0085,
-            0x00A0,
-            0x1680,
-            0x2000, 0x2001, 0x2002, 0x2003, 0x2004, 0x2005, 0x2006,
-            0x2007,
-            0x2008, 0x2009, 0x200A,
-            0x2028, 0x2029,
-            0x202F,
-            0x205F,
-            0x3000
-        };
-
         // To get this to compile with dotnet cli, we need to temporarily un-binary the magic values
         private const byte b0000_0111U = 0x07; //7
         private const byte b0000_1111U = 0x0F; //15
@@ -221,12 +202,6 @@ namespace System.Text
             codePoint = unchecked((uint)char.ConvertToUtf32(s, index));
 
             return true;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsWhitespace(uint codePoint)
-        {
-            return Array.BinarySearch<uint>(SortedWhitespaceCodePoints, codePoint) >= 0;
         }
     }
 }

--- a/src/System.Text.Utf8String/System/Text/Utf8String.cs
+++ b/src/System.Text.Utf8String/System/Text/Utf8String.cs
@@ -20,24 +20,23 @@ namespace System.Text.Utf8
 
         static Utf8String s_empty = new Utf8String(string.Empty);
 
-        public Utf8String(ReadOnlySpan<byte> buffer) => _buffer = buffer.ToArray();
+        public Utf8String(ReadOnlySpan<byte> utf8Bytes) => _buffer = utf8Bytes.ToArray();
         public Utf8String(Utf8Span utf8Span) => _buffer = utf8Span.Bytes.ToArray();
-        private Utf8String(byte[] dangerousBuffer) => _buffer = dangerousBuffer;
 
-        public Utf8String(string str)
+        public Utf8String(string utf16String)
         {
-            if (str == null)
+            if (utf16String == null)
             {
                 throw new ArgumentNullException("s", "String cannot be null");
             }
 
-            if (str == string.Empty)
+            if (utf16String == string.Empty)
             {
                 _buffer = ReadOnlySpan<byte>.Empty.ToArray();
             }
             else
             {
-                _buffer = Encoding.UTF8.GetBytes(str);
+                _buffer = Encoding.UTF8.GetBytes(utf16String);
             }
         }
 
@@ -45,79 +44,59 @@ namespace System.Text.Utf8
         /// This constructor is for use by the compiler.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public Utf8String(RuntimeFieldHandle utf8Data, int length) {
+        public Utf8String(RuntimeFieldHandle utf8Bytes, int length) {
             _buffer = new byte[length];
-            RuntimeHelpers.InitializeArray(_buffer, utf8Data);
+            RuntimeHelpers.InitializeArray(_buffer, utf8Bytes);
         }
 
-        public static explicit operator Utf8String(ArraySegment<byte> utf8Bytes)
-            => new Utf8String(utf8Bytes);
+        private Utf8String(byte[] noCopyUtf8Bytes) => _buffer = noCopyUtf8Bytes;
 
-        public static Utf8String Empty { get { return s_empty; } }
+        public static Utf8String Empty => s_empty;
 
-        /// <summary>
-        /// Returns length of the string in UTF-8 code units (bytes)
-        /// </summary>
-        public int Length => _buffer.Length;
+        public bool IsEmpty => Bytes.Length == 0;
 
-        public static implicit operator ReadOnlySpan<byte>(Utf8String utf8) => utf8.Bytes;
+        public Utf8CodePointEnumerator GetEnumerator() => new Utf8CodePointEnumerator(_buffer);
+
+        public static implicit operator ReadOnlySpan<byte>(Utf8String utf8String) => utf8String.Bytes;
         
-        public static explicit operator Utf8String(string s) => new Utf8String(s);
+        public static explicit operator Utf8String(string utf16String) => new Utf8String(utf16String);
         
-        public static explicit operator string(Utf8String s) => s.ToString();
+        public static explicit operator string(Utf8String utf8String) => utf8String.ToString();
 
         public ReadOnlySpan<byte> Bytes => _buffer;
 
-        public override string ToString()
-        {
-            // TODO: why do we return status here?
-            var status = Encodings.Utf8.ToUtf16Length(this.Bytes, out int bytesNeeded);
-            var result = new String(' ', bytesNeeded >> 1);
-            unsafe {
-                fixed(char* pResult = result){
-                    var resultBytes = new Span<byte>((void*)pResult, bytesNeeded);
-                    if(Encodings.Utf8.ToUtf16(this.Bytes, resultBytes, out int consumed, out int written) == OperationStatus.Done){
-                        Debug.Assert(written == resultBytes.Length);
-                        return result;
-                    }
-                }
-            }
-            return String.Empty; // TODO: is this what we want to do if Bytes are invalid UTF8? Can Bytes be invalid UTF8?
-        }
+        internal Utf8Span Span => new Utf8Span(Bytes);
+
+        public override string ToString() => Span.ToString();
 
         public bool ReferenceEquals(Utf8String other) => Object.ReferenceEquals(this, other);
 
         public bool Equals(Utf8String other) => Bytes.SequenceEqual(other.Bytes);
+        public bool Equals(Utf8Span other) => Bytes.SequenceEqual(other.Bytes);
+        public bool Equals(string other) => Span.Equals(other);
 
-        // TODO: is this efficient enough?
-        public bool Equals(string other)
+        public override bool Equals(object obj)
         {
-            Utf8CodePointEnumerator thisEnumerator = GetEnumerator();
-            Debug.Assert(BitConverter.IsLittleEndian);
-            Utf16LittleEndianCodePointEnumerator otherEnumerator = new Utf16LittleEndianCodePointEnumerator(other);
-
-            while (true)
+            if (obj is Utf8String)
             {
-                bool hasNext = thisEnumerator.MoveNext();
-                if (hasNext != otherEnumerator.MoveNext())
-                {
-                    return false;
-                }
-
-                if (!hasNext)
-                {
-                    return true;
-                }
-
-                if (thisEnumerator.Current != otherEnumerator.Current)
-                {
-                    return false;
-                }
+                return Equals((Utf8String)obj);
             }
+            if (obj is string)
+            {
+                return Equals((string)obj);
+            }
+
+            return false;
         }
+
+        public override int GetHashCode() => Span.GetHashCode();
 
         public static bool operator ==(Utf8String left, Utf8String right) => left.Equals(right);
         public static bool operator !=(Utf8String left, Utf8String right) => !left.Equals(right);
+        public static bool operator ==(Utf8String left, Utf8Span right) => left.Equals(right);
+        public static bool operator !=(Utf8String left, Utf8Span right) => !left.Equals(right);
+        public static bool operator ==(Utf8Span left, Utf8String right) => right.Equals(left);
+        public static bool operator !=(Utf8Span left, Utf8String right) => !right.Equals(left);
 
         // TODO: do we like all these O(N) operators? 
         public static bool operator ==(Utf8String left, string right) => left.Equals(right);
@@ -125,169 +104,27 @@ namespace System.Text.Utf8
         public static bool operator ==(string left, Utf8String right) => right.Equals(left);
         public static bool operator !=(string left, Utf8String right) => !right.Equals(left);
 
-        // TODO: implement Utf8String.CompareTo
-        public int CompareTo(Utf8String other) => throw new NotImplementedException();
-        public int CompareTo(string other) => throw new NotImplementedException();
+        public int CompareTo(Utf8String other) => Span.CompareTo(other);
+        public int CompareTo(string other) => Span.CompareTo(other);
+        public int CompareTo(Utf8Span other) => Span.CompareTo(other);
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="index">Index in UTF-8 code units (bytes)</param>
-        /// <returns>Length in UTF-8 code units (bytes)</returns>
-        // TODO: should all Utf8String slicing operations return Utf8Span?
-        public Utf8String Substring(int index) => Substring(index, Length - index);
+        public bool StartsWith(uint codePoint) => Span.StartsWith(codePoint);
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="index">Index in UTF-8 code units (bytes)</param>
-        /// <returns>Length in UTF-8 code units (bytes)</returns>
-        public Utf8String Substring(int index, int length)
-        {
-            if (length == 0)
-            {
-                return Empty;
-            }
+        public bool StartsWith(Utf8String value) => Span.StartsWith(value.Span);
 
-            return new Utf8String(_buffer.AsSpan().Slice(index, length));
-        }
+        public bool StartsWith(Utf8Span value) => Span.StartsWith(value);
 
-        // TODO: Naive algorithm, reimplement faster
-        // TODO: Should this be public?
-        public int IndexOf(Utf8String value)
-        {
-            if (value.Length == 0)
-            {
-                // TODO: Is this the right answer?
-                // TODO: Does this even make sense?
-                return 0;
-            }
+        public bool EndsWith(Utf8String value) => Span.EndsWith(value.Span);
 
-            if (Length == 0)
-            {
-                return StringNotFound;
-            }
+        public bool EndsWith(Utf8Span value) => Span.EndsWith(value);
 
-            Utf8String restOfTheString = this;
-            for (int i = 0; restOfTheString.Length <= Length; restOfTheString = Substring(++i))
-            {
-                int pos = restOfTheString.IndexOf(value.Bytes[0]);
-                if (pos == StringNotFound)
-                {
-                    return StringNotFound;
-                }
-                i += pos;
-                if (IsSubstringAt(i, value))
-                {
-                    return i;
-                }
-            }
+        public bool EndsWith(uint codePoint) => Span.EndsWith(codePoint);
 
-            return StringNotFound;
-        }
-
-        // TODO: Should this be public?
-        public int IndexOf(byte codeUnit) => _buffer.AsSpan().IndexOf(codeUnit);
-
-        // TODO: Should this be public?
-        public int IndexOf(uint codePoint)
-        {
-            Utf8CodePointEnumerator it = GetEnumerator();
-            while (it.MoveNext())
-            {
-                if (it.Current == codePoint)
-                {
-                    return it.PositionInCodeUnits;
-                }
-            }
-
-            return StringNotFound;
-        }
-
-        // TODO: Naive algorithm, reimplement faster - implemented to keep parity with IndexOf
-        public int LastIndexOf(Utf8String value)
-        {
-            // Special case for looking for empty strings
-            if (value.Length == 0)
-            {
-                // Maintain parity with .NET C#'s LastIndexOf
-                return Length == 0 ? 0 : Length - 1;
-            }
-
-            if (Length == 0)
-            {
-                return StringNotFound;
-            }
-
-            Utf8String restOfTheString = this;
-
-            for (int i = Length - 1; i >= value.Length - 1; restOfTheString = Substring(0, i--))
-            {
-                int pos = restOfTheString.LastIndexOf(value.Bytes[value.Length - 1]);
-                if (pos == StringNotFound)
-                {
-                    return StringNotFound;
-                }
-
-                int substringStart = pos - (value.Length - 1);
-                if (IsSubstringAt(substringStart, value))
-                {
-                    return substringStart;
-                }
-
-            }
-
-            return StringNotFound;
-
-        }
-
-        public int LastIndexOf(byte codeUnit)
-        {
-            for (int i = Length - 1; i >= 0; i--)
-            {
-                if (codeUnit == Bytes[i])
-                {
-                    return i;
-                }
-            }
-
-            return StringNotFound;
-        }
-
-        public int LastIndexOf(uint codePoint)
-        {
-            var it = new Utf8CodePointReverseEnumerator(Bytes);
-            while (it.MoveNext())
-            {
-                if (it.Current == codePoint)
-                {
-                    // Move to beginning of code point
-                    it.MoveNext();
-                    return it.PositionInCodeUnits;
-                }
-            }
-
-            return StringNotFound;
-        }
-
+        #region Slicing
         // TODO: Re-evaluate all Substring family methods and check their parameters name
         public bool TrySubstringFrom(Utf8String value, out Utf8String result)
         {
             int idx = IndexOf(value);
-
-            if (idx == StringNotFound)
-            {
-                result = default;
-                return false;
-            }
-
-            result = Substring(idx);
-            return true;
-        }
-
-        public bool TrySubstringFrom(byte codeUnit, out Utf8String result)
-        {
-            int idx = IndexOf(codeUnit);
 
             if (idx == StringNotFound)
             {
@@ -327,20 +164,6 @@ namespace System.Text.Utf8
             return true;
         }
 
-        public bool TrySubstringTo(byte codeUnit, out Utf8String result)
-        {
-            int idx = IndexOf(codeUnit);
-
-            if (idx == StringNotFound)
-            {
-                result = default;
-                return false;
-            }
-
-            result = Substring(0, idx);
-            return true;
-        }
-
         public bool TrySubstringTo(uint codePoint, out Utf8String result)
         {
             int idx = IndexOf(codePoint);
@@ -355,154 +178,20 @@ namespace System.Text.Utf8
             return true;
         }
 
-        public bool IsSubstringAt(int index, Utf8String s)
-        {
-            if (index < 0 || index + s.Length > Length)
-            {
-                return false;
-            }
-
-            return Substring(index, s.Length).Equals(s);
-        }
-
-        public void CopyTo(Span<byte> buffer) => _buffer.CopyTo(buffer);
-
-        // TODO: write better hashing function
-        // TODO: span.GetHashCode() + some constant?
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                if (Length <= 4)
-                {
-                    int hash = Length;
-                    for (int i = 0; i < Length; i++)
-                    {
-                        hash <<= 8;
-                        hash ^= (byte)Bytes[i];
-                    }
-                    return hash;
-                }
-                else
-                {
-                    int hash = Length;
-                    hash ^= (byte)Bytes[0];
-                    hash <<= 8;
-                    hash ^= (byte)Bytes[1];
-                    hash <<= 8;
-                    hash ^= (byte)Bytes[Length - 2];
-                    hash <<= 8;
-                    hash ^= (byte)Bytes[Length - 1];
-                    return hash;
-                }
-            }
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is Utf8String)
-            {
-                return Equals((Utf8String)obj);
-            }            
-            if (obj is string)
-            {
-                return Equals((string)obj);
-            }
-
-            return false;
-        }
-
-        public Utf8CodePointEnumerator GetEnumerator()
-        {
-            return new Utf8CodePointEnumerator(_buffer);
-        }
-
-        public bool StartsWith(uint codePoint)
-        {
-            Utf8CodePointEnumerator e = GetEnumerator();
-            if (!e.MoveNext())
-            {
-                return false;
-            }
-
-            return e.Current == codePoint;
-        }
-
-        public bool StartsWith(byte codeUnit)
-        {
-            if (Length == 0)
-            {
-                return false;
-            }
-
-            return Bytes[0] == codeUnit;
-        }
-
-        public bool StartsWith(Utf8String value)
-        {
-            if (value.Length > this.Length)
-            {
-                return false;
-            }
-
-            return this.Substring(0, value.Length).Equals(value);
-        }
-
-        public bool EndsWith(byte codeUnit)
-        {
-            if (Length == 0)
-            {
-                return false;
-            }
-
-            return Bytes[Length - 1] == codeUnit;
-        }
-
-        public bool EndsWith(Utf8String value)
-        {
-            if (Length < value.Length)
-            {
-                return false;
-            }
-
-            return this.Substring(Length - value.Length, value.Length).Equals(value);
-        }
-
-        public bool EndsWith(uint codePoint)
-        {
-            throw new NotImplementedException();
-        }
-
-        // TODO: This should return Utf16CodeUnits which should wrap byte[]/Span<byte>, same for other encoders
-        private static byte[] GetUtf8BytesFromString(string str)
-        {
-            var utf16 = str.AsReadOnlySpan().AsBytes();
-            var status = Encodings.Utf16.ToUtf8Length(utf16, out int needed);
-            if (status != Buffers.OperationStatus.Done)
-                return null;
-
-            var utf8 = new byte[needed];
-            status = Encodings.Utf16.ToUtf8(utf16, utf8, out int consumed, out int written);
-            if (status != Buffers.OperationStatus.Done)
-                // This shouldn't happen...
-                return null;
-
-            return utf8;
-        }
+        public Utf8String Trim() => TrimStart().TrimEnd();
 
         public Utf8String TrimStart()
         {
             Utf8CodePointEnumerator it = GetEnumerator();
-            while (it.MoveNext() && Utf8Helper.IsWhitespace(it.Current))
+            while (it.MoveNext() && Unicode.IsWhitespace(it.Current))
             {
             }
 
             return Substring(it.PositionInCodeUnits);
         }
 
-        // TODO: implement Utf8String.TrimStart
+        // TODO: implement Utf8String.Trim* methods
         public Utf8String TrimStart(uint[] trimCodePoints) => throw new NotImplementedException();
-        public Utf8String TrimStart(byte[] trimCodeUnits) => throw new NotImplementedException();
 
         public Utf8String TrimStart(Utf8String trimCharacters)
         {
@@ -544,17 +233,14 @@ namespace System.Text.Utf8
         public Utf8String TrimEnd()
         {
             var it = new Utf8CodePointReverseEnumerator(Bytes);
-            while (it.MoveNext() && Utf8Helper.IsWhitespace(it.Current))
+            while (it.MoveNext() && Unicode.IsWhitespace(it.Current))
             {
             }
 
             return Substring(0, it.PositionInCodeUnits);
         }
 
-        // TODO: implement Utf8String.TrimEnd
         public Utf8String TrimEnd(uint[] trimCodePoints) => throw new NotImplementedException();
-
-        public Utf8String TrimEnd(byte[] trimCodeUnits) => throw new NotImplementedException();
 
         public Utf8String TrimEnd(Utf8String trimCharacters)
         {
@@ -593,14 +279,32 @@ namespace System.Text.Utf8
             return Substring(0, it.PositionInCodeUnits);
         }
 
-        public Utf8String Trim()
+        public Utf8String Trim(uint[] trimCodePoints) => throw new NotImplementedException();
+        #endregion
+
+        // TODO: should we even have index based operations?
+        #region Index-based operations
+        public Utf8String Substring(int index) => Substring(index, Bytes.Length - index);
+
+        public Utf8String Substring(int index, int length)
         {
-            return TrimStart().TrimEnd();
+            if (length == 0)
+            {
+                return Empty;
+            }
+
+            return new Utf8String(_buffer.AsSpan().Slice(index, length));
         }
 
-        // TODO: implement Utf8String.Trim
-        public Utf8String Trim(uint[] trimCodePoints) => throw new NotImplementedException();
+        public int IndexOf(Utf8String value) => Bytes.IndexOf(value.Bytes);
 
-        public Utf8String Trim(byte[] trimCodeUnits) => throw new NotImplementedException();
+        public int IndexOf(uint codePoint) => Span.IndexOf(codePoint);
+
+        public int LastIndexOf(Utf8String value) => Span.LastIndexOf(value.Span);
+
+        public int LastIndexOf(uint codePoint) => Span.LastIndexOf(codePoint);
+
+        public bool IsSubstringAt(int index, Utf8String utf8String) => Span.IsSubstringAt(index, utf8String.Span);
+        #endregion
     }
 }

--- a/tests/System.Text.Http.Tests/GivenAnHttpHeaders.cs
+++ b/tests/System.Text.Http.Tests/GivenAnHttpHeaders.cs
@@ -43,7 +43,7 @@ namespace System.Text.Http.Tests
         public void It_returns_empty_string_when_header_is_not_present()
         {
             var httpHeader = new HttpHeadersSingleSegment(new Span<byte>(new UTF8Encoding().GetBytes(HeadersString)));
-            httpHeader["Content-Length"].Length.Should().Be(0);
+            httpHeader["Content-Length"].IsEmpty.Should().Be(true);
         }
 
         //[Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
@@ -121,13 +121,13 @@ namespace System.Text.Http.Tests
         //[Fact(Skip = "System.TypeLoadException : The generic type 'System.Collections.Generic.KeyValuePair`2' was used with an invalid instantiation in assembly 'System.Private.CoreLib")]
         public void CanParseBodylessRequest()
         {
-            var request = new Utf8Span("GET / HTTP/1.1\r\nConnection: close\r\n\r\n").CopyBytes().AsSpan();
+            var request = new Utf8Span("GET / HTTP/1.1\r\nConnection: close\r\n\r\n").Bytes;
             var parsed = HttpRequestSingleSegment.Parse(request);
             Assert.Equal(HttpMethod.Get, parsed.RequestLine.Method);
             Assert.Equal(HttpVersion.V1_1, parsed.RequestLine.Version);
             Assert.Equal("/", parsed.RequestLine.RequestUri.ToString(SymbolTable.InvariantUtf8));
             Assert.Equal(1, parsed.Headers.Count);
-            Assert.Equal(0, parsed.Body.Length);
+            Assert.True(parsed.Body.IsEmpty);
         }
     }
 }

--- a/tests/System.Text.Utf8String.Tests/TestHelper.cs
+++ b/tests/System.Text.Utf8String.Tests/TestHelper.cs
@@ -10,13 +10,13 @@ namespace System.Text.Utf8.Tests
     {
         public static void Validate(Utf8String str1, Utf8String str2)
         {
-            Assert.Equal(str1.Length, str2.Length);
+            Assert.Equal(str1.Bytes.Length, str2.Bytes.Length);
             Assert.True(str1.Bytes.SequenceEqual(str2.Bytes));
         }
 
         public static void Validate(Utf8Span str1, Utf8Span str2)
         {
-            Assert.Equal(str1.Length, str2.Length);
+            Assert.Equal(str1.Bytes.Length, str2.Bytes.Length);
             Assert.True(str1.Bytes.SequenceEqual(str2.Bytes));
         }
     }

--- a/tests/System.Text.Utf8String.Tests/Utf8Span.RandomTests.cs
+++ b/tests/System.Text.Utf8String.Tests/Utf8Span.RandomTests.cs
@@ -47,7 +47,7 @@ namespace System.Text.Utf8.Tests
         public void Length(int expectedLength, string str)
         {
             Utf8Span s = new Utf8Span(str);
-            Assert.Equal(expectedLength, s.Length);
+            Assert.Equal(expectedLength, s.Bytes.Length);
         }
 
         public static object[][] LengthInCodePointsTestCases = {
@@ -143,32 +143,6 @@ namespace System.Text.Utf8.Tests
         };
 
         [Theory]
-        [InlineData("", 'a')]
-        [InlineData("abc", 'a')]
-        [InlineData("v", 'v')]
-        [InlineData("1", 'a')]
-        [InlineData("1a", 'a')]
-        public void StartsWithCodeUnit(string s, char c)
-        {
-            Utf8Span u8s = new Utf8Span(s);
-            byte codeUnit = (byte)c;
-            Assert.Equal(s.StartsWith(c.ToString()), u8s.StartsWith(codeUnit));
-        }
-
-        [Theory]
-        [InlineData("", 'a')]
-        [InlineData("cba", 'a')]
-        [InlineData("v", 'v')]
-        [InlineData("1", 'a')]
-        [InlineData("a1", 'a')]
-        public void EndsWithCodeUnit(string s, char c)
-        {
-            Utf8Span u8s = new Utf8Span(s);
-            byte codeUnit = (byte)c;
-            Assert.Equal(s.EndsWith(c.ToString()), u8s.EndsWith(codeUnit));
-        }
-
-        [Theory]
         [InlineData("", "a")]
         [InlineData("abc", "a")]
         [InlineData("v", "v")]
@@ -200,30 +174,6 @@ namespace System.Text.Utf8.Tests
             Utf8Span u8pattern = new Utf8Span(pattern);
 
             Assert.Equal(s.EndsWith(pattern), u8s.EndsWith(u8pattern));
-        }
-
-        [Theory]
-        [InlineData("", 'a')]
-        [InlineData("abc", 'a')]
-        [InlineData("abc", 'b')]
-        [InlineData("abc", 'c')]
-        [InlineData("abc", 'd')]
-        public void SubstringFromCodeUnit(string s, char c)
-        {
-            Utf8Span u8s = new Utf8Span(s);
-            byte codeUnit = (byte)(c);
-            Utf8Span u8result;
-
-            int idx = s.IndexOf(c);
-            bool expectedToFind = idx != -1;
-
-            Assert.Equal(expectedToFind, u8s.TrySubstringFrom(codeUnit, out u8result));
-            if (expectedToFind)
-            {
-                string expected = s.Substring(idx);
-                TestHelper.Validate(new Utf8Span(expected), u8result);
-                Assert.Equal(expected, u8result.ToString());
-            }
         }
 
         [Theory]
@@ -436,19 +386,19 @@ namespace System.Text.Utf8.Tests
                 TestHelper.Validate(strFromArray, strFromPointer);
 
                 Array.Clear(buffer, 0, buffer.Length);
-                strFromArray.CopyTo(byteSpan);
+                strFromArray.Bytes.CopyTo(byteSpan);
                 Assert.Equal(textArray, buffer);
 
                 Array.Clear(buffer, 0, buffer.Length);
-                strFromPointer.CopyTo(byteSpan);
+                strFromPointer.Bytes.CopyTo(byteSpan);
                 Assert.Equal(textArray, buffer);
 
                 Array.Clear(buffer, 0, buffer.Length);
-                strFromArray.CopyTo(buffer);
+                strFromArray.Bytes.CopyTo(buffer);
                 Assert.Equal(textArray, buffer);
 
                 Array.Clear(buffer, 0, buffer.Length);
-                strFromPointer.CopyTo(buffer);
+                strFromPointer.Bytes.CopyTo(buffer);
                 Assert.Equal(textArray, buffer);
             }
         }
@@ -489,20 +439,20 @@ namespace System.Text.Utf8.Tests
         private void TestHashesSameForEquivalentString(Utf8Span a, Utf8Span b)
         {
             // for sanity
-            Assert.Equal(a.Length, b.Length);
+            Assert.Equal(a.Bytes.Length, b.Bytes.Length);
             TestHelper.Validate(a, b);
 
-            for (int i = 0; i < a.Length; i++)
+            for (int i = 0; i < a.Bytes.Length; i++)
             {
-                Utf8Span prefixOfA = a.Substring(i, a.Length - i);
-                Utf8Span prefixOfB = b.Substring(i, b.Length - i);
+                Utf8Span prefixOfA = a.Substring(i, a.Bytes.Length - i);
+                Utf8Span prefixOfB = b.Substring(i, b.Bytes.Length - i);
                 // sanity
                 TestHelper.Validate(prefixOfA, prefixOfB);
                 Assert.Equal(prefixOfA.GetHashCode(), prefixOfB.GetHashCode());
 
                 // for all suffixes
-                Utf8Span suffixOfA = a.Substring(a.Length - i, i);
-                Utf8Span suffixOfB = b.Substring(b.Length - i, i);
+                Utf8Span suffixOfA = a.Substring(a.Bytes.Length - i, i);
+                Utf8Span suffixOfB = b.Substring(b.Bytes.Length - i, i);
                 TestHelper.Validate(suffixOfA, suffixOfB);
             }
         }
@@ -841,12 +791,12 @@ namespace System.Text.Utf8.Tests
         [Theory, MemberData("EnsureCodeUnitsOfStringTestCases")]
         public void EnsureCodeUnitsOfStringByIndexingBytes(byte[] expectedBytes, string str)
         {
-            var Utf8Span = new Utf8Span(str);
-            Assert.Equal(expectedBytes.Length, Utf8Span.Length);
+            var utf8Span = new Utf8Span(str);
+            Assert.Equal(expectedBytes.Length, utf8Span.Bytes.Length);
 
-            for (int i = 0; i < Utf8Span.Length; i++)
+            for (int i = 0; i < utf8Span.Bytes.Length; i++)
             {
-                Assert.Equal(expectedBytes[i], (byte)Utf8Span.Bytes[i]);
+                Assert.Equal(expectedBytes[i], (byte)utf8Span.Bytes[i]);
             }
         }
     }

--- a/tests/System.Text.Utf8String.Tests/Utf8String.RandomTests.cs
+++ b/tests/System.Text.Utf8String.Tests/Utf8String.RandomTests.cs
@@ -36,7 +36,7 @@ namespace System.Text.Utf8.Tests
         public void Length(int expectedLength, string str)
         {
             Utf8String s = new Utf8String(str);
-            Assert.Equal(expectedLength, s.Length);
+            Assert.Equal(expectedLength, s.Bytes.Length);
         }
 
         public static object[][] LengthInCodePointsTestCases = {
@@ -132,32 +132,6 @@ namespace System.Text.Utf8.Tests
         };
 
         [Theory]
-        [InlineData("", 'a')]
-        [InlineData("abc", 'a')]
-        [InlineData("v", 'v')]
-        [InlineData("1", 'a')]
-        [InlineData("1a", 'a')]
-        public void StartsWithCodeUnit(string s, char c)
-        {
-            Utf8String u8s = new Utf8String(s);
-            byte codeUnit = (byte)c;
-            Assert.Equal(s.StartsWith(c.ToString()), u8s.StartsWith(codeUnit));
-        }
-
-        [Theory]
-        [InlineData("", 'a')]
-        [InlineData("cba", 'a')]
-        [InlineData("v", 'v')]
-        [InlineData("1", 'a')]
-        [InlineData("a1", 'a')]
-        public void EndsWithCodeUnit(string s, char c)
-        {
-            Utf8String u8s = new Utf8String(s);
-            byte codeUnit = (byte)c;
-            Assert.Equal(s.EndsWith(c.ToString()), u8s.EndsWith(codeUnit));
-        }
-
-        [Theory]
         [InlineData("", "a")]
         [InlineData("abc", "a")]
         [InlineData("v", "v")]
@@ -189,54 +163,6 @@ namespace System.Text.Utf8.Tests
             Utf8String u8pattern = new Utf8String(pattern);
 
             Assert.Equal(s.EndsWith(pattern), u8s.EndsWith(u8pattern));
-        }
-
-        [Theory]
-        [InlineData("", 'a')]
-        [InlineData("abc", 'a')]
-        [InlineData("abc", 'b')]
-        [InlineData("abc", 'c')]
-        [InlineData("abc", 'd')]
-        public void SubstringFromCodeUnit(string s, char c)
-        {
-            Utf8String u8s = new Utf8String(s);
-            byte codeUnit = (byte)(c);
-            Utf8String u8result;
-
-            int idx = s.IndexOf(c);
-            bool expectedToFind = idx != -1;
-
-            Assert.Equal(expectedToFind, u8s.TrySubstringFrom(codeUnit, out u8result));
-            if (expectedToFind)
-            {
-                string expected = s.Substring(idx);
-                TestHelper.Validate(new Utf8String(expected), u8result);
-                Assert.Equal(expected, u8result.ToString());
-            }
-        }
-
-        [Theory]
-        [InlineData("", 'a')]
-        [InlineData("abc", 'a')]
-        [InlineData("abc", 'b')]
-        [InlineData("abc", 'c')]
-        [InlineData("abc", 'd')]
-        public void SubstringToCodeUnit(string s, char c)
-        {
-            Utf8String u8s = new Utf8String(s);
-            byte codeUnit = (byte)(c);
-            Utf8String u8result;
-
-            int idx = s.IndexOf(c);
-            bool expectedToFind = idx != -1;
-
-            Assert.Equal(expectedToFind, u8s.TrySubstringTo(codeUnit, out u8result));
-            if (expectedToFind)
-            {
-                string expected = s.Substring(0, idx);
-                TestHelper.Validate(new Utf8String(expected), u8result);
-                Assert.Equal(expected, u8result.ToString());
-            }
         }
 
         private byte[] GetUtf8BytesFromCodePoints(List<uint> codePoints)
@@ -425,19 +351,19 @@ namespace System.Text.Utf8.Tests
                 TestHelper.Validate(strFromArray, strFromPointer);
 
                 Array.Clear(buffer, 0, buffer.Length);
-                strFromArray.CopyTo(byteSpan);
+                strFromArray.Bytes.CopyTo(byteSpan);
                 Assert.Equal(textArray, buffer);
 
                 Array.Clear(buffer, 0, buffer.Length);
-                strFromPointer.CopyTo(byteSpan);
+                strFromPointer.Bytes.CopyTo(byteSpan);
                 Assert.Equal(textArray, buffer);
 
                 Array.Clear(buffer, 0, buffer.Length);
-                strFromArray.CopyTo(buffer);
+                strFromArray.Bytes.CopyTo(buffer);
                 Assert.Equal(textArray, buffer);
 
                 Array.Clear(buffer, 0, buffer.Length);
-                strFromPointer.CopyTo(buffer);
+                strFromPointer.Bytes.CopyTo(buffer);
                 Assert.Equal(textArray, buffer);
             }
         }
@@ -478,20 +404,20 @@ namespace System.Text.Utf8.Tests
         private void TestHashesSameForEquivalentString(Utf8String a, Utf8String b)
         {
             // for sanity
-            Assert.Equal(a.Length, b.Length);
+            Assert.Equal(a.Bytes.Length, b.Bytes.Length);
             TestHelper.Validate(a, b);
 
-            for (int i = 0; i < a.Length; i++)
+            for (int i = 0; i < a.Bytes.Length; i++)
             {
-                Utf8String prefixOfA = a.Substring(i, a.Length - i);
-                Utf8String prefixOfB = b.Substring(i, b.Length - i);
+                Utf8String prefixOfA = a.Substring(i, a.Bytes.Length - i);
+                Utf8String prefixOfB = b.Substring(i, b.Bytes.Length - i);
                 // sanity
                 TestHelper.Validate(prefixOfA, prefixOfB);
                 Assert.Equal(prefixOfA.GetHashCode(), prefixOfB.GetHashCode());
 
                 // for all suffixes
-                Utf8String suffixOfA = a.Substring(a.Length - i, i);
-                Utf8String suffixOfB = b.Substring(b.Length - i, i);
+                Utf8String suffixOfA = a.Substring(a.Bytes.Length - i, i);
+                Utf8String suffixOfB = b.Substring(b.Bytes.Length - i, i);
                 TestHelper.Validate(suffixOfA, suffixOfB);
             }
         }
@@ -824,9 +750,9 @@ namespace System.Text.Utf8.Tests
         public void EnsureCodeUnitsOfStringByIndexingBytes(byte[] expectedBytes, string str)
         {
             var utf8String = new Utf8String(str);
-            Assert.Equal(expectedBytes.Length, utf8String.Length);
+            Assert.Equal(expectedBytes.Length, utf8String.Bytes.Length);
 
-            for (int i = 0; i < utf8String.Length; i++)
+            for (int i = 0; i < utf8String.Bytes.Length; i++)
             {
                 Assert.Equal(expectedBytes[i], utf8String.Bytes[i]);
             }


### PR DESCRIPTION
More cleanup. Mainly, I removed methods that operate on code units, streamlined Utf8String implementations by delegating to Utf8Span, and optimized some methods, e.g. ToString, LastIndexOf

cc: @ahsonkhan, @GrabYourPitchforks, @joshfree, @ianhays 
