### PR TITLE
Finished Position Cleanup

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/BufferSequence.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/BufferSequence.cs
@@ -53,14 +53,14 @@ namespace Microsoft.Net
         {
             if (position == default) {
                 item = Memory.Slice(0, _written);
-                if (advance) { position.Set(_next); }
+                if (advance) { position.SetItem(_next); }
                 return true;
             }
-            else if (position.IsInfinity) { item = default; return false; }
+            else if (position.IsEnd) { item = default; return false; }
 
-            var sequence = position.As<BufferSequence>();
+            var sequence = position.GetItem<BufferSequence>();
             item = sequence.Memory.Slice(0, sequence._written);
-            if (advance) { position.Set(sequence._next); }
+            if (advance) { position.SetItem(sequence._next); }
             return true;
         }
 
@@ -69,14 +69,14 @@ namespace Microsoft.Net
             if (position == default)
             {
                 item = Memory.Slice(0, _written);
-                if (advance) { position.Set(_next); }
+                if (advance) { position.SetItem(_next); }
                 return true;
             }
-            else if (position.IsInfinity) { item = default; return false; }
+            else if (position.IsEnd) { item = default; return false; }
 
-            var sequence = position.As<BufferSequence>();
+            var sequence = position.GetItem<BufferSequence>();
             item = sequence.Memory.Slice(0, sequence._written);
-            if (advance) { position.Set(sequence._next); }
+            if (advance) { position.SetItem(sequence._next); }
             return true;
         }
 

--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -23,7 +23,7 @@ namespace System.Buffers
             Span<byte> stackSpan = stackalloc byte[stackLength];
 
             Position poisition = default;
