### PR TITLE
Cleaned up IOutput based on API review

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/TcpConnectionFormatter.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/TcpConnectionFormatter.cs
@@ -30,12 +30,10 @@ namespace Microsoft.Net
 
         public SymbolTable SymbolTable => SymbolTable.InvariantUtf8;
 
-        public Span<byte> Buffer {
-            get {
-                var buffer = _buffer.AsSpan().Slice(ChunkPrefixSize + _written);
-                if (buffer.Length > 2) return buffer.Slice(0, buffer.Length - 2);
-                return Span<byte>.Empty;
-            }
+        public Span<byte> GetSpan() {
+            var buffer = _buffer.AsSpan().Slice(ChunkPrefixSize + _written);
+            if (buffer.Length > 2) return buffer.Slice(0, buffer.Length - 2);
+            return Span<byte>.Empty;
         }
 
         public void Advance(int bytes)

--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -137,7 +137,7 @@ namespace System.Buffers
             Position poisition = default;
             while (source.TryGet(ref poisition, out var sourceBuffer))
             {
-                Span<byte> outputSpan = destination.Buffer;
+                Span<byte> outputSpan = destination.GetSpan();
                 ReadOnlySpan<byte> sourceSpan = sourceBuffer.Span;
 
                 if (!remainder.IsEmpty)
@@ -160,7 +160,7 @@ namespace System.Buffers
                         if (status == OperationStatus.DestinationTooSmall)
                         {
                             destination.Enlarge();  // output buffer is too small
-                            outputSpan = destination.Buffer;
+                            outputSpan = destination.GetSpan();
 
                             if (outputSpan.Length - bytesWritten < 3)
                             {
@@ -186,7 +186,7 @@ namespace System.Buffers
                         afterMergeSlice = bytesConsumed - remainder.Length;
                         remainder = Span<byte>.Empty;
                         destination.Advance(bytesWritten);
-                        outputSpan = destination.Buffer;
+                        outputSpan = destination.GetSpan();
                     }
                 }
 
@@ -202,7 +202,7 @@ namespace System.Buffers
                 if (result == OperationStatus.DestinationTooSmall)
                 {
                     destination.Enlarge();  // output buffer is too small
-                    outputSpan = destination.Buffer;
+                    outputSpan = destination.GetSpan();
                     if (outputSpan.Length - written < 3)
                     {
                         return; // no more output space, user decides what to do.

--- a/src/System.Buffers.Experimental/System/Buffers/Text/BufferWriter_sequence.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Text/BufferWriter_sequence.cs
@@ -17,14 +17,14 @@ namespace System.Buffers.Text
         public BufferWriter(TOutput output)
         {
             _output = output;
-            _buffer = _output.Buffer;
+            _buffer = _output.GetSpan();
             _written = 0;
         }
 
         public void Flush()
         {
             _output.Advance(_written);
-            _buffer = _output.Buffer;
+            _buffer = _output.GetSpan();
             _written = 0;
         }
 
@@ -219,7 +219,7 @@ namespace System.Buffers.Text
             if (_buffer.Length > before) return _buffer;
 
             _output.Enlarge(desiredBufferSize);
-            _buffer = _output.Buffer;
+            _buffer = _output.GetSpan();
             Debug.Assert(_written == 0); // ensure still 0
             return _buffer;
         }

--- a/src/System.Buffers.Primitives/System/Buffers/IOutput.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/IOutput.cs
@@ -5,7 +5,7 @@ namespace System.Buffers
 {
     public interface IOutput
     {
-        Span<byte> Buffer { get; }
+        Span<byte> GetSpan();
         void Advance(int bytes);
 
         /// <summary>desiredBufferLength == 0 means "i don't care"</summary>

--- a/src/System.Collections.Sequences/System/Collections/Sequences/Position.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/Position.cs
@@ -33,8 +33,7 @@ namespace System.Collections.Sequences
         public static bool operator ==(Position left, Position right) => left.Index == right.Index && left._item == right._item;
         public static bool operator !=(Position left, Position right) => left.Index != right.Index || left._item != right._item;
 
-        public static Position operator +(Position position, int offset) => position.Offset(offset);
-        public static Position operator -(Position position, int offset) => position.Offset(-offset);
+        public static Position operator +(Position position, int offset) => new Position(position.Index + offset, position._item);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool Equals(Position position) => this == position;
@@ -56,7 +55,5 @@ namespace System.Collections.Sequences
             _item = item;
             _index = index;
         }
-
-        private Position Offset(int index) => new Position(Index + index, _item);
     }
 }

--- a/src/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs
@@ -116,7 +116,7 @@ namespace System.Collections.Sequences
             }
 
             item = default;
-            position = Position.End;
+            position = default;
             return false;
         }
 

