### PR TITLE
Add streaming UTF8 validator

### DIFF
--- a/src/System.Text.Primitives/System/Text/Encoders/Utf8Validator.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Utf8Validator.cs
@@ -1,0 +1,255 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers.Binary;
+using System.Diagnostics;
+
+namespace System.Buffers.Text
+{
+    /// <summary>
+    /// Allows processing discontiguous buffers of UTF-8 data, letting the caller know whether
+    /// any data seen so far is invalid UTF-8. The caller should invoke <see cref="TryConsume(ReadOnlySpan{byte, bool})"/>
+    /// in a loop until all data has been consumed.
+    /// </summary>
+    /// <remarks>
+    /// This type is a mutable struct.
+    /// </remarks>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    public struct Utf8Validator
+    {
+        /// <summary>
+        /// A sequence that represents a fresh no-partial-buffer validity checker.
+        /// </summary>
+        private const uint DefaultSequence = 0;
+
+        /// <summary>
+        /// A sequence that represents a validity checker which has seen invalid data.
+        /// </summary>
+        private const uint InvalidSequence = unchecked((uint)~0);
+
+        // Packed data that contains both the partial sequence seen and the expected number of bytes remaining.
+        // PS1B: partial sequence first byte, etc.
+        // LEN: BYTE stating how many bytes (0 .. 3) have been read so far into the partial sequence.
+        // If the high bit of LEN is set, an invalid sequence was seen earlier.
+        // Big-endian machine: [ PS1B, PS2B, PS3B, LEN ]
+        // Little-endian machine: [ PS3B, PS2B, PS1B, LEN ]
+        private uint _partialSequence;
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                if (_partialSequence == 0)
+                {
+                    return "Data VALID so far; no partial sequence consumed.";
+                }
+                else if (IsInvalid)
+                {
+                    return "Data INVALID.";
+                }
+                else
+                {
+                    switch ((byte)_partialSequence)
+                    {
+                        case 1:
+                            return (BitConverter.IsLittleEndian)
+                                ? $"Data VALID so far; partial sequence [ {(byte)(_partialSequence >> 8):X2} ] consumed."
+                                : $"Data VALID so far; partial sequence [ {(_partialSequence >> 24):X2} ] consumed.";
+                        case 2:
+                            return (BitConverter.IsLittleEndian)
+                                ? $"Data VALID so far; partial sequence [ {(byte)(_partialSequence >> 8):X2} {(byte)(_partialSequence >> 16):X2} ] consumed."
+                                : $"Data VALID so far; partial sequence [ {(_partialSequence >> 24):X2} {(_partialSequence >> 16):X2} ] consumed.";
+
+                        case 3:
+                            return (BitConverter.IsLittleEndian)
+                                ? $"Data VALID so far; partial sequence [ {(byte)(_partialSequence >> 8):X2} {(byte)(_partialSequence >> 16):X2} {(_partialSequence >> 24):X2} ] consumed."
+                                : $"Data VALID so far; partial sequence [ {(_partialSequence >> 24):X2} {(_partialSequence >> 16):X2} {(byte)(_partialSequence >> 8):X2} ] consumed.";
+
+                        default:
+                            return "** INTERNAL ERROR **";
+                    }
+                }
+            }
+        }
+
+        private bool IsInvalid => IsInvalidPartialSequence(_partialSequence);
+
+        private static uint ConsumeDataWithExistingPartialSequence(uint partialSequence, ReadOnlySpan<byte> utf8Bytes)
+        {
+            Debug.Assert(partialSequence != 0 && !IsInvalidPartialSequence(partialSequence));
+
+            int partialSequenceOriginalByteCount = (byte)partialSequence;
+
+            if (BitConverter.IsLittleEndian)
+            {
+                // When we turn this into a Span<byte>, want MSB to be the first byte of the partial sequence
+                partialSequence >>= 8;
+            }
+
+            // Copy as much data as we can from the input buffer to our partial sequence.
+
+            Span<byte> partialSequenceAsBytes = stackalloc byte[sizeof(uint)];
+            BinaryPrimitives.WriteMachineEndian(partialSequenceAsBytes, ref partialSequence);
+
+            int numBytesToCopyFromInputToPartialSequence = Math.Min(4 - partialSequenceOriginalByteCount, utf8Bytes.Length);
+            utf8Bytes.Slice(0, numBytesToCopyFromInputToPartialSequence).CopyTo(partialSequenceAsBytes.Slice(partialSequenceOriginalByteCount));
+            int partialSequenceNewByteCount = partialSequenceOriginalByteCount + numBytesToCopyFromInputToPartialSequence;
+
+            // And check for validity of the new (hopefully complete) partial sequence.
+
+            var validity = Utf8Utility.PeekFirstSequence(partialSequenceAsBytes.Slice(0, partialSequenceNewByteCount), out int numBytesConsumed, out _);
+            Debug.Assert(1 <= numBytesConsumed && numBytesConsumed <= 4);
+
+            if (validity == SequenceValidity.WellFormed)
+            {
+                // This is the happy path; we've consumed some set of bytes from the input
+                // buffer and it has caused the partial sequence to validate. Let's calculate
+                // how many bytes from the input buffer were required to complete the sequence,
+                // then strip them off the incoming data.
+
+                // n.b. This might not be the same as numBytesToCopyFromInputToPartialSequence.
+                int numBytesRequiredFromInputBufferToFinishPartialSequence = numBytesConsumed - partialSequenceOriginalByteCount;
+                return ConsumeDataWithoutExistingPartialSequence(utf8Bytes.Slice(numBytesRequiredFromInputBufferToFinishPartialSequence));
+            }
+            else if (validity == SequenceValidity.Incomplete)
+            {
+                // We've consumed all data available to us and we still have an incomplete sequence.
+                // It's still valid (until we see invalid bytes), so squirrel away what we've seen
+                // and report success to our caller.
+
+                Debug.Assert(numBytesConsumed < 4);
+                Debug.Assert(numBytesConsumed == partialSequenceNewByteCount);
+
+                // Put all partial data into the high 3 bytes, making room for us to
+                // write the count of partial bytes in the buffer as the low byte.
+
+                partialSequence = BinaryPrimitives.ReadMachineEndian<uint>(partialSequenceAsBytes);
+                if (BitConverter.IsLittleEndian)
+                {
+                    return (partialSequence << 8) | (uint)numBytesConsumed;
+                }
+                else
+                {
+                    return (partialSequence & unchecked((uint)~0xFF)) | (uint)numBytesConsumed;
+                }
+            }
+            else
+            {
+                // Truly invalid data.
+                // (Shouldn't have gotten 'Empty' or 'WellFormed'.)
+
+                Debug.Assert(validity == SequenceValidity.Invalid);
+
+                return InvalidSequence;
+            }
+        }
+
+        private static uint ConsumeDataWithoutExistingPartialSequence(ReadOnlySpan<byte> utf8Bytes)
+        {
+            var indexOfFirstInvalidSequence = Utf8Utility.GetIndexOfFirstInvalidUtf8Sequence(utf8Bytes);
+            if (indexOfFirstInvalidSequence < 0)
+            {
+                // Successfully consumed entire buffer without error.
+
+                return DefaultSequence;
+            }
+            else
+            {
+                // Couldn't consume entire buffer; is this due to a partial buffer or truly invalid data?
+
+                utf8Bytes = utf8Bytes.Slice(indexOfFirstInvalidSequence);
+                var validity = Utf8Utility.PeekFirstSequence(utf8Bytes, out int numBytesConsumed, out _);
+                if (validity == SequenceValidity.Incomplete)
+                {
+                    // Saw a partial (not invalid) sequence, remember it for next time.
+
+                    Debug.Assert(1 <= numBytesConsumed && numBytesConsumed <= 3);
+
+                    // Put all partial data into the high 3 bytes, making room for us to
+                    // write the count of partial bytes in the buffer as the low byte.
+
+                    Span<byte> partialSequenceAsBytes = stackalloc byte[sizeof(uint)];
+                    BinaryPrimitives.WriteMachineEndian(partialSequenceAsBytes, ref numBytesConsumed);
+
+                    if (BitConverter.IsLittleEndian)
+                    {
+                        utf8Bytes.Slice(0, numBytesConsumed).CopyTo(partialSequenceAsBytes.Slice(1));
+                    }
+                    else
+                    {
+                        utf8Bytes.Slice(0, numBytesConsumed).CopyTo(partialSequenceAsBytes);
+                    }
+
+                    return BinaryPrimitives.ReadMachineEndian<uint>(partialSequenceAsBytes);
+                }
+                else
+                {
+                    // Truly invalid data.
+                    // (Shouldn't have gotten 'Empty' or 'WellFormed'.)
+
+                    Debug.Assert(validity == SequenceValidity.Invalid);
+
+                    return InvalidSequence;
+                }
+            }
+        }
+
+        private static bool IsInvalidPartialSequence(uint partialSequence) => ((byte)partialSequence & 0x80) != 0;
+
+        /// <summary>
+        /// Consumes UTF-8 data from the provided buffer. If <paramref name="utf8Bytes"/> ends
+        /// with an incomplete (but not invalid) sequence, this instance will save the
+        /// incomplete sequence, this method will return <see langword="true"/>, and the
+        /// next call to this method will automatically prepend the saved sequence before
+        /// processing. This allows the caller to invoke this method in a loop passing in
+        /// discontiguous buffers, even if UTF-8 sequences are split across those buffers.
+        /// If this method returns <see langword="false"/>, the entire instance is marked
+        /// as invalid, and all subsequent calls to this method will also return <see langword="false"/>.
+        /// </summary>
+        /// <param name="utf8Bytes">A buffer containing UTF-8 data to validate.</param>
+        /// <param name="isFinalChunk">
+        /// <see langword="true"/> if the caller will pass no more data to the validator,
+        /// <see langword="false"/> if the caller will pass more data to the validator.
+        /// If <see langword="true"/>, the validator will treat an incomplete sequence at
+        /// the end of <paramref name="utf8Bytes"/> as an error instead of saving it for
+        /// the next call.
+        /// </param>
+        /// <returns>
+        /// <see langword="true"/> if no invalid data has yet been seen,
+        /// <see langword="false"/> if invalid data has ever been seen.
+        /// </returns>
+        /// <remarks>
+        /// It is important that the caller invoke this method with
+        /// <paramref name="isFinalChunk"/>=<see langword="true"/> when there is no more
+        /// data, otherwise the caller may inadvertently believe that the entire input data
+        /// is valid even if there's an unfinished UTF-8 sequence at the very end of the data.
+        /// It's also ok for the caller to pass an empty span for <paramref name="utf8Bytes"/>
+        /// when calling with <paramref name="isFinalChunk"/>=<see langword="true"/> to signal
+        /// "there is no more data; fail if there were unfinished sequences in the previous call."
+        /// </remarks>
+        public bool TryConsume(ReadOnlySpan<byte> utf8Bytes, bool isFinalChunk)
+        {
+            if (utf8Bytes.Length > 0 && !IsInvalid)
+            {
+                if (_partialSequence == 0)
+                {
+                    _partialSequence = ConsumeDataWithoutExistingPartialSequence(utf8Bytes);
+                }
+                else
+                {
+                    _partialSequence = ConsumeDataWithExistingPartialSequence(_partialSequence, utf8Bytes);
+                }
+            }
+
+            // If the caller signaled the end of the data stream but there's still an
+            // unfinished sequence awaiting processing, this is failure.
+
+            if (isFinalChunk && _partialSequence != 0)
+            {
+                _partialSequence = InvalidSequence;
+            }
+
+            return !IsInvalid;
+        }
+    }
+}