-            while (source.TryGet(ref poisition, out var sourceBuffer, true))
+            while (source.TryGet(ref poisition, out var sourceBuffer))
             {
                 Span<byte> outputSpan = destination.Buffer;
                 ReadOnlySpan<byte> sourceSpan = sourceBuffer.Span;
@@ -146,7 +146,7 @@ namespace System.Buffers
 
             Position position = default;
             int runningIndex = first.Length;
-            while(sequence.TryGet(ref position, out var memory, advance: true))
+            while(sequence.TryGet(ref position, out var memory))
             {
                 index = memory.Span.IndexOf(value);
                 if (index != -1) return index + runningIndex;

--- a/src/System.Collections.Sequences/System.Collections.Sequences.csproj
+++ b/src/System.Collections.Sequences/System.Collections.Sequences.csproj
@@ -9,5 +9,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
+    <PackageReference Include="System.ValueTuple">
+      <Version>4.5.0-preview2-25707-02</Version>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/System.Collections.Sequences/System.Collections.Sequences.csproj
+++ b/src/System.Collections.Sequences/System.Collections.Sequences.csproj
@@ -9,8 +9,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-    <PackageReference Include="System.ValueTuple">
-      <Version>4.5.0-preview2-25707-02</Version>
-    </PackageReference>
+    <PackageReference Include="System.ValueTuple" Version="$(CoreFxStableVersion)" />
   </ItemGroup>
 </Project>

--- a/src/System.Collections.Sequences/System/Collections/Sequences/ArrayList.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/ArrayList.cs
@@ -9,32 +9,19 @@ namespace System.Collections.Sequences
     {
         ResizableArray<T> _items;
 
-        public ArrayList()
-        {
-            _items = new ResizableArray<T>(0);
-        }
-        public ArrayList(int capacity)
-        {
-            _items = new ResizableArray<T>(capacity);
-        }
+        public ArrayList() => _items = new ResizableArray<T>(0);
+
+        public ArrayList(int capacity) => _items = new ResizableArray<T>(capacity);
 
         public int Length => _items.Count;
 
         public T this[int index] => _items[index];
 
-        public void Add(T item)
-        {
-            _items.Add(item);
-        }
+        public void Add(T item) => _items.Add(item);
 
-        public SequenceEnumerator<T> GetEnumerator()
-        {
-            return new SequenceEnumerator<T>(this);
-        }
+        public SequenceEnumerator<T> GetEnumerator() => new SequenceEnumerator<T>(this);
 
-        public bool TryGet(ref Position position, out T item, bool advance = true)
-        {
-            return _items.TryGet(ref position, out item, advance);
-        }
+        public bool TryGet(ref Position position, out T item, bool advance = true) =>
+            _items.TryGet(ref position, out item, advance);
     }
 }

--- a/src/System.Collections.Sequences/System/Collections/Sequences/Position.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/Position.cs
@@ -10,38 +10,58 @@ namespace System.Collections.Sequences
     public struct Position : IEquatable<Position>
     {
         long _index;
-        object _obj;
+        object _item;
 
         public static explicit operator int(Position position) => (int)position._index;
+
         public static implicit operator long(Position position) => position._index;
-        public T As<T>() => _obj == null || IsInfinity ? default : (T)_obj;
-        public bool IsInfinity => this == Infinity;
 
-        public static readonly Position Infinity = new Position(new object(), long.MaxValue);
+        public long GetIndex() => _index;
 
-        public static Position operator +(Position position, long value) => new Position(position._obj, position._index + value);
+        public T GetItem<T>() => _item == null || IsEnd ? default : (T)_item;
 
-        public static Position operator -(Position position, long value) => new Position(position._obj, position._index - value);
+        public (T item, long index) Get<T>() => (GetItem<T>(), this);
 
-        public static bool operator ==(Position left, Position right) => left._index == right._index && left._obj == right._obj;
-        public static bool operator !=(Position left, Position right) => left._index != right._index || left._obj != right._obj;
-
-        public void Set(long value) => _index = value;
-
-        public void Set(int value) => _index = value;
+        public void SetIndex(long index) => _index = index;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Set<T>(T item)
+        public void SetItem<T>(T item) where T:class
         {
-            if(EqualityComparer<T>.Default.Equals(item, default)) this = Infinity;
-            else _obj = item;
+            if (item == null) this = End;
+            else _item = item;
         }
 
-        private Position(object obj, long index)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Set<T>(T item, long index) where T : class
         {
-            _obj = obj;
-            _index = index;
+            if (item == null) this = End;
+            else
+            {
+                _item = item;
+                _index = index;
+            }
         }
+
+        public void Advance<T>(T item, long offset) where T:class
+        {
+            if (item == null) this = End;
+            else
+            {
+                _item = item;
+                _index += offset;
+            }
+        }
+
+        public static Position operator +(Position position, long offset) => new Position(position._item, position._index + offset);
+
+        public static Position operator -(Position position, long offset) => new Position(position._item, position._index - offset);
+
+        public static readonly Position End = new Position(new object(), long.MaxValue);
+
+        public bool IsEnd => this == End;
+
+        public static bool operator ==(Position left, Position right) => left._index == right._index && left._item == right._item;
+        public static bool operator !=(Position left, Position right) => left._index != right._index || left._item != right._item;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool Equals(Position position) => this == position;
@@ -52,10 +72,16 @@ namespace System.Collections.Sequences
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() =>
-            _index.GetHashCode() ^ (_obj == null ? 0 : _obj.GetHashCode());
+            _index.GetHashCode() ^ (_item == null ? 0 : _item.GetHashCode());
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() =>
-            _obj == null ? @"{_index}" : @"{_index}, {_obj}";
+            _item == null ? @"{_index}" : @"{_index}, {_obj}";
+
+        private Position(object obj, long index)
+        {
+            _item = obj;
+            _index = index;
+        }
     }
 }

--- a/src/System.Collections.Sequences/System/Collections/Sequences/Position.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/Position.cs
@@ -25,7 +25,7 @@ namespace System.Collections.Sequences
         public void SetIndex(long index) => _index = index;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void SetItem<T>(T item) where T:class
+        public void SetItem<T>(T item) where T : class
         {
             if (item == null) this = End;
             else _item = item;
@@ -42,7 +42,7 @@ namespace System.Collections.Sequences
             }
         }
 
-        public void Advance<T>(T item, long offset) where T:class
+        public void Advance<T>(T item, long offset) where T : class
         {
             if (item == null) this = End;
             else

--- a/src/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs
@@ -6,12 +6,14 @@ namespace System.Collections.Sequences
     // a List<T> like type designed to be embeded in other types
     public struct ResizableArray<T>
     {
+        private static T[] s_empty = new T[0];
+
         private T[] _array;
         private int _count;
 
         public ResizableArray(int capacity)
         {
-            _array = new T[capacity];
+            _array = capacity == 0 ? s_empty : new T[capacity];
             _count = 0;
         }
 
@@ -114,7 +116,7 @@ namespace System.Collections.Sequences
             }
 
             item = default;
-            position = Position.Infinity;
+            position = Position.End;
             return false;
         }
 

