### PR TITLE
Changed IMemoryList based on Pipelines API Review

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/BufferSequence.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/BufferSequence.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Net
 
         public Span<byte> Free => new Span<byte>(_array, _written, _array.Length - _written);
 
-        public IMemoryList<byte> Rest => _next;
+        public IMemoryList<byte> Next => _next;
 
         public int WrittenByteCount => _written;
 

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/MemoryList.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/MemoryList.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Sequences;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace System.Buffers
@@ -37,7 +35,7 @@ namespace System.Buffers
 
         public Memory<byte> Memory => _data;
 
-        public IMemoryList<byte> Rest => _next;
+        public IMemoryList<byte> Next => _next;
 
         public long VirtualIndex => _virtualIndex;
 

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadOnlyBytes.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadOnlyBytes.cs
@@ -98,7 +98,7 @@ namespace System.Buffers
                             break;
                         }
                         index -= m.Length;
-                        sl = sl.Rest;
+                        sl = sl.Next;
                     }
 
                     var el = sl;
@@ -117,7 +117,7 @@ namespace System.Buffers
                         {
                             return new ReadOnlyBytes(sl, (int)index, el, m.Length);
                         }
-                        el = el.Rest;
+                        el = el.Next;
                     }
                 default:
                     throw new NotImplementedException();
@@ -293,7 +293,7 @@ namespace System.Buffers
                 {
                     var first = _start as IMemoryList<byte>;
                     item = first.Memory.Slice(_startIndex);
-                    if (advance) position = Position.Create(first.Rest);
+                    if (advance) position = Position.Create(first.Next);
                     if (ReferenceEquals(_end, _start)){
                         item = item.Slice(0, (int)Length);
                         if (advance) position = Position.End;
@@ -310,7 +310,7 @@ namespace System.Buffers
                 }
                 else
                 {
-                    if (advance) position = Position.Create(node.Rest);
+                    if (advance) position = Position.Create(node.Next);
                 }
                 return true;
             }

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadWriteBytes.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadWriteBytes.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Sequences;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 namespace System.Buffers
 {
@@ -97,7 +95,7 @@ namespace System.Buffers
                             break;
                         }
                         index -= m.Length;
-                        sl = sl.Rest;
+                        sl = sl.Next;
                     }
 
                     var el = sl;
@@ -116,7 +114,7 @@ namespace System.Buffers
                         {
                             return new ReadWriteBytes(sl, (int)index, el, m.Length);
                         }
-                        el = el.Rest;
+                        el = el.Next;
                     }
                 default:
                     throw new NotImplementedException();
@@ -293,7 +291,7 @@ namespace System.Buffers
                 {
                     var first = _start as IMemoryList<byte>;
                     item = first.Memory.Slice(_startIndex);
-                    if (advance) position = Position.Create(first.Rest);
+                    if (advance) position = Position.Create(first.Next);
                     if (ReferenceEquals(_end, _start))
                     {
                         item = item.Slice(0, (int)Length);
@@ -311,7 +309,7 @@ namespace System.Buffers
                 }
                 else
                 {
-                    if (advance) position = Position.Create(node.Rest);
+                    if (advance) position = Position.Create(node.Next);
                 }
                 return true;
             }

--- a/src/System.Buffers.Primitives/System/Collections/IMemoryList.cs
+++ b/src/System.Buffers.Primitives/System/Collections/IMemoryList.cs
@@ -1,18 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Sequences;
-
-namespace System.Buffers
+namespace System.Collections.Sequences
 {
-    public interface IMemoryList<T> : ISequence<Memory<T>>, ISequence<ReadOnlyMemory<T>>
+    public interface IMemoryList<T>
     {
         Memory<T> Memory { get; }
 
-        IMemoryList<T> Rest { get; }
+        IMemoryList<T> Next { get; }
 
         long VirtualIndex { get; }
-
-        int CopyTo(Span<T> buffer);
     }
 }

--- a/src/System.IO.Pipelines/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/System/IO/Pipelines/BufferSegment.cs
@@ -2,20 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Collections.Sequences;
 using System.Diagnostics;
 using System.Text;
 
 namespace System.IO.Pipelines
 {
-    public interface IMemoryList<T>
-    {
-        Memory<T> Memory { get; }
-
-        IMemoryList<T> Next { get; }
-
-        long VirtualIndex { get; }
-    }
-
     internal class BufferSegment: IMemoryList<byte>
     {
         /// <summary>

--- a/src/System.IO.Pipelines/System/IO/Pipelines/ReadCursorOperations.cs
+++ b/src/System.IO.Pipelines/System/IO/Pipelines/ReadCursorOperations.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Collections.Sequences;
 using System.Runtime.CompilerServices;
 
 namespace System.IO.Pipelines

--- a/src/System.IO.Pipelines/System/IO/Pipelines/ReadableBuffer.cs
+++ b/src/System.IO.Pipelines/System/IO/Pipelines/ReadableBuffer.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
-using System.Collections.Generic;
+using System.Collections.Sequences;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace System.IO.Pipelines

--- a/tests/System.Buffers.Experimental.Tests/SequenceExtensionsTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/SequenceExtensionsTests.cs
@@ -79,7 +79,7 @@ namespace System.Buffers.Tests
             {
                 var value = (byte)(i + 1);
 
-                var listPosition = Sequence.PositionOf(first, value);
+                var listPosition = MemoryListExtensions.PositionOf(first, value);
                 var (node, index) = listPosition.Get<IMemoryList<byte>>();
 
                 if (!listPosition.IsEnd)


### PR DESCRIPTION
- Renamed Rest to Next
- Removed interfaces it extended
- Removed CopyTo
- Updated pipelines to use this (shared) interface

@pakrym, @ahsonkhan, @joshfree 