### PR TITLE
Fast TaskRunScheduler

### DIFF
--- a/src/System.IO.Pipelines/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/System.IO.Pipelines.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>An abstraction for doing efficient asynchronous IO</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>
     <!--<DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);BLOCK_LEASE_TRACKING</DefineConstants>-->

--- a/src/System.IO.Pipelines/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/System/IO/Pipelines/Pipe.cs
@@ -20,7 +20,6 @@ namespace System.IO.Pipelines
         private static readonly Action<object> _signalReaderAwaitable = state => ((Pipe)state).ReaderCancellationRequested();
         private static readonly Action<object> _signalWriterAwaitable = state => ((Pipe)state).WriterCancellationRequested();
         private static readonly Action<object> _invokeCompletionCallbacks = state => ((PipeCompletionCallbacks)state).Execute();
-        private static readonly Action<object> _scheduleContinuation = o => ((Action)o)();
 
         // This sync objects protects the following state:
         // 1. _commitHead & _commitHeadIndex
@@ -628,7 +627,7 @@ namespace System.IO.Pipelines
         {
             if (action != null)
             {
-                scheduler.Schedule(_scheduleContinuation, action);
+                scheduler.Schedule(action);
             }
         }
 

--- a/src/System.IO.Pipelines/System/Threading/InlineScheduler.cs
+++ b/src/System.IO.Pipelines/System/Threading/InlineScheduler.cs
@@ -4,8 +4,11 @@
 
 namespace System.Threading
 {
-    internal class InlineScheduler : Scheduler
+    internal sealed class InlineScheduler : Scheduler
     {
+        // Override and seal class to ensure a devirtualised call through to Schedule
+        public override void Schedule(Action action) => Schedule(ScheduleAction, action);
+
         public override void Schedule(Action<object> action, object state)
         {
             action(state);

--- a/src/System.IO.Pipelines/System/Threading/Scheduler.cs
+++ b/src/System.IO.Pipelines/System/Threading/Scheduler.cs
@@ -5,9 +5,13 @@ namespace System.Threading
 {
     public abstract class Scheduler
     {
+        private protected static readonly Action<object> ScheduleAction = o => ((Action)o)();
+
         public static Scheduler TaskRun { get; } = new TaskRunScheduler();
         public static Scheduler Inline { get; } = new InlineScheduler();
 
         public abstract void Schedule(Action<object> action, object state);
+
+        public virtual void Schedule(Action action) => Schedule(ScheduleAction, action);
     }
 }

--- a/src/System.IO.Pipelines/System/Threading/TaskRunScheduler.cs
+++ b/src/System.IO.Pipelines/System/Threading/TaskRunScheduler.cs
@@ -6,8 +6,11 @@ using System.Threading.Tasks;
 
 namespace System.Threading
 {
-    internal class TaskRunScheduler : Scheduler
+    internal sealed class TaskRunScheduler : Scheduler
     {
+        // Override and seal class to ensure a devirtualised call through to Schedule
+        public override void Schedule(Action action) => Schedule(ScheduleAction, action);
+
         public override void Schedule(Action<object> action, object state)
         {
             Task.Factory.StartNew(action, state);

--- a/src/System.IO.Pipelines/System/Threading/TaskRunScheduler.cs
+++ b/src/System.IO.Pipelines/System/Threading/TaskRunScheduler.cs
@@ -2,18 +2,77 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.Threading
 {
     internal sealed class TaskRunScheduler : Scheduler
     {
-        // Override and seal class to ensure a devirtualised call through to Schedule
-        public override void Schedule(Action action) => Schedule(ScheduleAction, action);
+        public override void Schedule(Action action)
+        {
+#if NETCOREAPP2_1
+            ThreadPool.QueueUserWorkItem(_actionAsTask, action, preferLocal: true);
+#elif NETSTANDARD2_0
+            ThreadPool.QueueUserWorkItem(_actionAsTask, action);
+#else
+            Task.Factory.StartNew(ScheduleAction, action);
+#endif
+        }
 
         public override void Schedule(Action<object> action, object state)
         {
+#if NETCOREAPP2_1
+            ThreadPool.QueueUserWorkItem(_actionObjectAsTask, new ActionObjectAsTask(action, state), preferLocal: true);
+#elif NETSTANDARD2_0
+            ThreadPool.QueueUserWorkItem(_actionObjectAsTask, new ActionObjectAsTask(action, state));
+#else
             Task.Factory.StartNew(action, state);
+#endif
         }
+
+#if NETCOREAPP2_1 || NETSTANDARD2_0
+        private readonly static WaitCallback _actionAsTask = state =>
+        {
+            try
+            {
+                ((Action)state)();
+            }
+            catch (Exception ex)
+            {
+                // Create faulted Task for the TaskScheulder to handle exception
+                // rather than letting it escape onto the ThreadPool and crashing the process
+                Task.FromException(ex);
+            }
+        };
+
+        private readonly static WaitCallback _actionObjectAsTask = state => ((ActionObjectAsTask)state).Run();
+
+        private sealed class ActionObjectAsTask
+        {
+            private Action<object> _action;
+            private object _state;
+
+            public ActionObjectAsTask(Action<object> action, object state)
+            {
+                _action = action;
+                _state = state;
+            }
+
+            public void Run()
+            {
+                try
+                {
+                    _action(_state);
+                }
+                catch (Exception ex)
+                {
+                    // Create faulted Task for the TaskScheulder to handle exception
+                    // rather than letting it escape onto the ThreadPool and crashing the process
+                    Task.FromException(ex);
+                }
+            }
+        }
+#endif
     }
 }


### PR DESCRIPTION
`Task.Factory.StartNew` is slow compared to `QueueUserWorkItem` or the newer lower contention `QueueUserWorkItem(preferLocal: true)` https://github.com/dotnet/corefx/issues/12442

Since the returned Task is just ignored; might as well use the faster versions (which `Task.Factory.StartNew` essentially ends up calling - more or less...)

Resolves: https://github.com/dotnet/corefxlab/issues/2002
Resolves: #2000 (due to rebase on  #2001)

/cc @davidfowl @pakrym 