### PR TITLE
Added always available Length to ReadOnlyBytes

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Net.Http
 
         public override int Length => _array.Length;
 
+        long IReadOnlyBufferList<byte>.Length => Length;
+
         public override Span<byte> Span
         {
             get
@@ -141,6 +143,16 @@ namespace Microsoft.Net.Http
                 var handle = GCHandle.Alloc(_array, GCHandleType.Pinned);
                 return new MemoryHandle(this, (void*)handle.AddrOfPinnedObject(), handle);
             }
+        }
+
+        int IReadOnlyBufferList<byte>.CopyTo(Span<byte> buffer)
+        {
+            throw new NotImplementedException();
+        }
+
+        bool ISequence<ReadOnlyMemory<byte>>.TryGet(ref Position position, out ReadOnlyMemory<byte> item, bool advance)
+        {
+            throw new NotImplementedException();
         }
 
         internal OwnedBuffer _next;

--- a/src/System.Buffers.Experimental/System/Buffers/IReadOnlyBufferList.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/IReadOnlyBufferList.cs
@@ -11,5 +11,7 @@ namespace System.Buffers
         ReadOnlyMemory<T> First { get; }
 
         IReadOnlyBufferList<T> Rest { get; }
+
+        long Length { get; }
     }
 }

--- a/src/System.Buffers.Experimental/System/Buffers/ReadOnlyBytes.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/ReadOnlyBytes.cs
@@ -29,24 +29,16 @@ namespace System.Buffers
         }
 
         public ReadOnlyBytes(ReadOnlyMemory<byte> first, IReadOnlyBufferList<byte> rest) :
-            this(first, rest, first.Length + rest.Length)
-        { }
+            this(first, rest, first.Length + (rest == null ? 0 : rest.Length)) { }
 
         public ReadOnlyBytes(ReadOnlyMemory<byte> buffer) :
-            this(buffer, null, buffer.Length)
-        { }
+            this(buffer, null, buffer.Length) { }
 
         public ReadOnlyBytes(IReadOnlyBufferList<byte> segments) :
-            this(segments.First, segments.Rest, segments.Length)
-        { }
+            this(segments == null ? ReadOnlyMemory<byte>.Empty : segments.First, segments?.Rest, segments == null ? 0 : segments.Length) { }
 
         public ReadOnlyBytes(IReadOnlyBufferList<byte> segments, long length) :
-            this(segments.First, segments.Rest, length)
-        {
-            // TODO: should they be runtime/release checks?
-            Debug.Assert(segments != null);
-            Debug.Assert(segments.Length >= length);
-        }
+            this(segments == null ? ReadOnlyMemory<byte>.Empty : segments.First, segments?.Rest, length) { }
 
         public bool TryGet(ref Position position, out ReadOnlyMemory<byte> value, bool advance = true)
         {
@@ -114,7 +106,7 @@ namespace System.Buffers
                 if(slice.Length > 0) {
                     return new ReadOnlyBytes(slice);
                 }
-                return ReadOnlyBytes.Empty;
+                return Empty;
             }
             if (first.Length > index)
             {
@@ -214,7 +206,7 @@ namespace System.Buffers
             internal BufferListNode _rest;
             public ReadOnlyMemory<byte> First => _first;
 
-            public long Length => _first.Length + (_rest==null?0:_rest.Length);
+            public long Length => _first.Length + (_rest == null ? 0 : _rest.Length);
 
             public IReadOnlyBufferList<byte> Rest => _rest;
 
@@ -314,3 +306,5 @@ namespace System.Buffers
         }
     }
 }
+
+

