### PR TITLE
Added HTTP parser benchmarks simulating parsing with cursors

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/ReadOnlyBytes.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/ReadOnlyBytes.cs
@@ -201,6 +201,27 @@ namespace System.Buffers
             return CursorOf(Rest, value);
         }
 
+        public Cursor CursorAt(int index)
+        {
+            ReadOnlySpan<byte> first = _first.Span;
+            int firstLength = first.Length;
+
+            if (index < firstLength)
+            {
+                if (_all == null)
+                {
+                    return new Cursor(null, firstLength - index);
+                }
+                else
+                {
+                    var allIndex = index + (_all.First.Length - firstLength);
+                    return new Cursor(_all, allIndex);
+                }
+            }
+            if (Rest == null) return default;
+            return CursorAt(Rest, index - firstLength);
+        }
+
         private static Cursor CursorOf(IReadOnlyMemoryList<byte> list, byte value)
         {
             ReadOnlySpan<byte> first = list.First.Span;
@@ -208,6 +229,19 @@ namespace System.Buffers
             if (index != -1) return new Cursor(list, index);
             if (list.Rest == null) return default;
             return CursorOf(list.Rest, value);
+        }
+
+        private static Cursor CursorAt(IReadOnlyMemoryList<byte> list, int index)
+        {
+            if (list == null) return default;
+            ReadOnlySpan<byte> first = list.First.Span;
+            int firstLength = first.Length;
+
+            if (index < firstLength)
+            {
+                return new Cursor(list, index);
+            }
+            return CursorAt(list.Rest, index - firstLength);
         }
 
         public int CopyTo(Span<byte> buffer)

--- a/tests/Benchmarks/HttpParserBench.cs
+++ b/tests/Benchmarks/HttpParserBench.cs
@@ -67,6 +67,40 @@ public class HttpParserBench
     }
 
     [Benchmark(InnerIterationCount = Itterations)]
+    static bool RequestLineRobCursors()
+    {
+        var buffer = new ReadOnlyBytes(s_plaintextTechEmpowerRequestBytes);
+        var parser = new HttpParser();
+        var request = new Request();
+        ReadOnlyBytes.Cursor consumed = default;
+        ReadOnlyBytes.Cursor read;
+        bool success = true;
+
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement())
+            {
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    success = success && parser.ParseRequestLine(ref request, buffer, out consumed, out read);
+                    success = success && parser.ParseRequestLine(ref request, buffer, out consumed, out read);
+                    success = success && parser.ParseRequestLine(ref request, buffer, out consumed, out read);
+                    success = success && parser.ParseRequestLine(ref request, buffer, out consumed, out read);
+                    success = success && parser.ParseRequestLine(ref request, buffer, out consumed, out read);
+                    success = success && parser.ParseRequestLine(ref request, buffer, out consumed, out read);
+                    success = success && parser.ParseRequestLine(ref request, buffer, out consumed, out read);
+                    success = success && parser.ParseRequestLine(ref request, buffer, out consumed, out read);
+                    success = success && parser.ParseRequestLine(ref request, buffer, out consumed, out read);
+                    success = success && parser.ParseRequestLine(ref request, buffer, out consumed, out read);
+
+                }
+            }
+        }
+
+        return success;
+    }
+
+    [Benchmark(InnerIterationCount = Itterations)]
     static bool RequestLineRob()
     {
         var buffer = new ReadOnlyBytes(s_plaintextTechEmpowerRequestBytes);
@@ -122,6 +156,40 @@ public class HttpParserBench
                     success = success && parser.ParseHeaders(request, buffer, out consumed, out examined, out consumedBytes);
                     success = success && parser.ParseHeaders(request, buffer, out consumed, out examined, out consumedBytes);
                     success = success && parser.ParseHeaders(request, buffer, out consumed, out examined, out consumedBytes);
+                }
+            }
+        }
+
+        return success;
+    }
+
+    [Benchmark(InnerIterationCount = Itterations)]
+    static bool HeadersRobCursors()
+    {
+        var buffer = new ReadOnlyBytes(s_plaintextTechEmpowerHeadersBytes);
+        var parser = new HttpParser();
+        var request = new Request();
+        ReadOnlyBytes.Cursor consumed = default;
+        ReadOnlyBytes.Cursor examined;
+        int consumedBytes;
+        bool success = true;
+
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement())
+            {
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    success = success && parser.ParseHeaders(ref request, buffer, out consumed, out examined, out consumedBytes);
+                    success = success && parser.ParseHeaders(ref request, buffer, out consumed, out examined, out consumedBytes);
+                    success = success && parser.ParseHeaders(ref request, buffer, out consumed, out examined, out consumedBytes);
+                    success = success && parser.ParseHeaders(ref request, buffer, out consumed, out examined, out consumedBytes);
+                    success = success && parser.ParseHeaders(ref request, buffer, out consumed, out examined, out consumedBytes);
+                    success = success && parser.ParseHeaders(ref request, buffer, out consumed, out examined, out consumedBytes);
+                    success = success && parser.ParseHeaders(ref request, buffer, out consumed, out examined, out consumedBytes);
+                    success = success && parser.ParseHeaders(ref request, buffer, out consumed, out examined, out consumedBytes);
+                    success = success && parser.ParseHeaders(ref request, buffer, out consumed, out examined, out consumedBytes);
+                    success = success && parser.ParseHeaders(ref request, buffer, out consumed, out examined, out consumedBytes);
                 }
             }
         }