--- a/tests/System.Text.Primitives.Tests/Encoding/Utf8UtilTests.Validation.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/Utf8UtilTests.Validation.cs
@@ -274,7 +274,7 @@ namespace System.Text.Primitives.Tests.Encoding
         {
             Assert.Equal(2, invalidSequence.Length);
 
-            byte[] KNOWN_GOOD_BYTES = DecodeHex(E_ACUTE);
+            byte[] KNOWN_GOOD_BYTES = TestHelper.DecodeHex(E_ACUTE);
 
             byte[] toTest = invalidSequence.Concat(invalidSequence).Concat(KNOWN_GOOD_BYTES).ToArray(); // at start of first DWORD
             GetIndexOfFirstInvalidUtf8Sequence_Test_Core(toTest, 0, 0, 0);
@@ -296,7 +296,7 @@ namespace System.Text.Primitives.Tests.Encoding
         {
             Assert.Equal(3, invalidSequence.Length);
 
-            byte[] KNOWN_GOOD_BYTES = DecodeHex(EURO_SYMBOL);
+            byte[] KNOWN_GOOD_BYTES = TestHelper.DecodeHex(EURO_SYMBOL);
 
             byte[] toTest = invalidSequence.Concat(invalidSequence).Concat(KNOWN_GOOD_BYTES).ToArray(); // at start of first DWORD
             GetIndexOfFirstInvalidUtf8Sequence_Test_Core(toTest, 0, 0, 0);
@@ -318,7 +318,7 @@ namespace System.Text.Primitives.Tests.Encoding
         {
             Assert.Equal(4, invalidSequence.Length);
 
-            byte[] KNOWN_GOOD_BYTES = DecodeHex(GRINNING_FACE);
+            byte[] KNOWN_GOOD_BYTES = TestHelper.DecodeHex(GRINNING_FACE);
 
             byte[] toTest = invalidSequence.Concat(invalidSequence).Concat(KNOWN_GOOD_BYTES).ToArray();
             GetIndexOfFirstInvalidUtf8Sequence_Test_Core(toTest, 0, 0, 0);
@@ -328,7 +328,7 @@ namespace System.Text.Primitives.Tests.Encoding
         }
 
         private static void GetIndexOfFirstInvalidUtf8Sequence_Test_Core(string inputHex, int expectedRetVal, int expectedRuneCount, int expectedSurrogatePairCount)
-            => GetIndexOfFirstInvalidUtf8Sequence_Test_Core(DecodeHex(inputHex), expectedRetVal, expectedRuneCount, expectedSurrogatePairCount);
+            => GetIndexOfFirstInvalidUtf8Sequence_Test_Core(TestHelper.DecodeHex(inputHex), expectedRetVal, expectedRuneCount, expectedSurrogatePairCount);
 
         private static void GetIndexOfFirstInvalidUtf8Sequence_Test_Core(byte[] input, int expectedRetVal, int expectedRuneCount, int expectedSurrogatePairCount)
         {
@@ -345,33 +345,6 @@ namespace System.Text.Primitives.Tests.Encoding
             Assert.Equal(expectedRetVal, indexOfFirstInvalidChar);
             Assert.Equal(expectedRuneCount, actualRuneCount);
             Assert.Equal(expectedSurrogatePairCount, actualSurrogatePairCount);
-        }
-
-        private static byte[] DecodeHex(string input)
-        {
-            int ParseNibble(char ch)
-            {
-                ch -= (char)'0';
-                if (ch < 10) { return ch; }
-
-                ch -= (char)('A' - '0');
-                if (ch < 6) { return (ch + 10); }
-
-                ch -= (char)('a' - 'A');
-                if (ch < 6) { return (ch + 10); }
-
-                throw new Exception("Invalid hex character.");
-            }
-
-            if (input.Length % 2 != 0) { throw new Exception("Invalid hex data."); }
-
-            byte[] retVal = new byte[input.Length / 2];
-            for (int i = 0; i < retVal.Length; i++)
-            {
-                retVal[i] = (byte)((ParseNibble(input[2 * i]) << 4) | ParseNibble(input[2 * i + 1]));
-            }
-
-            return retVal;
         }
     }
 }