--- a/src/System.Text.Http/System/Text/Http/HttpRequest.cs
+++ b/src/System.Text.Http/System/Text/Http/HttpRequest.cs
@@ -190,7 +190,8 @@ namespace System.Text.Http
 
         public static Utf8Span ToUtf8Span(this ReadOnlyBytes bytes, SymbolTable symbolTable)
         {
-            var sb = new ArrayFormatter(bytes.ComputeLength(), SymbolTable.InvariantUtf8);
+            if (bytes.Length > int.MaxValue) throw new ArgumentOutOfRangeException(nameof(bytes));
+            var sb = new ArrayFormatter((int)bytes.Length, SymbolTable.InvariantUtf8);
             if (symbolTable == SymbolTable.InvariantUtf8)
             {
                 var position = Position.First;

--- a/tests/System.Buffers.Experimental.Tests/BytesReader.cs
+++ b/tests/System.Buffers.Experimental.Tests/BytesReader.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace System.Buffers.Tests
 {
-    public partial class ReadOnlyBytesTests
+    public partial class BytesReaderTests
     {
         [Fact]
         public void SingleSegmentBytesReader()
@@ -72,18 +72,24 @@ namespace System.Buffers.Tests
 
             var ab = reader.ReadBytesUntil((byte)' ');
             Assert.Equal("AB", ab.ToString(SymbolTable.InvariantUtf8));
+            Assert.Equal(2, reader.Index);
 
             reader.Advance(1);
+            Assert.Equal(3, reader.Index);
+
             var cd = reader.ReadBytesUntil((byte)'#');
             Assert.Equal("CD", cd.ToString(SymbolTable.InvariantUtf8));
+            Assert.Equal(5, reader.Index);
 
             reader.Advance(1);
+            Assert.Equal(6, reader.Index);
+
             var ef = reader.ReadBytesUntil(new byte[] { (byte)'&', (byte)'&' });
             Assert.Equal("EF", ef.ToString(SymbolTable.InvariantUtf8));
+            Assert.Equal(8, reader.Index);
 
             reader.Advance(2);
-
-            //Assert.True(reader.IsEmpty);
+            Assert.Equal(10, reader.Index);
         }
 
         [Fact]
@@ -113,21 +119,27 @@ namespace System.Buffers.Tests
 
             Assert.True(reader.TryParseUInt64(out u64));
             Assert.Equal(123ul, u64);
+            Assert.Equal(3, reader.Index);
 
             Assert.True(reader.TryParseBoolean(out b));
             Assert.Equal(true, b);
+            Assert.Equal(7, reader.Index);
 
             Assert.True(reader.TryParseUInt64(out u64));
             Assert.Equal(456ul, u64);
+            Assert.Equal(10, reader.Index);
 
             Assert.True(reader.TryParseBoolean(out b));
             Assert.Equal(true, b);
+            Assert.Equal(14, reader.Index);
 
             Assert.True(reader.TryParseUInt64(out u64));
             Assert.Equal(789ul, u64);
+            Assert.Equal(17, reader.Index);
 
             Assert.True(reader.TryParseBoolean(out b));
             Assert.Equal(false, b);
+            Assert.Equal(22, reader.Index);
 
             //Assert.True(reader.IsEmpty);
         }

--- a/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.Buffers.Tests
 {
-    public partial class ReadOnlyBytesTests
+    public partial class BytesReaderTests
     {
         [Fact]
         public void SingleSegmentBasics()
@@ -18,13 +18,7 @@ namespace System.Buffers.Tests
             var span = sliced.First.Span;
             Assert.Equal((byte)2, span[0]);
 
-            Assert.Equal(buffer.Length, bytes.Length.Value);
-            Assert.Equal(buffer.Length, bytes.ComputeLength());
-
-            bytes = new ReadOnlyBytes(buffer, null, -1);
-            Assert.False(bytes.Length.HasValue);
-            Assert.Equal(buffer.Length, bytes.ComputeLength());
-            Assert.Equal(buffer.Length, bytes.Length.Value);
+            Assert.Equal(buffer.Length, bytes.Length);
         }
 
         [Fact]
@@ -36,9 +30,7 @@ namespace System.Buffers.Tests
 
             bytes = Parse("A|CD|EFG");
 
-            Assert.False(bytes.Length.HasValue);
-            Assert.Equal(6, bytes.ComputeLength());
-            Assert.Equal(6, bytes.Length.Value);
+            Assert.Equal(6, bytes.Length);
         }
 
         [Fact]
@@ -72,7 +64,7 @@ namespace System.Buffers.Tests
             for(int i=1; i<=totalLength; i++) {
                 sliced  = bytes.Slice(i);
                 span = sliced.First.Span;
-                Assert.Equal(totalLength - i, sliced.ComputeLength());
+                Assert.Equal(totalLength - i, sliced.Length);
                 if(i!=totalLength) Assert.Equal(i, span[0]);
             }
             Assert.Equal(0, span.Length);
@@ -97,39 +89,6 @@ namespace System.Buffers.Tests
                 var copied = bytes.CopyTo(copy);
                 Assert.Equal(copy.Length, copied);
                 for(int i=0; i<copied; i++) {
-                    Assert.Equal(array[i], copy[i]);
-                }
-            }
-
-            { // copy to larger
-                var copy = new byte[array.Length + 1];
-                var copied = bytes.CopyTo(copy);
-                Assert.Equal(array.Length, copied);
-                for (int i = 0; i < copied; i++) {
-                    Assert.Equal(array[i], copy[i]);
-                }
-            }
-        }
-
-        [Fact]
-        public void SingleSegmentCopyToUnknownLength()
-        {
-            var array = new byte[] { 0, 1, 2, 3, 4, 5, 6 };
-            ReadOnlyMemory<byte> buffer = array;
-            var bytes = new ReadOnlyBytes(buffer, null, -1);
-
-            { // copy to equal
-                var copy = new byte[array.Length];
-                var copied = bytes.CopyTo(copy);
-                Assert.Equal(array.Length, copied);
-                Assert.Equal(array, copy);
-            }
-
-            { // copy to smaller
-                var copy = new byte[array.Length - 1];
-                var copied = bytes.CopyTo(copy);
-                Assert.Equal(copy.Length, copied);
-                for (int i = 0; i < copied; i++) {
                     Assert.Equal(array[i], copy[i]);
                 }
             }


### PR DESCRIPTION
In addition changed the ReadOnlyBytes.Length to long.

cc: @ahsonkhan, @pakrym, @davidfowl

The current perf results (from HttpParserBench) are even better (30% better). I think the main difference is from less cache misses as in ReadOnlyBytes data is more localized (less references to follow to get to the first segment)

Test Name                         | Metric                                        | Iterations |    AVERAGE 
:--------------------------------- |:--------------------------------------------- |:----------:| ----------: 
 HttpParserBench.FullRequestRb     | Duration                                      |    100     |     17.497
 HttpParserBench.FullRequestRb     | Instructions Retired                          |    100     | 1.391E+008
 HttpParserBench.FullRequestRb     | Branch Mispredictions                         |    100     |  14827.520
 HttpParserBench.FullRequestRb     | Cache Misses                                  |    100     |  33873.920
 HttpParserBench.FullRequestRb     | Allocations |    100     |      0.000
 HttpParserBench.FullRequestRob    | Duration                                      |    100     |     11.805 
 HttpParserBench.FullRequestRob    | Instructions Retired                          |    100     | 1.047E+008
 HttpParserBench.FullRequestRob    | Branch Mispredictions                         |    100     |  11591.680
 HttpParserBench.FullRequestRob    | Cache Misses                                  |    100     |  22241.280 
 HttpParserBench.FullRequestRob    | Allocations |    100     |      0.000