@@ -203,12 +271,16 @@ public class HttpParserBench
                 for (int i = 0; i < Benchmark.InnerIterationCount; i++) {
                     success = success && parser.ParseRequestLine(request, buffer, out consumed, out examined);
                     success = success && parser.ParseHeaders(request, buffer.Slice(consumed), out consumed, out examined, out consumedBytes);
+
                     success = success && parser.ParseRequestLine(request, buffer, out consumed, out examined);
                     success = success && parser.ParseHeaders(request, buffer.Slice(consumed), out consumed, out examined, out consumedBytes);
+
                     success = success && parser.ParseRequestLine(request, buffer, out consumed, out examined);
                     success = success && parser.ParseHeaders(request, buffer.Slice(consumed), out consumed, out examined, out consumedBytes);
+
                     success = success && parser.ParseRequestLine(request, buffer, out consumed, out examined);
                     success = success && parser.ParseHeaders(request, buffer.Slice(consumed), out consumed, out examined, out consumedBytes);
+
                     success = success && parser.ParseRequestLine(request, buffer, out consumed, out examined);
                     success = success && parser.ParseHeaders(request, buffer.Slice(consumed), out consumed, out examined, out consumedBytes);
                 }
@@ -248,6 +320,34 @@ public class HttpParserBench
     }
 
     [Benchmark(InnerIterationCount = Itterations)]
+    static bool FullRequestRobCursors()
+    {
+        var buffer = new ReadOnlyBytes(s_plaintextTechEmpowerRequestBytes);
+        var parser = new HttpParser();
+        var request = new RequestStruct();
+        ReadOnlyBytes.Cursor consumed = default;
+        ReadOnlyBytes.Cursor examined;
+        bool success = true;
+
+        foreach (var iteration in Benchmark.Iterations)
+        {
+            using (iteration.StartMeasurement())
+            {
+                for (int i = 0; i < Benchmark.InnerIterationCount; i++)
+                {
+                    success = success && parser.ParseRequest(ref request, buffer, out consumed, out examined);
+                    success = success && parser.ParseRequest(ref request, buffer, out consumed, out examined);
+                    success = success && parser.ParseRequest(ref request, buffer, out consumed, out examined);
+                    success = success && parser.ParseRequest(ref request, buffer, out consumed, out examined);
+                    success = success && parser.ParseRequest(ref request, buffer, out consumed, out examined);
+                }
+            }
+        }
+
+        return success;
+    }
+
+    [Benchmark(InnerIterationCount = Itterations)]
     static int FullRequestLegacy()
     {
         var buffer = new ReadOnlyBytes(s_plaintextTechEmpowerRequestBytes);
@@ -266,6 +366,54 @@ public class HttpParserBench
         }
 
         return request.BodyIndex;
