### PR TITLE
SpanWriter now supports multiple transformations

### DIFF
--- a/src/System.Azure.Experimental/System/Azure/CosmosDbAuthorizationHeader.cs
+++ b/src/System.Azure.Experimental/System/Azure/CosmosDbAuthorizationHeader.cs
@@ -42,7 +42,7 @@ namespace System.Azure.Authentication
             writer.Write(tokenVersion);
             writer.Write("&sig=");
 
-            writer.WriteBytes(hash, Base64.BytesToUtf8Encoder);
+            writer.WriteBytes(hash, default, Base64.BytesToUtf8Encoder);
 
             if (UrlEncoder.Utf8.Encode(writer.Written, output, out var consumed, out bytesWritten) != OperationStatus.Done)
             {
@@ -74,7 +74,7 @@ namespace System.Azure.Authentication
             writer.Write(tokenVersion);
             writer.Write(s_sigLiteral);
 
-            writer.WriteBytes(hash, Base64.BytesToUtf8Encoder);
+            writer.WriteBytes(hash, default, Base64.BytesToUtf8Encoder);
 
             if (UrlEncoder.Utf8.Encode(writer.Written, output, out var consumed, out bytesWritten) != OperationStatus.Done)
             {

--- a/src/System.Azure.Experimental/System/Azure/StorageAccessSignature.cs
+++ b/src/System.Azure.Experimental/System/Azure/StorageAccessSignature.cs
@@ -25,7 +25,7 @@ namespace System.Azure.Authentication
                 writer.Write(canonicalizedResource);
                 hash.Append(writer.Written);
                 writer.Index = 0;
-                writer.WriteBytes(hash, Base64.BytesToUtf8Encoder);
+                writer.WriteBytes(hash, default, Base64.BytesToUtf8Encoder);
                 bytesWritten = writer.Index;
                 return true;
             }
@@ -47,7 +47,7 @@ namespace System.Azure.Authentication
                 writer.Write(canonicalizedResource);
                 hash.Append(writer.Written);
                 writer.Index = 0;
-                writer.WriteBytes(hash, Base64.BytesToUtf8Encoder);
+                writer.WriteBytes(hash, default, Base64.BytesToUtf8Encoder);
                 bytesWritten = writer.Index;
                 return true;
             }

--- a/src/System.Text.Primitives/System/Text/Encoders/Ascii/Ascii_casing.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Ascii/Ascii_casing.cs
@@ -13,6 +13,7 @@ namespace System.Buffers.Text
             static readonly byte[] s_toUpper = new byte[128];
 
             public static readonly IBufferTransformation ToLowercase = new ToLowerTransformation();
+            public static readonly IBufferTransformation ToUppercase = new ToUpperTransformation();
 
             static Ascii()
             {
@@ -76,14 +77,29 @@ namespace System.Buffers.Text
             {
                 OperationStatus IBufferOperation.Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written)
                 {
-                    var result = Ascii.ToLower(input, output, out written);
+                    var result = ToLower(input, output, out written);
                     consumed = written;
                     return result;
                 }
 
                 OperationStatus IBufferTransformation.Transform(Span<byte> buffer, int dataLength, out int written)
                 {
-                    return Ascii.ToLowerInPlace(buffer.Slice(0, dataLength), out written);
+                    return ToLowerInPlace(buffer.Slice(0, dataLength), out written);
+                }
+            }
+
+            internal class ToUpperTransformation : IBufferTransformation
+            {
+                OperationStatus IBufferOperation.Execute(ReadOnlySpan<byte> input, Span<byte> output, out int consumed, out int written)
+                {
+                    var result = ToUpper(input, output, out written);
+                    consumed = written;
+                    return result;
+                }
+
+                OperationStatus IBufferTransformation.Transform(Span<byte> buffer, int dataLength, out int written)
+                {
+                    return ToUpperInPlace(buffer.Slice(0, dataLength), out written);
                 }
             }
         }