--- a/tests/System.Text.Primitives.Tests/Encoding/Utf8ValidatorTests.cs
+++ b/tests/System.Text.Primitives.Tests/Encoding/Utf8ValidatorTests.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers.Text;
+using System.Linq;
+using System.Text.Primitives.Tests.MemoryProtection;
+using Xunit;
+
+namespace System.Text.Primitives.Tests.Encoding
+{
+    public class Utf8ValidatorTests
+    {
+        [Fact]
+        public void TryConsume_EmptySequence_ReturnsSuccess()
+        {
+            // Arrange
+
+            Utf8Validator validator = new Utf8Validator();
+
+            // Act & assert
+
+            Assert.True(validator.TryConsume(ReadOnlySpan<byte>.Empty, isFinalChunk: false));
+            Assert.True(validator.TryConsume(ReadOnlySpan<byte>.Empty, isFinalChunk: true));
+        }
+
+        [Fact]
+        public void TryConsume_WithPartialSequence_FollowedByEmptySequence_AsFinalChunk_ReturnsFailure()
+        {
+            // Arrange
+
+            Utf8Validator validator = new Utf8Validator();
+
+            // Act & assert
+
+            Assert.True(validator.TryConsume(new byte[] { 0xC2 }, isFinalChunk: false)); // [ C2 ] is valid start of incomplete multi-byte sequence
+            Assert.True(validator.TryConsume(ReadOnlySpan<byte>.Empty, isFinalChunk: false));
+            Assert.False(validator.TryConsume(ReadOnlySpan<byte>.Empty, isFinalChunk: true));
+        }
+
+        [Fact]
+        public void TryConsume_OnceInvalid_AlwaysInvalid()
+        {
+            // Arrange
+
+            Utf8Validator validator = new Utf8Validator();
+
+            // Act & assert
+
+            Assert.False(validator.TryConsume(new byte[] { 0xFF }, isFinalChunk: true)); // [ FF ] is always an invalid byte
+            Assert.False(validator.TryConsume(new byte[] { 0x20 }, isFinalChunk: false));
+            Assert.False(validator.TryConsume(new byte[] { 0x20 }, isFinalChunk: true));
+        }
+
+        [Fact]
+        public void TryConsume_WithNoExistingPartialSequence_AndValidCompleteInputs_ReturnsSuccess()
+        {
+            // Arrange
+
+            Utf8Validator validator = new Utf8Validator();
+
+            // Act & assert
+
+            Assert.True(validator.TryConsume(new byte[] { 0x10, 0x11, 0x12, 0x13 }, isFinalChunk: true));
+            Assert.True(validator.TryConsume(new byte[] { 0x20, 0x21, 0x22, 0x23 }, isFinalChunk: true));
+        }
+
+        [Theory]
+        [InlineData(new object[] { new[] { "20", "21", "22", "23", "24" } })]
+        [InlineData(new object[] { new[] { "C2", "80", "C2", "80C2", "80C280C280" } })]
+        [InlineData(new object[] { new[] { "E0", "BF", "BF", "E0BF", "BFE0", "BFBFE0BFBF", "E0BF", "BFE0BFBFE0BFBF" } })]
+        [InlineData(new object[] { new[] { "F1", "80", "80", "80", "F180", "8080", "F180", "8080F1", "808080F1", "808080F1808080" } })]
+        public void TryConsume_SuccessCases(string[] chunks)
+        {
+            // Arrange
+
+            Utf8Validator validator = new Utf8Validator();
+
+            // Act & assert - loop
+
+            foreach (var chunk in chunks)
+            {
+                Assert.True(validator.TryConsume(TestHelper.DecodeHex(chunk), isFinalChunk: false));
+            }
+
+            // Act & assert - final
+
+            Assert.True(validator.TryConsume(ReadOnlySpan<byte>.Empty, isFinalChunk: true));
+        }
+
+
+        [Theory]
+        [InlineData(new object[] { new[] { "80" } })] // standalone continuation byte
+        [InlineData(new object[] { new[] { "C2", "80C2", "80C280C2", "C2" } })] // C2 C2 is not a valid multi-byte sequence
+        [InlineData(new object[] { new[] { "C2", "80C2", "80C280C2", "80C220" } })] // C2 20 is not a valid multi-byte sequence
+        [InlineData(new object[] { new[] { "C2", "80C2", "80C280C2", "80C180" } })] // C1 is never a valid code unit
+        [InlineData(new object[] { new[] { "F4", "808080F4", "8080", "80F490" } })] // out-of-range sequence
+        [InlineData(new object[] { new[] { "F0", "908080F0", "80" } })] // overlong sequence
+        public void TryConsume_FailureCases(string[] chunks)
+        {
+            // Arrange
+
+            Utf8Validator validator = new Utf8Validator();
+
+            // Act & assert - all but last chunk
+
+            for (int i = 0; i < chunks.Length - 1; i++)
+            {
+                Assert.True(validator.TryConsume(TestHelper.DecodeHex(chunks[i]), isFinalChunk: false));
+            }
+
+            // Act & assert - final chunk (which should be bad)
+
+            Assert.False(validator.TryConsume(TestHelper.DecodeHex(chunks.Last()), isFinalChunk: false));
+        }
+    }
+}

