### PR TITLE
Eliminated All Length Computations

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/OwnedBuffer.cs
@@ -38,8 +38,6 @@ namespace Microsoft.Net.Http
 
         public override int Length => _array.Length;
 
-        long IReadOnlyBufferList<byte>.Length => Length;
-
         public override Span<byte> Span
         {
             get
@@ -48,6 +46,8 @@ namespace Microsoft.Net.Http
                 return _array.AsSpan();
             }
         }
+
+        long IReadOnlyBufferList<byte>.Index => 0;
 
         public int CopyTo(Span<byte> buffer)
         {

--- a/src/System.Buffers.Experimental/System/Buffers/BytesReader.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BytesReader.cs
@@ -43,12 +43,6 @@ namespace System.Buffers
         public BytesReader(ReadOnlyBytes bytes) : this(bytes, SymbolTable.InvariantUtf8)
         { }
 
-        public BytesReader(IReadOnlyBufferList<byte> bytes) : this(bytes, SymbolTable.InvariantUtf8)
-        { }
-
-        public BytesReader(IReadOnlyBufferList<byte> bytes, SymbolTable encoder) : this(new ReadOnlyBytes(bytes, bytes.Length))
-        { }
-
         public byte Peek() => _currentSegment.Span[_currentSegmentIndex];
 
         public ReadOnlySpan<byte> Unread => _currentSegment.Span.Slice(_currentSegmentIndex);

--- a/src/System.Buffers.Experimental/System/Buffers/IReadOnlyBufferList.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/IReadOnlyBufferList.cs
@@ -12,6 +12,6 @@ namespace System.Buffers
 
         IReadOnlyBufferList<T> Rest { get; }
 
-        long Length { get; }
+        long Index { get; }
     }
 }

--- a/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
@@ -229,7 +229,7 @@ namespace System.Buffers.Tests
                 var slice = rob.Slice(c2, c5);
 
                 Assert.Equal(2, slice.First.Span[0]);
-                Assert.Equal(4, slice.Length);
+                Assert.Equal(3, slice.Length);
             }
         }
 


### PR DESCRIPTION
Eliminated all length computations using the same "running index" trick used in ReadabaleBuffer.

cc: @pakrym, @davidfowl, @ahsonkhan, @joshfree 