+    }
+}
+
+static class HttpParserExtensions
+{
+    public static bool ParseRequestLine<T>(this HttpParser parser, ref T handler, in ReadOnlyBytes buffer, out ReadOnlyBytes.Cursor consumed, out ReadOnlyBytes.Cursor examined) where T : IHttpRequestLineHandler
+    {
+        if(parser.ParseRequestLine(ref handler, buffer, out int consumedBytes))
+        {
+            consumed = buffer.CursorAt(consumedBytes);
+            examined = consumed;
+            return true;
+        }
+        consumed = buffer.CursorAt(0);
+        examined = default;
+        return false;
+    }
+
+    public static bool ParseHeaders<T>(this HttpParser parser, ref T handler, in ReadOnlyBytes buffer, out ReadOnlyBytes.Cursor consumed, out ReadOnlyBytes.Cursor examined, out int consumedBytes) where T : IHttpHeadersHandler
+    {
+        if (parser.ParseHeaders(ref handler, buffer, out consumedBytes))
+        {
+            consumed = buffer.CursorAt(consumedBytes);
+            examined = consumed;
+            return true;
+        }
+        consumed = buffer.CursorAt(0);
+        examined = default;
+        return false;
+    }
+
+    public static bool ParseRequest<T>(this HttpParser parser, ref T handler, in ReadOnlyBytes buffer, out ReadOnlyBytes.Cursor consumed, out ReadOnlyBytes.Cursor examined) where T : IHttpRequestLineHandler, IHttpHeadersHandler
+    {
+        if (
+            parser.ParseRequestLine(ref handler, buffer, out var consumedRLBytes) &&
+            parser.ParseHeaders(ref handler, buffer.Slice(consumedRLBytes), out var consumedHDBytes)
+        )
+        {
+            consumed = buffer.CursorAt(consumedRLBytes + consumedHDBytes);
+            examined = consumed;
+            return true;
+        }
+        else
+        {
+            consumed = buffer.CursorAt(0);
+            examined = default;
+            return false;
+        }
     }
 }
 


### PR DESCRIPTION
Added benchmarks measuring the performance of calling int based ROB parser APIs and then translating the into to cursors. 

here are the perf results:

 Benchmark                       | Metric               | Unit  |    Average 
:------------------------------------- |:-------------------- |:-----:| ----------:
 HttpParserBench.FullRequestRb         | Duration             | msec  |     12.503 
 HttpParserBench.FullRequestRb         | Instructions Retired | count | 1.446E+008 
 HttpParserBench.FullRequestRb         | Cache Misses         | count |   7331.840 
 HttpParserBench.FullRequestRob        | Duration             | msec  |      8.324 
 HttpParserBench.FullRequestRob        | Instructions Retired | count | 1.058E+008 
 HttpParserBench.FullRequestRob        | Cache Misses         | count |   5529.600 
 HttpParserBench.FullRequestRobCursors | Duration             | msec  |      9.509 
 HttpParserBench.FullRequestRobCursors | Instructions Retired | count | 1.163E+008 
 HttpParserBench.FullRequestRobCursors | Cache Misses         | count |   6389.760 

cc: @ahsonkhan, @joshfree, @davidfowl, @pakrym 

Note, that since ROB does not store a pointer to the last segment, default(Cursor) means that the whole ROB was examined. We could change the int based parsers to return the index of where they stopped to parse in the case of failure (just like our transformation APIs) and then examined could return the cursor at the location where the parser ran out of data.