### PR TITLE
Remove use of DangerousGetPinnableReference and use Memory.GetReference instead

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/TcpServer.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/TcpServer.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.Net.Interop;
 using System;
+using System.Runtime.InteropServices;
 
 namespace Microsoft.Net.Sockets
 {
@@ -163,7 +164,7 @@ namespace Microsoft.Net.Sockets
         public unsafe int Send(ReadOnlySpan<byte> buffer)
         {
             // TODO: This can work with Span<byte> because it's synchronous but we need async pinning support
-            fixed (byte* bytes = &buffer.DangerousGetPinnableReference())
+            fixed (byte* bytes = &MemoryMarshal.GetReference(buffer))
             {
                 IntPtr pointer = new IntPtr(bytes);
                 return SendPinned(pointer, buffer.Length);
@@ -193,7 +194,7 @@ namespace Microsoft.Net.Sockets
         public unsafe int Receive(Span<byte> buffer)
         {
             // TODO: This can work with Span<byte> because it's synchronous but we need async pinning support
-            fixed (byte* bytes = &buffer.DangerousGetPinnableReference())
+            fixed (byte* bytes = &MemoryMarshal.GetReference(buffer))
             {
                 IntPtr pointer = new IntPtr(bytes);
                 return ReceivePinned(pointer, buffer.Length);

--- a/samples/System.Numerics.Tensors.Samples/TensorSamples/Access.cs
+++ b/samples/System.Numerics.Tensors.Samples/TensorSamples/Access.cs
@@ -59,10 +59,10 @@ namespace TensorSamples
         
         public static unsafe void DumpContentsSparse(CompressedSparseTensor<double> tensor)
         {
-            fixed (double* valuesPtr = &tensor.Values.Span.DangerousGetPinnableReference())
-            fixed (int* compressedCountsPtr = &tensor.CompressedCounts.Span.DangerousGetPinnableReference())
-            fixed (int* indicesPtr = &tensor.Indices.Span.DangerousGetPinnableReference())
-            fixed (int* stridesPtr = &tensor.Strides.DangerousGetPinnableReference())
+            fixed (double* valuesPtr = &MemoryMarshal.GetReference(tensor.Values.Span))
+            fixed (int* compressedCountsPtr = &MemoryMarshal.GetReference(tensor.CompressedCounts.Span))
+            fixed (int* indicesPtr = &MemoryMarshal.GetReference(tensor.Indices.Span))
+            fixed (int* stridesPtr = &MemoryMarshal.GetReference(tensor.Strides))
             {
                 DumpContentsSparse(valuesPtr, compressedCountsPtr, indicesPtr, stridesPtr, tensor.Rank, tensor.NonZeroCount);
             }
@@ -70,8 +70,8 @@ namespace TensorSamples
 
         public static unsafe void DumpContentsDense(DenseTensor<double> tensor)
         {
-            fixed (double* valuesPtr = &tensor.Buffer.Span.DangerousGetPinnableReference())
-            fixed (int* stridesPtr = &tensor.Strides.DangerousGetPinnableReference())
+            fixed (double* valuesPtr = &MemoryMarshal.GetReference(tensor.Buffer.Span))
+            fixed (int* stridesPtr = &MemoryMarshal.GetReference(tensor.Strides))
             {
                 DumpContentsDense(valuesPtr, stridesPtr, tensor.Rank, (int)tensor.Length);
             }

--- a/samples/System.Numerics.Tensors.Samples/TensorSamples/MutateSparse.cs
+++ b/samples/System.Numerics.Tensors.Samples/TensorSamples/MutateSparse.cs
@@ -33,9 +33,9 @@ namespace TensorSamples
 
         public static unsafe double ScalarPowerSparse(CompressedSparseTensor<double> tensor, int exponent)
         {
-            fixed (double* valuesPtr = &tensor.Values.Span.DangerousGetPinnableReference())
-            fixed (int* compressedCountsPtr = &tensor.CompressedCounts.Span.DangerousGetPinnableReference())
-            fixed (int* indicesPtr = &tensor.Indices.Span.DangerousGetPinnableReference())
+            fixed (double* valuesPtr = &MemoryMarshal.GetReference(tensor.Values.Span))
+            fixed (int* compressedCountsPtr = &MemoryMarshal.GetReference(tensor.CompressedCounts.Span))
+            fixed (int* indicesPtr = &MemoryMarshal.GetReference(tensor.Indices.Span))
             {
                 return ScalarPowerSparse(valuesPtr, compressedCountsPtr, indicesPtr, tensor.Dimensions.ToArray(), tensor.Rank, tensor.NonZeroCount, exponent);
             }

--- a/samples/System.Numerics.Tensors.Samples/TensorSamples/PreAllocate.cs
+++ b/samples/System.Numerics.Tensors.Samples/TensorSamples/PreAllocate.cs
@@ -33,7 +33,7 @@ namespace TensorSamples
 
             var result = new DenseTensor<double>(dimensions);
             
-            fixed (double* dataPtr = &result.Buffer.Span.DangerousGetPinnableReference())
+            fixed (double* dataPtr = &MemoryMarshal.GetReference(result.Buffer.Span))
             {
                 GetMultTablePreAllocated(maxNumber, dataPtr, result.Buffer.Length);
             }
@@ -43,7 +43,7 @@ namespace TensorSamples
 
         public static unsafe double GetRowSum(DenseTensor<double> tensor, int row)
         {
-            fixed(double* dataPtr = &tensor.Buffer.Span.DangerousGetPinnableReference())
+            fixed(double* dataPtr = &MemoryMarshal.GetReference(tensor.Buffer.Span))
             {
                 return GetRowSum(dataPtr, tensor.Dimensions.ToArray(), tensor.Rank, row);
             }

--- a/samples/System.Numerics.Tensors.Samples/TensorSamples/ReversePInvoke.cs
+++ b/samples/System.Numerics.Tensors.Samples/TensorSamples/ReversePInvoke.cs
@@ -41,7 +41,7 @@ namespace TensorSamples
 
         public static unsafe double GetRowSum(DenseTensor<double> tensor, int row)
         {
-            fixed(double* dataPtr = &tensor.Buffer.Span.DangerousGetPinnableReference())
+            fixed(double* dataPtr = &MemoryMarshal.GetReference(tensor.Buffer.Span))
             {
                 return GetRowSum(dataPtr, tensor.Dimensions.ToArray(), tensor.Rank, row);
             }

--- a/samples/System.Numerics.Tensors.Samples/TensorSamples/WrapNativeMemory.cs
+++ b/samples/System.Numerics.Tensors.Samples/TensorSamples/WrapNativeMemory.cs
@@ -63,7 +63,7 @@ namespace TensorSamples
 
         public static unsafe double GetRowSum(DenseTensor<double> tensor, int row)
         {
-            fixed(double* dataPtr = &tensor.Buffer.Span.DangerousGetPinnableReference())
+            fixed(double* dataPtr = &MemoryMarshal.GetReference(tensor.Buffer.Span))
             {
                 return GetRowSum(dataPtr, tensor.Dimensions.ToArray(), tensor.Rank, row);
             }
@@ -71,7 +71,7 @@ namespace TensorSamples
 
         public static unsafe void GetMultiplicationTablePreallocated(int maxNumber, DenseTensor<double> tensor)
         {
-            fixed (double* dataPtr = &tensor.Buffer.Span.DangerousGetPinnableReference())
+            fixed (double* dataPtr = &MemoryMarshal.GetReference(tensor.Buffer.Span))
             {
                 GetMultTablePreAllocated(maxNumber, dataPtr, tensor.Buffer.Length);
             }

--- a/src/System.Azure.Experimental/System/Azure/Sha256.Windows.cs
+++ b/src/System.Azure.Experimental/System/Azure/Sha256.Windows.cs
@@ -29,7 +29,7 @@ namespace System.Buffers.Cryptography
         public int OutputSize => 256 / 8; // Sha256 length in bytes
         public unsafe void Append(ReadOnlySpan<byte> input)
         {
-            fixed (byte* pInput = &input.DangerousGetPinnableReference())
+            fixed (byte* pInput = &MemoryMarshal.GetReference(input))
             {
                 var result = BCryptHashData(_hash, pInput, input.Length, 0);
                 if (result != 0) throw new Exception();
@@ -43,7 +43,7 @@ namespace System.Buffers.Cryptography
 
             unsafe
             {
-                fixed (byte* pOutput = &buffer.DangerousGetPinnableReference())
+                fixed (byte* pOutput = &MemoryMarshal.GetReference(buffer))
                 {
                     var result = BCryptFinishHash(_hash, pOutput, OutputSize, 0);
                     if (result != 0) throw new Exception();

--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections.Sequences;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Numerics;
+using System.Runtime.InteropServices;
 
 namespace System.Buffers
 {
@@ -233,7 +234,7 @@ namespace System.Buffers
                 return false;
             }
 
-            return TryIndicesOf(ref buffer.DangerousGetPinnableReference(), value, length, indices, out numberOfIndices);
+            return TryIndicesOf(ref MemoryMarshal.GetReference(buffer), value, length, indices, out numberOfIndices);
         }
 
         public static bool TryIndicesOf(this ReadOnlySpan<byte> buffer, byte value, Span<int> indices, out int numberOfIndices)
@@ -245,7 +246,7 @@ namespace System.Buffers
                 return false;
             }
 
-            return TryIndicesOf(ref buffer.DangerousGetPinnableReference(), value, length, indices, out numberOfIndices);
+            return TryIndicesOf(ref MemoryMarshal.GetReference(buffer), value, length, indices, out numberOfIndices);
         }
 
         private unsafe static bool TryIndicesOf(ref byte searchSpace, byte value, int length, Span<int> indices, out int numberOfIndices)

--- a/src/System.Buffers.Experimental/System/Buffers/Text/BufferWriter_sequence.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Text/BufferWriter_sequence.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.Utf8;
 
 namespace System.Buffers.Text
@@ -34,7 +35,7 @@ namespace System.Buffers.Text
             if (bytes.Length > 0 && free.Length >= bytes.Length)
             {
                 ref byte pSource = ref bytes[0];
-                ref byte pDest = ref free.DangerousGetPinnableReference();
+                ref byte pDest = ref MemoryMarshal.GetReference(free);
 
                 Unsafe.CopyBlockUnaligned(ref pDest, ref pSource, (uint)bytes.Length);
 
@@ -63,7 +64,7 @@ namespace System.Buffers.Text
             if (length > 0 && free.Length >= length)
             {
                 ref byte pSource = ref bytes[index];
-                ref byte pDest = ref free.DangerousGetPinnableReference();
+                ref byte pDest = ref MemoryMarshal.GetReference(free);
 
                 Unsafe.CopyBlockUnaligned(ref pDest, ref pSource, (uint)length);
 
@@ -189,7 +190,7 @@ namespace System.Buffers.Text
                 var chunkLength = Math.Min(length, free.Length);
 
                 ref byte pSource = ref bytes[index];
-                ref byte pDest = ref free.DangerousGetPinnableReference();
+                ref byte pDest = ref MemoryMarshal.GetReference(free);
 
                 Unsafe.CopyBlockUnaligned(ref pDest, ref pSource, (uint)chunkLength);
 

--- a/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli.cs
+++ b/src/System.IO.Compression.Brotli/System/IO/Compression/Brotli.cs
@@ -3,12 +3,13 @@
 // See the LICENSE file in the project root for more information.
 using System.Buffers;
 using System.IO.Compression.Resources;
+using System.Runtime.InteropServices;
 
 #if BIT64
     using nuint = System.UInt64;
 #else
     using nuint = System.UInt32;
-#endif 
+#endif
 
 namespace System.IO.Compression
 {
@@ -152,8 +153,8 @@ namespace System.IO.Compression
             unsafe
             {
                 IntPtr bufIn, bufOut;
-                fixed (byte* inBytes = &source.DangerousGetPinnableReference())
-                fixed (byte* outBytes = &destination.DangerousGetPinnableReference())
+                fixed (byte* inBytes = &MemoryMarshal.GetReference(source))
+                fixed (byte* outBytes = &MemoryMarshal.GetReference(destination))
                 {
                     bufIn = new IntPtr(inBytes);
                     bufOut = new IntPtr(outBytes);
@@ -186,8 +187,8 @@ namespace System.IO.Compression
                 IntPtr bufIn, bufOut;
                 while (bytesConsumed > 0)
                 {
-                    fixed (byte* inBytes = &source.DangerousGetPinnableReference())
-                    fixed (byte* outBytes = &destination.DangerousGetPinnableReference())
+                    fixed (byte* inBytes = &MemoryMarshal.GetReference(source))
+                    fixed (byte* outBytes = &MemoryMarshal.GetReference(destination))
                     {
                         bufIn = new IntPtr(inBytes);
                         bufOut = new IntPtr(outBytes);
@@ -218,8 +219,8 @@ namespace System.IO.Compression
             unsafe
             {
                 IntPtr bufIn, bufOut;
-                fixed (byte* inBytes = &source.DangerousGetPinnableReference())
-                fixed (byte* outBytes = &destination.DangerousGetPinnableReference())
+                fixed (byte* inBytes = &MemoryMarshal.GetReference(source))
+                fixed (byte* outBytes = &MemoryMarshal.GetReference(destination))
                 {
                     bufIn = new IntPtr(inBytes);
                     bufOut = new IntPtr(outBytes);

--- a/src/System.IO.Pipelines.File/FileReader.cs
+++ b/src/System.IO.Pipelines.File/FileReader.cs
@@ -112,7 +112,7 @@ namespace System.IO.Pipelines.File
             public unsafe void Read()
             {
                 var buffer = Writer.Alloc(2048);
-                fixed (byte* source = &buffer.Buffer.Span.DangerousGetPinnableReference())
+                fixed (byte* source = &MemoryMarshal.GetReference(buffer.Buffer.Span))
                 {
                     var count = buffer.Buffer.Length;
 

--- a/src/System.IO.Pipelines.Text.Primitives/ReadableBufferExtensions.cs
+++ b/src/System.IO.Pipelines.Text.Primitives/ReadableBufferExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers.Text;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.Parsing;
 using System.Text.Utf8;
 
@@ -132,7 +133,7 @@ namespace System.IO.Pipelines.Text.Primitives
             var asciiString = new string('\0', len);
 
             fixed (char* destination = asciiString)
-            fixed (byte* source = &span.DangerousGetPinnableReference()) {
+            fixed (byte* source = &MemoryMarshal.GetReference(span)) {
                 if (!AsciiUtilities.TryGetAsciiString(source, destination, len)) {
                     ThrowInvalidOperation();
                 }
@@ -166,7 +167,7 @@ namespace System.IO.Pipelines.Text.Primitives
 
                 foreach (var memory in buffer)
                 {
-                    fixed (byte* source = &memory.Span.DangerousGetPinnableReference())
+                    fixed (byte* source = &MemoryMarshal.GetReference(memory.Span))
                     {
                         if (!AsciiUtilities.TryGetAsciiString(source, output + offset, memory.Length))
                         {

--- a/src/System.IO.Pipelines/System/IO/Pipelines/WritableBufferWriter.cs
+++ b/src/System.IO.Pipelines/System/IO/Pipelines/WritableBufferWriter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.IO.Pipelines
 {
@@ -31,7 +32,7 @@ namespace System.IO.Pipelines
             if (source.Length > 0 && _span.Length >= source.Length)
             {
                 ref byte pSource = ref source[0];
-                ref byte pDest = ref _span.DangerousGetPinnableReference();
+                ref byte pDest = ref MemoryMarshal.GetReference(_span);
 
                 Unsafe.CopyBlockUnaligned(ref pDest, ref pSource, (uint)source.Length);
 
@@ -58,7 +59,7 @@ namespace System.IO.Pipelines
             if (length > 0 && _span.Length >= length)
             {
                 ref byte pSource = ref source[offset];
-                ref byte pDest = ref _span.DangerousGetPinnableReference();
+                ref byte pDest = ref MemoryMarshal.GetReference(_span);
 
                 Unsafe.CopyBlockUnaligned(ref pDest, ref pSource, (uint)length);
 
@@ -84,7 +85,7 @@ namespace System.IO.Pipelines
                 var writable = Math.Min(remaining, _span.Length);
 
                 ref byte pSource = ref source[offset];
-                ref byte pDest = ref _span.DangerousGetPinnableReference();
+                ref byte pDest = ref MemoryMarshal.GetReference(_span);
 
                 Unsafe.CopyBlockUnaligned(ref pDest, ref pSource, (uint)writable);
 

--- a/src/System.Net.Libuv/System/Net/Libuv/Stream.cs
+++ b/src/System.Net.Libuv/System/Net/Libuv/Stream.cs
@@ -87,7 +87,7 @@ namespace System.Net.Libuv
             // This can work with Span<byte> because it's synchronous but we need pinning support
             EnsureNotDisposed();
 
-            fixed (byte* source = &data.DangerousGetPinnableReference())
+            fixed (byte* source = &MemoryMarshal.GetReference(data))
             {
                 var length = data.Length;
 
@@ -109,7 +109,7 @@ namespace System.Net.Libuv
             // This can work with Span<byte> because it's synchronous but we need pinning support
             EnsureNotDisposed();
             
-            fixed (byte* source = &data.Span.DangerousGetPinnableReference())
+            fixed (byte* source = &MemoryMarshal.GetReference(data.Span))
             {
                 var length = data.Length;
                 

--- a/src/System.Text.Http.Parser/HttpParser.cs
+++ b/src/System.Text.Http.Parser/HttpParser.cs
@@ -6,6 +6,7 @@ using System.Collections.Sequences;
 using System.IO.Pipelines;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.Http.Parser.Internal;
 
 namespace System.Text.Http.Parser
@@ -68,7 +69,7 @@ namespace System.Text.Http.Parser
             }
 
             // Fix and parse the span
-            fixed (byte* data = &span.DangerousGetPinnableReference())
+            fixed (byte* data = &MemoryMarshal.GetReference(span))
             {
                 ParseRequestLine(ref handler, data, span.Length);
             }
@@ -101,7 +102,7 @@ namespace System.Text.Http.Parser
             }
 
             // Fix and parse the span
-            fixed (byte* data = &span.DangerousGetPinnableReference())
+            fixed (byte* data = &MemoryMarshal.GetReference(span))
             {
                 ParseRequestLine(ref handler, data, span.Length);
             }
@@ -247,7 +248,7 @@ namespace System.Text.Http.Parser
                     var span = reader.Span;
                     var remaining = span.Length - reader.Index;
 
-                    fixed (byte* pBuffer = &span.DangerousGetPinnableReference())
+                    fixed (byte* pBuffer = &MemoryMarshal.GetReference(span))
                     {
                         while (remaining > 0)
                         {
@@ -332,7 +333,7 @@ namespace System.Text.Http.Parser
                                 var headerSpan = buffer.Slice(current, lineEnd).ToSpan();
                                 length = headerSpan.Length;
 
-                                fixed (byte* pHeader = &headerSpan.DangerousGetPinnableReference())
+                                fixed (byte* pHeader = &MemoryMarshal.GetReference(headerSpan))
                                 {
                                     TakeSingleHeader(pHeader, length, ref handler);
                                 }
@@ -375,7 +376,7 @@ namespace System.Text.Http.Parser
 
             while (true)
             {
-                fixed (byte* pBuffer = &currentSpan.DangerousGetPinnableReference())
+                fixed (byte* pBuffer = &MemoryMarshal.GetReference(currentSpan))
                 {
                     while (remaining > 0)
                     {
@@ -443,7 +444,7 @@ namespace System.Text.Http.Parser
                             var headerSpan = buffer.Slice(index, end - index + 1).ToSpan();
                             length = headerSpan.Length;
 
-                            fixed (byte* pHeader = &headerSpan.DangerousGetPinnableReference())
+                            fixed (byte* pHeader = &MemoryMarshal.GetReference(headerSpan))
                             {
                                 TakeSingleHeader(pHeader, length, ref handler);
                             }

--- a/src/System.Text.Http.Parser/HttpUtilities.cs
+++ b/src/System.Text.Http.Parser/HttpUtilities.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Buffers.Text;
 
 using static System.Buffers.Binary.BinaryPrimitives;
@@ -107,7 +108,7 @@ namespace System.Text.Http.Parser.Internal
             var asciiString = new string('\0', span.Length);
 
             fixed (char* output = asciiString)
-            fixed (byte* buffer = &span.DangerousGetPinnableReference())
+            fixed (byte* buffer = &MemoryMarshal.GetReference(span))
             {
                 // This version if AsciiUtilities returns null if there are any null (0 byte) characters
                 // in the string
@@ -152,7 +153,7 @@ namespace System.Text.Http.Parser.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool GetKnownMethod(this Span<byte> span, out Http.Method method, out int length)
         {
-            fixed (byte* data = &span.DangerousGetPinnableReference())
+            fixed (byte* data = &MemoryMarshal.GetReference(span))
             {
                 method = GetKnownMethod(data, span.Length, out length);
                 return method != Http.Method.Custom;
@@ -206,7 +207,7 @@ namespace System.Text.Http.Parser.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool GetKnownVersion(this Span<byte> span, out Http.Version knownVersion, out byte length)
         {
-            fixed (byte* data = &span.DangerousGetPinnableReference())
+            fixed (byte* data = &MemoryMarshal.GetReference(span))
             {
                 knownVersion = GetKnownVersion(data, span.Length);
                 if (knownVersion != Http.Version.Unknown)
@@ -265,7 +266,7 @@ namespace System.Text.Http.Parser.Internal
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool GetKnownHttpScheme(this Span<byte> span, out HttpScheme knownScheme)
         {
-            fixed (byte* data = &span.DangerousGetPinnableReference())
+            fixed (byte* data = &MemoryMarshal.GetReference(span))
             {
                 return GetKnownHttpScheme(data, span.Length, out knownScheme);
             }

--- a/src/System.Text.Json/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonReader.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers.Text;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Text.Json
 {
@@ -91,7 +92,7 @@ namespace System.Text.Json
         /// <returns>True if the token was read successfully, else false.</returns>
         public bool Read()
         {
-            ref byte bytes = ref _buffer.DangerousGetPinnableReference();
+            ref byte bytes = ref MemoryMarshal.GetReference(_buffer);
             int length = _buffer.Length;
             int skip = SkipWhiteSpace(ref bytes, length);
 
@@ -313,7 +314,7 @@ namespace System.Text.Json
                 }
 
                 // Calculate the real start of the number based on our current buffer location.
-                int startIndex = (int)Unsafe.ByteOffset(ref _buffer.DangerousGetPinnableReference(), ref src);
+                int startIndex = (int)Unsafe.ByteOffset(ref MemoryMarshal.GetReference(_buffer), ref src);
 
                 Value = _buffer.Slice(startIndex, idx);
                 ValueType = JsonValueType.Number;
@@ -335,7 +336,7 @@ namespace System.Text.Json
                 }
 
                 // Calculate the real start of the number based on our current buffer location.
-                int startIndex = (int)Unsafe.ByteOffset(ref _buffer.DangerousGetPinnableReference(), ref src);
+                int startIndex = (int)Unsafe.ByteOffset(ref MemoryMarshal.GetReference(_buffer), ref src);
 
                 // consumed is in characters, but our buffer is in bytes, so we need to double it for buffer slicing.
                 int bytesConsumed = idx << 1;
@@ -669,7 +670,7 @@ namespace System.Text.Json
 
             // Calculate the real start of the property name based on our current buffer location.
             // Also, skip the opening JSON quote character.
-            int startIndex = (int)Unsafe.ByteOffset(ref _buffer.DangerousGetPinnableReference(), ref src) + 1;
+            int startIndex = (int)Unsafe.ByteOffset(ref MemoryMarshal.GetReference(_buffer), ref src) + 1;
 
             Value = _buffer.Slice(startIndex, idx - 2); // -2 to exclude the quote characters.
             ValueType = JsonValueType.String;
@@ -695,7 +696,7 @@ namespace System.Text.Json
 
             // Calculate the real start of the property name based on our current buffer location.
             // Also, skip the opening JSON quote character.
-            int startIndex = (int)Unsafe.ByteOffset(ref _buffer.DangerousGetPinnableReference(), ref src) + 2;
+            int startIndex = (int)Unsafe.ByteOffset(ref MemoryMarshal.GetReference(_buffer), ref src) + 2;
 
             // idx is in characters, but our buffer is in bytes, so we need to double it for buffer slicing.
             // Also, remove the quote characters as well.

--- a/src/System.Text.Json/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonWriter.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers.Text;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.Formatting;
 
 namespace System.Text.Json
@@ -333,13 +334,13 @@ namespace System.Text.Json
         {
             if (UseFastUtf8)
             {
-                EnsureBuffer(1).DangerousGetPinnableReference() = value;
+                MemoryMarshal.GetReference(EnsureBuffer(1)) = value;
                 _output.Advance(1);
             }
             else if (UseFastUtf16)
             {
                 var buffer = EnsureBuffer(2);
-                Unsafe.As<byte, char>(ref buffer.DangerousGetPinnableReference()) = (char)value;
+                Unsafe.As<byte, char>(ref MemoryMarshal.GetReference(buffer)) = (char)value;
                 _output.Advance(2);
             }
             else
@@ -518,7 +519,7 @@ namespace System.Text.Json
             bytesNeeded += (indent + 1) * 2;
 
             var buffer = EnsureBuffer(bytesNeeded);
-            ref byte utf8Bytes = ref buffer.DangerousGetPinnableReference();
+            ref byte utf8Bytes = ref MemoryMarshal.GetReference(buffer);
             int idx = 0;
 
             if (newline)
@@ -546,7 +547,7 @@ namespace System.Text.Json
 
             var buffer = EnsureBuffer(bytesNeeded);
             var span = buffer.NonPortableCast<byte, char>();
-            ref char utf16Bytes = ref span.DangerousGetPinnableReference();
+            ref char utf16Bytes = ref MemoryMarshal.GetReference(span);
             int idx = 0;
 
             if (newline)

--- a/src/System.Text.Primitives/System/Text/Encoders/Ascii/Ascii_encoding.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Ascii/Ascii_encoding.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Buffers.Text
 {
@@ -24,7 +25,7 @@ namespace System.Buffers.Text
                 unsafe
                 {
                     fixed (char* destination = result)
-                    fixed (byte* source = &bytes.DangerousGetPinnableReference())
+                    fixed (byte* source = &MemoryMarshal.GetReference(bytes))
                     {
                         if (!TryGetAsciiString(source, destination, len))
                         {
@@ -50,7 +51,7 @@ namespace System.Buffers.Text
                 unsafe
                 {
                     fixed (char* destination = result)
-                    fixed (byte* source = &bytes.DangerousGetPinnableReference())
+                    fixed (byte* source = &MemoryMarshal.GetReference(bytes))
                     {
                         if (!TryGetAsciiString(source, destination, len))
                         {

--- a/src/System.Text.Primitives/System/Text/Encoders/Utf16.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Utf16.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Buffers.Text
 {
@@ -57,7 +58,7 @@ namespace System.Buffers.Text
                 // running all the tests twice per code-point
                 try
                 {
-                    ref char utf16 = ref Unsafe.As<byte, char>(ref source.DangerousGetPinnableReference());
+                    ref char utf16 = ref Unsafe.As<byte, char>(ref MemoryMarshal.GetReference(source));
                     int utf16Length = source.Length >> 1; // byte => char count
 
                     for (int i = 0; i < utf16Length; i++)
@@ -110,8 +111,8 @@ namespace System.Buffers.Text
                 // KEEP THIS IMPLEMENTATION IN SYNC WITH https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
                 //
                 //
-                fixed (byte* chars = &source.DangerousGetPinnableReference())
-                fixed (byte* bytes = &destination.DangerousGetPinnableReference())
+                fixed (byte* chars = &MemoryMarshal.GetReference(source))
+                fixed (byte* bytes = &MemoryMarshal.GetReference(destination))
                 {
                     char* pSrc = (char*)chars;
                     byte* pTarget = bytes;
@@ -439,7 +440,7 @@ namespace System.Buffers.Text
             {
                 bytesNeeded = 0;
 
-                ref byte src = ref source.DangerousGetPinnableReference();
+                ref byte src = ref MemoryMarshal.GetReference(source);
                 int srcLength = source.Length;
                 int srcIndex = 0;
 
@@ -487,10 +488,10 @@ namespace System.Buffers.Text
                 bytesConsumed = 0;
                 bytesWritten = 0;
 
-                ref byte src = ref source.DangerousGetPinnableReference();
+                ref byte src = ref MemoryMarshal.GetReference(source);
                 int srcLength = source.Length;
 
-                ref byte dst = ref destination.DangerousGetPinnableReference();
+                ref byte dst = ref MemoryMarshal.GetReference(destination);
                 int dstLength = destination.Length;
 
                 while (srcLength - bytesConsumed >= sizeof(char))

--- a/src/System.Text.Primitives/System/Text/Encoders/Utf32.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Utf32.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Buffers.Text
 {
@@ -51,7 +52,7 @@ namespace System.Buffers.Text
             {
                 bytesNeeded = 0;
 
-                ref uint utf32 = ref Unsafe.As<byte, uint>(ref source.DangerousGetPinnableReference());
+                ref uint utf32 = ref Unsafe.As<byte, uint>(ref MemoryMarshal.GetReference(source));
                 int utf32Length = source.Length >> 2; // byte => uint count
 
                 for (int i = 0; i < utf32Length; i++)
@@ -88,10 +89,10 @@ namespace System.Buffers.Text
                 bytesConsumed = 0;
                 bytesWritten = 0;
 
-                ref byte src = ref source.DangerousGetPinnableReference();
+                ref byte src = ref MemoryMarshal.GetReference(source);
                 int srcLength = source.Length;
 
-                ref byte dst = ref destination.DangerousGetPinnableReference();
+                ref byte dst = ref MemoryMarshal.GetReference(destination);
                 int dstLength = destination.Length;
 
                 while (srcLength - bytesConsumed >= sizeof(uint))
@@ -183,7 +184,7 @@ namespace System.Buffers.Text
             {
                 int index = 0;
                 int length = source.Length;
-                ref byte src = ref source.DangerousGetPinnableReference();
+                ref byte src = ref MemoryMarshal.GetReference(source);
 
                 bytesNeeded = 0;
 
@@ -217,8 +218,8 @@ namespace System.Buffers.Text
             /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
             public static OperationStatus ToUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
             {
-                ref byte src = ref source.DangerousGetPinnableReference();
-                ref byte dst = ref destination.DangerousGetPinnableReference();
+                ref byte src = ref MemoryMarshal.GetReference(source);
+                ref byte dst = ref MemoryMarshal.GetReference(destination);
                 int srcLength = source.Length;
                 int dstLength = destination.Length;
 

--- a/src/System.Text.Primitives/System/Text/Encoders/Utf8.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Utf8.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Buffers.Text
 {
@@ -91,8 +92,8 @@ namespace System.Buffers.Text
             /// <returns>A <see cref="OperationStatus"/> value representing the state of the conversion.</returns>
             public unsafe static OperationStatus ToUtf16(ReadOnlySpan<byte> source, Span<byte> destination, out int bytesConsumed, out int bytesWritten)
             {
-                fixed (byte* pUtf8 = &source.DangerousGetPinnableReference())
-                fixed (byte* pUtf16 = &destination.DangerousGetPinnableReference())
+                fixed (byte* pUtf8 = &MemoryMarshal.GetReference(source))
+                fixed (byte* pUtf16 = &MemoryMarshal.GetReference(destination))
                 {
                     byte* pSrc = pUtf8;
                     byte* pSrcEnd = pSrc + source.Length;
@@ -541,8 +542,8 @@ namespace System.Buffers.Text
 
                 int srcLength = source.Length;
                 int dstLength = destination.Length;
-                ref byte src = ref source.DangerousGetPinnableReference();
-                ref byte dst = ref destination.DangerousGetPinnableReference();
+                ref byte src = ref MemoryMarshal.GetReference(source);
+                ref byte dst = ref MemoryMarshal.GetReference(destination);
 
                 while (bytesConsumed < srcLength && bytesWritten < dstLength)
                 {

--- a/src/System.Text.Primitives/System/Text/Encoders/Utf8Util.Validation.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Utf8Util.Validation.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 //
 // This file contains workhorse methods for performing validation of UTF-8 byte sequences.
@@ -95,7 +96,7 @@ namespace System.Buffers.Text
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int GetIndexOfFirstInvalidUtf8Sequence(ReadOnlySpan<byte> input, out int scalarCount, out int surrogatePairCount)
-            => GetIndexOfFirstInvalidUtf8Sequence(ref input.DangerousGetPinnableReference(), input.Length, out scalarCount, out surrogatePairCount);
+            => GetIndexOfFirstInvalidUtf8Sequence(ref MemoryMarshal.GetReference(input), input.Length, out scalarCount, out surrogatePairCount);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static int GetIndexOfFirstInvalidUtf8Sequence(ref byte inputBuffer, int inputLength, out int scalarCount, out int surrogatePairCount)

--- a/src/System.Text.Primitives/System/Text/Formatters/Utf16Formatter_guid.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Utf16Formatter_guid.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Buffers.Text
 {
@@ -34,7 +35,7 @@ namespace System.Buffers.Text
             }
 
             Span<char> dst = buffer.NonPortableCast<byte, char>();
-            ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
+            ref char utf16Bytes = ref MemoryMarshal.GetReference(dst);
             byte* bytes = (byte*)&value;
             int idx = 0;
 

--- a/src/System.Text.Primitives/System/Text/Formatters/Utf16Formatter_ints.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Utf16Formatter_ints.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Buffers.Text
 {
@@ -29,7 +30,7 @@ namespace System.Buffers.Text
                 return false;
             }
 
-            ref char utf16Bytes = ref span.DangerousGetPinnableReference();
+            ref char utf16Bytes = ref MemoryMarshal.GetReference(span);
             int idx = 0;
 
             if (value < 0)
@@ -87,7 +88,7 @@ namespace System.Buffers.Text
                 return false;
             }
 
-            ref char utf16Bytes = ref span.DangerousGetPinnableReference();
+            ref char utf16Bytes = ref MemoryMarshal.GetReference(span);
             FormattingHelpers.WriteDigits(lastDigit, 1, ref utf16Bytes, 0);
             bytesWritten += sizeof(char);
             return true;
@@ -118,7 +119,7 @@ namespace System.Buffers.Text
                 return false;
             }
 
-            ref char utf16Bytes = ref span.DangerousGetPinnableReference();
+            ref char utf16Bytes = ref MemoryMarshal.GetReference(span);
             long v = value;
 
             if (v < 0)
@@ -193,7 +194,7 @@ namespace System.Buffers.Text
                 return false;
             }
 
-            ref char utf16Bytes = ref span.DangerousGetPinnableReference();
+            ref char utf16Bytes = ref MemoryMarshal.GetReference(span);
             var idx = 0;
 
             // Write the last group
@@ -248,7 +249,7 @@ namespace System.Buffers.Text
             }
 
             string hexTable = useLower ? HexTableLower : HexTableUpper;
-            ref char utf16Bytes = ref span.DangerousGetPinnableReference();
+            ref char utf16Bytes = ref MemoryMarshal.GetReference(span);
             int idx = charsNeeded;
 
             for (v = value; digits-- > 0; v >>= 4)

--- a/src/System.Text.Primitives/System/Text/Formatters/Utf16Formatter_time.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Utf16Formatter_time.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Buffers.Text
 {
@@ -98,7 +99,7 @@ namespace System.Buffers.Text
             }
 
             Span<char> dst = buffer.NonPortableCast<byte, char>();
-            ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
+            ref char utf16Bytes = ref MemoryMarshal.GetReference(dst);
 
             FormattingHelpers.WriteDigits(value.Month, 2, ref utf16Bytes, 0);
             Unsafe.Add(ref utf16Bytes, 2) = Slash;
@@ -173,7 +174,7 @@ namespace System.Buffers.Text
             }
 
             Span<char> dst = buffer.NonPortableCast<byte, char>();
-            ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
+            ref char utf16Bytes = ref MemoryMarshal.GetReference(dst);
 
             FormattingHelpers.WriteDigits(value.Year, 4, ref utf16Bytes, 0);
             Unsafe.Add(ref utf16Bytes, 4) = Minus;
@@ -232,7 +233,7 @@ namespace System.Buffers.Text
             }
 
             Span<char> dst = buffer.NonPortableCast<byte, char>();
-            ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
+            ref char utf16Bytes = ref MemoryMarshal.GetReference(dst);
 
             var dayAbbrev = DayAbbreviations[(int)value.DayOfWeek];
             Unsafe.Add(ref utf16Bytes, 0) = dayAbbrev[0];
@@ -281,7 +282,7 @@ namespace System.Buffers.Text
             }
 
             Span<char> dst = buffer.NonPortableCast<byte, char>();
-            ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
+            ref char utf16Bytes = ref MemoryMarshal.GetReference(dst);
 
             var dayAbbrev = DayAbbreviationsLowercase[(int)value.DayOfWeek];
             Unsafe.Add(ref utf16Bytes, 0) = dayAbbrev[0];
@@ -364,7 +365,7 @@ namespace System.Buffers.Text
             }
 
             Span<char> dst = buffer.NonPortableCast<byte, char>();
-            ref char utf16Bytes = ref dst.DangerousGetPinnableReference();
+            ref char utf16Bytes = ref MemoryMarshal.GetReference(dst);
             int idx = 0;
 
             if (showSign)

--- a/src/System.Text.Primitives/System/Text/SymbolTable/SymbolTable_utf16.cs
+++ b/src/System.Text.Primitives/System/Text/SymbolTable/SymbolTable_utf16.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.Buffers.Text
 {
@@ -41,7 +42,7 @@ namespace System.Buffers.Text
                 if (utf8 > 0x7F)
                     goto ExitFailed;
 
-                Unsafe.As<byte, char>(ref destination.DangerousGetPinnableReference()) = (char)utf8;
+                Unsafe.As<byte, char>(ref MemoryMarshal.GetReference(destination)) = (char)utf8;
                 bytesWritten = 2;
                 return true;
 
@@ -67,7 +68,7 @@ namespace System.Buffers.Text
                 if (source.Length < 2)
                     goto ExitFailed;
 
-                ref char value = ref Unsafe.As<byte, char>(ref source.DangerousGetPinnableReference());
+                ref char value = ref Unsafe.As<byte, char>(ref MemoryMarshal.GetReference(source));
                 if (value > 0x7F)
                     goto ExitFailed;
 

--- a/tests/System.IO.Pipelines.Extensions.Tests/ReadableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Extensions.Tests/ReadableBufferFacts.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.IO.Pipelines.Testing;
 using System.IO.Pipelines.Text.Primitives;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Formatting;
 using System.Threading.Tasks;
@@ -367,7 +368,7 @@ namespace System.IO.Pipelines.Tests
 
         private unsafe void TestValue(ref ReadableBuffer readBuffer, ulong value)
         {
-            fixed (byte* ptr = &readBuffer.First.Span.DangerousGetPinnableReference())
+            fixed (byte* ptr = &MemoryMarshal.GetReference(readBuffer.First.Span))
             {
                 string s = value.ToString(CultureInfo.InvariantCulture);
                 int written;


### PR DESCRIPTION
**Part of:**
https://github.com/dotnet/corefx/issues/25412
https://github.com/dotnet/corefx/issues/25615

**Depends on the following to go through first:**
https://github.com/dotnet/corefx/pull/25961 (and subsequent consumption of CoreFx libraries in CoreFxLab)
> Cannot use method 'MemoryMarshal.GetReference<byte>(ReadOnlySpan<byte>)' as a ref or out value because it is a readonly variable

I didn't find any uses of DangerousTryGetArray to remove.

Following the staging plan from here: https://github.com/dotnet/corefx/issues/23881#issuecomment-343767740

- [x] Add MemoryExtensions.GetReference/TryGetArray
- [x] Convert all uses of DangerousGetPinnableReference/DangerousTryGetArray in coreclr, corefx, corert, corefxlab, aspnet, ... to MemoryExtensions.GetReference
- [ ] Change DangerousGetPinnableReference to whatever we like to make it fit the pinning pattern and remove DangerousTryGetArray.

Doing it this way will avoid the need for complex staging or things being on the floor for extensive periods of time.

cc @jkotas, @stephentoub, @KrzysztofCwalina, @davidfowl, @pakrym, @joshfree, @eerhardt 