### PR TITLE
Added BytesReader.TryRead(out int)

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/Text/BytesReader.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Text/BytesReader.cs
@@ -1,21 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Buffers.Text;
+using System.Buffers.Binary;
 using System.Collections.Sequences;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace System.Buffers.Text
 {
-    public static class BytesReader
-    {
-        public static BytesReader<T> Create<T>(T sequence) where T : ISequence<ReadOnlyMemory<byte>>
-        {
-            return new BytesReader<T>(sequence);
-        }
-    }
-
     /// <summary>
     /// Used to read text from byte buffers
     /// </summary>
@@ -24,11 +16,8 @@ namespace System.Buffers.Text
         readonly TSequence _bytes;
         Position _currentSegmentPosition;
         Position _nextSegmentPosition;
-        ReadOnlyMemory<byte> _currentMemory; // TODO: I think this can be removed
         ReadOnlySpan<byte> _currentSpan;
         int _currentSpanIndex;
-
-        readonly SymbolTable _symbolTable;
 
         // TODO: should there be a ctor that takes sequence + position? 
         // TODO: should there be a type that is sequence + position?
@@ -37,9 +26,8 @@ namespace System.Buffers.Text
             _bytes = bytes;
             _currentSegmentPosition = bytes.First;
             _nextSegmentPosition = _currentSegmentPosition;
-            _bytes.TryGet(ref _nextSegmentPosition, out _currentMemory);
-            _currentSpan = _currentMemory.Span;
-            _symbolTable = SymbolTable.InvariantUtf8;
+            _bytes.TryGet(ref _nextSegmentPosition, out ReadOnlyMemory<byte> memory);
+            _currentSpan = memory.Span;
             _currentSpanIndex = 0;
         }
 
@@ -48,9 +36,7 @@ namespace System.Buffers.Text
             _bytes = default;
             _nextSegmentPosition = default;
             _currentSegmentPosition = Position.Create(0);
-            _currentMemory = bytes;
             _currentSpan = bytes.Span;
-            _symbolTable = SymbolTable.InvariantUtf8;
             _currentSpanIndex = 0;
         }
 
@@ -59,9 +45,7 @@ namespace System.Buffers.Text
             _bytes = default;
             _nextSegmentPosition = default;
             _currentSegmentPosition = Position.Create(0);
-            _currentMemory = default;
             _currentSpan = bytes;
-            _symbolTable = SymbolTable.InvariantUtf8;
             _currentSpanIndex = 0;
         }
 
@@ -109,14 +93,14 @@ namespace System.Buffers.Text
             range.To = PositionOf(delimiter);
             if (!range.To.IsEnd)
             {
-                Seek(range.To);
-                Seek(delimiter.Length);
+                Advance(range.To);
+                Advance(delimiter.Length);
             }
             return range;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Seek(long count)
+        public void Advance(long count)
         {
             var unreadLength = _currentSpan.Length - _currentSpanIndex;
             if (count <= unreadLength)
@@ -125,42 +109,40 @@ namespace System.Buffers.Text
             }
             else
             {
-                if (!_bytes.TryGet(ref _nextSegmentPosition, out _currentMemory))
+                if (!_bytes.TryGet(ref _nextSegmentPosition, out ReadOnlyMemory<byte> memory))
                 {
                     throw new ArgumentOutOfRangeException(nameof(count));
                 }
-                _currentSpan = _currentMemory.Span;
+                _currentSpan = memory.Span;
                 _currentSpanIndex = 0;
-                Seek(count - unreadLength);
+                Advance(count - unreadLength);
             }
         }
 
-        public void Seek(Position position)
+        public void Advance(Position position)
         {
             _currentSegmentPosition = position;
             _nextSegmentPosition = position;
-            if (_bytes.TryGet(ref _nextSegmentPosition, out _currentMemory))
+            if (_bytes.TryGet(ref _nextSegmentPosition, out ReadOnlyMemory<byte> memory))
             {
-                _currentSpan = _currentMemory.Span;
+                _currentSpan = memory.Span;
             }
             else
             {
                 _currentSpan = default;
             }
             _currentSpanIndex = 0;
-
         }
 
         #region Parsing Methods
         // TODO: how to we chose the lengths of the temp buffers?
         // TODO: these methods call the slow overloads of Parsers.Custom.TryParseXXX. Do we need fast path?
         // TODO: these methods hardcode the format. Do we need this to be something that can be specified?
