### PR TITLE
Removed Position.End

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/BufferSequence.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/BufferSequence.cs
@@ -51,11 +51,9 @@ namespace Microsoft.Net
         public bool TryGet(ref Position position, out Memory<byte> item, bool advance = true)
         {
             if (position == default) {
-                item = Memory.Slice(0, _written);
-                if (advance) { position = Position.Create(_next); }
-                return true;
+                item = default;
+                return false;
             }
-            else if (position.IsEnd) { item = default; return false; }
 
             var sequence = position.GetItem<BufferSequence>();
             item = sequence.Memory.Slice(0, sequence._written);
@@ -67,11 +65,9 @@ namespace Microsoft.Net
         {
             if (position == default)
             {
-                item = Memory.Slice(0, _written);
-                if (advance) { position = Position.Create(_next); }
-                return true;
+                item = default;
+                return false;
             }
-            else if (position.IsEnd) { item = default; return false; }
 
             var sequence = position.GetItem<BufferSequence>();
             item = sequence.WrittenMemory;

--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -49,7 +49,7 @@ namespace System.Buffers
             return copied;
         }
 
-        public static Position PositionOf(this IMemoryList<byte> list, byte value)
+        public static Position? PositionOf(this IMemoryList<byte> list, byte value)
         {
             while (list != null)
             {
@@ -58,7 +58,7 @@ namespace System.Buffers
                 if (index != -1) return Position.Create(list, index);
                 list = list.Next;
             }
-            return Position.End;
+            return null;
         }
 
         // TODO (pri 3): I am pretty sure this whole routine can be written much better

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/MemoryList.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/MemoryList.cs
@@ -75,15 +75,6 @@ namespace System.Buffers
         {
             if (position == default)
             {
-                item = _data;
-                if (advance)
-                {
-                    position = Position.Create(_next);
-                }
-                return (!_data.IsEmpty || _next != null);
-            }
-            else if (position.IsEnd)
-            {
                 item = default;
                 return false;
             }

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadWriteBytes.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadWriteBytes.cs
@@ -269,7 +269,7 @@ namespace System.Buffers
 
         public bool TryGet(ref Position position, out Memory<byte> item, bool advance = true)
         {
-            if (position.IsEnd)
+            if (position == default)
             {
                 item = default;
                 return false;
@@ -281,31 +281,18 @@ namespace System.Buffers
                 var start = _startIndex + position.Index;
                 var length = _endIndex - _startIndex - position.Index;
                 item = new Memory<byte>(array, start, length);
-                if (advance) position = Position.End;
+                if (advance) position = default;
                 return true;
             }
 
             if (Kind == Type.MemoryList)
             {
-                if (position == default)
-                {
-                    var first = _start as IMemoryList<byte>;
-                    item = first.Memory.Slice(_startIndex);
-                    if (advance) position = Position.Create(first.Next);
-                    if (ReferenceEquals(_end, _start))
-                    {
-                        item = item.Slice(0, (int)Length);
-                        if (advance) position = Position.End;
-                    }
-                    return true;
-                }
-
                 var (node, index) = position.Get<IMemoryList<byte>>();
                 item = node.Memory.Slice(index);
                 if (ReferenceEquals(node, _end))
                 {
                     item = item.Slice(0, _endIndex - index);
-                    if (advance) position = Position.End;
+                    if (advance) position = default;
                 }
                 else
                 {

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/SequenceExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/SequenceExtensions.cs
@@ -11,7 +11,7 @@ namespace System.Buffers
     {
         public static ReadOnlySpan<byte> ToSpan<T>(this T sequence) where T : ISequence<ReadOnlyMemory<byte>>
         {
-            Position position = default;
+            Position position = sequence.First;
             ResizableArray<byte> array = new ResizableArray<byte>(1024);
             while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> buffer))
             {
@@ -26,7 +26,7 @@ namespace System.Buffers
         // be used as a type parameter.
         public static long IndexOf<TSequence>(TSequence sequence, byte value) where TSequence : ISequence<ReadOnlyMemory<byte>>
         {
-            Position position = default;
+            Position position = sequence.First;
             int totalIndex = 0;
             while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> memory))
             {
@@ -39,7 +39,7 @@ namespace System.Buffers
 
         public static long IndexOf<TSequence>(TSequence sequence, byte v1, byte v2) where TSequence : ISequence<ReadOnlyMemory<byte>>
         {
-            Position position = default;
+            Position position = sequence.First;
             int totalIndex = 0;
             while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> memory))
             {
@@ -68,9 +68,9 @@ namespace System.Buffers
             return -1;
         }
 
-        public static Position PositionOf<TSequence>(this TSequence sequence, byte value) where TSequence : ISequence<ReadOnlyMemory<byte>>
+        public static Position? PositionOf<TSequence>(this TSequence sequence, byte value) where TSequence : ISequence<ReadOnlyMemory<byte>>
         {
-            if (sequence == null) return Position.End;
+            if (sequence == null) return null;
 
             Position position = sequence.First;
             Position result = position;
@@ -84,12 +84,12 @@ namespace System.Buffers
                 }
                 result = position;
             }
-            return Position.End;
+            return null;
         }
 
-        public static Position PositionAt<TSequence>(this TSequence sequence, long index) where TSequence : ISequence<ReadOnlyMemory<byte>>
+        public static Position? PositionAt<TSequence>(this TSequence sequence, long index) where TSequence : ISequence<ReadOnlyMemory<byte>>
         {
-            if (sequence == null) return Position.End;
+            if (sequence == null) return null;
 
             Position position = sequence.First;
             Position result = position;
@@ -105,7 +105,7 @@ namespace System.Buffers
                 result = position;
             }
 
-            return Position.End;
+            return null;
         }
 
         public static int Copy<TSequence>(TSequence sequence, Span<byte> buffer) where TSequence : ISequence<ReadOnlyMemory<byte>>
@@ -170,7 +170,7 @@ namespace System.Buffers
                 return false;
             }
 
-            consumed = sequence.PositionAt(consumedBytes);
+            consumed = sequence.PositionAt(consumedBytes).GetValueOrDefault();
             return true;
         }
     }