--- a/src/System.IO.Pipelines.Extensions/WritableBufferOutput.cs
+++ b/src/System.IO.Pipelines.Extensions/WritableBufferOutput.cs
@@ -14,7 +14,7 @@ namespace System.IO.Pipelines
             _writer = writer;
         }
 
-        public Span<byte> Buffer => _writer.Buffer.Span;
+        public Span<byte> GetSpan() => _writer.Buffer.Span;
 
         public void Advance(int bytes)
         {
@@ -29,7 +29,8 @@ namespace System.IO.Pipelines
         private int ComputeActualSize(int desiredBufferLength)
         {
             if (desiredBufferLength < 256) desiredBufferLength = 256;
-            if (desiredBufferLength < Buffer.Length) desiredBufferLength = Buffer.Length * 2;
+            var length = GetSpan().Length;
+            if (desiredBufferLength < length) desiredBufferLength = length * 2;
             return desiredBufferLength;
         }
     }

--- a/src/System.IO.Pipelines.Text.Primitives/PipelineTextOutput.cs
+++ b/src/System.IO.Pipelines.Text.Primitives/PipelineTextOutput.cs
@@ -21,14 +21,10 @@ namespace System.IO.Pipelines.Text.Primitives
 
         public SymbolTable SymbolTable { get; }
 
-        public Span<byte> Buffer
+        public Span<byte> GetSpan()
         {
-            get
-            {
-                EnsureBuffer();
-
-                return _writableBuffer.Buffer.Span;
-            }
+            EnsureBuffer();
+            return _writableBuffer.Buffer.Span;
         }
 
         public void Advance(int bytes)