-        public bool TryParseBoolean(out bool value)
+        public bool TryParse(out bool value)
         {
             var unread = Unread;
-            if (CustomParser.TryParseBoolean(unread, out value, out int consumed, _symbolTable))
+            if (Utf8Parser.TryParse(unread, out value, out int consumed))
             {
-                Debug.Assert(consumed <= unread.Length);
                 if (unread.Length > consumed)
                 {
                     _currentSpanIndex += consumed;
@@ -168,22 +150,22 @@ namespace System.Buffers.Text
                 }
             }
 
-            Span<byte> tempSpan = stackalloc byte[15];
-            CopyTo(this, tempSpan, out var copied);
+            Span<byte> tempSpan = stackalloc byte[5];
+            var copied = CopyTo(this, tempSpan);
 
-            if (CustomParser.TryParseBoolean(tempSpan.Slice(0, copied), out value, out consumed, _symbolTable))
+            if (Utf8Parser.TryParse(tempSpan.Slice(0, copied), out value, out consumed))
             {
-                Seek(consumed);
+                Advance(consumed);
                 return true;
             }
 
             return false;
         }
 
-        public bool TryParseUInt64(out ulong value)
+        public bool TryParse(out ulong value)
         {
             var unread = Unread;
-            if (CustomParser.TryParseUInt64(unread, out value, out int consumed, default, _symbolTable))
+            if (Utf8Parser.TryParse(unread, out value, out int consumed))
             {
                 if (unread.Length > consumed)
                 {
@@ -192,16 +174,47 @@ namespace System.Buffers.Text
                 }
             }
 
-            Span<byte> tempSpan = stackalloc byte[32];
-            CopyTo(this, tempSpan, out int copied);
-
-            if (CustomParser.TryParseUInt64(tempSpan.Slice(0, copied), out value, out consumed, 'G', _symbolTable))
+            Span<byte> tempSpan = stackalloc byte[30];
+            var copied = CopyTo(this, tempSpan);
+            if (Utf8Parser.TryParse(tempSpan.Slice(0, copied), out value, out consumed))
             {
-                Seek(consumed);
+                Advance(consumed);
                 return true;
             }
-
             return false;
+        }
+        #endregion
+
+        #region Binary Read APIs
+        public bool TryRead(out int value, bool littleEndian = false)
+        {
+            var unread = Unread;
+            if (littleEndian) {
+                if (BinaryPrimitives.TryReadInt32LittleEndian(unread, out value)) {
+                    Advance(sizeof(int));
+                    return true;
+                }
+            }
+            else if (BinaryPrimitives.TryReadInt32BigEndian(unread, out value)) {
+                Advance(sizeof(int));
+                return true;
+            }           
+
+            Span<byte> span = stackalloc byte[4];
+            var copied = CopyTo(this, span);
+            if (copied < 4) {
+                value = default;
+                return false;
+            }
+
+            if (littleEndian) {
+                value = BinaryPrimitives.ReadInt32LittleEndian(span);
+            }
+            else {
+                value = BinaryPrimitives.ReadInt32BigEndian(span);
+            }
+            Advance(sizeof(int));
+            return true;
         }
         #endregion
 
@@ -231,21 +244,20 @@ namespace System.Buffers.Text
             var nextPosition = _nextSegmentPosition;
             var currentPosition = _currentSegmentPosition;
             var previousPosition = _nextSegmentPosition;
-            var memory = _currentMemory;
-            while (_bytes.TryGet(ref _nextSegmentPosition, out _currentMemory))
+            while (_bytes.TryGet(ref _nextSegmentPosition, out ReadOnlyMemory<byte> memory))
             {
-                index = _currentMemory.Span.IndexOf(value);
+                var span = memory.Span;
+                index = span.IndexOf(value);
                 if (index != -1)
                 {
                     _currentSegmentPosition = previousPosition;
-                    _currentSpan = _currentMemory.Span;
+                    _currentSpan = span;
                     _currentSpanIndex = index + 1;
                     return _currentSegmentPosition + index;
                 }
                 previousPosition = _nextSegmentPosition;
             }
 
-            _currentMemory = memory;
             _nextSegmentPosition = nextPosition;
             _currentSegmentPosition = currentPosition;
             return Position.End;
@@ -276,25 +288,32 @@ namespace System.Buffers.Text
             throw new NotImplementedException();
         }
 
-        static void CopyTo(BytesReader<TSequence> bytes, Span<byte> buffer, out int copied)
+        static int CopyTo(BytesReader<TSequence> bytes, Span<byte> buffer)
         {
             var first = bytes.Unread;
             if (first.Length > buffer.Length)
             {
                 first.Slice(0, buffer.Length).CopyTo(buffer);
-                copied = buffer.Length;
+                return buffer.Length;
             }
             else if (first.Length == buffer.Length)
             {
                 first.CopyTo(buffer);
-                copied = buffer.Length;
+                return buffer.Length;
             }
             else
             {
                 first.CopyTo(buffer);
-                copied = first.Length;
-                copied += Sequence.Copy(bytes._bytes, bytes._nextSegmentPosition, buffer.Slice(copied));
+                return first.Length + Sequence.Copy(bytes._bytes, bytes._nextSegmentPosition, buffer.Slice(first.Length));
             }
+        }
+    }
+
+    public static class BytesReader
+    {
+        public static BytesReader<T> Create<T>(T sequence) where T : ISequence<ReadOnlyMemory<byte>>
+        {
+            return new BytesReader<T>(sequence);
         }
     }
 }

