### PR TITLE
Update many projects to netstandard1.3

### DIFF
--- a/src/System.Binary.Base64/System.Binary.Base64.csproj
+++ b/src/System.Binary.Base64/System.Binary.Base64.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Non-allocating Base64 encoder and decoded</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <PackageTags>.NET non-allocating Base64 encoder and decoder</PackageTags>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>

--- a/src/System.Buffers.Experimental/System.Buffers.Experimental.csproj
+++ b/src/System.Buffers.Experimental/System.Buffers.Experimental.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Pool of unmanaged Span&lt;byte&gt; values</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>Span Spans Pool corefxlab</PackageTags>
   </PropertyGroup>

--- a/src/System.Net.Libuv/System.Net.Libuv.csproj
+++ b/src/System.Net.Libuv/System.Net.Libuv.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>libuv .NET Core wrapper</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>.NET libuv corefxlab</PackageTags>
   </PropertyGroup>

--- a/src/System.Text.Encodings.Web.Utf8/System.Text.Encodings.Web.Utf8.csproj
+++ b/src/System.Text.Encodings.Web.Utf8/System.Text.Encodings.Web.Utf8.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Provides types for encoding and escaping strings for use in JavaScript, HyperText Markup Language (HTML), and uniform resource locators (URL).</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTags>Encoding;Decoding</PackageTags>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>
   </PropertyGroup>

--- a/src/System.Text.Formatting.Globalization/System.Text.Formatting.Globalization.csproj
+++ b/src/System.Text.Formatting.Globalization/System.Text.Formatting.Globalization.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>A formatting library for pl-PL</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTags>pl PL formatting globalization corefxlab</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Text.Formatting/System.Text.Formatting.csproj
+++ b/src/System.Text.Formatting/System.Text.Formatting.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Non-allocating formatting library</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>.NET formatting corefxlab</PackageTags>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>

--- a/src/System.Text.Http.Parser/System.Text.Http.Parser.csproj
+++ b/src/System.Text.Http.Parser/System.Text.Http.Parser.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>HTTP Parser</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>HTTP Parser</PackageTags>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>

--- a/src/System.Text.Http/System.Text.Http.csproj
+++ b/src/System.Text.Http/System.Text.Http.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Non-allocating HTTP parser</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTags>HTTP parser parsing .NET non-allocating corefxlab</PackageTags>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Text.Json.Dynamic/System.Text.Json.Dynamic.csproj
+++ b/src/System.Text.Json.Dynamic/System.Text.Json.Dynamic.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>JSON dynamic object</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>.NET json non-allocating corefxlab</PackageTags>
   </PropertyGroup>

--- a/src/System.Text.Json/System.Text.Json.csproj
+++ b/src/System.Text.Json/System.Text.Json.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Non-allocating JSON reader and writer</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>.NET json non-allocating corefxlab</PackageTags>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>

--- a/src/System.Text.Primitives/System.Text.Primitives.csproj
+++ b/src/System.Text.Primitives/System.Text.Primitives.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Efficient parsing, formatting, and encoding APIs</Description>
     <Copyright>Microsoft Corporation, All rights reserved.</Copyright>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>.NET formatting parsing encoding UTF8</PackageTags>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>

--- a/src/System.Text.Utf8String/System.Text.Utf8String.csproj
+++ b/src/System.Text.Utf8String/System.Text.Utf8String.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Efficient UTF-8 String Manipulation and Storage.</Description>
     <Copyright>Microsoft Corporation, All rights reserved.</Copyright>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>.NET UTF-8 String</PackageTags>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>


### PR DESCRIPTION
I'll be making some changes to System.Text.Primitives that rely on `netstandard1.3` APIs, so proactively upgrading that project. This PR also upgrades all of the projects that directly or indirectly pull that in as a dependency.