### PR TITLE
Pipelines Pool Abstraction

### DIFF
--- a/samples/System.IO.Pipelines.Samples/Libuv/RawLibuvHttpClientSample.cs
+++ b/samples/System.IO.Pipelines.Samples/Libuv/RawLibuvHttpClientSample.cs
@@ -25,7 +25,7 @@ namespace System.IO.Pipelines.Samples
             return await client.ConnectAsync();
         }
 
-        protected override MemoryPool GetBufferPool()
+        protected override MemoryPool<byte> GetBufferPool()
         {
             return thread.Pool;
         }

--- a/samples/System.IO.Pipelines.Samples/Rio/RawRioHttpClientSample.cs
+++ b/samples/System.IO.Pipelines.Samples/Rio/RawRioHttpClientSample.cs
@@ -16,7 +16,7 @@ namespace System.IO.Pipelines.Samples
             throw new NotImplementedException();
         }
 
-        protected override MemoryPool GetBufferPool()
+        protected override MemoryPool<byte> GetBufferPool()
         {
             throw new NotImplementedException();
         }

--- a/samples/System.IO.Pipelines.Samples/Rio/RioHttpServer.cs
+++ b/samples/System.IO.Pipelines.Samples/Rio/RioHttpServer.cs
@@ -103,7 +103,7 @@ namespace System.IO.Pipelines.Samples.Http
             }
         }
 
-        private static async Task ProcessConnection<TContext>(IHttpApplication<TContext> application, MemoryPool memoryPool, Socket socket)
+        private static async Task ProcessConnection<TContext>(IHttpApplication<TContext> application, MemoryPool<byte> memoryPool, Socket socket)
         {
             using (var ns = new NetworkStream(socket))
             {

--- a/samples/System.IO.Pipelines.Samples/SampleBase/RawHttpClientSampleBase.cs
+++ b/samples/System.IO.Pipelines.Samples/SampleBase/RawHttpClientSampleBase.cs
@@ -35,7 +35,7 @@ namespace System.IO.Pipelines.Samples
             }
         }
 
-        protected abstract MemoryPool GetBufferPool();
+        protected abstract MemoryPool<byte> GetBufferPool();
 
         protected abstract Task<IPipeConnection> GetConnection();
 