--- a/tests/System.Buffers.Experimental.Tests/BytesReaderTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/BytesReaderTests.cs
@@ -34,22 +34,31 @@ namespace System.Buffers.Tests
                 new byte[] { 1, 2       },
                 new byte[] { 3, 4       },
                 new byte[] { 5, 6, 7, 8 },
-                new byte[] { 8          }
+                new byte[] { 8, 0       },
+                new byte[] { 1,         },
+                new byte[] { 0, 2,      },
+                new byte[] { 1, 2, 3, 4 },
             });
 
             var reader = BytesReader.Create(bytes);
 
-            var value = bytes.Slice(reader.ReadRange(2)).ToSpan();
-            Assert.Equal(0, value[0]);
-            Assert.Equal(1, value[1]);
+            var span = bytes.Slice(reader.ReadRange(2)).ToSpan();
+            Assert.Equal(0, span[0]);
+            Assert.Equal(1, span[1]);
 
-            value = bytes.Slice(reader.ReadRange(5)).ToSpan();
-            Assert.Equal(3, value[0]);
-            Assert.Equal(4, value[1]);
+            span = bytes.Slice(reader.ReadRange(5)).ToSpan();
+            Assert.Equal(3, span[0]);
+            Assert.Equal(4, span[1]);
 
-            value = bytes.Slice(reader.ReadRange(new byte[] { 8, 8 })).ToSpan();
-            Assert.Equal(6, value[0]);
-            Assert.Equal(7, value[1]);
+            span = bytes.Slice(reader.ReadRange(new byte[] { 8, 8 })).ToSpan();
+            Assert.Equal(6, span[0]);
+            Assert.Equal(7, span[1]);
+
+            Assert.True(reader.TryRead(out int value, true));
+            Assert.Equal(BitConverter.ToInt32(new byte[] { 0, 1, 0, 2 }), value);
+
+            Assert.True(reader.TryRead(out value));
+            Assert.Equal(BitConverter.ToInt32(new byte[] { 4, 3, 2, 1 }), value);
         }
 
         [Fact]
@@ -87,22 +96,22 @@ namespace System.Buffers.Tests
             ReadOnlyBytes bytes = Parse("12|3Tr|ue|456Tr|ue7|89False|");
             var reader = BytesReader.Create(bytes);
 
-            Assert.True(reader.TryParseUInt64(out ulong u64));
+            Assert.True(reader.TryParse(out ulong u64));
             Assert.Equal(123ul, u64);
 
-            Assert.True(reader.TryParseBoolean(out bool b));
+            Assert.True(reader.TryParse(out bool b));
             Assert.Equal(true, b);
 
-            Assert.True(reader.TryParseUInt64(out u64));
+            Assert.True(reader.TryParse(out u64));
             Assert.Equal(456ul, u64);
 
-            Assert.True(reader.TryParseBoolean(out b));
+            Assert.True(reader.TryParse(out b));
             Assert.Equal(true, b);
 
-            Assert.True(reader.TryParseUInt64(out u64));
+            Assert.True(reader.TryParse(out u64));
             Assert.Equal(789ul, u64);
 
-            Assert.True(reader.TryParseBoolean(out b));
+            Assert.True(reader.TryParse(out b));
             Assert.Equal(false, b);
         }
 


### PR DESCRIPTION
I also added perf tests comparing BytesReader to raw Utf8Formatter and to ReadableBufferReader (raw APIs). All three are in the same ballpark, which is good! ... especially considering that BytesReader is doing an additional check that it important for parsing straddling buffers.

 Benchmarks.dll                                  | Metric               | Unit  | Average 
:----------------------------------------------- |:-------------------- |:-----:|----------:
 BytesReaderBench.ParseInt32BytesReader          | Duration             | msec  |      1.056 
 BytesReaderBench.ParseInt32BytesReader          | Instructions Retired | count | 1.495E+007 
 BytesReaderBench.ParseInt32BytesReader          | Cache Misses         | count |   1478.656 
 BytesReaderBench.ParseInt32ReadableBufferReader | Duration             | msec  |      1.235 
 BytesReaderBench.ParseInt32ReadableBufferReader | Instructions Retired | count | 1.637E+007 
 BytesReaderBench.ParseInt32ReadableBufferReader | Cache Misses         | count |   2240.512 
 BytesReaderBench.ParseInt32Utf8Parser           | Duration             | msec  |      0.881 
 BytesReaderBench.ParseInt32Utf8Parser           | Instructions Retired | count | 1.249E+007 
 BytesReaderBench.ParseInt32Utf8Parser           | Cache Misses         | count |   1196.032 

@ahsonkhan, @davidfowl, @jkotas, @vancem, @pakrym, @joshfree 