--- a/src/System.Collections.Sequences/System/Collections/Sequences/Position.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/Position.cs
@@ -12,7 +12,7 @@ namespace System.Collections.Sequences
         readonly int _index;
 
         public static Position Create<T>(T item, int index = 0) where T : class
-            => item == null ? End : new Position(index, item);
+            => item == null ? default : new Position(index, item);
 
         public static implicit operator Position(int index) => new Position(index, null);
 
@@ -21,14 +21,10 @@ namespace System.Collections.Sequences
         public int Index => _index;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T GetItem<T>() => _item == null || IsEnd ? default : (T)_item;
+        public T GetItem<T>() => _item == null ? default : (T)_item;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public (T item, int index) Get<T>() => (GetItem<T>(), (int)this);
-
-        public static readonly Position End = new Position(int.MaxValue, new object());
-
-        public bool IsEnd => this == End;
 
         public static bool operator ==(Position left, Position right) => left.Index == right.Index && left._item == right._item;
         public static bool operator !=(Position left, Position right) => left.Index != right.Index || left._item != right._item;
@@ -48,7 +44,7 @@ namespace System.Collections.Sequences
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() =>
-            IsEnd ? "END" : _item == null ? $"{Index}" : $"{Index}, {_item}";
+            this==default ? "(default)" : _item == null ? $"{Index}" : $"{Index}, {_item}";
 
         private Position(int index, object item)
         {

--- a/src/System.IO.Pipelines.Extensions/ReadableBufferSequence.cs
+++ b/src/System.IO.Pipelines.Extensions/ReadableBufferSequence.cs
@@ -20,10 +20,6 @@ namespace System.IO.Pipelines
         {
             if (position == default)
             {
-                position = First;
-            }
-            else if (position == Position.End)
-            {
                 item = default;
                 return false;
             }

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/SequenceFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/SequenceFormatter.cs
@@ -23,7 +23,7 @@ namespace System.Text.Formatting
 
         Position _currentPosition = default;
         int _currentWrittenBytes;
-        Position _previousPosition = Position.End;
+        Position _previousPosition = default;
         int _previousWrittenBytes;
         int _totalWritten;
 
@@ -31,6 +31,7 @@ namespace System.Text.Formatting
         {
             _symbolTable = symbolTable;
             _buffers = buffers;
+            _currentPosition = _buffers.First;
             _previousWrittenBytes = -1;
         }
 

--- a/src/System.Text.Http.Parser/HttpParser.cs
+++ b/src/System.Text.Http.Parser/HttpParser.cs
@@ -368,9 +368,14 @@ namespace System.Text.Http.Parser
         {
             var index = 0;
             consumedBytes = 0;
-            Position position = default;
+            Position position = buffer.First;
 
-            ReadOnlySpan<byte> currentSpan = buffer.Memory.Span;
+            if(!buffer.TryGet(ref position, out ReadOnlyMemory<byte> currentMemory))
+            {
+                consumedBytes = 0;
+                return false;
+            }
+            ReadOnlySpan<byte> currentSpan = currentMemory.Span;
             var remaining = currentSpan.Length;
 
             while (true)
@@ -453,16 +458,6 @@ namespace System.Text.Http.Parser
                         index += length;
                         consumedBytes += length;
                         remaining -= length;
-                    }
-                }
-
-                // This is just to get the position to be at the second segment
-                if (position == default)
-                {
-                    if (!buffer.TryGet(ref position, out ReadOnlyMemory<byte> current))
-                    {
-                        consumedBytes = 0;
-                        return false;
                     }
                 }
 

--- a/tests/Benchmarks/HttpParserBench.cs
+++ b/tests/Benchmarks/HttpParserBench.cs
@@ -355,11 +355,11 @@ static class HttpParserExtensions
     {
         if(parser.ParseRequestLine(ref handler, buffer, out int consumedBytes))
         {
-            consumed = buffer.PositionAt(consumedBytes);
+            consumed = buffer.PositionAt(consumedBytes).GetValueOrDefault();
             examined = consumed;
             return true;
         }
-        consumed = buffer.PositionAt(0);
+        consumed = buffer.PositionAt(0).GetValueOrDefault();
         examined = default;
         return false;
     }
@@ -368,11 +368,11 @@ static class HttpParserExtensions
     {
         if (parser.ParseHeaders(ref handler, buffer, out consumedBytes))
         {
-            consumed = buffer.PositionAt(consumedBytes);
+            consumed = buffer.PositionAt(consumedBytes).GetValueOrDefault();
             examined = consumed;
             return true;
         }
-        consumed = buffer.PositionAt(0);
+        consumed = buffer.PositionAt(0).GetValueOrDefault();
         examined = default;
         return false;
     }
@@ -384,13 +384,13 @@ static class HttpParserExtensions
             parser.ParseHeaders(ref handler, buffer.Slice(consumedRLBytes), out var consumedHDBytes)
         )
         {
-            consumed = buffer.PositionAt(consumedRLBytes + consumedHDBytes);
+            consumed = buffer.PositionAt(consumedRLBytes + consumedHDBytes).GetValueOrDefault();
             examined = consumed;
             return true;
         }
         else
         {
-            consumed = buffer.PositionAt(0);
+            consumed = buffer.PositionAt(0).GetValueOrDefault();
             examined = default;
             return false;
         }

