### PR TITLE
Changed BytesReader to a by-ref struct

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/SequenceExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/SequenceExtensions.cs
@@ -92,6 +92,20 @@ namespace System.Buffers
             return copied;
         }
 
+        public static int Copy<TSequence>(TSequence sequence, Position from, Span<byte> buffer) where TSequence : ISequence<ReadOnlyMemory<byte>>
+        {
+            int copied = 0;
+            while (sequence.TryGet(ref from, out ReadOnlyMemory<byte> memory, true))
+            {
+                var span = memory.Span;
+                var toCopy = Math.Min(span.Length, buffer.Length - copied);
+                span.Slice(0, toCopy).CopyTo(buffer.Slice(copied));
+                copied += toCopy;
+                if (copied >= buffer.Length) break;
+            }
+            return copied;
+        }
+
         public static bool TryParse<TSequence>(TSequence sequence, out int value, out int consumed) where TSequence : ISequence<ReadOnlyMemory<byte>>
         {
             var position = sequence.First;

--- a/src/System.Collections.Sequences/System/Collections/Sequences/Position.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/Position.cs
@@ -53,6 +53,9 @@ namespace System.Collections.Sequences
         public static bool operator ==(Position left, Position right) => left.Index == right.Index && left._item == right._item;
         public static bool operator !=(Position left, Position right) => left.Index != right.Index || left._item != right._item;
 
+        public static Position operator +(Position position, int offset) => position.Offset(offset);
+        public static Position operator -(Position position, int offset) => position.Offset(-offset);
+
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool Equals(Position position) => this == position;
 
@@ -73,5 +76,7 @@ namespace System.Collections.Sequences
             _item = item;
             Index = index;
         }
+
+        private Position Offset(int index) => new Position(Index + index, _item);
     }
 }

--- a/tests/Benchmarks/BytesReaderBench.cs
+++ b/tests/Benchmarks/BytesReaderBench.cs
@@ -6,6 +6,7 @@ using Microsoft.Xunit.Performance;
 using System;
 using System.Buffers;
 using System.Buffers.Text;
+using System.Collections.Sequences;
 using System.Text;
 
 public class BytesReaderBench
@@ -33,15 +34,14 @@ public class BytesReaderBench
 
         foreach (var iteration in Benchmark.Iterations)
         {
-            var reader = new BytesReader(s_bytes, SymbolTable.InvariantUtf8);
+            var reader = BytesReader.Create(s_bytes);
 
             using (iteration.StartMeasurement())
             {
                 while (true)
                 {
-                    var result = reader.ReadRangeUntil(eol);
-                    if (result == null) break;
-                    reader.Advance(eol.Length);
+                    var range = reader.ReadRange(eol);
+                    if (range.To == Position.End) break;
                 }
             }
         }

--- a/tests/System.Buffers.Experimental.Tests/BytesReaderTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/BytesReaderTests.cs
@@ -14,23 +14,16 @@ namespace System.Buffers.Tests
         public void SingleSegmentBytesReader()
         {
             ReadOnlyBytes bytes = Create("AB CD#EF&&");
-            var reader = new BytesReader(bytes);
+            var reader = BytesReader.Create(bytes);
 
-            var ab = reader.ReadBytesUntil((byte)' ');
-            Assert.True(ab.HasValue);
+            var ab = bytes.Slice(reader.ReadRange((byte)' '));
             Assert.Equal("AB", ab.ToString(SymbolTable.InvariantUtf8));
 
-            reader.Advance(1);
-            var cd = reader.ReadBytesUntil((byte)'#');
+            var cd = bytes.Slice(reader.ReadRange((byte)'#'));
             Assert.Equal("CD", cd.ToString(SymbolTable.InvariantUtf8));
 
-            reader.Advance(1);
-            var ef = reader.ReadBytesUntil(new byte[] { (byte)'&', (byte)'&' });
+            var ef = bytes.Slice(reader.ReadRange(new byte[] { (byte)'&', (byte)'&' }));
             Assert.Equal("EF", ef.ToString(SymbolTable.InvariantUtf8));
-
-            reader.Advance(2);
-
-            //Assert.True(reader.IsEmpty);
         }
 
         [Fact]
@@ -44,101 +37,73 @@ namespace System.Buffers.Tests
                 new byte[] { 8          }
             });
 
-            var reader = new BytesReader(bytes);
+            var reader = BytesReader.Create(bytes);
 
-            var value = reader.ReadBytesUntil(2).Value.ToSpan();
+            var value = bytes.Slice(reader.ReadRange(2)).ToSpan();
             Assert.Equal(0, value[0]);
             Assert.Equal(1, value[1]);
-            reader.Advance(1);
 
-            value = reader.ReadBytesUntil(5).Value.ToSpan();
+            value = bytes.Slice(reader.ReadRange(5)).ToSpan();
             Assert.Equal(3, value[0]);
             Assert.Equal(4, value[1]);
-            reader.Advance(1);
 
-            value = reader.ReadBytesUntil(new byte[] { 8, 8 }).Value.ToSpan();
+            value = bytes.Slice(reader.ReadRange(new byte[] { 8, 8 })).ToSpan();
             Assert.Equal(6, value[0]);
             Assert.Equal(7, value[1]);
