### PR TITLE
Added Sequence TryParseInt32

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -112,18 +112,6 @@ namespace System.Buffers
             return;
         }
 
-        public static ReadOnlySpan<byte> ToSpan<T>(this T bufferSequence) where T : ISequence<ReadOnlyMemory<byte>>
-        {
-            Position position = default;
-            ResizableArray<byte> array = new ResizableArray<byte>(1024);
-            while (bufferSequence.TryGet(ref position, out ReadOnlyMemory<byte> buffer))
-            {
-                array.AddAll(buffer.Span);
-            }
-            array.Resize(array.Count);
-            return array.Span.Slice(0, array.Count);
-        }
-
         // span creation helpers:
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long IndexOf(this IMemoryList<byte> sequence, ReadOnlySpan<byte> value)
@@ -136,24 +124,6 @@ namespace System.Buffers
             if (rest == null) return -1;
 
             return IndexOfStraddling(first, sequence.Rest, value);
-        }
-
-        public static long IndexOf(this IMemoryList<byte> sequence, byte value)
-        {
-            var first = sequence.Memory.Span;
-            long index = first.IndexOf(value);
-            if (index != -1) return index;
-
-            Position position = default;
-            int virtualIndex = first.Length;
-            while(sequence.TryGet(ref position, out ReadOnlyMemory<byte> memory))
-            {
-                index = memory.Span.IndexOf(value);
-                if (index != -1) return index + virtualIndex;
-                virtualIndex += memory.Length;
-            }
-
-            return -1;
         }
 
         // TODO (pri 3): I am pretty sure this whole routine can be written much better

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadOnlyBytes.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadOnlyBytes.cs
@@ -198,7 +198,7 @@ namespace System.Buffers
         {
             var rest = Rest;
             if (rest == null) return -1;
-            long index = rest.IndexOf(value);
+            long index = Sequence.IndexOf(rest, value); 
             if (index != -1) return firstLength + index;
             return -1;
         }

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadWriteBytes.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadWriteBytes.cs
@@ -190,7 +190,7 @@ namespace System.Buffers
         {
             var rest = Rest;
             if (rest == null) return -1;
-            long index = rest.IndexOf(value);
+            long index = Sequence.IndexOf(rest, value); 
             if (index != -1) return firstLength + index;
             return -1;
         }

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/SequenceExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/SequenceExtensions.cs
@@ -2,13 +2,26 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers.Text;
 using System.Collections.Sequences;
 
 namespace System.Buffers
 {
-    public static class SequenceExtensions
+    public static class Sequence
     {
-        // TODO: this cannot be an extension method (as I would like iot to be).
+        public static ReadOnlySpan<byte> ToSpan<T>(this T sequence) where T : ISequence<ReadOnlyMemory<byte>>
+        {
+            Position position = default;
+            ResizableArray<byte> array = new ResizableArray<byte>(1024);
+            while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> buffer))
+            {
+                array.AddAll(buffer.Span);
+            }
+            array.Resize(array.Count);
+            return array.Span.Slice(0, array.Count);
+        }
+
+        // TODO: this cannot be an extension method (as I would like it to be).
         // If I make it an extensions method, the compiler complains Span<T> cannot
         // be used as a type parameter.
         public static long IndexOf<TSequence>(TSequence sequence, byte value) where TSequence : ISequence<ReadOnlyMemory<byte>>
@@ -41,6 +54,79 @@ namespace System.Buffers
                 result = position;
             }
             return Position.End;
+        }
+
+        public static Position PositionAt<TSequence>(this TSequence sequence, long index) where TSequence : ISequence<ReadOnlyMemory<byte>>
+        {
+            if (sequence == null) return Position.End;
+
+            Position position = sequence.First;
+            Position result = position;
+            while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> memory))
+            {
+                var span = memory.Span;
+                if(span.Length > index)
+                {
+                    result.Index += (int)index;
+                    return result;
+                }
+                index -= span.Length;
+                result = position;
+            }
+
+            return Position.End;
+        }
+
+        public static int Copy<TSequence>(TSequence sequence, Span<byte> buffer) where TSequence : ISequence<ReadOnlyMemory<byte>>
+        {
+            int copied = 0;
+            var position = sequence.First;
+            while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> memory, true))
+            {
+                var span = memory.Span;
+                var toCopy = Math.Min(span.Length, buffer.Length - copied);
+                span.Slice(0, toCopy).CopyTo(buffer.Slice(copied));
+                copied += toCopy;
+                if (copied >= buffer.Length) break;
+            }
+            return copied;
+        }
+
+        public static bool TryParse<TSequence>(TSequence sequence, out int value, out int consumed) where TSequence : ISequence<ReadOnlyMemory<byte>>
+        {
+            var position = sequence.First;
+            if(sequence.TryGet(ref position, out ReadOnlyMemory<byte> memory))
+            {
+                var span = memory.Span;
+                if(Utf8Parser.TryParse(span, out value, out consumed) && consumed < span.Length)
+                {
+                    return true;
+                }
+
+                Span<byte> temp = stackalloc byte[11]; // TODO: it would be good to have APIs to return constants related to sizes of needed buffers
+                var copied = Copy(sequence, temp);
+                // we need to slice temp, as we might stop zeroing stack allocated buffers
+                if (Utf8Parser.TryParse(temp.Slice(0, copied), out value, out consumed))
+                {
+                    return true;
+                }      
+            }
+
+            value = default;
+            consumed = default;
+            return false;
+        }
+
+        public static bool TryParse<TSequence>(TSequence sequence, out int value, out Position consumed) where TSequence : ISequence<ReadOnlyMemory<byte>>
+        {
+            if(!TryParse(sequence, out value, out int consumedBytes))
+            {
+                consumed = default;
+                return false;
+            }
+
+            consumed = sequence.PositionAt(consumedBytes);
+            return true;
         }
     }
 }

--- a/src/System.Buffers.Experimental/System/Buffers/Text/BytesReader.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Text/BytesReader.cs
@@ -196,10 +196,6 @@ namespace System.Buffers.Text
                 Advance(toAdvanceUnreadSegments); // TODO: this recursive implementation could be optimized
             }
         }
-
-        long IndexOf(IMemoryList<byte> sequence, byte value)
-            => sequence.IndexOf(value);
-
         long IndexOfStraddling(ReadOnlySpan<byte> value)
         {
             var rest = _unreadSegments.Rest;
@@ -251,7 +247,7 @@ namespace System.Buffers.Text
             var rest = _unreadSegments.Rest;
             if (rest == null) return -1;
 
-            var index = IndexOf(rest, value);
+            var index = Sequence.IndexOf(rest, value);
             if (index == -1)
             {
                 return -1;


### PR DESCRIPTION
This adds the ability to parse ints out of memory sequences. There are two overloads: one returns number of consumed bytes, the other returns a Position of the first unconsumed byte. The later overload is not optimized, but for now I just wanted to validate that there are no fundamental issues with the representation of memory sequences when it comes to parsing. I will measure perf and optimize the methods in a subsequent PR.

cc: @davidfowl, @halter73, @terrajobst, @ahsonkhan