--- a/src/System.Collections.Sequences/System/Collections/Sequences/SequenceEnumerator.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/SequenceEnumerator.cs
@@ -10,21 +10,36 @@ namespace System.Collections.Sequences
         Position _position;
         ISequence<T> _sequence;
         T _current;
-        bool first; // this is needed so that MoveNext does not advance the first time it's called
 
-        public SequenceEnumerator(ISequence<T> sequence) {
+        public SequenceEnumerator(ISequence<T> sequence)
+        {
             _sequence = sequence;
             _position = default;
             _current = default;
-            first = true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool MoveNext() {
-            var result = _sequence.TryGet(ref _position, out _current, advance: !first);
-            first = false;
-            return result;
+        public bool MoveNext() => _sequence.TryGet(ref _position, out _current);
+
+        public T Current => _current;
+    }
+
+    public struct SequenceEnumerator<T, TSequence>
+        where TSequence : ISequence<T>
+    {
+        Position _position;
+        TSequence _sequence;
+        T _current;
+
+        public SequenceEnumerator(TSequence sequence)
+        {
+            _sequence = sequence;
+            _position = default;
+            _current = default;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool MoveNext() => _sequence.TryGet(ref _position, out _current);
 
         public T Current => _current;
     }

--- a/src/System.IO.Pipelines.Extensions/ReadableBufferSequence.cs
+++ b/src/System.IO.Pipelines.Extensions/ReadableBufferSequence.cs
@@ -24,25 +24,25 @@ namespace System.IO.Pipelines
                 {
                     if (_buffer.Start.IsEnd)
                     {
-                        position = Position.Infinity;
+                        position = Position.End;
                     }
                     else
                     {
-                        position.Set(_buffer.Start.Segment.Next);
+                        position.SetItem(_buffer.Start.Segment.Next);
                     }
                 }
                 return true;
             }
-            else if (position == Position.Infinity)
+            else if (position == Position.End)
             {
                 item = default;
                 return false;
             }
 
-            var currentSegment = position.As<BufferSegment>();
+            var currentSegment = position.GetItem<BufferSegment>();
             if (advance)
             {
-                position.Set(currentSegment.Next);
+                position.SetItem(currentSegment.Next);
             }
             if (currentSegment == _buffer.End.Segment)
             {

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/SequenceFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/SequenceFormatter.cs
@@ -23,7 +23,7 @@ namespace System.Text.Formatting
 
         Position _currentPosition = default;
         int _currentWrittenBytes;
-        Position _previousPosition = Position.Infinity;
+        Position _previousPosition = Position.End;
         int _previousWrittenBytes;
         int _totalWritten;
 

--- a/src/System.Text.Http.Parser/HttpParser.cs
+++ b/src/System.Text.Http.Parser/HttpParser.cs
@@ -459,14 +459,14 @@ namespace System.Text.Http.Parser
                 // This is just to get the position to be at the second segment
                 if (position == default)
                 {
-                    if (!buffer.TryGet(ref position, out ReadOnlyMemory<byte> current, advance: true))
+                    if (!buffer.TryGet(ref position, out ReadOnlyMemory<byte> current))
                     {
                         consumedBytes = 0;
                         return false;
                     }
                 }
 
-                if (buffer.TryGet(ref position, out var nextSegment, advance: true))
+                if (buffer.TryGet(ref position, out var nextSegment))
                 {
                     currentSpan = nextSegment.Span;
                     remaining = currentSpan.Length + remaining;

--- a/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
@@ -14,7 +14,7 @@ namespace System.Buffers.Tests
         {
             ReadOnlyMemory<byte> buffer = new byte[] { 1, 2, 3, 4, 5, 6 };
             var bytes = new ReadOnlyBytes(buffer);
-            var sliced  = bytes.Slice(1, 3);
+            var sliced = bytes.Slice(1, 3);
             var span = sliced.First.Span;
             Assert.Equal((byte)2, span[0]);
 
@@ -42,11 +42,12 @@ namespace System.Buffers.Tests
 
             ReadOnlyBytes sliced = bytes;
             ReadOnlySpan<byte> span;
-            for(int i=1; i<=array.Length; i++) {
-                sliced  = bytes.Slice(i);
+            for (int i = 1; i <= array.Length; i++)
+            {
+                sliced = bytes.Slice(i);
                 span = sliced.First.Span;
                 Assert.Equal(array.Length - i, span.Length);
-                if(i!=array.Length) Assert.Equal(i, span[0]);
+                if (i != array.Length) Assert.Equal(i, span[0]);
             }
             Assert.Equal(0, span.Length);
         }
@@ -61,11 +62,12 @@ namespace System.Buffers.Tests
 
             ReadOnlyBytes sliced = bytes;
             ReadOnlySpan<byte> span;
-            for(int i=1; i<=totalLength; i++) {
-                sliced  = bytes.Slice(i);
+            for (int i = 1; i <= totalLength; i++)
+            {
+                sliced = bytes.Slice(i);
                 span = sliced.First.Span;
                 Assert.Equal(totalLength - i, sliced.Length);
-                if(i!=totalLength) Assert.Equal(i, span[0]);
+                if (i != totalLength) Assert.Equal(i, span[0]);
             }
             Assert.Equal(0, span.Length);
         }
@@ -251,7 +253,8 @@ namespace System.Buffers.Tests
                 var copy = new byte[array.Length - 1];
                 var copied = bytes.CopyTo(copy);
                 Assert.Equal(copy.Length, copied);
-                for(int i=0; i<copied; i++) {
+                for (int i = 0; i < copied; i++)
+                {
                     Assert.Equal(array[i], copy[i]);
                 }
             }
@@ -260,7 +263,8 @@ namespace System.Buffers.Tests
                 var copy = new byte[array.Length + 1];
                 var copied = bytes.CopyTo(copy);
                 Assert.Equal(array.Length, copied);
-                for (int i = 0; i < copied; i++) {
+                for (int i = 0; i < copied; i++)
+                {
                     Assert.Equal(array[i], copy[i]);
                 }
             }
@@ -278,7 +282,8 @@ namespace System.Buffers.Tests
                 var copy = new byte[totalLength];
                 var copied = bytes.CopyTo(copy);
                 Assert.Equal(totalLength, copied);
-                for (int i = 0; i < totalLength; i++) {
+                for (int i = 0; i < totalLength; i++)
+                {
                     Assert.Equal(i, copy[i]);
                 }
             }
@@ -287,7 +292,8 @@ namespace System.Buffers.Tests
                 var copy = new byte[totalLength - 1];
                 var copied = bytes.CopyTo(copy);
                 Assert.Equal(copy.Length, copied);
-                for (int i = 0; i < copied; i++) {
+                for (int i = 0; i < copied; i++)
+                {
                     Assert.Equal(i, copy[i]);
                 }
             }
@@ -296,7 +302,8 @@ namespace System.Buffers.Tests
                 var copy = new byte[totalLength + 1];
                 var copied = bytes.CopyTo(copy);
                 Assert.Equal(totalLength, copied);
-                for (int i = 0; i < totalLength; i++) {
+                for (int i = 0; i < totalLength; i++)
+                {
                     Assert.Equal(i, copy[i]);
                 }
             }
@@ -338,7 +345,8 @@ namespace System.Buffers.Tests
             Assert.Equal(10, bytes.First.Length);
             Assert.Equal(9, bytes.First.Span[9]);
 
-            for(int i=0; i<20; i++){
+            for (int i = 0; i < 20; i++)
+            {
                 var index = bytes.IndexOf((byte)i);
                 Assert.Equal(i, index);
             }
@@ -372,8 +380,16 @@ namespace System.Buffers.Tests
         public void EmptyReadOnlyBytesEnumeration()
         {
             var bytes = ReadOnlyBytes.Empty;
-            Position position = default;
-            Assert.False(bytes.TryGet(ref position, out ReadOnlyMemory<byte> segment));
+            {
+                Position position = default;
+                Assert.False(bytes.TryGet(ref position, out ReadOnlyMemory<byte> segment));
+            }
+            {
+                foreach (var segment in bytes)
+                {
+                    Assert.False(true);
+                }
+            }
         }
 
         [Fact]
@@ -383,13 +399,24 @@ namespace System.Buffers.Tests
             {
                 var multibytes = Parse("A|CD|EFG");
                 multibytes = multibytes.Slice(i);
-                Position position = default;
-                var length = 0;
-                while (multibytes.TryGet(ref position, out ReadOnlyMemory<byte> segment))
+
                 {
-                    length += segment.Length;
+                    Position position = default;
+                    var length = 0;
+                    while (multibytes.TryGet(ref position, out ReadOnlyMemory<byte> segment))
+                    {
+                        length += segment.Length;
+                    }
+                    Assert.Equal(6 - i, length);
                 }
-                Assert.Equal(6 - i, length);
+                {
+                    var length = 0;
+                    foreach (var segment in multibytes)
+                    {
+                        length += segment.Length;
+                    }
+                    Assert.Equal(6 - i, length);
+                }
             }
         }
 
@@ -400,13 +427,24 @@ namespace System.Buffers.Tests
             {
                 var multibytes = Parse("A|CD|EFG");
                 multibytes = multibytes.Slice(0, i);
-                Position position = default;
-                var length = 0;
-                while (multibytes.TryGet(ref position, out ReadOnlyMemory<byte> segment))
+
                 {
-                    length += segment.Length;
+                    Position position = default;
+                    var length = 0;
+                    while (multibytes.TryGet(ref position, out ReadOnlyMemory<byte> segment))
+                    {
+                        length += segment.Length;
+                    }
+                    Assert.Equal(i, length);
                 }
-                Assert.Equal(i, length);
+                {
+                    var length = 0;
+                    foreach (var segment in multibytes)
+                    {
+                        length += segment.Length;
+                    }
+                    Assert.Equal(i, length);
+                }
             }
         }
 

--- a/tests/System.Collections.Sequences.Tests/BasicUnitTests.cs
+++ b/tests/System.Collections.Sequences.Tests/BasicUnitTests.cs
@@ -46,7 +46,7 @@ namespace System.Collections.Sequences.Tests
         [InlineData(new int[] { 1, 2, 3 })]
         public void LinkedContainer(int[] array)
         {
-             LinkedContainer<int> collection = CreateLinkedContainer(array);
+            LinkedContainer<int> collection = CreateLinkedContainer(array);
 
             Position position = default;
             int arrayIndex = array.Length;

--- a/tests/System.Collections.Sequences.Tests/BasicUnitTests.cs
+++ b/tests/System.Collections.Sequences.Tests/BasicUnitTests.cs
@@ -12,7 +12,7 @@ namespace System.Collections.Sequences.Tests
         [Theory]
         [InlineData(new int[] { })]
         [InlineData(new int[] { 1 })]
-        [InlineData(new int[] { 1, 2, 3})]
+        [InlineData(new int[] { 1, 2, 3 })]
         public void ArrayList(int[] array)
         {
             ArrayList<int> collection = CreateArrayList(array);
@@ -23,6 +23,14 @@ namespace System.Collections.Sequences.Tests
             {
                 Assert.Equal(array[arrayIndex++], item);
             }
+            Assert.Equal(array.Length, arrayIndex);
+
+            arrayIndex = 0;
+            foreach (int item in collection)
+            {
+                Assert.Equal(array[arrayIndex++], item);
+            }
+            Assert.Equal(array.Length, arrayIndex);
         }
 
         private static ArrayList<int> CreateArrayList(int[] array)
@@ -38,7 +46,7 @@ namespace System.Collections.Sequences.Tests
         [InlineData(new int[] { 1, 2, 3 })]
         public void LinkedContainer(int[] array)
         {
-            LinkedContainer<int> collection = CreateLinkedContainer(array);
+             LinkedContainer<int> collection = CreateLinkedContainer(array);
 
             Position position = default;
             int arrayIndex = array.Length;

--- a/tests/System.Collections.Sequences.Tests/SampleCollections/Hashtable.cs
+++ b/tests/System.Collections.Sequences.Tests/SampleCollections/Hashtable.cs
@@ -91,19 +91,19 @@ namespace System.Collections.Sequences
         {
             item = default;
 
-            if (_count == 0 | position == Position.Infinity) {
-                position = Position.Infinity;
+            if (_count == 0 | position == Position.End) {
+                position = Position.End;
                 return false;
             }
 
             if (position == default) {
                 var firstOccupiedSlot = FindFirstStartingAt(0);
                 if (firstOccupiedSlot == -1) {
-                    position = Position.Infinity;
+                    position = Position.End;
                     return false;
                 }
 
-                position.Set(firstOccupiedSlot);
+                position.SetIndex(firstOccupiedSlot);
             }
 
             var index = (int)position;
@@ -114,9 +114,9 @@ namespace System.Collections.Sequences
 
             if (advance) {
                 var first = FindFirstStartingAt(index + 1);
-                position.Set(first);
+                position.SetIndex(first);
                 if (first == -1) {
-                    position = Position.Infinity;
+                    position = Position.End;
                 }
             }
 

--- a/tests/System.Collections.Sequences.Tests/SampleCollections/LinkedContainer.cs
+++ b/tests/System.Collections.Sequences.Tests/SampleCollections/LinkedContainer.cs
@@ -28,42 +28,28 @@ namespace System.Collections.Sequences
 
         public bool TryGet(ref Position position, out T item, bool advance = true)
         {
-            item = default;
-
-            if(_count == 0) {
-                position = Position.Infinity;
+            if(_count == 0)
+            {
+                item = default;
                 return false;
             }
 
-            if (position.IsInfinity) {
-                return false;
-            }
-
-            if(position == default) {
+            if (position == default)
+            {
                 item = _head._item;
-                if (advance) position.Set(_head._next);
-                if (_head._next == null) position = Position.Infinity;
-                return true;
+                if (advance) position.SetItem(_head._next);
+                return _count > 0;
             }
 
-            var node = position.As<Node>();
-            
+            var node = position.GetItem<Node>();
             if (node == null) {
-                position = Position.Infinity;
+                item = default;
+                position = Position.End;
                 return false;
-            }
-
-            if (advance) {
-                if (node._next != null) {
-                    position.Set(node._next);
-                    if (node._next == null) position = Position.Infinity;
-                }
-                else {
-                    position = Position.Infinity;
-                }
             }
 
             item = node._item;
+            if (advance) { position.SetItem(node._next); }
             return true;
         }
 


### PR DESCRIPTION
Common usage examples:

1. Calling ISequence\<T\>
```c#
ISequence<T> collection = ...

Position position = default;
while (collection.TryGet(ref position, out int item)) {
    Console.WriteLine(item);
}
```
2. Array-based data structure implementation, e.g. [ResizableArray\<T\>](https://github.com/dotnet/corefxlab/blob/master/src/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs#L107)
```c#
public bool TryGet(ref Position position, out T item, bool advance = true)
{
    int index = (int)position;
    if (index < _count) {
        item = _array[index];
        if (advance) { position += 1; }
        return true;
    }

    item = default;
    position = Position.End;
    return false;
}
```

3. Linked List implementation, e.g. [LinkedContainer\<T\>](https://github.com/dotnet/corefxlab/blob/master/tests/System.Collections.Sequences.Tests/SampleCollections/LinkedContainer.cs#L29)
```c#

public bool TryGet(ref Position position, out T item, bool advance = true)
{
    if(_count == 0)
    {
        item = default;
        return false;
    }

    if (position == default)
    {
        item = _head._item;
        if (advance) position.SetItem(_head._next);
        return _count > 0;
    }

    var node = position.GetItem<Node>();
    if (node == null) {
        item = default;
        position = Position.End;
        return false;
    }

    item = node._item;
    if (advance) { position.SetItem(node._next); }
    return true;
}
````
4. Buffer sequence with running index implementation (e.g. [ReadOnlyBytes](https://github.com/dotnet/corefxlab/blob/master/src/System.Buffers.Experimental/System/Buffers/ReadOnlyBytes.cs#L44)) 
```c#
public bool TryGet(ref Position position, out ReadOnlyMemory<byte> value, bool advance = true)
{
    if (position == default)
    {
        value = _first;
        if (advance) position.Advance(Rest, _first.Length);
        return (!_first.IsEmpty || _all != null);
    }

    var (rest, runningIndex) = position.Get<IReadOnlyMemoryList<byte>>();
    if (rest == null)
    {
        value = default;
        return false;
    }

    value = rest.First;
    // We need to slice off the last segment based on length of this. 
    // ReadOnlyBytes is a potentially shorted view over a longer buffer list.
    if (value.Length + runningIndex > _totalLength)
    {
        value = value.Slice(0, (int)(_totalLength - runningIndex));
        if (value.Length == 0) return false;
    }

    if (advance) position.Advance(rest.Rest, value.Length);
    return true;
}
```

cc: @ahsonkhan, @davidfowl, @halter73, @terrajobst, @GrabYourPitchforks, @YohDeadfall 