-            reader.Advance(2);
-
-            //Assert.True(reader.IsEmpty);
         }
 
         [Fact]
         public void MultiSegmentBytesReader()
         {
             ReadOnlyBytes bytes = Parse("A|B |CD|#EF&|&");
-            var reader = new BytesReader(bytes);
+            var reader = BytesReader.Create(bytes);
 
-            var ab = reader.ReadBytesUntil((byte)' ');
+            var ab = bytes.Slice(reader.ReadRange((byte)' '));
             Assert.Equal("AB", ab.ToString(SymbolTable.InvariantUtf8));
-            Assert.Equal(2, reader.Index);
 
-            reader.Advance(1);
-            Assert.Equal(3, reader.Index);
-
-            var cd = reader.ReadBytesUntil((byte)'#');
+            var cd = bytes.Slice(reader.ReadRange((byte)'#'));
             Assert.Equal("CD", cd.ToString(SymbolTable.InvariantUtf8));
-            Assert.Equal(5, reader.Index);
 
-            reader.Advance(1);
-            Assert.Equal(6, reader.Index);
-
-            var ef = reader.ReadBytesUntil(new byte[] { (byte)'&', (byte)'&' });
-            Assert.Equal("EF", ef.ToString(SymbolTable.InvariantUtf8));
-            Assert.Equal(8, reader.Index);
-
-            reader.Advance(2);
-            Assert.Equal(10, reader.Index);
-        }
+            var ef = bytes.Slice(reader.ReadRange(new byte[] { (byte)'&', (byte)'&' }));
+            Assert.Equal("EF", ef.ToString(SymbolTable.InvariantUtf8));        }
 
         [Fact]
         public void EmptyBytesReader()
         {
             ReadOnlyBytes bytes = Create("");
-            var reader = new BytesReader(bytes);
-            var found = reader.ReadBytesUntil((byte)' ');
-            Assert.Equal("", found.ToString(SymbolTable.InvariantUtf8));
+            var reader = BytesReader.Create(bytes);
+            var range = reader.ReadRange((byte)' ');
+            Assert.Equal(Position.End, range.To);
 
             bytes = Parse("|");
-            reader = new BytesReader(bytes);
-            found = reader.ReadBytesUntil((byte)' ');
-            Assert.Equal("", found.ToString(SymbolTable.InvariantUtf8));
-
-            //Assert.True(reader.IsEmpty);
+            reader = BytesReader.Create(bytes);
+            range = reader.ReadRange((byte)' ');
+            Assert.Equal(Position.End, range.To);
         }
 
         [Fact]
         public void BytesReaderParse()
         {
             ReadOnlyBytes bytes = Parse("12|3Tr|ue|456Tr|ue7|89False|");
-            var reader = new BytesReader(bytes);
+            var reader = BytesReader.Create(bytes);
 
             Assert.True(reader.TryParseUInt64(out ulong u64));
             Assert.Equal(123ul, u64);
-            Assert.Equal(3, reader.Index);
 
             Assert.True(reader.TryParseBoolean(out bool b));
             Assert.Equal(true, b);
-            Assert.Equal(7, reader.Index);
 
             Assert.True(reader.TryParseUInt64(out u64));
             Assert.Equal(456ul, u64);
-            Assert.Equal(10, reader.Index);
 
             Assert.True(reader.TryParseBoolean(out b));
             Assert.Equal(true, b);
-            Assert.Equal(14, reader.Index);
 
             Assert.True(reader.TryParseUInt64(out u64));
             Assert.Equal(789ul, u64);
-            Assert.Equal(17, reader.Index);
 
             Assert.True(reader.TryParseBoolean(out b));
             Assert.Equal(false, b);
-            Assert.Equal(22, reader.Index);
-
-            //Assert.True(reader.IsEmpty);
         }
 
         static byte[] s_eol = new byte[] { (byte)'\r', (byte)'\n' };
@@ -157,13 +122,12 @@ namespace System.Buffers.Tests
             var eol = new Span<byte>(s_eol);
             var bytes = new ReadOnlyBytes(data);
 
-            var reader = new BytesReader(bytes, SymbolTable.InvariantUtf8);
+            var reader = BytesReader.Create(bytes);
 
             while (true)
             {
-                var result = reader.ReadBytesUntil(eol);
-                if (result == null) break;
-                reader.Advance(2);
+                var range = reader.ReadRange(eol);
+                if (range.To == Position.End) break;
             }
         }
     }

--- a/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
@@ -219,7 +219,7 @@ namespace System.Buffers.Tests
                 var slice = rob.Slice(c2, c5);
 
                 Assert.Equal(2, slice.Memory.Span[0]);
-                Assert.Equal(4, slice.Length);
+                Assert.Equal(3, slice.Length);
             }
 
             // multi segment


### PR DESCRIPTION
+ lots of API changes to BytesReader to:
1. Make it work with arbitrary sequences
2. Make it Position based, as opposed to index based

@ahsonkhan, @davidfowl

Note: there is lots of NYI code paths (and probably bugs). I just want to first get the model to a stable state before I implement all the code paths.