--- a/tests/System.Buffers.Experimental.Tests/BytesReaderTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/BytesReaderTests.cs
@@ -71,7 +71,7 @@ namespace System.Buffers.Tests
             var reader = BytesReader.Create(bytes);
 
             Assert.True(reader.TryReadBytes(out var ab, (byte)' '));
-            Assert.Equal("AB", ab.ToString(SymbolTable.InvariantUtf8));
+            Assert.Equal("AB", ab.Utf8ToString());
 
             Assert.True(reader.TryReadBytes(out var cd, (byte)'#'));
             Assert.Equal("CD", cd.Utf8ToString());
@@ -172,7 +172,7 @@ namespace System.Buffers.Tests
             var sb = new StringBuilder();
             if (symbolTable == SymbolTable.InvariantUtf8)
             {
-                Position position = default;
+                Position position = bytes.First;
                 while (bytes.TryGet(ref position, out ReadOnlyMemory<byte> segment))
                 {
                     sb.Append(new Utf8Span(segment.Span).ToString());
@@ -189,7 +189,7 @@ namespace System.Buffers.Tests
         {
             var sb = new StringBuilder();
 
-            Position position = default;
+            Position position = bytes.First;
             while (bytes.TryGet(ref position, out ReadOnlyMemory<byte> segment))
             {
                 sb.Append(new Utf8Span(segment.Span).ToString());

--- a/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/ReadOnlyBytesTests.cs
@@ -83,8 +83,8 @@ namespace System.Buffers.Tests
             ReadOnlyBytes allBytesSlice2 = allBytes.Slice(2);
             ReadOnlyBytes allBytesSlice3 = allBytes.Slice(3);
 
-            var positionOf3 = allBytes.PositionOf(3);
-            var positionOf1 = allBytes.PositionOf(1);
+            var positionOf3 = allBytes.PositionOf(3).GetValueOrDefault();
+            var positionOf1 = allBytes.PositionOf(1).GetValueOrDefault();
 
             // all bytes
             {
@@ -147,8 +147,8 @@ namespace System.Buffers.Tests
 
             ReadOnlyBytes allBytesSlice = allBytes.Slice(1);
 
-            var positionOf3 = allBytes.PositionOf(3);
-            var positionOf1 = allBytes.PositionOf(1);
+            var positionOf3 = allBytes.PositionOf(3).GetValueOrDefault();
+            var positionOf1 = allBytes.PositionOf(1).GetValueOrDefault();
 
             // all bytes
             {
@@ -183,7 +183,7 @@ namespace System.Buffers.Tests
             // single segment
             {
                 var rob = ListHelper.CreateRob(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
-                var c = rob.PositionOf(5);
+                var c = rob.PositionOf(5).GetValueOrDefault();
 
                 var slice1 = rob.Slice(2).Slice(c);
                 var slice2 = rob.Slice(c).Slice(2);
@@ -196,7 +196,7 @@ namespace System.Buffers.Tests
             // multi segment
             {
                 var rob = ListHelper.CreateRob(new byte[] { 1, 2, 3 }, new byte[] { 4, 5, 6, 7, 8 });
-                var c = rob.PositionOf(5);
+                var c = rob.PositionOf(5).GetValueOrDefault();
 
                 var slice1 = rob.Slice(2).Slice(c);
                 var slice2 = rob.Slice(c).Slice(2);
@@ -213,8 +213,8 @@ namespace System.Buffers.Tests
             // single segment
             {
                 var rob = new ReadOnlyBytes(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
-                var c2 = rob.PositionOf(2);
-                var c5 = rob.PositionOf(5);
+                var c2 = rob.PositionOf(2).GetValueOrDefault();
+                var c5 = rob.PositionOf(5).GetValueOrDefault();
 
                 var slice = rob.Slice(c2, c5);
 
@@ -225,8 +225,8 @@ namespace System.Buffers.Tests
             // multi segment
             {
                 var rob = ListHelper.CreateRob(new byte[] { 1, 2, 3 }, new byte[] { 4, 5, 6, 7, 8 });
-                var c2 = rob.PositionOf(2);
-                var c5 = rob.PositionOf(5);
+                var c2 = rob.PositionOf(2).GetValueOrDefault();
+                var c5 = rob.PositionOf(5).GetValueOrDefault();
 
                 var slice = rob.Slice(c2, c5);
 
@@ -357,7 +357,7 @@ namespace System.Buffers.Tests
         {
             var buffer = new byte[] { 1, 2, 3, 4, 5, 6 };
             var bytes = new ReadOnlyBytes(buffer);
-            Position position = default;
+            Position position = bytes.First;
             int length = 0;
             ReadOnlyMemory<byte> segment;
             while (bytes.TryGet(ref position, out segment))
@@ -367,7 +367,7 @@ namespace System.Buffers.Tests
             Assert.Equal(buffer.Length, length);
 
             var multibytes = Parse("A|CD|EFG");
-            position = default;
+            position = multibytes.First;
             length = 0;
             while (multibytes.TryGet(ref position, out segment))
             {
@@ -401,7 +401,7 @@ namespace System.Buffers.Tests
                 multibytes = multibytes.Slice(i);
 
                 {
-                    Position position = default;
+                    Position position = multibytes.First;
                     var length = 0;
                     while (multibytes.TryGet(ref position, out ReadOnlyMemory<byte> segment))
                     {
@@ -429,7 +429,7 @@ namespace System.Buffers.Tests
                 multibytes = multibytes.Slice(0, i);
 
                 {
-                    Position position = default;
+                    Position position = multibytes.First;
                     var length = 0;
                     while (multibytes.TryGet(ref position, out ReadOnlyMemory<byte> segment))
                     {

--- a/tests/System.Buffers.Experimental.Tests/SequenceExtensionsTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/SequenceExtensionsTests.cs
@@ -73,16 +73,16 @@ namespace System.Buffers.Tests
             Assert.Equal(4, bytes.Length);
 
             // Static method call to avoid calling instance methods
-            Assert.Equal(Position.End, Sequence.PositionOf(bytes, 0));
+            Assert.False(Sequence.PositionOf(bytes, 0).HasValue);
 
             for (int i = 0; i < bytes.Length; i++)
             {
                 var value = (byte)(i + 1);
 
-                var listPosition = MemoryListExtensions.PositionOf(first, value);
+                var listPosition = MemoryListExtensions.PositionOf(first, value).GetValueOrDefault();
                 var (node, index) = listPosition.Get<IMemoryList<byte>>();
 
-                if (!listPosition.IsEnd)
+                if (listPosition != default)
                 {
                     Assert.Equal(value, node.Memory.Span[index]);
                 }
@@ -105,11 +105,11 @@ namespace System.Buffers.Tests
                 }
                 else
                 {
-                    Assert.Equal(Position.End, robPosition);
-                    Assert.Equal(Position.End, robSequencePosition);
+                    Assert.False(robPosition.HasValue);
+                    Assert.False(robSequencePosition.HasValue);
                 }
 
-                if (listPosition != Position.End)
+                if (listPosition != default)
                 {
                     robSlice = bytes.Slice(listPosition);
                     Assert.Equal(value, robSlice.Memory.Span[0]);

--- a/tests/System.Collections.Sequences.Tests/SampleCollections/Hashtable.cs
+++ b/tests/System.Collections.Sequences.Tests/SampleCollections/Hashtable.cs
@@ -93,15 +93,15 @@ namespace System.Collections.Sequences
         {
             item = default;
 
-            if (_count == 0 | position == Position.End) {
-                position = Position.End;
+            if (_count == 0 | position == default) {
+                position = default;
                 return false;
             }
 
             if (position == default) {
                 var firstOccupiedSlot = FindFirstStartingAt(0);
                 if (firstOccupiedSlot == -1) {
-                    position = Position.End;
+                    position = default;
                     return false;
                 }
 
@@ -118,7 +118,7 @@ namespace System.Collections.Sequences
                 var first = FindFirstStartingAt(index + 1);
                 position = first;
                 if (first == -1) {
-                    position = Position.End;
+                    position = default;
                 }
             }
 

--- a/tests/System.Collections.Sequences.Tests/SampleCollections/LinkedContainer.cs
+++ b/tests/System.Collections.Sequences.Tests/SampleCollections/LinkedContainer.cs
@@ -30,23 +30,16 @@ namespace System.Collections.Sequences
 
         public bool TryGet(ref Position position, out T item, bool advance = true)
         {
-            if(_count == 0)
+            if(_count == 0 || position == default)
             {
                 item = default;
                 return false;
             }
 
-            if (position == default)
-            {
-                item = _head._item;
-                if (advance) position = Position.Create(_head._next);
-                return _count > 0;
-            }
-
             var node = position.GetItem<Node>();
             if (node == null) {
                 item = default;
-                position = Position.End;
+                position = default;
                 return false;
             }
 

--- a/tests/System.IO.Pipelines.Extensions.Tests/ReadableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Extensions.Tests/ReadableBufferFacts.cs
@@ -32,7 +32,9 @@ namespace System.IO.Pipelines.Tests
             _pipe = new Pipe(new PipeOptions(_pool));
         }
         public void Dispose()
-        {  GC.Collect();GC.Collect();
+        {
+            GC.Collect();
+            GC.Collect();
             GC.WaitForPendingFinalizers();
             _pipe.Writer.Complete();
             _pipe.Reader.Complete();
@@ -43,7 +45,7 @@ namespace System.IO.Pipelines.Tests
         public void ReadableBufferSequenceWorks()
         {
             var readable = BufferUtilities.CreateBuffer(new byte[] { 1 }, new byte[] { 2, 2 }, new byte[] { 3, 3, 3 }).AsSequence();
-            Position position = default;
+            Position position = readable.First;
             int spanCount = 0;
             while (readable.TryGet(ref position, out ReadOnlyMemory<byte> memory))
             {

--- a/tests/System.Text.Http.Parser.Tests/HttpParserBasicTests.cs
+++ b/tests/System.Text.Http.Parser.Tests/HttpParserBasicTests.cs
@@ -42,7 +42,7 @@ namespace System.Text.Http.Parser.Tests
         {
             var parser = new HttpParser();
 
-            for (int pivot = 24; pivot < requestText.Length; pivot++) {
+            for (int pivot = 26; pivot < requestText.Length; pivot++) {
                 var front = requestText.Substring(0, pivot);
                 var back = requestText.Substring(pivot);
 
@@ -58,7 +58,8 @@ namespace System.Text.Http.Parser.Tests
                     Assert.True(parser.ParseRequestLine(ref request, buffer, out var consumed));
                     Assert.Equal(25, consumed);
 
-                    Assert.True(parser.ParseHeaders(ref request, buffer.Slice(consumed), out consumed));
+                    var unconsumed = buffer.Slice(consumed);
+                    Assert.True(parser.ParseHeaders(ref request, unconsumed, out consumed));
                     Assert.Equal(8, consumed);
                 }
                 catch {


### PR DESCRIPTION
cc: @pakrym, @davidfowl, @joshfree, @ahsonkhan 

When sequences move to end default(Position) is returned from TryGet
Before calling ISequence<T>.TryGet for the first time, the calling code has to call ISequence<T>.First, as default position no longer mean the first item (necessarily)
APIs like buffer.PositionOf(byte value) return Position? (nullable). They return null if value is not found

All these changes were requested by @pakrym to allow him to use Position in pipelines instead of ReadCursor.