--- a/src/System.Text.Formatting/System/Text/Formatting/CompositeFormat.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/CompositeFormat.cs
@@ -128,12 +128,12 @@ namespace System.Text.Formatting
         // TODO: this should be removed and an ability to append substrings should be added
         static void Append<TFormatter>(this TFormatter formatter, string whole, int index, int count) where TFormatter : ITextOutput
         {
-            var buffer = formatter.Buffer;
+            var buffer = formatter.GetSpan();
             var maxBytes = count << 4; // this is the worst case, i.e. 4 bytes per char
             while(buffer.Length < maxBytes)
             {
                 formatter.Enlarge(maxBytes);
-                buffer = formatter.Buffer;
+                buffer = formatter.GetSpan();
             }
 
             // this should be optimized using fixed pointer to substring, but I will wait with this till we design proper substring

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/ArrayFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/ArrayFormatter.cs
@@ -32,7 +32,7 @@ namespace System.Text.Formatting
 
         public SymbolTable SymbolTable => _symbolTable;
 
-        public Span<byte> Buffer => Free.AsSpan();
+        public Span<byte> GetSpan() => Free.AsSpan();
 
         public void Enlarge(int desiredBufferLength = 0)
         {

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/OutputFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/OutputFormatter.cs
@@ -22,7 +22,7 @@ namespace System.Text.Formatting
         {
         }
 
-        public Span<byte> Buffer => _output.Buffer;
+        public Span<byte> GetSpan() => _output.GetSpan();
 
         public SymbolTable SymbolTable => _symbolTable;
 

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/SequenceFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/SequenceFormatter.cs
@@ -34,12 +34,8 @@ namespace System.Text.Formatting
             _previousWrittenBytes = -1;
         }
 
-        Span<byte> IOutput.Buffer
-        {
-            get {
-                return Current.Span.Slice(_currentWrittenBytes);
-            }
-        }
+        Span<byte> IOutput.GetSpan()
+            => Current.Span.Slice(_currentWrittenBytes);
 
         private Memory<byte> Current {
             get {

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/StreamFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/StreamFormatter.cs
@@ -30,16 +30,13 @@ namespace System.Text.Formatting
             _stream = stream;
         }
 
-        Span<byte> IOutput.Buffer
+        Span<byte> IOutput.GetSpan()
         {
-            get
+            if (_buffer == null)
             {
-                if (_buffer == null)
-                {
-                    _buffer = _pool.Rent(256);
-                }
-                return new Span<byte>(_buffer);
+                _buffer = _pool.Rent(256);
             }
+            return new Span<byte>(_buffer);
         }
 
         void IOutput.Enlarge(int desiredBufferLength)

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/StringFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/StringFormatter.cs
@@ -60,7 +60,7 @@ namespace System.Text.Formatting
             return text;
         }
 
-        Span<byte> IOutput.Buffer => _buffer.Free.AsSpan();
+        Span<byte> IOutput.GetSpan() => _buffer.Free.AsSpan();
 
         void IOutput.Enlarge(int desiredBufferLength)
         {

--- a/src/System.Text.Formatting/System/Text/Formatting/IOutputExtensions.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/IOutputExtensions.cs
@@ -18,7 +18,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter, T>(this TFormatter formatter, T value, SymbolTable symbolTable, StandardFormat format = default) where T : IBufferFormattable where TFormatter : IOutput
         {
-            if (!value.TryFormat(formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!value.TryFormat(formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }
@@ -65,7 +65,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, ReadOnlySpan<char> value, SymbolTable symbolTable) where TFormatter : IOutput
         {
-            var result = symbolTable.TryEncode(value, formatter.Buffer, out int consumed, out int written);
+            var result = symbolTable.TryEncode(value, formatter.GetSpan(), out int consumed, out int written);
             if (result)
                 formatter.Advance(written);
 
@@ -97,7 +97,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, Utf8Span value, SymbolTable symbolTable) where TFormatter : IOutput
         {
-            if (!symbolTable.TryEncode(value, formatter.Buffer, out int consumed, out int bytesWritten))
+            if (!symbolTable.TryEncode(value, formatter.GetSpan(), out int consumed, out int bytesWritten))
             {
                 return false;
             }
@@ -114,7 +114,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, uint value, SymbolTable symbolTable, StandardFormat format = default) where TFormatter : IOutput
         {   
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }
@@ -131,7 +131,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, ulong value, SymbolTable symbolTable, StandardFormat format = default) where TFormatter : IOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }
@@ -148,7 +148,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, int value, SymbolTable symbolTable, StandardFormat format = default) where TFormatter : IOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }
@@ -165,7 +165,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, long value, SymbolTable symbolTable, StandardFormat format = default) where TFormatter : IOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }
@@ -182,7 +182,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, byte value, SymbolTable symbolTable, StandardFormat format = default) where TFormatter : IOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }
@@ -199,7 +199,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, sbyte value, SymbolTable symbolTable, StandardFormat format = default) where TFormatter : IOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }
@@ -216,7 +216,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, ushort value, SymbolTable symbolTable, StandardFormat format = default) where TFormatter : IOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }
@@ -233,7 +233,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, short value, SymbolTable symbolTable, StandardFormat format = default) where TFormatter : IOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }
@@ -250,7 +250,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, Guid value, SymbolTable symbolTable, StandardFormat format = default) where TFormatter : IOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }
@@ -267,7 +267,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, DateTime value, SymbolTable symbolTable, StandardFormat format = default) where TFormatter : IOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }
@@ -284,7 +284,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, DateTimeOffset value, SymbolTable symbolTable, StandardFormat format = default) where TFormatter : IOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }
@@ -301,7 +301,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, TimeSpan value, SymbolTable symbolTable, StandardFormat format = default) where TFormatter : IOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }
@@ -318,7 +318,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, float value, SymbolTable symbolTable, StandardFormat format = default) where TFormatter : IOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }
@@ -335,7 +335,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, double value, SymbolTable symbolTable, StandardFormat format = default) where TFormatter : IOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, symbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, symbolTable))
             {
                 return false;
             }