--- a/tests/System.Text.Primitives.Tests/TestHelper.cs
+++ b/tests/System.Text.Primitives.Tests/TestHelper.cs
@@ -15,6 +15,34 @@ namespace System.Text.Primitives.Tests
     {
         public const int LoadIterations = 30000;
 
+        // Converts a hex string to binary.
+        public static byte[] DecodeHex(string input)
+        {
+            int ParseNibble(char ch)
+            {
+                ch -= (char)'0';
+                if (ch < 10) { return ch; }
+
+                ch -= (char)('A' - '0');
+                if (ch < 6) { return (ch + 10); }
+
+                ch -= (char)('a' - 'A');
+                if (ch < 6) { return (ch + 10); }
+
+                throw new Exception("Invalid hex character.");
+            }
+
+            if (input.Length % 2 != 0) { throw new Exception("Invalid hex data."); }
+
+            byte[] retVal = new byte[input.Length / 2];
+            for (int i = 0; i < retVal.Length; i++)
+            {
+                retVal[i] = (byte)((ParseNibble(input[2 * i]) << 4) | ParseNibble(input[2 * i + 1]));
+            }
+
+            return retVal;
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void DoNotIgnore(uint value, int consumed)
         {


### PR DESCRIPTION
Introduces a type that can perform streaming validation of UTF-8 byte sequences. This is intended to be a drop-in replacement for existing streaming validators such as the one that exists at https://github.com/dotnet/corefx/blob/5617d3996c8cb1c3d3332f6c03dd5f3bf785623f/src/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs#L1326. This type also demonstrates how some of the primitives (such as inspecting the first sequence or getting the index of the first invalid sequence) hanging off of `Utf8Utility` can be used.

The type is currently a mutable struct, 4 bytes in length. This should provide respectable performance on all platforms and avoids allocations. Alternative designs can be considered if it's too difficult to consume this type.