### PR TITLE
Update Roslyn to 2.6.0-beta3-62316-02

### DIFF
--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RuntimeFrameworkVersion>2.1.0-preview1-25915-02</RuntimeFrameworkVersion>
     <CoreFxStableVersion>4.3.0</CoreFxStableVersion>
-    <RoslynVersion>2.6.0-beta2-62211-02</RoslynVersion>
+    <RoslynVersion>2.6.0-beta3-62316-02</RoslynVersion>
     <SystemMemoryVersion>4.5.0-preview1-25915-02</SystemMemoryVersion>
     <SystemCompilerServicesUnsafeVersion>4.5.0-preview1-25915-02</SystemCompilerServicesUnsafeVersion>
     <SystemNumericsVectorsVersion>4.5.0-preview1-25915-02</SystemNumericsVectorsVersion>


### PR DESCRIPTION
Updating to the latest Roslyn as a pre-stage test to putting this version in dotnet/buildtools.