--- a/samples/System.IO.Pipelines.Samples/Socket/RawSocketHttpClientSample.cs
+++ b/samples/System.IO.Pipelines.Samples/Socket/RawSocketHttpClientSample.cs
@@ -11,7 +11,7 @@ namespace System.IO.Pipelines.Samples
 {
     public class RawSocketHttpClientSample : RawHttpClientSampleBase
     {
-        private MemoryPool pool;
+        private MemoryPool<byte> pool;
 
         public RawSocketHttpClientSample()
         {
@@ -27,7 +27,7 @@ namespace System.IO.Pipelines.Samples
             return Task.FromResult((IPipeConnection)pipeConnection);
         }
 
-        protected override MemoryPool GetBufferPool()
+        protected override MemoryPool<byte> GetBufferPool()
         {
             return pool;
         }

--- a/samples/System.IO.Pipelines.Samples/Socket/SocketHttpClientHandler.cs
+++ b/samples/System.IO.Pipelines.Samples/Socket/SocketHttpClientHandler.cs
@@ -11,7 +11,7 @@ namespace System.IO.Pipelines.Samples
 {
     public class SocketHttpClientHandler : PipelineHttpClientHandler
     {
-        MemoryPool bufferPool = new MemoryPool();
+        MemoryPool<byte> bufferPool = new MemoryPool();
 
         protected override void Dispose(bool disposing)
         {

--- a/samples/System.IO.Pipelines.Samples/Socket/SocketHttpServer.cs
+++ b/samples/System.IO.Pipelines.Samples/Socket/SocketHttpServer.cs
@@ -56,7 +56,7 @@ namespace System.IO.Pipelines.Samples.Http
             _listenSocket = null;
         }
 
-        private static async Task ProcessConnection<TContext>(IHttpApplication<TContext> application, MemoryPool memoryPool, Socket socket)
+        private static async Task ProcessConnection<TContext>(IHttpApplication<TContext> application, MemoryPool<byte> memoryPool, Socket socket)
         {
             using (var ns = new NetworkStream(socket))
             {

--- a/src/System.Buffers.Experimental/System/Buffers/Native/NativeMemoryPool.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Native/NativeMemoryPool.cs
@@ -7,7 +7,9 @@ namespace System.Buffers.Native
 {
     public unsafe sealed partial class NativeMemoryPool : MemoryPool<byte>
     {
-        static NativeMemoryPool s_shared = new NativeMemoryPool(4096);
+        const int DefaultSize = 4096;
+
+        static NativeMemoryPool s_shared = new NativeMemoryPool(DefaultSize);
         object _lock = new object();
         bool _disposed;
 
@@ -41,8 +43,9 @@ namespace System.Buffers.Native
 
         public override int MaxBufferSize => 1024 * 1024 * 1024;
 
-        public override OwnedMemory<byte> Rent(int numberOfBytes)
+        public override OwnedMemory<byte> Rent(int numberOfBytes = DefaultSize)
         {
+            if (numberOfBytes == AnySize) numberOfBytes = DefaultSize;
             if (numberOfBytes < 1 || numberOfBytes > MaxBufferSize) throw new ArgumentOutOfRangeException(nameof(numberOfBytes));
             if (numberOfBytes > _bufferSize) new NotSupportedException();
 

--- a/src/System.Buffers.Experimental/System/Buffers/Native/NativeMemoryPool.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Native/NativeMemoryPool.cs
@@ -39,9 +39,11 @@ namespace System.Buffers.Native
             Marshal.FreeHGlobal(_memory);
         }
 
+        public override int MaxBufferSize => 1024 * 1024 * 1024;
+
         public override OwnedMemory<byte> Rent(int numberOfBytes)
         {
-            if (numberOfBytes < 1) throw new ArgumentOutOfRangeException(nameof(numberOfBytes));
+            if (numberOfBytes < 1 || numberOfBytes > MaxBufferSize) throw new ArgumentOutOfRangeException(nameof(numberOfBytes));
             if (numberOfBytes > _bufferSize) new NotSupportedException();
 
             int i;

--- a/src/System.Buffers.Primitives/System/Buffers/Pooling/ArrayMemoryPool.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Pooling/ArrayMemoryPool.cs
@@ -17,11 +17,10 @@ namespace System.Buffers.Internal
 
         public override int MaxBufferSize => 1024 * 1024 * 1024;
 
-        public override OwnedMemory<T> Rent(int minimumBufferSize = DefaultSize)
+        public override OwnedMemory<T> Rent(int minimumBufferSize = AnySize)
         {
-            if (minimumBufferSize == 0) minimumBufferSize = 32;
-            else if (minimumBufferSize == AnySize) minimumBufferSize = DefaultSize;
-            else if (minimumBufferSize > MaxBufferSize) throw new ArgumentOutOfRangeException(nameof(minimumBufferSize));
+            if (minimumBufferSize == AnySize) minimumBufferSize = DefaultSize;
+            else if (minimumBufferSize > MaxBufferSize || minimumBufferSize < 1) throw new ArgumentOutOfRangeException(nameof(minimumBufferSize));
             return new ArrayPoolMemory(minimumBufferSize);
         }
 

--- a/src/System.Buffers.Primitives/System/Buffers/Pooling/ArrayMemoryPool.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Pooling/ArrayMemoryPool.cs
@@ -14,8 +14,11 @@ namespace System.Buffers.Internal
 
         public static ArrayMemoryPool<T> Shared => s_shared;
 
+        public override int MaxBufferSize => 1024 * 1024 * 1024;
+
         public override OwnedMemory<T> Rent(int minimumBufferSize)
         {
+            if (minimumBufferSize > MaxBufferSize) throw new ArgumentOutOfRangeException(nameof(minimumBufferSize));
             return new ArrayPoolMemory(minimumBufferSize);
         }
 

--- a/src/System.Buffers.Primitives/System/Buffers/Pooling/ArrayMemoryPool.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Pooling/ArrayMemoryPool.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -10,15 +9,19 @@ namespace System.Buffers.Internal
 {
     internal sealed class ArrayMemoryPool<T> : MemoryPool<T>
     {
+        const int DefaultSize = 4096;
+
         readonly static ArrayMemoryPool<T> s_shared = new ArrayMemoryPool<T>();
 
         public static ArrayMemoryPool<T> Shared => s_shared;
 
         public override int MaxBufferSize => 1024 * 1024 * 1024;
 
-        public override OwnedMemory<T> Rent(int minimumBufferSize)
+        public override OwnedMemory<T> Rent(int minimumBufferSize = DefaultSize)
         {
-            if (minimumBufferSize > MaxBufferSize) throw new ArgumentOutOfRangeException(nameof(minimumBufferSize));
+            if (minimumBufferSize == 0) minimumBufferSize = 32;
+            else if (minimumBufferSize == AnySize) minimumBufferSize = DefaultSize;
+            else if (minimumBufferSize > MaxBufferSize) throw new ArgumentOutOfRangeException(nameof(minimumBufferSize));
             return new ArrayPoolMemory(minimumBufferSize);
         }
 

--- a/src/System.Buffers.Primitives/System/Buffers/Pooling/MemoryPool.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Pooling/MemoryPool.cs
@@ -9,6 +9,8 @@ namespace System.Buffers
 
         public abstract OwnedMemory<T> Rent(int minimumBufferSize);
 
+        public abstract int MaxBufferSize { get;  }
+
         public void Dispose()
         {
             Dispose(true);

--- a/src/System.Buffers.Primitives/System/Buffers/Pooling/MemoryPool.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Pooling/MemoryPool.cs
@@ -5,9 +5,11 @@ namespace System.Buffers
 {
     public abstract class MemoryPool<T> : IDisposable
     {
+        public const int AnySize = int.MinValue;
+
         public static MemoryPool<T> Default => Internal.ArrayMemoryPool<T>.Shared;
 
-        public abstract OwnedMemory<T> Rent(int minimumBufferSize);
+        public abstract OwnedMemory<T> Rent(int minimumBufferSize = AnySize);
 
         public abstract int MaxBufferSize { get;  }
 

--- a/src/System.IO.Pipelines.Networking.Libuv/UvThread.cs
+++ b/src/System.IO.Pipelines.Networking.Libuv/UvThread.cs
@@ -30,7 +30,7 @@ namespace System.IO.Pipelines.Networking.Libuv
 
         public UvLoopHandle Loop { get; private set; }
 
-        public MemoryPool Pool { get; } = new MemoryPool();
+        public MemoryPool<byte> Pool { get; } = new MemoryPool();
 
         public WriteReqPool WriteReqPool { get; }
 

--- a/src/System.IO.Pipelines.Networking.Sockets/SocketListener.cs
+++ b/src/System.IO.Pipelines.Networking.Sockets/SocketListener.cs
@@ -16,8 +16,8 @@ namespace System.IO.Pipelines.Networking.Sockets
         private readonly bool _ownsPool;
         private Socket _socket;
         private Socket Socket => _socket;
-        private MemoryPool _pool;
-        private MemoryPool PipePool => _pool;
+        private MemoryPool<byte> _pool;
+        private MemoryPool<byte> PipePool => _pool;
         private Func<SocketConnection, Task> Callback { get; set; }
         static readonly EventHandler<SocketAsyncEventArgs> _asyncCompleted = OnAsyncCompleted;
 
@@ -25,7 +25,7 @@ namespace System.IO.Pipelines.Networking.Sockets
         /// Creates a new SocketListener instance
         /// </summary>
         /// <param name="pool">Optionally allows the underlying <see cref="PipePool"/> (and hence memory pool) to be specified; if one is not provided, a <see cref="PipePool"/> will be instantiated and owned by the listener</param>
-        public SocketListener(MemoryPool pool = null)
+        public SocketListener(MemoryPool<byte> pool = null)
         {
             _ownsPool = pool == null;
             _pool = pool ?? new MemoryPool();

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/Pool/MemoryPool.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/Pool/MemoryPool.cs
@@ -73,7 +73,7 @@ namespace System.Buffers
             _slabDeallocationCallback = deallocationCallback;
         }
 
-        public override OwnedMemory<byte> Rent(int size)
+        public override OwnedMemory<byte> Rent(int size = AnySize)
         {
             if (size == AnySize) size = _blockLength;
             else if (size > _blockLength)

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/Pool/MemoryPool.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/Pool/MemoryPool.cs
@@ -10,7 +10,7 @@ namespace System.Buffers
     /// <summary>
     /// Used to allocate and distribute re-usable blocks of memory.
     /// </summary>
-    public class MemoryPool : MemoryPool<byte>
+    class RioMemoryPool : MemoryPool<byte>
     {
         /// <summary>
         /// The gap between blocks' starting address. 4096 is chosen because most operating systems are 4k pages in size and alignment.
@@ -50,25 +50,35 @@ namespace System.Buffers
         /// Thread-safe collection of blocks which are currently in the pool. A slab will pre-allocate all of the block tracking objects
         /// and add them to this collection. When memory is requested it is taken from here first, and when it is returned it is re-added.
         /// </summary>
-        private readonly ConcurrentQueue<MemoryPoolBlock> _blocks = new ConcurrentQueue<MemoryPoolBlock>();
+        private readonly ConcurrentQueue<RioMemoryPoolBlock> _blocks = new ConcurrentQueue<RioMemoryPoolBlock>();
 
         /// <summary>
         /// Thread-safe collection of slabs which have been allocated by this pool. As long as a slab is in this collection and slab.IsActive,
         /// the blocks will be added to _blocks when returned.
         /// </summary>
-        private readonly ConcurrentStack<MemoryPoolSlab> _slabs = new ConcurrentStack<MemoryPoolSlab>();
+        private readonly ConcurrentStack<RioMemoryPoolSlab> _slabs = new ConcurrentStack<RioMemoryPoolSlab>();
 
         /// <summary>
         /// This is part of implementing the IDisposable pattern.
         /// </summary>
         private bool _disposedValue = false; // To detect redundant calls
 
+        private Action<RioMemoryPoolSlab> _slabAllocationCallback;
+
+        private Action<RioMemoryPoolSlab> _slabDeallocationCallback;
+
+        public RioMemoryPool(Action<RioMemoryPoolSlab> allocationCallback = null, Action<RioMemoryPoolSlab> deallocationCallback = null)
+        {
+            _slabAllocationCallback = allocationCallback;
+            _slabDeallocationCallback = deallocationCallback;
+        }
+
         public override OwnedMemory<byte> Rent(int size)
         {
             if (size == AnySize) size = _blockLength;
             else if (size > _blockLength)
             {
-                PipelinesThrowHelper.ThrowArgumentOutOfRangeException_BufferRequestTooLarge(_blockLength);
+                RioPipelinesThrowHelper.ThrowArgumentOutOfRangeException_BufferRequestTooLarge(_blockLength);
             }
 
             var block = Lease();
@@ -79,11 +89,11 @@ namespace System.Buffers
         /// Called to take a block from the pool.
         /// </summary>
         /// <returns>The block that is reserved for the called. It must be passed to Return when it is no longer being used.</returns>
-        private MemoryPoolBlock Lease()
+        private RioMemoryPoolBlock Lease()
         {
             Debug.Assert(!_disposedValue, "Block being leased from disposed pool!");
 
-            if (_blocks.TryDequeue(out MemoryPoolBlock block))
+            if (_blocks.TryDequeue(out RioMemoryPoolBlock block))
             {
                 // block successfully taken from the stack - return it
 
@@ -107,10 +117,13 @@ namespace System.Buffers
         /// Internal method called when a block is requested and the pool is empty. It allocates one additional slab, creates all of the
         /// block tracking objects, and adds them all to the pool.
         /// </summary>
-        private MemoryPoolBlock AllocateSlab()
+        private RioMemoryPoolBlock AllocateSlab()
         {
-            var slab = MemoryPoolSlab.Create(_slabLength);
+            var slab = RioMemoryPoolSlab.Create(_slabLength);
             _slabs.Push(slab);
+
+            _slabAllocationCallback?.Invoke(slab);
+            slab._deallocationCallback = _slabDeallocationCallback;
 
             var basePtr = slab.NativePointer;
             var firstOffset = (int)((_blockStride - 1) - ((ulong)(basePtr + _blockStride - 1) % _blockStride));
@@ -122,7 +135,7 @@ namespace System.Buffers
                 offset + _blockLength < poolAllocationLength;
                 offset += _blockStride)
             {
-                var block = MemoryPoolBlock.Create(
+                var block = RioMemoryPoolBlock.Create(
                     offset,
                     _blockLength,
                     this,
@@ -134,7 +147,7 @@ namespace System.Buffers
             }
 
             // return last block rather than adding to pool
-            var newBlock = MemoryPoolBlock.Create(
+            var newBlock = RioMemoryPoolBlock.Create(
                     offset,
                     _blockLength,
                     this,
@@ -151,7 +164,7 @@ namespace System.Buffers
         /// leaving "dead zones" in the slab due to lost block tracking objects.
         /// </summary>
         /// <param name="block">The block to return. It must have been acquired by calling Lease on the same memory pool instance.</param>
-        internal void Return(MemoryPoolBlock block)
+        internal void Return(RioMemoryPoolBlock block)
         {
 #if BLOCK_LEASE_TRACKING
             Debug.Assert(block.Pool == this, "Returned block was not leased from this pool");
@@ -181,7 +194,7 @@ namespace System.Buffers
 #endif
                 if (disposing)
                 {
-                    while (_slabs.TryPop(out MemoryPoolSlab slab))
+                    while (_slabs.TryPop(out RioMemoryPoolSlab slab))
                     {
                         // dispose managed state (managed objects).
                         slab.Dispose();
@@ -189,7 +202,7 @@ namespace System.Buffers
                 }
 
                 // Discard blocks in pool
-                while (_blocks.TryDequeue(out MemoryPoolBlock block))
+                while (_blocks.TryDequeue(out RioMemoryPoolBlock block))
                 {
                     GC.SuppressFinalize(block);
                 }

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/Pool/MemoryPoolBlock.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/Pool/MemoryPoolBlock.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+using System.Threading;
+using System.Diagnostics;
+using System.IO.Pipelines;
+
+namespace System.Buffers
+{
+    /// <summary>
+    /// Block tracking object used by the byte buffer memory pool. A slab is a large allocation which is divided into smaller blocks. The
+    /// individual blocks are then treated as independent array segments.
+    /// </summary>
+    internal class RioMemoryPoolBlock : OwnedMemory<byte>
+    {
+        private readonly int _offset;
+        private readonly int _length;
+        private int _referenceCount;
+        private bool _disposed;
+
+        /// <summary>
+        /// This object cannot be instantiated outside of the static Create method
+        /// </summary>
+        protected RioMemoryPoolBlock(RioMemoryPool pool, RioMemoryPoolSlab slab, int offset, int length)
+        {
+            _offset = offset;
+            _length = length;
+
+            Pool = pool;
+            Slab = slab;
+        }
+
+        /// <summary>
+        /// Back-reference to the memory pool which this block was allocated from. It may only be returned to this pool.
+        /// </summary>
+        public RioMemoryPool Pool { get; }
+
+        /// <summary>
+        /// Back-reference to the slab from which this block was taken, or null if it is one-time-use memory.
+        /// </summary>
+        public RioMemoryPoolSlab Slab { get; }
+
+        public override int Length => _length;
+
+        public override Span<byte> Span
+        {
+            get
+            {
+                if (IsDisposed) RioPipelinesThrowHelper.ThrowObjectDisposedException(nameof(RioMemoryPoolBlock));
+                return new Span<byte>(Slab.Array, _offset, _length);
+            }
+        }
+
+#if BLOCK_LEASE_TRACKING
+        public bool IsLeased { get; set; }
+        public string Leaser { get; set; }
+#endif
+
+        ~RioMemoryPoolBlock()
+        {
+            if (Slab != null && Slab.IsActive)
+            {
+#if DEBUG
+                Debug.Assert(false, $"{Environment.NewLine}{Environment.NewLine}*** Block being garbage collected instead of returned to pool" +
+#if BLOCK_LEASE_TRACKING
+                    $": {Leaser}" +
+#endif
+                    $" ***{ Environment.NewLine}");
+#endif
+
+                // Need to make a new object because this one is being finalized
+                Pool.Return(new RioMemoryPoolBlock(Pool, Slab, _offset, _length));
+            }
+        }
+
+        internal static RioMemoryPoolBlock Create(
+            int offset,
+            int length,
+            RioMemoryPool pool,
+            RioMemoryPoolSlab slab)
+        {
+            return new RioMemoryPoolBlock(pool, slab, offset, length);
+        }
+
+        /// <summary>
+        /// ToString overridden for debugger convenience. This displays the "active" byte information in this block as ASCII characters.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            RioSpanLiteralExtensions.AppendAsLiteral(Memory.Span, builder);
+            return builder.ToString();
+        }
+
+        protected void OnZeroReferences()
+        {
+            Pool.Return(this);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _disposed = true;
+        }
+
+        public override void Retain()
+        {
+            if (IsDisposed) RioPipelinesThrowHelper.ThrowObjectDisposedException(nameof(RioMemoryPoolBlock));
+            Interlocked.Increment(ref _referenceCount);
+        }
+
+        public override bool Release()
+        {
+            int newRefCount = Interlocked.Decrement(ref _referenceCount);
+            if (newRefCount < 0) RioPipelinesThrowHelper.ThrowInvalidOperationException(ExceptionResource.ReferenceCountZero);
+            if (newRefCount == 0)
+            {
+               OnZeroReferences();
+               return false;
+            }
+            return true;
+        }
+
+        protected override bool IsRetained => _referenceCount > 0;
+        public override bool IsDisposed => _disposed;
+
+        // In kestrel both MemoryPoolBlock and OwnedMemory end up in the same assembly so
+        // this method access modifiers need to be `protected internal`
+        protected override bool TryGetArray(out ArraySegment<byte> arraySegment)
+        {
+            if (IsDisposed) RioPipelinesThrowHelper.ThrowObjectDisposedException(nameof(RioMemoryPoolBlock));
+            arraySegment = new ArraySegment<byte>(Slab.Array, _offset, _length);
+            return true;
+        }
+
+        public override MemoryHandle Pin()
+        {
+            if (IsDisposed) RioPipelinesThrowHelper.ThrowObjectDisposedException(nameof(RioMemoryPoolBlock));
+            Retain();
+            unsafe
+            {
+                return new MemoryHandle(this, (Slab.NativePointer + _offset).ToPointer());
+            }
+        }
+    }
+}

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/Pool/PipelinesThrowHelper.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/Pool/PipelinesThrowHelper.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.IO.Pipelines
+{
+    internal class RioPipelinesThrowHelper
+    {    
+        public static void ThrowInvalidOperationException(ExceptionResource resource, string location = null)
+        {
+            throw GetInvalidOperationException(resource, location);
+        }
+ 
+        public static void ThrowArgumentOutOfRangeException_BufferRequestTooLarge(int maxSize)
+        {
+            throw GetArgumentOutOfRangeException_BufferRequestTooLarge(maxSize);
+        }
+
+        public static void ThrowObjectDisposedException(string objectName)
+        {
+            throw GetObjectDisposedException(objectName);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static InvalidOperationException GetInvalidOperationException(ExceptionResource resource, string location = null)
+        {
+            return new InvalidOperationException(GetResourceString(resource, location));
+        }
+     
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentOutOfRangeException GetArgumentOutOfRangeException_BufferRequestTooLarge(int maxSize)
+        {
+            return new ArgumentOutOfRangeException(GetArgumentName(ExceptionArgument.size),
+                $"Cannot allocate more than {maxSize} bytes in a single buffer");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ObjectDisposedException GetObjectDisposedException(string objectName)
+        {
+            return new ObjectDisposedException(objectName);
+        }
+
+        private static string GetArgumentName(ExceptionArgument argument)
+        {
+            Debug.Assert(Enum.IsDefined(typeof(ExceptionArgument), argument),
+                "The enum value is not defined, please check the ExceptionArgument Enum.");
+
+            return argument.ToString();
+        }
+
+        private static string GetResourceString(ExceptionResource argument, string location = null)
+        {
+            Debug.Assert(Enum.IsDefined(typeof(ExceptionResource), argument),
+                "The enum value is not defined, please check the ExceptionResource Enum.");
+
+            // Should be look up with environment resources
+            string resourceString = null;
+            switch (argument)
+            {
+                case ExceptionResource.AlreadyWriting:
+                    resourceString = "Already writing.";
+                    break;
+                case ExceptionResource.NotWritingNoAlloc:
+                    resourceString = "No writing operation. Make sure Alloc() was called.";
+                    break;
+                case ExceptionResource.NoWriteToComplete:
+                    resourceString = "No writing operation to complete.";
+                    break;
+                case ExceptionResource.AlreadyReading:
+                    resourceString = "Already reading.";
+                    break;
+                case ExceptionResource.NoReadToComplete:
+                    resourceString = "No reading operation to complete.";
+                    break;
+                case ExceptionResource.NoConcurrentOperation:
+                    resourceString = "Concurrent reads or writes are not supported.";
+                    break;
+                case ExceptionResource.GetResultNotCompleted:
+                    resourceString = "Can't GetResult unless completed";
+                    break;
+                case ExceptionResource.NoWritingAllowed:
+                    resourceString = "Writing is not allowed after writer was completed";
+                    break;
+                case ExceptionResource.NoReadingAllowed:
+                    resourceString = "Reading is not allowed after reader was completed";
+                    break;
+                case ExceptionResource.CompleteWriterActiveWriter:
+                    resourceString = "Can't complete writer while writing.";
+                    break;
+                case ExceptionResource.CompleteReaderActiveReader:
+                    resourceString = "Can't complete reader while reading.";
+                    break;
+                case ExceptionResource.AdvancingPastBufferSize:
+                    resourceString = "Can't advance past buffer size";
+                    break;
+                case ExceptionResource.AdvancingWithNoBuffer:
+                    resourceString = "Can't advance without buffer allocated";
+                    break;
+                case ExceptionResource.BackpressureDeadlock:
+                    resourceString = "Advancing examined to the end would cause pipe to deadlock because FlushAsync is waiting";
+                    break;
+                case ExceptionResource.AdvanceToInvalidCursor:
+                    resourceString = "Pipe is already advanced past provided cursor";
+                    break;
+                case ExceptionResource.ReferenceCountZero:
+                    resourceString = "Can't release when reference count is already zero";
+                    break;
+                case ExceptionResource.BufferDoesNotBelongToPool:
+                    resourceString = "Can't return buffers that were not rented from this pool";
+                    break;
+            }
+
+            resourceString = resourceString ?? $"Error ResourceKey not defined {argument}.";
+
+            if (location != null)
+            {
+                resourceString += Environment.NewLine;
+                resourceString += "From: " + location.Replace("at ", ">> ");
+            }
+
+            return resourceString;
+        }
+    }
+
+    internal enum ExceptionArgument
+    {
+        minimumSize,
+        bytesWritten,
+        destination,
+        offset,
+        length,
+        data,
+        size
+    }
+
+    internal enum ExceptionResource
+    {
+        AlreadyWriting,
+        NotWritingNoAlloc,
+        NoWriteToComplete,
+        AlreadyReading,
+        NoReadToComplete,
+        NoConcurrentOperation,
+        GetResultNotCompleted,
+        NoWritingAllowed,
+        NoReadingAllowed,
+        CompleteWriterActiveWriter,
+        CompleteReaderActiveReader,
+        AdvancingPastBufferSize,
+        AdvancingWithNoBuffer,
+        BackpressureDeadlock,
+        AdvanceToInvalidCursor,
+        ReferenceCountZero,
+        BufferDoesNotBelongToPool,
+    }
+}

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/Pool/SpanLiteralExtensions.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/Pool/SpanLiteralExtensions.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace System.IO.Pipelines
+{
+    internal class RioSpanLiteralExtensions
+    {
+        internal static void AppendAsLiteral(Span<byte> span, StringBuilder sb)
+        {
+            for (int i = 0; i < span.Length; i++)
+            {
+                AppendCharLiteral((char) span[i], sb);
+            }
+        }
+
+        internal static void AppendCharLiteral(char c, StringBuilder sb)
+        {
+            switch (c)
+            {
+                case '\'':
+                    sb.Append(@"\'");
+                    break;
+                case '\"':
+                    sb.Append("\\\"");
+                    break;
+                case '\\':
+                    sb.Append(@"\\");
+                    break;
+                case '\0':
+                    sb.Append(@"\0");
+                    break;
+                case '\a':
+                    sb.Append(@"\a");
+                    break;
+                case '\b':
+                    sb.Append(@"\b");
+                    break;
+                case '\f':
+                    sb.Append(@"\f");
+                    break;
+                case '\n':
+                    sb.Append(@"\n");
+                    break;
+                case '\r':
+                    sb.Append(@"\r");
+                    break;
+                case '\t':
+                    sb.Append(@"\t");
+                    break;
+                case '\v':
+                    sb.Append(@"\v");
+                    break;
+                default:
+                    // ASCII printable character
+                    if (!char.IsControl(c))
+                    {
+                        sb.Append(c);
+                        // As UTF16 escaped character
+                    }
+                    else
+                    {
+                        sb.Append(@"\u");
+                        sb.Append(((int) c).ToString("x4"));
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/src/System.IO.Pipelines/System/Buffers/MemoryPool.cs
+++ b/src/System.IO.Pipelines/System/Buffers/MemoryPool.cs
@@ -39,7 +39,7 @@ namespace System.Buffers
         /// Max allocation block size for pooled blocks,
         /// larger values can be leased but they will be disposed after use rather than returned to the pool.
         /// </summary>
-        public const int MaxPooledBlockLength = _blockLength;
+        public override int MaxBufferSize { get; } = _blockLength;
 
         /// <summary>
         /// 4096 * 32 gives you a slabLength of 128k contiguous bytes allocated per slab
@@ -63,9 +63,15 @@ namespace System.Buffers
         /// </summary>
         private bool _disposedValue = false; // To detect redundant calls
 
-        private Action<MemoryPoolSlab> _slabAllocationCallback;
+        private Action<OwnedMemory<byte>> _slabAllocationCallback;
 
-        private Action<MemoryPoolSlab> _slabDeallocationCallback;
+        private Action<OwnedMemory<byte>> _slabDeallocationCallback;
+
+        public MemoryPool(Action<OwnedMemory<byte>> allocationCallback = null, Action<OwnedMemory<byte>> deallocationCallback = null)
+        {
+            _slabAllocationCallback = allocationCallback;
+            _slabDeallocationCallback = deallocationCallback;
+        }
 
         public override OwnedMemory<byte> Rent(int size)
         {
@@ -76,16 +82,6 @@ namespace System.Buffers
 
             var block = Lease();
             return block;
-        }
-
-        public void RegisterSlabAllocationCallback(Action<MemoryPoolSlab> callback)
-        {
-            _slabAllocationCallback = callback;
-        }
-
-        public void RegisterSlabDeallocationCallback(Action<MemoryPoolSlab> callback)
-        {
-            _slabDeallocationCallback = callback;
         }
 
         /// <summary>

--- a/src/System.IO.Pipelines/System/Buffers/MemoryPool.cs
+++ b/src/System.IO.Pipelines/System/Buffers/MemoryPool.cs
@@ -63,7 +63,7 @@ namespace System.Buffers
         /// </summary>
         private bool _disposedValue = false; // To detect redundant calls
 
-        public override OwnedMemory<byte> Rent(int size)
+        public override OwnedMemory<byte> Rent(int size = AnySize)
         {
             if (size == AnySize) size = _blockLength;
             else if (size > _blockLength)

--- a/src/System.IO.Pipelines/System/Buffers/MemoryPoolBlock.cs
+++ b/src/System.IO.Pipelines/System/Buffers/MemoryPoolBlock.cs
@@ -12,7 +12,7 @@ namespace System.Buffers
     /// Block tracking object used by the byte buffer memory pool. A slab is a large allocation which is divided into smaller blocks. The
     /// individual blocks are then treated as independent array segments.
     /// </summary>
-    public class MemoryPoolBlock : OwnedMemory<byte>
+    internal class MemoryPoolBlock : OwnedMemory<byte>
     {
         private readonly int _offset;
         private readonly int _length;

--- a/src/System.IO.Pipelines/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/System/IO/Pipelines/Pipe.cs
@@ -27,7 +27,7 @@ namespace System.IO.Pipelines
         // 3. _readerAwaitable & _writerAwaitable
         private readonly object _sync = new object();
 
-        private readonly MemoryPool _pool;
+        private readonly MemoryPool<byte> _pool;
         private readonly long _maximumSizeHigh;
         private readonly long _maximumSizeLow;
 

--- a/src/System.IO.Pipelines/System/IO/Pipelines/PipeOptions.cs
+++ b/src/System.IO.Pipelines/System/IO/Pipelines/PipeOptions.cs
@@ -10,7 +10,7 @@ namespace System.IO.Pipelines
     public class PipeOptions
     {
         public PipeOptions(
-            MemoryPool pool,
+            MemoryPool<byte> pool,
             IScheduler readerScheduler = null,
             IScheduler writerScheduler = null,
             long maximumSizeHigh = 0,
@@ -31,6 +31,6 @@ namespace System.IO.Pipelines
 
         public IScheduler ReaderScheduler { get; }
 
-        public MemoryPool Pool { get; }
+        public MemoryPool<byte> Pool { get; }
     }
 }

--- a/tests/Benchmarks/Helpers/Listener.cs
+++ b/tests/Benchmarks/Helpers/Listener.cs
@@ -13,7 +13,7 @@ namespace System.IO.Pipelines.Samples
         private readonly List<PipeConnection> _connections = new List<PipeConnection>();
         private Task[] _connectionTasks;
 
-        public FakeListener(MemoryPool pool, int concurrentConnections)
+        public FakeListener(MemoryPool<byte> pool, int concurrentConnections)
         {
             for (int i = 0; i < concurrentConnections; i++)
             {

--- a/tests/System.IO.Pipelines.Extensions.Tests/PipelineReaderWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Extensions.Tests/PipelineReaderWriterFacts.cs
@@ -13,7 +13,7 @@ namespace System.IO.Pipelines.Tests
     public class PipelineReaderWriterFacts : IDisposable
     {
         private IPipe _pipe;
-        private MemoryPool _pool;
+        private MemoryPool<byte> _pool;
 
         public PipelineReaderWriterFacts()
         {

--- a/tests/System.IO.Pipelines.Extensions.Tests/ReadableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Extensions.Tests/ReadableBufferFacts.cs
@@ -24,7 +24,7 @@ namespace System.IO.Pipelines.Tests
         const int BlockSize = 4032;
 
         private IPipe _pipe;
-        private MemoryPool _pool;
+        private MemoryPool<byte> _pool;
 
         public ReadableBufferFacts()
         {


### PR DESCRIPTION
This is an experiment in making pipelines pooling into a true abstraction, i.e. pipelines use MemoryPool<byte> instead of MemoryPool concrete class. The only usage of the concrete class is to create the default instances.

@davidfowl, @pakrym, @ahsonkhan, any thoughts?
