### PR TITLE
Set the DOTNET_MULTILEVEL_LOOKUP env variable in the package script

### DIFF
--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -9,6 +9,8 @@ $dotnetExePath="$repoRoot\dotnetcli\dotnet.exe"
 $nugetPath = "$repoRoot\nuget\nuget.exe"
 $packagesPath = "$repoRoot\packages"
 
+$env:DOTNET_MULTILEVEL_LOOKUP = 0
+
 Function Ensure-Nuget-Exists {
     if (!(Test-Path "$nugetPath")) {
         if (!(Test-Path "$repoRoot\nuget")) {


### PR DESCRIPTION
Related to https://github.com/dotnet/corefxlab/pull/1866

This will override the global install of the dotnet cli and use the repo-specific version.

See https://github.com/dotnet/corefx/issues/24698#issuecomment-337794414 for more info.

cc @dotnet/corefxlab-contrib 