--- a/tests/System.Buffers.Experimental.Tests/SpanWriterTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/SpanWriterTests.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Binary.Base64;
+using System.Buffers;
+using System.Buffers.Text;
+using System.Text;
+using System.Text.Utf8;
+using Xunit;
+using static System.Buffers.Binary.BinaryPrimitives;
+
+namespace System.Buffers.Tests
+{
+    public partial class SpanWritersTests
+    {
+        static IBufferTransformation[] s_transformations = new IBufferTransformation[] {
+            Encodings.Ascii.ToLowercase,
+            Encodings.Ascii.ToUppercase,
+            Base64.Utf8ToBytesDecoder,
+            Base64.BytesToUtf8Encoder
+        };
+
+        [Fact]
+        public void Basics()
+        {
+            Span<IBufferTransformation> transformations = s_transformations;
+            Span<byte> buffer = stackalloc byte[256];
+            var writer = new SpanWriter(buffer);
+
+            writer.Index = 0;
+            writer.Write("AaBc", transformations.Slice(0, 2));
+            Assert.Equal("AABC", Encodings.Utf8.ToString(writer.Written));
+
+            writer.Index = 0;
+            writer.Write("AaBc", transformations.Slice(0, 1));
+            Assert.Equal("aabc", Encodings.Utf8.ToString(writer.Written));
+
+            writer.Index = 0;
+            writer.Write("AaBc", transformations.Slice(1, 1));
+            Assert.Equal("AABC", Encodings.Utf8.ToString(writer.Written));
+
+            writer.Index = 0;
+            writer.Write("AaBc", transformations);
+            Assert.Equal("AABC", Encodings.Utf8.ToString(writer.Written));
+        }
+
+        [Fact]
+        public void Writable()
+        {
+            Span<IBufferTransformation> transformations = s_transformations;
+            Span<byte> buffer = stackalloc byte[256];
+            var writer = new SpanWriter(buffer);
+
+            var ulonger = new UInt128();
+            ulonger.Lower = ulong.MaxValue;
+            ulonger.Upper = 1;
+
+            writer.WriteBytes(ulonger, default, transformations.Slice(3));
+            var result = Encodings.Utf8.ToString(writer.Written);
+            Assert.Equal("//////////8BAAAAAAAAAA==", result);
+
+            var ulongerSpan = new Span<UInt128>(new UInt128[1]); 
+            Assert.Equal(OperationStatus.Done, Base64.DecodeFromUtf8(writer.Written, ulongerSpan.AsBytes(), out int consumed, out int written));
+            Assert.Equal(ulongerSpan[0].Lower, ulonger.Lower);
+            Assert.Equal(ulongerSpan[0].Upper, ulonger.Upper);
+        }
+    }
+
+    public struct UInt128 : IWritable
+    {
+        public ulong Lower;
+        public ulong Upper;
+
+        const int size = sizeof(ulong) * 2;
+
+        public bool TryWrite(Span<byte> buffer, out int written, ParsedFormat format = default)
+        {
+            if (!format.IsDefault) throw new Exception("invalid format");
+
+            if (buffer.Length < size)
+            {
+                written = 0;
+                return false;
+            }
+
+            if (BitConverter.IsLittleEndian)
+            {
+                WriteMachineEndian(buffer, ref Lower);
+                WriteMachineEndian(buffer.Slice(sizeof(ulong)), ref Upper);
+            }
+            else
+            {
+                WriteMachineEndian(buffer, ref Upper);
+                WriteMachineEndian(buffer.Slice(sizeof(ulong)), ref Lower);
+            }
+            written = size;
+            return true;
+        }
+    }
+}

--- a/tests/System.Buffers.Experimental.Tests/System.Buffers.Experimental.Tests.csproj
+++ b/tests/System.Buffers.Experimental.Tests/System.Buffers.Experimental.Tests.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
   <!-- Project references -->
   <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Binary.Base64\System.Binary.Base64.csproj" />
     <ProjectReference Include="..\..\src\System.Buffers.Experimental\System.Buffers.Experimental.csproj" />
     <ProjectReference Include="..\..\src\System.IO.Pipelines.Extensions\System.IO.Pipelines.Extensions.csproj" />
     <ProjectReference Include="..\..\src\System.IO.Pipelines.Testing\System.IO.Pipelines.Testing.csproj" />


### PR DESCRIPTION
I added the ability to pass multiple transformations when writing to SpanWriter, e.g.

```c#
ReadOnlySpan<IBufferTransformation> transformations = ...
var writer = new SpanWriter(buffer);
writer.Write("Hello", default, transformations);
```

@ahsonkhan, @joshfree, @GrabYourPitchforks 