### PR TITLE
Improve perf of Date.AddMonths

### DIFF
--- a/src/System.Time/System/Date.cs
+++ b/src/System.Time/System/Date.cs
@@ -1651,7 +1651,7 @@ namespace System
         // Exactly the same as GetDatePart(int part), except computing all of
         // year/month/day rather than just one of them.  Used when all three
         // are needed rather than redoing the computations for each.
-        internal void GetDatePart(out int year, out int month, out int day)
+        private void GetDatePart(out int year, out int month, out int day)
         {
             // n = number of days since 1/1/0001
             int n = _dayNumber;

--- a/src/System.Time/System/Date.cs
+++ b/src/System.Time/System/Date.cs
@@ -417,9 +417,7 @@ namespace System
 
             Contract.EndContractBlock();
 
-            int y = GetDatePart(DatePartYear);
-            int m = GetDatePart(DatePartMonth);
-            int d = GetDatePart(DatePartDay);
+            GetDatePart(out int y, out int m, out int d);
             int i = m - 1 + months;
 
             if (i >= 0)
@@ -1572,7 +1570,7 @@ namespace System
         }
 
         /// <summary>
-        /// Returns a given date part of this DateTime. This method is used
+        /// Returns a given date part of this Date. This method is used
         /// to compute the year, day-of-year, month, or day part.
         /// </summary>
         private int GetDatePart(int part)
@@ -1648,6 +1646,65 @@ namespace System
 
             // Return 1-based day-of-month
             return n - days[m - 1] + 1;
+        }
+
+        // Exactly the same as GetDatePart(int part), except computing all of
+        // year/month/day rather than just one of them.  Used when all three
+        // are needed rather than redoing the computations for each.
+        internal void GetDatePart(out int year, out int month, out int day)
+        {
+            // n = number of days since 1/1/0001
+            int n = _dayNumber;
+
+            // y400 = number of whole 400-year periods since 1/1/0001
+            int y400 = n / DaysPer400Years;
+            
+            // n = day number within 400-year period
+            n -= y400 * DaysPer400Years;
+            
+            // y100 = number of whole 100-year periods within 400-year period
+            int y100 = n / DaysPer100Years;
+            
+            // Last 100-year period has an extra day, so decrement result if 4
+            if (y100 == 4) y100 = 3;
+            
+            // n = day number within 100-year period
+            n -= y100 * DaysPer100Years;
+            
+            // y4 = number of whole 4-year periods within 100-year period
+            int y4 = n / DaysPer4Years;
+            
+            // n = day number within 4-year period
+            n -= y4 * DaysPer4Years;
+            
+            // y1 = number of whole years within 4-year period
+            int y1 = n / DaysPerYear;
+            
+            // Last year has an extra day, so decrement result if 4
+            if (y1 == 4) y1 = 3;
+            
+            // compute year
+            year = y400 * 400 + y100 * 100 + y4 * 4 + y1 + 1;
+            
+            // n = day number within year
+            n -= y1 * DaysPerYear;
+            
+            // dayOfYear = n + 1;
+            // Leap year calculation looks different from IsLeapYear since y1, y4,
+            // and y100 are relative to year 1, not year 0
+            bool leapYear = y1 == 3 && (y4 != 24 || y100 == 3);
+            int[] days = leapYear ? DaysToMonth366 : DaysToMonth365;
+
+            // All months have less than 32 days, so n >> 5 is a good conservative
+            // estimate for the month
+            int m = (n >> 5) + 1;
+            
+            // m = 1-based month number
+            while (n >= days[m]) m++;
+            
+            // compute month and day
+            month = m;
+            day = n - days[m - 1] + 1;
         }
 
         /// <summary>


### PR DESCRIPTION
Uses the three-part `GetDatePart` function, copied from the `System.DateTime` implementation in coreclr.