--- a/src/System.Text.Formatting/System/Text/Formatting/ITextOutputExtensions.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/ITextOutputExtensions.cs
@@ -18,7 +18,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter, T>(this TFormatter formatter, T value, StandardFormat format = default) where T : IBufferFormattable where TFormatter : ITextOutput
         {
-            if (!value.TryFormat(formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!value.TryFormat(formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }
@@ -35,7 +35,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, byte value, StandardFormat format = default) where TFormatter : ITextOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }
@@ -52,7 +52,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, sbyte value, StandardFormat format = default) where TFormatter : ITextOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }
@@ -69,7 +69,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, ushort value, StandardFormat format = default) where TFormatter : ITextOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }
@@ -86,7 +86,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, short value, StandardFormat format = default) where TFormatter : ITextOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }
@@ -103,7 +103,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, uint value, StandardFormat format = default) where TFormatter : ITextOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }
@@ -120,7 +120,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, int value, StandardFormat format = default) where TFormatter : ITextOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }
@@ -137,7 +137,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, ulong value, StandardFormat format = default) where TFormatter : ITextOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }
@@ -154,7 +154,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, long value, StandardFormat format = default) where TFormatter : ITextOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }
@@ -207,7 +207,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, Utf8Span value) where TFormatter : ITextOutput
         {
-            if (!formatter.SymbolTable.TryEncode(value, formatter.Buffer, out int consumed, out int bytesWritten))
+            if (!formatter.SymbolTable.TryEncode(value, formatter.GetSpan(), out int consumed, out int bytesWritten))
             {
                 return false;
             }
@@ -224,7 +224,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, Guid value, StandardFormat format = default) where TFormatter : ITextOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }
@@ -241,7 +241,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, DateTime value, StandardFormat format = default) where TFormatter : ITextOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }
@@ -258,7 +258,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, DateTimeOffset value, StandardFormat format = default) where TFormatter : ITextOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }
@@ -275,7 +275,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, TimeSpan value, StandardFormat format = default) where TFormatter : ITextOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }
@@ -292,7 +292,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, float value, StandardFormat format = default) where TFormatter : ITextOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }
@@ -309,7 +309,7 @@ namespace System.Text.Formatting
 
         public static bool TryAppend<TFormatter>(this TFormatter formatter, double value, StandardFormat format = default) where TFormatter : ITextOutput
         {
-            if (!CustomFormatter.TryFormat(value, formatter.Buffer, out int bytesWritten, format, formatter.SymbolTable))
+            if (!CustomFormatter.TryFormat(value, formatter.GetSpan(), out int bytesWritten, format, formatter.SymbolTable))
             {
                 return false;
             }

--- a/src/System.Text.Http/System/Text/Http/IFormatterHttpExtensions.cs
+++ b/src/System.Text.Http/System/Text/Http/IFormatterHttpExtensions.cs
@@ -110,10 +110,10 @@ namespace System.Text.Http.Formatter
 
         public static void AppendHttpNewLine<TFormatter>(this TFormatter formatter) where TFormatter : ITextOutput
         {
-            var buffer = formatter.Buffer;
+            var buffer = formatter.GetSpan();
             while(buffer.Length < 2) {
                 formatter.Enlarge(2);
-                buffer = formatter.Buffer;
+                buffer = formatter.GetSpan();
             }
             buffer[0] = 13;
             buffer[1] = 10;
@@ -124,7 +124,7 @@ namespace System.Text.Http.Formatter
         {
             while (true)
             {
-                var buffer = formatter.Buffer;
+                var buffer = formatter.GetSpan();
                 if (bytes.Length > buffer.Length)
                 {
                     formatter.Enlarge(bytes.Length);

--- a/src/System.Text.Json/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.Json/System/Text/Json/JsonWriter.cs
@@ -344,7 +344,7 @@ namespace System.Text.Json
             }
             else
             {
-                var buffer = _output.Buffer;
+                var buffer = _output.GetSpan();
                 int written;
                 while (!_output.SymbolTable.TryEncode(value, buffer, out written))
                     buffer = EnsureBuffer();
@@ -365,7 +365,7 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteNumber(long value)
         {
-            var buffer = _output.Buffer;
+            var buffer = _output.GetSpan();
             int written;
             while (!CustomFormatter.TryFormat(value, buffer, out written, JsonConstants.NumberFormat, _output.SymbolTable))
                 buffer = EnsureBuffer();
@@ -376,7 +376,7 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteNumber(ulong value)
         {
-            var buffer = _output.Buffer;
+            var buffer = _output.GetSpan();
             int written;
             while (!CustomFormatter.TryFormat(value, buffer, out written, JsonConstants.NumberFormat, _output.SymbolTable))
                 buffer = EnsureBuffer();
@@ -387,7 +387,7 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteDateTime(DateTime value)
         {
-            var buffer = _output.Buffer;
+            var buffer = _output.GetSpan();
             int written;
             while (!CustomFormatter.TryFormat(value, buffer, out written, JsonConstants.DateTimeFormat, _output.SymbolTable))
                 buffer = EnsureBuffer();
@@ -398,7 +398,7 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteDateTimeOffset(DateTimeOffset value)
         {
-            var buffer = _output.Buffer;
+            var buffer = _output.GetSpan();
             int written;
             while (!CustomFormatter.TryFormat(value, buffer, out written, JsonConstants.DateTimeFormat, _output.SymbolTable))
                 buffer = EnsureBuffer();
@@ -409,7 +409,7 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteGuid(Guid value)
         {
-            var buffer = _output.Buffer;
+            var buffer = _output.GetSpan();
             int written;
             while (!CustomFormatter.TryFormat(value, buffer, out written, JsonConstants.GuidFormat, _output.SymbolTable))
                 buffer = EnsureBuffer();
@@ -424,7 +424,7 @@ namespace System.Text.Json
 
             if (UseFastUtf8)
             {
-                Span<byte> destination = _output.Buffer;
+                Span<byte> destination = _output.GetSpan();
 
                 while (true)
                 {
@@ -453,7 +453,7 @@ namespace System.Text.Json
             }
             else
             {
-                Span<byte> destination = _output.Buffer;
+                Span<byte> destination = _output.GetSpan();
                 if (!_output.SymbolTable.TryEncode(source, destination, out int consumed, out int written))
                     destination = EnsureBuffer();
 
@@ -464,7 +464,7 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteJsonValue(ReadOnlySpan<byte> values)
         {
-            var buffer = _output.Buffer;
+            var buffer = _output.GetSpan();
             int written;
             while (!_output.SymbolTable.TryEncode(values, buffer, out int consumed, out written))
                 buffer = EnsureBuffer();
@@ -571,13 +571,13 @@ namespace System.Text.Json
             // larger than we are likely to need.
             const int BufferEnlargeCount = 1024;
 
-            var buffer = _output.Buffer;
+            var buffer = _output.GetSpan();
             var currentSize = buffer.Length;
             if (currentSize >= needed)
                 return buffer;
 
             _output.Enlarge(BufferEnlargeCount);
-            buffer = _output.Buffer;
+            buffer = _output.GetSpan();
 
             int newSize = buffer.Length;
             if (newSize < needed || newSize <= currentSize)

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -96,7 +96,7 @@ namespace System.Binary.Base64Experimental.Tests
 
         public Span<byte> GetBuffer => _buffer;
 
-        public Span<byte> Buffer => _buffer.AsSpan().Slice(_written);
+        public Span<byte> GetSpan() => _buffer.AsSpan().Slice(_written);
 
         public void Advance(int bytes)
         {

--- a/tests/System.Buffers.Experimental.Tests/BufferWriterTests_sequence.cs
+++ b/tests/System.Buffers.Experimental.Tests/BufferWriterTests_sequence.cs
@@ -48,7 +48,7 @@ namespace System.Buffers.Tests
         byte[] _current = new byte[0];
         List<byte[]> _commited = new List<byte[]>();
 
-        public Span<byte> Buffer => _current;
+        public Span<byte> GetSpan() => _current;
 
         public void Advance(int bytes)
         {


### PR DESCRIPTION
cc: @pakrym, @davidfowl, @joshfree, @ahsonkhan 

Changing IOutput.Span to GetSpan to communicate that repeatedly getting the span might be expensive.