### PR TITLE
Another set of API review changes

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/BufferSequence.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/BufferSequence.cs
@@ -8,7 +8,7 @@ using System.Collections.Sequences;
 
 namespace Microsoft.Net
 {
-    class BufferSequence : IMemoryList<byte>, IDisposable
+    class BufferSequence : IBufferList, IDisposable
     {
         public const int DefaultBufferSize = 1024;
 
@@ -29,7 +29,7 @@ namespace Microsoft.Net
 
         public Span<byte> Free => new Span<byte>(_array, _written, _array.Length - _written);
 
-        public IMemoryList<byte> Next => _next;
+        public IBufferList Next => _next;
 
         public int WrittenByteCount => _written;
 

--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -15,7 +15,7 @@ namespace System.Buffers
     {
         // span creation helpers:
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long IndexOf(this IMemoryList<byte> list, ReadOnlySpan<byte> value)
+        public static long IndexOf(this IBufferList list, ReadOnlySpan<byte> value)
         {
             var first = list.Memory.Span;
             var index = first.IndexOf(value);
@@ -27,7 +27,7 @@ namespace System.Buffers
             return IndexOfStraddling(first, list.Next, value);
         }
 
-        public static int CopyTo(this IMemoryList<byte> list, Span<byte> destination)
+        public static int CopyTo(this IBufferList list, Span<byte> destination)
         {
             var current = list.Memory.Span;
             int copied = 0;
@@ -50,7 +50,7 @@ namespace System.Buffers
             return copied;
         }
 
-        public static Position? PositionOf(this IMemoryList<byte> list, byte value)
+        public static Position? PositionOf(this IBufferList list, byte value)
         {
             while (list != null)
             {
@@ -65,7 +65,7 @@ namespace System.Buffers
         // TODO (pri 3): I am pretty sure this whole routine can be written much better
 
         // searches values that potentially straddle between first and rest
-        internal static long IndexOfStraddling(this ReadOnlySpan<byte> first, IMemoryList<byte> rest, ReadOnlySpan<byte> value)
+        internal static long IndexOfStraddling(this ReadOnlySpan<byte> first, IBufferList rest, ReadOnlySpan<byte> value)
         {
             Debug.Assert(first.IndexOf(value) == -1);
             if (rest == null) return -1;

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/BufferList.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/BufferList.cs
@@ -6,36 +6,36 @@ using System.Text;
 
 namespace System.Buffers
 {
-    public class MemoryList : IMemoryList<byte>
+    public class BufferList : IBufferList
     {
         private Memory<byte> _data;
-        private MemoryList _next;
+        private BufferList _next;
         private long _virtualIndex;
 
-        public MemoryList(Memory<byte> bytes)
+        public BufferList(Memory<byte> bytes)
         {
             _data = bytes;
             _next = null;
             _virtualIndex = 0;
         }
 
-        private MemoryList(Memory<byte> bytes, long virtualIndex)
+        private BufferList(Memory<byte> bytes, long virtualIndex)
         {
             _data = bytes;
             _virtualIndex = virtualIndex;
         }
 
-        public MemoryList Append(Memory<byte> bytes)
+        public BufferList Append(Memory<byte> bytes)
         {
             if (_next != null) throw new InvalidOperationException("Node cannot be appended");
-            var node = new MemoryList(bytes, _virtualIndex + _data.Length);
+            var node = new BufferList(bytes, _virtualIndex + _data.Length);
             _next = node;
             return node;
         }
 
         public Memory<byte> Memory => _data;
 
-        public IMemoryList<byte> Next => _next;
+        public IBufferList Next => _next;
 
         public long VirtualIndex => _virtualIndex;
 
@@ -79,21 +79,21 @@ namespace System.Buffers
                 return false;
             }
             
-            var (list, index) = position.Get<MemoryList>();
+            var (list, index) = position.Get<BufferList>();
             item = list._data.Slice(index);
             if (advance) { position = new Position(list._next, 0); }
             return true;
         }
 
-        public static (MemoryList first, MemoryList last) Create(params byte[][] buffers)
+        public static (BufferList first, BufferList last) Create(params byte[][] buffers)
         {
             if(buffers.Length == 0 || (buffers.Length == 1 && buffers[0].Length == 0))
             {
-                var list = new MemoryList(Memory<byte>.Empty);
+                var list = new BufferList(Memory<byte>.Empty);
                 return (list, list);
             }
 
-            MemoryList first = new MemoryList(buffers[0]);
+            BufferList first = new BufferList(buffers[0]);
             var last = first;
             for (int i = 1; i < buffers.Length; i++)
             {

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadOnlyBytes.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadOnlyBytes.cs
@@ -44,7 +44,7 @@ namespace System.Buffers
         }
 
         // TODO: Hide this ctor and force users to pass Positions. This will let us hide Position.Object 
-        public ReadOnlyBytes(IMemoryList<byte> first, IMemoryList<byte> last)
+        public ReadOnlyBytes(IBufferList first, IBufferList last)
         {
             _start = first;
             _startIndex = 0;
@@ -89,7 +89,7 @@ namespace System.Buffers
                 case Type.Array:
                     return new ReadOnlyBytes((byte[])_start, (int)(_startIndex + index), (int)length);
                 case Type.MemoryList:
-                    var sl = (IMemoryList<byte>)_start;
+                    var sl = (IBufferList)_start;
                     index += _startIndex;
                     while(true)
                     {
@@ -143,7 +143,7 @@ namespace System.Buffers
                     var (array, index) = position.Get<byte[]>();
                     return new ReadOnlyBytes(array, index, array.Length - index);
                 case Type.MemoryList:
-                    return Slice(position, new Position((IMemoryList<byte>)_end, _endIndex));
+                    return Slice(position, new Position((IBufferList)_end, _endIndex));
                 default: throw new NotImplementedException();
             }
         }
@@ -157,8 +157,8 @@ namespace System.Buffers
                     var (array, index) = start.Get<byte[]>();
                     return new ReadOnlyBytes(array, index, (int)end - index);
                 case Type.MemoryList:
-                    var (startList, startIndex) = start.Get<IMemoryList<byte>>();
-                    var (endList, endIndex) = end.Get<IMemoryList<byte>>();
+                    var (startList, startIndex) = start.Get<IBufferList>();
+                    var (endList, endIndex) = end.Get<IBufferList>();
                     return new ReadOnlyBytes(startList, startIndex, endList, endIndex);
                 default:
                     throw new NotImplementedException();
@@ -176,7 +176,7 @@ namespace System.Buffers
                     case Type.Array:
                         return new ReadOnlyMemory<byte>((byte[])_start, _startIndex, _endIndex - _startIndex);
                     case Type.MemoryList:
-                        var list = (IMemoryList<byte>)_start;
+                        var list = (IBufferList)_start;
                         if (ReferenceEquals(list, _end))
                         {
                             return list.Memory.Slice(_startIndex, _endIndex - _startIndex);
@@ -200,8 +200,8 @@ namespace System.Buffers
                     case Type.Array:
                         return _endIndex - _startIndex;
                     case Type.MemoryList:
-                        var sl = (IMemoryList<byte>)_start;
-                        var el = (IMemoryList<byte>)_end;
+                        var sl = (IBufferList)_start;
+                        var el = (IBufferList)_end;
                         return (el.VirtualIndex + _endIndex) - (sl.VirtualIndex + _startIndex);
                     default:
                         throw new NotImplementedException();
@@ -231,7 +231,7 @@ namespace System.Buffers
             get {
                 if (_start is byte[]) return Type.Array;
                 if (_start is OwnedMemory<byte>) return Type.OwnedMemory;
-                if (_start is IMemoryList<byte>) return Type.MemoryList;
+                if (_start is IBufferList) return Type.MemoryList;
                 throw new NotSupportedException();
             }
         }
@@ -290,7 +290,7 @@ namespace System.Buffers
 
             if (Kind == Type.MemoryList)
             {
-                var (node, index) = position.Get<IMemoryList<byte>>();
+                var (node, index) = position.Get<IBufferList>();
                 item = node.Memory.Slice(index);
                 if (ReferenceEquals(node, _end))
                 {

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadWriteBytes.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadWriteBytes.cs
@@ -40,7 +40,7 @@ namespace System.Buffers
             Validate();
         }
 
-        public ReadWriteBytes(IMemoryList<byte> first, IMemoryList<byte> last)
+        public ReadWriteBytes(IBufferList first, IBufferList last)
         {
             _start = first;
             _startIndex = 0;
@@ -85,7 +85,7 @@ namespace System.Buffers
                 case Type.Array:
                     return new ReadWriteBytes((byte[])_start, (int)(_startIndex + index), (int)length);
                 case Type.MemoryList:
-                    var sl = (IMemoryList<byte>)_start;
+                    var sl = (IBufferList)_start;
                     index += _startIndex;
                     while (true)
                     {
@@ -139,7 +139,7 @@ namespace System.Buffers
                     var (array, index) = position.Get<byte[]>();
                     return new ReadWriteBytes(array, index, array.Length - index);
                 case Type.MemoryList:
-                    return Slice(position, new Position((IMemoryList<byte>)_end, _endIndex));
+                    return Slice(position, new Position((IBufferList)_end, _endIndex));
                 default: throw new NotImplementedException();
             }
         }
@@ -153,8 +153,8 @@ namespace System.Buffers
                     var (array, index) = start.Get<byte[]>();
                     return new ReadWriteBytes(array, index, (int)end - index);
                 case Type.MemoryList:
-                    var (startList, startIndex) = start.Get<IMemoryList<byte>>();
-                    var (endList, endIndex) = end.Get<IMemoryList<byte>>();
+                    var (startList, startIndex) = start.Get<IBufferList>();
+                    var (endList, endIndex) = end.Get<IBufferList>();
                     return new ReadWriteBytes(startList, startIndex, endList, endIndex);
                 default:
                     throw new NotImplementedException();
@@ -173,7 +173,7 @@ namespace System.Buffers
                     case Type.Array:
                         return new ReadOnlyMemory<byte>((byte[])_start, _startIndex, _endIndex - _startIndex);
                     case Type.MemoryList:
-                        var list = (IMemoryList<byte>)_start;
+                        var list = (IBufferList)_start;
                         if (ReferenceEquals(list, _end))
                         {
                             return list.Memory.Slice(_startIndex, _endIndex - _startIndex);
@@ -197,8 +197,8 @@ namespace System.Buffers
                     case Type.Array:
                         return _endIndex - _startIndex;
                     case Type.MemoryList:
-                        var sl = (IMemoryList<byte>)_start;
-                        var el = (IMemoryList<byte>)_end;
+                        var sl = (IBufferList)_start;
+                        var el = (IBufferList)_end;
                         return (el.VirtualIndex + _endIndex) - (sl.VirtualIndex + _startIndex);
                     default:
                         throw new NotImplementedException();
@@ -228,7 +228,7 @@ namespace System.Buffers
             get {
                 if (_start is byte[]) return Type.Array;
                 if (_start is OwnedMemory<byte>) return Type.OwnedMemory;
-                if (_start is IMemoryList<byte>) return Type.MemoryList;
+                if (_start is IBufferList) return Type.MemoryList;
                 throw new NotSupportedException();
             }
         }
@@ -287,7 +287,7 @@ namespace System.Buffers
 
             if (Kind == Type.MemoryList)
             {
-                var (node, index) = position.Get<IMemoryList<byte>>();
+                var (node, index) = position.Get<IBufferList>();
                 item = node.Memory.Slice(index);
                 if (ReferenceEquals(node, _end))
                 {

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -51,7 +51,7 @@ namespace System.Buffers
         /// </summary>
         public Position End => BufferEnd;
 
-        public ReadOnlyBuffer(Position start, Position end)
+        private ReadOnlyBuffer(Position start, Position end)
         {
             Debug.Assert(start.Segment != null);
             Debug.Assert(end.Segment != null);
@@ -233,13 +233,13 @@ namespace System.Buffers
             return new Enumerator(this);
         }
 
-        public Position Move(Position cursor, long count)
+        public Position Seek(Position position, long count)
         {
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
             }
-            return Seek(cursor, BufferEnd, count, false);
+            return Seek(position, BufferEnd, count, false);
         }
 
         public bool TryGet(ref Position cursor, out ReadOnlyMemory<byte> data, bool advance = true)
@@ -253,7 +253,7 @@ namespace System.Buffers
             return result;
         }
 
-        public int Seek(out Position result, byte byte0)
+        public Position? PositionOf(byte byte0)
         {
             var enumerator = GetEnumerator();
             while (enumerator.MoveNext())
@@ -263,51 +263,11 @@ namespace System.Buffers
                 int index = span.IndexOf(byte0);
                 if (index != -1)
                 {
-                    result = enumerator.CreateCursor(index);
-                    return span[index];
+                    return enumerator.CreateCursor(index);
                 }
             }
 
-            result = End;
-            return -1;
-        }
-
-        public int Seek(out Position result, byte byte0, byte byte1)
-        {
-            var enumerator = GetEnumerator();
-            while (enumerator.MoveNext())
-            {
-                var span = enumerator.Current.Span;
-                int index = span.IndexOfAny(byte0, byte1);
-
-                if (index != -1)
-                {
-                    result = enumerator.CreateCursor(index);
-                    return span[index];
-                }
-            }
-
-            result = End;
-            return -1;
-        }
-
-        public int Seek(out Position result, byte byte0, byte byte1, byte byte2)
-        {
-            var enumerator = GetEnumerator();
-            while (enumerator.MoveNext())
-            {
-                var span = enumerator.Current.Span;
-                int index = span.IndexOfAny(byte0, byte1, byte2);
-
-                if (index != -1)
-                {
-                    result = enumerator.CreateCursor(index);
-                    return span[index];
-                }
-            }
-
-            result = End;
-            return -1;
+            return null;
         }
 
         /// <summary>
@@ -369,7 +329,7 @@ namespace System.Buffers
 
             public Position CreateCursor(int index)
             {
-                return _readOnlyBuffer.Move(_current, index);
+                return _readOnlyBuffer.Seek(_current, index);
             }
         }
     }

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -287,20 +287,19 @@ namespace System.Buffers
             return result;
         }
 
-        public Position? PositionOf(byte byte0)
+        public Position? PositionOf(byte value)
         {
-            var enumerator = GetEnumerator();
-            while (enumerator.MoveNext())
+            Position position = Start;
+            Position result = position;
+            while (TryGet(ref position, out ReadOnlyMemory<byte> memory))
             {
-                var span = enumerator.Current.Span;
-
-                int index = span.IndexOf(byte0);
+                var index = memory.Span.IndexOf( value);
                 if (index != -1)
                 {
-                    return enumerator.CreateCursor(index);
+                    return Seek(result, index);
                 }
+                result = position;
             }
-
             return null;
         }
 
@@ -359,11 +358,6 @@ namespace System.Buffers
             public void Reset()
             {
                 ThrowHelper.ThrowNotSupportedException();
-            }
-
-            public Position CreateCursor(int index)
-            {
-                return _readOnlyBuffer.Seek(_current, index);
             }
         }
     }

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -252,7 +252,64 @@ namespace System.Buffers
 
             return result;
         }
-        
+
+        public int Seek(out Position result, byte byte0)
+        {
+            var enumerator = GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                var span = enumerator.Current.Span;
+
+                int index = span.IndexOf(byte0);
+                if (index != -1)
+                {
+                    result = enumerator.CreateCursor(index);
+                    return span[index];
+                }
+            }
+
+            result = End;
+            return -1;
+        }
+
+        public int Seek(out Position result, byte byte0, byte byte1)
+        {
+            var enumerator = GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                var span = enumerator.Current.Span;
+                int index = span.IndexOfAny(byte0, byte1);
+
+                if (index != -1)
+                {
+                    result = enumerator.CreateCursor(index);
+                    return span[index];
+                }
+            }
+
+            result = End;
+            return -1;
+        }
+
+        public int Seek(out Position result, byte byte0, byte byte1, byte byte2)
+        {
+            var enumerator = GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                var span = enumerator.Current.Span;
+                int index = span.IndexOfAny(byte0, byte1, byte2);
+
+                if (index != -1)
+                {
+                    result = enumerator.CreateCursor(index);
+                    return span[index];
+                }
+            }
+
+            result = End;
+            return -1;
+        }
+
         /// <summary>
         /// An enumerator over the <see cref="ReadOnlyBuffer"/>
         /// </summary>

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer.cs
@@ -61,7 +61,7 @@ namespace System.Buffers
             BufferEnd = end;
         }
 
-        public ReadOnlyBuffer(IMemoryList<byte> startSegment, int offset, IMemoryList<byte> endSegment, int endIndex)
+        public ReadOnlyBuffer(IBufferList startSegment, int offset, IBufferList endSegment, int endIndex)
         {
             Debug.Assert(startSegment != null);
             Debug.Assert(endSegment != null);

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer_helpers.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer_helpers.cs
@@ -10,63 +10,6 @@ namespace System.Buffers
 {
     public readonly partial struct ReadOnlyBuffer 
     {
-        public static int Seek(Position begin, Position end, out Position result, byte byte0)
-        {
-            var enumerator = new ReadOnlyBuffer(begin, end).GetEnumerator();
-            while (enumerator.MoveNext())
-            {
-                var span = enumerator.Current.Span;
-
-                int index = span.IndexOf(byte0);
-                if (index != -1)
-                {
-                    result = enumerator.CreateCursor(index);
-                    return span[index];
-                }
-            }
-
-            result = end;
-            return -1;
-        }
-
-        public static int Seek(Position begin, Position end, out Position result, byte byte0, byte byte1)
-        {
-            var enumerator = new ReadOnlyBuffer(begin, end).GetEnumerator();
-            while (enumerator.MoveNext())
-            {
-                var span = enumerator.Current.Span;
-                int index = span.IndexOfAny(byte0, byte1);
-
-                if (index != -1)
-                {
-                    result = enumerator.CreateCursor(index);
-                    return span[index];
-                }
-            }
-
-            result = end;
-            return -1;
-        }
-
-        public static int Seek(Position begin, Position end, out Position result, byte byte0, byte byte1, byte byte2)
-        {
-            var enumerator = new ReadOnlyBuffer(begin, end).GetEnumerator();
-            while (enumerator.MoveNext())
-            {
-                var span = enumerator.Current.Span;
-                int index = span.IndexOfAny(byte0, byte1, byte2);
-
-                if (index != -1)
-                {
-                    result = enumerator.CreateCursor(index);
-                    return span[index];
-                }
-            }
-
-            result = end;
-            return -1;
-        }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool TryGetBuffer(Position begin, Position end, out ReadOnlyMemory<byte> data, out Position next)
         {

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer_helpers.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer_helpers.cs
@@ -22,7 +22,7 @@ namespace System.Buffers
                     next = default;
                     return false;
 
-                case IMemoryList<byte> bufferSegment:
+                case IBufferList bufferSegment:
                     var startIndex = begin.Index;
                     var endIndex = bufferSegment.Memory.Length;
 
@@ -148,8 +148,8 @@ namespace System.Buffers
             var segment = begin.Segment;
             switch (segment)
             {
-                case IMemoryList<byte> bufferSegment:
-                    return GetLength(bufferSegment, begin.Index, end.GetSegment<IMemoryList<byte>>(), end.Index);
+                case IBufferList bufferSegment:
+                    return GetLength(bufferSegment, begin.Index, end.GetSegment<IBufferList>(), end.Index);
                 case byte[] _:
                 case OwnedMemory<byte> _:
                     return end.Index - begin.Index;
@@ -161,9 +161,9 @@ namespace System.Buffers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static long GetLength(
-            IMemoryList<byte> start,
+            IBufferList start,
             int startIndex,
-            IMemoryList<byte> endSegment,
+            IBufferList endSegment,
             int endIndex)
         {
             if (start == endSegment)
@@ -188,8 +188,8 @@ namespace System.Buffers
                         ThrowHelper.ThrowCursorOutOfBoundsException();
                     }
                     return;
-                case IMemoryList<byte> memoryList:
-                    if(newCursor.GetSegment<IMemoryList<byte>>().VirtualIndex - end.Index > memoryList.VirtualIndex - newCursor.Index)
+                case IBufferList memoryList:
+                    if(newCursor.GetSegment<IBufferList>().VirtualIndex - end.Index > memoryList.VirtualIndex - newCursor.Index)
                     {
                         ThrowHelper.ThrowCursorOutOfBoundsException();
                     }
@@ -200,10 +200,10 @@ namespace System.Buffers
             }
         }
 
-        private class ReadOnlyBufferSegment: IMemoryList<byte>
+        private class ReadOnlyBufferSegment: IBufferList
         {
             public Memory<byte> Memory { get; set; }
-            public IMemoryList<byte> Next { get; set; }
+            public IBufferList Next { get; set; }
             public long VirtualIndex { get; set; }
         }
     }

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer_helpers.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBuffer_helpers.cs
@@ -199,5 +199,12 @@ namespace System.Buffers
                     return;
             }
         }
+
+        private class ReadOnlyBufferSegment: IMemoryList<byte>
+        {
+            public Memory<byte> Memory { get; set; }
+            public IMemoryList<byte> Next { get; set; }
+            public long VirtualIndex { get; set; }
+        }
     }
 }

--- a/src/System.Buffers.Primitives/System/Collections/IBufferList.cs
+++ b/src/System.Buffers.Primitives/System/Collections/IBufferList.cs
@@ -3,11 +3,11 @@
 
 namespace System.Collections.Sequences
 {
-    public interface IMemoryList<T>
+    public interface IBufferList
     {
-        Memory<T> Memory { get; }
+        Memory<byte> Memory { get; }
 
-        IMemoryList<T> Next { get; }
+        IBufferList Next { get; }
 
         long VirtualIndex { get; }
     }

--- a/src/System.IO.Pipelines.Extensions/DefaultReadableBufferExtensions.cs
+++ b/src/System.IO.Pipelines.Extensions/DefaultReadableBufferExtensions.cs
@@ -132,7 +132,7 @@ namespace System.IO.Pipelines
 
                 if (found)
                 {
-                    cursor = buffer.Move(buffer.Start, seek);
+                    cursor = buffer.Seek(buffer.Start, seek);
                     slice = buffer.Slice(buffer.Start, cursor);
                     return true;
                 }

--- a/src/System.IO.Pipelines/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/System/IO/Pipelines/BufferSegment.cs
@@ -8,7 +8,7 @@ using System.Text;
 
 namespace System.IO.Pipelines
 {
-    internal class BufferSegment: IMemoryList<byte>
+    internal class BufferSegment: IBufferList
     {
         /// <summary>
         /// The Start represents the offset into Array where the range of "active" bytes begins. At the point when the block is leased
@@ -86,7 +86,7 @@ namespace System.IO.Pipelines
 
         public int Length => End - Start;
 
-        public IMemoryList<byte> Next => NextSegment;
+        public IBufferList Next => NextSegment;
 
         /// <summary>
         /// If true, data should not be written into the backing block after the End offset. Data between start and end should never be modified

--- a/src/System.Text.Http.Parser/HttpParser.cs
+++ b/src/System.Text.Http.Parser/HttpParser.cs
@@ -47,7 +47,7 @@ namespace System.Text.Http.Parser
             var lineIndex = span.IndexOf(ByteLF);
             if (lineIndex >= 0)
             {
-                consumed = buffer.Move(consumed, lineIndex + 1);
+                consumed = buffer.Seek(consumed, lineIndex + 1);
                 span = span.Slice(0, lineIndex + 1);
             }
             else if (buffer.IsSingleSpan)
@@ -322,15 +322,16 @@ namespace System.Text.Http.Parser
                                 var current = reader.Position;
                                 var subBuffer = buffer.Slice(reader.Position);
                                 // Split buffers
-                                if (subBuffer.Seek(out var lineEnd, ByteLF) == -1)
+                                var lineEnd = subBuffer.PositionOf(ByteLF);
+                                if (!lineEnd.HasValue)
                                 {
                                     // Not there
                                     return false;
                                 }
 
                                 // Make sure LF is included in lineEnd
-                                lineEnd = subBuffer.Move(lineEnd, 1);
-                                var headerSpan = subBuffer.Slice(current, lineEnd).ToSpan();
+                                lineEnd = subBuffer.Seek(lineEnd.Value, 1);
+                                var headerSpan = subBuffer.Slice(current, lineEnd.Value).ToSpan();
                                 length = headerSpan.Length;
 
                                 fixed (byte* pHeader = &MemoryMarshal.GetReference(headerSpan))
@@ -639,13 +640,15 @@ namespace System.Text.Http.Parser
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static bool TryGetNewLineSpan(in ReadOnlyBuffer buffer, out Position found)
         {
-            if (buffer.Seek(out found, ByteLF) != -1)
+            var position = buffer.PositionOf(ByteLF);
+            if (position.HasValue)
             {
                 // Move 1 byte past the \n
-                found = buffer.Move(found, 1);
+                found = buffer.Seek(position.Value, 1);
                 return true;
             }
 
+            found = default;
             return false;
         }
 

--- a/src/System.Text.Http.Parser/HttpParser.cs
+++ b/src/System.Text.Http.Parser/HttpParser.cs
@@ -320,17 +320,17 @@ namespace System.Text.Http.Parser
                             else
                             {
                                 var current = reader.Position;
-
+                                var subBuffer = buffer.Slice(reader.Position);
                                 // Split buffers
-                                if (ReadOnlyBuffer.Seek(current, bufferEnd, out var lineEnd, ByteLF) == -1)
+                                if (subBuffer.Seek(out var lineEnd, ByteLF) == -1)
                                 {
                                     // Not there
                                     return false;
                                 }
 
                                 // Make sure LF is included in lineEnd
-                                lineEnd = buffer.Move(lineEnd, 1);
-                                var headerSpan = buffer.Slice(current, lineEnd).ToSpan();
+                                lineEnd = subBuffer.Move(lineEnd, 1);
+                                var headerSpan = subBuffer.Slice(current, lineEnd).ToSpan();
                                 length = headerSpan.Length;
 
                                 fixed (byte* pHeader = &MemoryMarshal.GetReference(headerSpan))
@@ -639,8 +639,7 @@ namespace System.Text.Http.Parser
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static bool TryGetNewLineSpan(in ReadOnlyBuffer buffer, out Position found)
         {
-            var start = buffer.Start;
-            if (ReadOnlyBuffer.Seek(start, buffer.End, out found, ByteLF) != -1)
+            if (buffer.Seek(out found, ByteLF) != -1)
             {
                 // Move 1 byte past the \n
                 found = buffer.Move(found, 1);

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -76,7 +76,7 @@ namespace System.Binary.Base64Experimental.Tests
             }
             Assert.Equal(1000, sum);
 
-            var (first, last) = MemoryList.Create(input);
+            var (first, last) = BufferList.Create(input);
            
             var output = new TestOutput();
             Base64Experimental.Utf8ToBytesDecoder.Pipe(new ReadOnlyBytes(first, last), output);

--- a/tests/System.Buffers.Experimental.Tests/BytesReaderTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/BytesReaderTests.cs
@@ -160,7 +160,7 @@ namespace System.Buffers.Tests
         public static ReadOnlyBytes CreateRob(params byte[][] buffers)
         {
             if (buffers.Length == 1) return new ReadOnlyBytes(buffers[0]);
-            var (first, last) = MemoryList.Create(buffers);
+            var (first, last) = BufferList.Create(buffers);
             return new ReadOnlyBytes(first, last);
         }
     }

--- a/tests/System.Buffers.Experimental.Tests/SequenceExtensionsTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/SequenceExtensionsTests.cs
@@ -64,7 +64,7 @@ namespace System.Buffers.Tests
         [Fact]
         public void SequencePositionOfMultiSegment()
         {
-            var (first, last) = MemoryList.Create(
+            var (first, last) = BufferList.Create(
                 new byte[] { 1, 2 },
                 new byte[] { 3, 4 }
             );
@@ -80,7 +80,7 @@ namespace System.Buffers.Tests
                 var value = (byte)(i + 1);
 
                 var listPosition = MemoryListExtensions.PositionOf(first, value).GetValueOrDefault();
-                var (node, index) = listPosition.Get<IMemoryList<byte>>();
+                var (node, index) = listPosition.Get<IBufferList>();
 
                 if (listPosition != default)
                 {
@@ -131,7 +131,7 @@ namespace System.Buffers.Tests
             {
                 var front = memory.Slice(0, pivot);
                 var back = memory.Slice(pivot);
-                var first = new MemoryList(front);
+                var first = new BufferList(front);
                 var last = first.Append(back);
 
                 var bytes = new ReadOnlyBytes(first, last);

--- a/tests/System.Buffers.Primitives.Tests/BufferSegment.cs
+++ b/tests/System.Buffers.Primitives.Tests/BufferSegment.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace System.IO.Pipelines.Testing
 {
-    internal class BufferSegment: IMemoryList<byte>
+    internal class BufferSegment: IBufferList
     {
         public int Start { get; private set; }
         
@@ -73,7 +73,7 @@ namespace System.IO.Pipelines.Testing
 
         public int Length => End - Start;
 
-        public IMemoryList<byte> Next => NextSegment;
+        public IBufferList Next => NextSegment;
 
         /// <summary>
         /// If true, data should not be written into the backing block after the End offset. Data between start and end should never be modified

--- a/tests/System.Buffers.Primitives.Tests/BufferUtilities.cs
+++ b/tests/System.Buffers.Primitives.Tests/BufferUtilities.cs
@@ -51,7 +51,7 @@ namespace System.IO.Pipelines.Testing
                 i++;
             } while (i < inputs.Length);
 
-            return new ReadOnlyBuffer(new Position(first, 0), new Position(last, last.Length));
+            return new ReadOnlyBuffer(first, 0, last, last.Length);
         }
 
         public static ReadOnlyBuffer CreateBuffer(params string[] inputs)

--- a/tests/System.Buffers.Primitives.Tests/ReadOnlyBufferFactory.cs
+++ b/tests/System.Buffers.Primitives.Tests/ReadOnlyBufferFactory.cs
@@ -24,7 +24,7 @@ namespace System.IO.Pipelines.Tests
         {
             return CreateWithContent(Encoding.ASCII.GetBytes(data));
         }
-
+        
         internal class ArrayTestBufferFactory : ReadOnlyBufferFactory
         {
             public override ReadOnlyBuffer CreateOfSize(int size)
@@ -54,7 +54,7 @@ namespace System.IO.Pipelines.Tests
                 return new ReadOnlyBuffer(new OwnedArray<byte>(startSegment), 10, data.Length);
             }
         }
-
+ 
         internal class SingleSegmentTestBufferFactory: ReadOnlyBufferFactory
         {
             public override ReadOnlyBuffer CreateOfSize(int size)

--- a/tests/System.Buffers.Primitives.Tests/ReadableBufferFacts.cs
+++ b/tests/System.Buffers.Primitives.Tests/ReadableBufferFacts.cs
@@ -89,7 +89,7 @@ namespace System.IO.Pipelines.Tests
         public void ReadableBufferMove_MovesReadCursor()
         {
             var buffer = Factory.CreateOfSize(100);
-            var cursor = buffer.Move(buffer.Start, 65);
+            var cursor = buffer.Seek(buffer.Start, 65);
             Assert.Equal(buffer.Slice(65).Start, cursor);
         }
 
@@ -97,14 +97,14 @@ namespace System.IO.Pipelines.Tests
         public void ReadableBufferMove_ChecksBounds()
         {
             var buffer = Factory.CreateOfSize(100);
-            Assert.Throws<InvalidOperationException>(() => buffer.Move(buffer.Start, 101));
+            Assert.Throws<InvalidOperationException>(() => buffer.Seek(buffer.Start, 101));
         }
 
         [Fact]
         public void ReadableBufferMove_DoesNotAlowNegative()
         {
             var buffer = Factory.CreateOfSize(20);
-            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Move(buffer.Start, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Seek(buffer.Start, -1));
         }
 
         [Fact]
@@ -128,10 +128,10 @@ namespace System.IO.Pipelines.Tests
             bufferSegment2.SetMemory(new OwnedArray<byte>(new byte[100]), 0, 50);
             bufferSegment1.SetNext(bufferSegment2);
 
-            var readableBuffer = new ReadOnlyBuffer(new Position(bufferSegment1, 0), new Position(bufferSegment2, 50));
+            var readableBuffer = new ReadOnlyBuffer(bufferSegment1, 0, bufferSegment2, 50);
 
-            var c1 = readableBuffer.Move(readableBuffer.Start, 25); // segment 1 index 75
-            var c2 = readableBuffer.Move(readableBuffer.Start, 55); // segment 2 index 5
+            var c1 = readableBuffer.Seek(readableBuffer.Start, 25); // segment 1 index 75
+            var c2 = readableBuffer.Seek(readableBuffer.Start, 55); // segment 2 index 5
 
             var sliced = readableBuffer.Slice(c1, c2);
 
@@ -148,9 +148,9 @@ namespace System.IO.Pipelines.Tests
             bufferSegment2.SetMemory(new OwnedArray<byte>(new byte[100]), 0, 0);
             bufferSegment1.SetNext(bufferSegment2);
 
-            var readableBuffer = new ReadOnlyBuffer(new Position(bufferSegment1, 0), new Position(bufferSegment2, 0));
+            var readableBuffer = new ReadOnlyBuffer(bufferSegment1, 0, bufferSegment2, 0);
 
-            var c1 = readableBuffer.Move(readableBuffer.Start, 50);
+            var c1 = readableBuffer.Seek(readableBuffer.Start, 50);
 
             Assert.Equal(0, c1.Index);
             Assert.Equal(bufferSegment2, c1.Segment);

--- a/tests/System.Buffers.Primitives.Tests/ReadableBufferFacts.cs
+++ b/tests/System.Buffers.Primitives.Tests/ReadableBufferFacts.cs
@@ -178,7 +178,7 @@ namespace System.IO.Pipelines.Tests
             var memories = new Memory<byte>[] { new byte[] {1, 2, 3}, new byte[] {4, 5, 6}};
             var readableBuffer = new ReadOnlyBuffer(memories);
 
-            Assert.Equal(new byte[] {1, 2, 3, 4, 5}, readableBuffer.ToArray());
+            Assert.Equal(new byte[] {1, 2, 3, 4, 5, 6}, readableBuffer.ToArray());
         }
 
         public static TheoryData<Action<ReadOnlyBuffer>> OutOfRangeSliceCases => new TheoryData<Action<ReadOnlyBuffer>>

--- a/tests/System.Buffers.Primitives.Tests/ReadableBufferFacts.cs
+++ b/tests/System.Buffers.Primitives.Tests/ReadableBufferFacts.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Collections.Generic;
 using System.Collections.Sequences;
 using System.IO.Pipelines.Testing;
 using System.Linq;
@@ -162,13 +163,22 @@ namespace System.IO.Pipelines.Tests
             var readableBuffer = new ReadOnlyBuffer(new byte[] {1, 2, 3, 4, 5}, 2, 3);
             Assert.Equal(readableBuffer.ToArray(), new byte[] {3, 4, 5});
         }
-
+        
         [Fact]
         public void Create_WorksWithOwnedMemory()
         {
             var memory = new OwnedArray<byte>(new byte[] {1, 2, 3, 4, 5});
             var readableBuffer = new ReadOnlyBuffer(memory, 2, 3);
             Assert.Equal(new byte[] {3, 4, 5}, readableBuffer.ToArray());
+        }
+
+        [Fact]
+        public void Create_WorksWithIEnumerableOfMemory()
+        {
+            var memories = new Memory<byte>[] { new byte[] {1, 2, 3}, new byte[] {4, 5, 6}};
+            var readableBuffer = new ReadOnlyBuffer(memories);
+
+            Assert.Equal(new byte[] {1, 2, 3, 4, 5}, readableBuffer.ToArray());
         }
 
         public static TheoryData<Action<ReadOnlyBuffer>> OutOfRangeSliceCases => new TheoryData<Action<ReadOnlyBuffer>>

--- a/tests/System.Buffers.Primitives.Tests/ReadableBufferReaderFacts.cs
+++ b/tests/System.Buffers.Primitives.Tests/ReadableBufferReaderFacts.cs
@@ -95,10 +95,7 @@ namespace System.IO.Pipelines.Tests
             first.SetMemory(new OwnedArray<byte>(new byte[] { 1, 2 }), 0, 2);
             first.SetNext(last);
 
-            var start = new Position(first, first.Start);
-            var end = new Position(last, last.Start);
-
-            var reader = BufferReader.Create(new ReadOnlyBuffer(start, end));
+            var reader = BufferReader.Create(new ReadOnlyBuffer(first, first.Start, last, last.Start));
             reader.Take();
             reader.Take();
             reader.Take();

--- a/tests/System.Buffers.Primitives.Tests/ReadableBufferReaderFacts.cs
+++ b/tests/System.Buffers.Primitives.Tests/ReadableBufferReaderFacts.cs
@@ -60,7 +60,7 @@ namespace System.IO.Pipelines.Tests
             public SegmentPerByte() : base(ReadOnlyBufferFactory.SegmentPerByte) { }
             internal SegmentPerByte(ReadOnlyBufferFactory factory) : base(factory) { }
         }
-
+        
         internal ReadOnlyBufferFactory Factory { get; }
 
         internal ReadableBufferReaderFacts(ReadOnlyBufferFactory factory)

--- a/tests/System.IO.Pipelines.Performance.Tests/PipeThroughput.cs
+++ b/tests/System.IO.Pipelines.Performance.Tests/PipeThroughput.cs
@@ -144,7 +144,7 @@ namespace System.IO.Pipelines.Performance.Tests
             for (int i = 0; i < InnerLoopCount; i++)
             {
                 var writableBuffer = _pipe.Writer.Alloc(1);
-                var writer = new WritableBufferWriter(writableBuffer);
+                var writer = OutputWriter.Create(writableBuffer);
 
                 foreach (var write in _plaintextWrites)
                 {

--- a/tests/System.IO.Pipelines.Performance.Tests/ReadCursorOperationsThroughput.cs
+++ b/tests/System.IO.Pipelines.Performance.Tests/ReadCursorOperationsThroughput.cs
@@ -128,16 +128,15 @@ namespace System.IO.Pipelines.Performance.Tests
 
                     if (length == -1)
                     {
-                        var current = reader.Position;
-
-                        if (ReadOnlyBuffer.Seek(current, end, out var found, (byte)'\n') == -1)
+                        var subBuffer = buffer.Slice(reader.Position);
+                        if (subBuffer.Seek(out var found, (byte)'\n') == -1)
                         {
                             // We're done
                             return;
                         }
 
                         length = span.Length;
-                        skip = (int)buffer.Slice(current, found).Length + 1;
+                        skip = (int)subBuffer.Slice(0, found).Length + 1;
                     }
                     else
                     {
@@ -153,17 +152,14 @@ namespace System.IO.Pipelines.Performance.Tests
 
         private static void FindAllNewLines(ReadOnlyBuffer buffer)
         {
-            var start = buffer.Start;
-            var end = buffer.End;
-
             while (true)
             {
-                if (ReadOnlyBuffer.Seek(start, end, out var found, (byte)'\n') == -1)
+                if (buffer.Seek(out var found, (byte)'\n') == -1)
                 {
                     break;
                 }
 
-                start = buffer.Move(found, 1);
+                buffer = buffer.Slice(found).Slice(1);
             }
         }
     }

--- a/tests/System.IO.Pipelines.Performance.Tests/ReadCursorOperationsThroughput.cs
+++ b/tests/System.IO.Pipelines.Performance.Tests/ReadCursorOperationsThroughput.cs
@@ -129,14 +129,15 @@ namespace System.IO.Pipelines.Performance.Tests
                     if (length == -1)
                     {
                         var subBuffer = buffer.Slice(reader.Position);
-                        if (subBuffer.Seek(out var found, (byte)'\n') == -1)
+                        var position = subBuffer.PositionOf((byte)'\n');
+                        if (position == null)
                         {
                             // We're done
                             return;
                         }
 
                         length = span.Length;
-                        skip = (int)subBuffer.Slice(0, found).Length + 1;
+                        skip = (int)subBuffer.Slice(0, position.Value).Length + 1;
                     }
                     else
                     {
@@ -154,12 +155,13 @@ namespace System.IO.Pipelines.Performance.Tests
         {
             while (true)
             {
-                if (buffer.Seek(out var found, (byte)'\n') == -1)
+                var position = buffer.PositionOf((byte)'\n');
+                if (position == null)
                 {
                     break;
                 }
 
-                buffer = buffer.Slice(found).Slice(1);
+                buffer = buffer.Slice(position.Value).Slice(1);
             }
         }
     }

--- a/tests/System.IO.Pipelines.Tests/BackpressureTests.cs
+++ b/tests/System.IO.Pipelines.Tests/BackpressureTests.cs
@@ -56,7 +56,7 @@ namespace System.IO.Pipelines.Tests
             Assert.False(flushAsync.IsCompleted);
 
             var result = _pipe.Reader.ReadAsync().GetAwaiter().GetResult();
-            var consumed = result.Buffer.Move(result.Buffer.Start, 33);
+            var consumed = result.Buffer.Seek(result.Buffer.Start, 33);
             _pipe.Reader.Advance(consumed, consumed);
 
             Assert.True(flushAsync.IsCompleted);
@@ -74,7 +74,7 @@ namespace System.IO.Pipelines.Tests
             Assert.False(flushAsync.IsCompleted);
 
             var result = _pipe.Reader.ReadAsync().GetAwaiter().GetResult();
-            var consumed = result.Buffer.Move(result.Buffer.Start, 32);
+            var consumed = result.Buffer.Seek(result.Buffer.Start, 32);
             _pipe.Reader.Advance(consumed, consumed);
 
             Assert.False(flushAsync.IsCompleted);
@@ -119,7 +119,7 @@ namespace System.IO.Pipelines.Tests
             Assert.False(flushAsync.IsCompleted);
 
             var result = _pipe.Reader.ReadAsync().GetAwaiter().GetResult();
-            var consumed = result.Buffer.Move(result.Buffer.Start, 33);
+            var consumed = result.Buffer.Seek(result.Buffer.Start, 33);
             _pipe.Reader.Advance(consumed, consumed);
 
             Assert.True(flushAsync.IsCompleted);
@@ -142,7 +142,7 @@ namespace System.IO.Pipelines.Tests
             Assert.False(flushAsync.IsCompleted);
 
             var result = _pipe.Reader.ReadAsync().GetAwaiter().GetResult();
-            var consumed = result.Buffer.Move(result.Buffer.Start, 31);
+            var consumed = result.Buffer.Seek(result.Buffer.Start, 31);
             Assert.Throws<InvalidOperationException>(() => _pipe.Reader.Advance(consumed, result.Buffer.End));
 
             _pipe.Reader.Advance(result.Buffer.End, result.Buffer.End);

--- a/tests/System.IO.Pipelines.Tests/PipelineReaderWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/PipelineReaderWriterFacts.cs
@@ -136,7 +136,7 @@ namespace System.IO.Pipelines.Tests
 
             Assert.Equal("Hello World", Encoding.ASCII.GetString(result.Buffer.ToArray()));
 
-            _pipe.Reader.Advance(result.Buffer.Move(result.Buffer.Start, 6));
+            _pipe.Reader.Advance(result.Buffer.Seek(result.Buffer.Start, 6));
 
             result = await _pipe.Reader.ReadAsync();
 

--- a/tests/System.IO.Pipelines.Tests/SeekTests.cs
+++ b/tests/System.IO.Pipelines.Tests/SeekTests.cs
@@ -99,10 +99,10 @@ namespace System.IO.Pipelines.Tests
         public void TestSeekByteLimitWithinSameBlock(string input, char seek, int limit, int expectedBytesScanned, int expectedReturnValue)
         {
             // Arrange
-            var buffer = Factory.CreateWithContent(input);
+            var originalBuffer = Factory.CreateWithContent(input);
 
             // Act
-            buffer = limit > input.Length ? buffer : buffer.Slice(0, limit);
+            var buffer = limit > input.Length ? originalBuffer : originalBuffer.Slice(0, limit);
 
             var returnValue = buffer.Seek(out Position result, (byte)seek);
             var returnValue_1 = buffer.Seek(out result, (byte)seek, (byte)seek);
@@ -115,7 +115,7 @@ namespace System.IO.Pipelines.Tests
 
             if (expectedReturnValue != -1)
             {
-                Assert.Equal(buffer.Slice(result).ToArray(), Encoding.ASCII.GetBytes(input.Substring(expectedBytesScanned - 1)));
+                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedBytesScanned - 1)), originalBuffer.Slice(result).ToArray());
             }
         }
 
@@ -127,23 +127,21 @@ namespace System.IO.Pipelines.Tests
             // Arrange
             var afterSeek = (byte)'B';
 
-            var buffer = Factory.CreateWithContent(input);
+            var originalBuffer = Factory.CreateWithContent(input);
 
-            var start = buffer.Start;
-            var scan1 = buffer.Start;
-            var veryEnd = buffer.End;
+            var scan1 = originalBuffer.Start;
             var scan2_1 = scan1;
             var scan2_2 = scan1;
             var scan3_1 = scan1;
             var scan3_2 = scan1;
             var scan3_3 = scan1;
-            var end = buffer.End;
+            var buffer = originalBuffer;
 
             // Act
-            var endReturnValue = buffer.Seek(out end, (byte)limitAfter);
+            var endReturnValue = originalBuffer.Seek(out var end, (byte)limitAfter);
             if (endReturnValue != -1)
             {
-                buffer = buffer.Slice(end, 1);
+                buffer = originalBuffer.Slice(end).Slice(1);
             }
 
             var returnValue1 = buffer.Seek(out scan1, (byte)seek);
@@ -167,12 +165,12 @@ namespace System.IO.Pipelines.Tests
             {
                 var expectedEndIndex = input.IndexOf(seek);
 
-                Assert.Equal(buffer.Slice(scan1).ToArray(), Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)));
-                Assert.Equal(buffer.Slice(scan2_1).ToArray(), Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)));
-                Assert.Equal(buffer.Slice(scan2_2).ToArray(), Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)));
-                Assert.Equal(buffer.Slice(scan3_1).ToArray(), Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)));
-                Assert.Equal(buffer.Slice(scan3_2).ToArray(), Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)));
-                Assert.Equal(buffer.Slice(scan3_3).ToArray(), Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)));
+                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)), originalBuffer.Slice(scan1).ToArray());
+                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)), originalBuffer.Slice(scan2_1).ToArray());
+                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)), originalBuffer.Slice(scan2_2).ToArray());
+                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)), originalBuffer.Slice(scan3_1).ToArray());
+                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)), originalBuffer.Slice(scan3_2).ToArray());
+                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)), originalBuffer.Slice(scan3_3).ToArray());
             }
         }
 

--- a/tests/System.IO.Pipelines.Tests/SeekTests.cs
+++ b/tests/System.IO.Pipelines.Tests/SeekTests.cs
@@ -123,7 +123,7 @@ namespace System.IO.Pipelines.Tests
                 var expectedEndIndex = input.IndexOf(seek);
 
                 Assert.NotNull(returnValue1);
-                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)), originalBuffer.Slice(scan1).ToArray());
+                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)), originalBuffer.Slice(returnValue1.Value).ToArray());
             }
         }
 

--- a/tests/System.IO.Pipelines.Tests/SeekTests.cs
+++ b/tests/System.IO.Pipelines.Tests/SeekTests.cs
@@ -68,8 +68,6 @@ namespace System.IO.Pipelines.Tests
         public void MemorySeek(string raw, string search, char expectResult, int expectIndex)
         {
             var cursors = Factory.CreateWithContent(raw);
-            Position start = cursors.Start;
-            Position end = cursors.End;
             Position result = default;
 
             var searchFor = search.ToCharArray();
@@ -77,15 +75,15 @@ namespace System.IO.Pipelines.Tests
             int found = -1;
             if (searchFor.Length == 1)
             {
-                found = ReadOnlyBuffer.Seek(start, end, out result, (byte)searchFor[0]);
+                found = cursors.Seek(out result, (byte)searchFor[0]);
             }
             else if (searchFor.Length == 2)
             {
-                found = ReadOnlyBuffer.Seek(start, end, out result, (byte)searchFor[0], (byte)searchFor[1]);
+                found = cursors.Seek(out result, (byte)searchFor[0], (byte)searchFor[1]);
             }
             else if (searchFor.Length == 3)
             {
-                found = ReadOnlyBuffer.Seek(start, end, out result, (byte)searchFor[0], (byte)searchFor[1], (byte)searchFor[2]);
+                found = cursors.Seek(out result, (byte)searchFor[0], (byte)searchFor[1], (byte)searchFor[2]);
             }
             else
             {
@@ -104,10 +102,11 @@ namespace System.IO.Pipelines.Tests
             var buffer = Factory.CreateWithContent(input);
 
             // Act
-            var end = limit > input.Length ? buffer.End : buffer.Slice(0, limit).End;
-            var returnValue = ReadOnlyBuffer.Seek(buffer.Start, end, out Position result, (byte)seek);
-            var returnValue_1 = ReadOnlyBuffer.Seek(buffer.Start, end, out result, (byte)seek, (byte)seek);
-            var returnValue_2 = ReadOnlyBuffer.Seek(buffer.Start, end, out result, (byte)seek, (byte)seek, (byte)seek);
+            buffer = limit > input.Length ? buffer : buffer.Slice(0, limit);
+
+            var returnValue = buffer.Seek(out Position result, (byte)seek);
+            var returnValue_1 = buffer.Seek(out result, (byte)seek, (byte)seek);
+            var returnValue_2 = buffer.Seek(out result, (byte)seek, (byte)seek, (byte)seek);
 
             // Assert
             Assert.Equal(expectedReturnValue, returnValue);
@@ -141,17 +140,18 @@ namespace System.IO.Pipelines.Tests
             var end = buffer.End;
 
             // Act
-            var endReturnValue = ReadOnlyBuffer.Seek(start, veryEnd, out end, (byte)limitAfter);
+            var endReturnValue = buffer.Seek(out end, (byte)limitAfter);
             if (endReturnValue != -1)
             {
-                end = buffer.Slice(end, 1).End;
+                buffer = buffer.Slice(end, 1);
             }
-            var returnValue1 = ReadOnlyBuffer.Seek(start, end, out scan1, (byte)seek);
-            var returnValue2_1 = ReadOnlyBuffer.Seek(start, end, out scan2_1, (byte)seek, afterSeek);
-            var returnValue2_2 = ReadOnlyBuffer.Seek(start, end, out scan2_2, afterSeek, (byte)seek);
-            var returnValue3_1 = ReadOnlyBuffer.Seek(start, end, out scan3_1, (byte)seek, afterSeek, afterSeek);
-            var returnValue3_2 = ReadOnlyBuffer.Seek(start, end, out scan3_2, afterSeek, (byte)seek, afterSeek);
-            var returnValue3_3 = ReadOnlyBuffer.Seek(start, end, out scan3_3, afterSeek, afterSeek, (byte)seek);
+
+            var returnValue1 = buffer.Seek(out scan1, (byte)seek);
+            var returnValue2_1 = buffer.Seek(out scan2_1, (byte)seek, afterSeek);
+            var returnValue2_2 = buffer.Seek(out scan2_2, afterSeek, (byte)seek);
+            var returnValue3_1 = buffer.Seek(out scan3_1, (byte)seek, afterSeek, afterSeek);
+            var returnValue3_2 = buffer.Seek(out scan3_2, afterSeek, (byte)seek, afterSeek);
+            var returnValue3_3 = buffer.Seek(out scan3_3, afterSeek, afterSeek, (byte)seek);
 
 
             // Assert

--- a/tests/System.IO.Pipelines.Tests/SeekTests.cs
+++ b/tests/System.IO.Pipelines.Tests/SeekTests.cs
@@ -141,7 +141,7 @@ namespace System.IO.Pipelines.Tests
             var endReturnValue = originalBuffer.Seek(out var end, (byte)limitAfter);
             if (endReturnValue != -1)
             {
-                buffer = originalBuffer.Slice(end).Slice(1);
+                buffer = originalBuffer.Slice(buffer.Start, buffer.Move(end, 1));
             }
 
             var returnValue1 = buffer.Seek(out scan1, (byte)seek);

--- a/tests/System.IO.Pipelines.Tests/SeekTests.cs
+++ b/tests/System.IO.Pipelines.Tests/SeekTests.cs
@@ -46,52 +46,26 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Theory]
-        [InlineData("a", "a", 'a', 0)]
-        [InlineData("ab", "a", 'a', 0)]
-        [InlineData("aab", "a", 'a', 0)]
-        [InlineData("acab", "a", 'a', 0)]
-        [InlineData("acab", "c", 'c', 1)]
-        [InlineData("abcdefghijklmnopqrstuvwxyz", "lo", 'l', 11)]
-        [InlineData("abcdefghijklmnopqrstuvwxyz", "ol", 'l', 11)]
-        [InlineData("abcdefghijklmnopqrstuvwxyz", "ll", 'l', 11)]
-        [InlineData("abcdefghijklmnopqrstuvwxyz", "lmr", 'l', 11)]
-        [InlineData("abcdefghijklmnopqrstuvwxyz", "rml", 'l', 11)]
-        [InlineData("abcdefghijklmnopqrstuvwxyz", "mlr", 'l', 11)]
-        [InlineData("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", "lmr", 'l', 11)]
-        [InlineData("aaaaaaaaaaalmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", "lmr", 'l', 11)]
-        [InlineData("aaaaaaaaaaacmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", "lmr", 'm', 12)]
-        [InlineData("aaaaaaaaaaarmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", "lmr", 'r', 11)]
-        [InlineData("/localhost:5000/PATH/%2FPATH2/ HTTP/1.1", " %?", '%', 21)]
-        [InlineData("/localhost:5000/PATH/%2FPATH2/?key=value HTTP/1.1", " %?", '%', 21)]
-        [InlineData("/localhost:5000/PATH/PATH2/?key=value HTTP/1.1", " %?", '?', 27)]
-        [InlineData("/localhost:5000/PATH/PATH2/ HTTP/1.1", " %?", ' ', 27)]
-        public void MemorySeek(string raw, string search, char expectResult, int expectIndex)
+        [InlineData("a", 'a', 0)]
+        [InlineData("ab", 'a', 0)]
+        [InlineData("aab", 'a', 0)]
+        [InlineData("acab", 'a', 0)]
+        [InlineData("acab", 'c', 1)]
+        [InlineData("abcdefghijklmnopqrstuvwxyz", 'l', 11)]
+        [InlineData("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", 'l', 11)]
+        [InlineData("aaaaaaaaaaacmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", 'm', 12)]
+        [InlineData("aaaaaaaaaaarmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", 'r', 11)]
+        [InlineData("/localhost:5000/PATH/%2FPATH2/ HTTP/1.1", '%', 21)]
+        [InlineData("/localhost:5000/PATH/%2FPATH2/?key=value HTTP/1.1", '%', 21)]
+        [InlineData("/localhost:5000/PATH/PATH2/?key=value HTTP/1.1", '?', 27)]
+        [InlineData("/localhost:5000/PATH/PATH2/ HTTP/1.1", ' ', 27)]
+        public void MemorySeek(string raw, char searchFor, int expectIndex)
         {
             var cursors = Factory.CreateWithContent(raw);
-            Position result = default;
-
-            var searchFor = search.ToCharArray();
-
-            int found = -1;
-            if (searchFor.Length == 1)
-            {
-                found = cursors.Seek(out result, (byte)searchFor[0]);
-            }
-            else if (searchFor.Length == 2)
-            {
-                found = cursors.Seek(out result, (byte)searchFor[0], (byte)searchFor[1]);
-            }
-            else if (searchFor.Length == 3)
-            {
-                found = cursors.Seek(out result, (byte)searchFor[0], (byte)searchFor[1], (byte)searchFor[2]);
-            }
-            else
-            {
-                Assert.False(true, "Invalid test sample.");
-            }
-
-            Assert.Equal(expectResult, found);
-            Assert.Equal(cursors.Slice(result).ToArray(), Encoding.ASCII.GetBytes(raw.Substring(expectIndex)));
+            var result = cursors.PositionOf((byte)searchFor);
+            
+            Assert.NotNull(result);
+            Assert.Equal(cursors.Slice(result.Value).ToArray(), Encoding.ASCII.GetBytes(raw.Substring(expectIndex)));
         }
 
         [Theory]
@@ -104,18 +78,21 @@ namespace System.IO.Pipelines.Tests
             // Act
             var buffer = limit > input.Length ? originalBuffer : originalBuffer.Slice(0, limit);
 
-            var returnValue = buffer.Seek(out Position result, (byte)seek);
-            var returnValue_1 = buffer.Seek(out result, (byte)seek, (byte)seek);
-            var returnValue_2 = buffer.Seek(out result, (byte)seek, (byte)seek, (byte)seek);
+            var result = buffer.PositionOf((byte) seek);
 
             // Assert
-            Assert.Equal(expectedReturnValue, returnValue);
-            Assert.Equal(expectedReturnValue, returnValue_1);
-            Assert.Equal(expectedReturnValue, returnValue_2);
+            if (expectedReturnValue == -1)
+            {
+                Assert.Null(result);
+            }
+            else
+            {
+                Assert.NotNull(result);
+            }
 
             if (expectedReturnValue != -1)
             {
-                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedBytesScanned - 1)), originalBuffer.Slice(result).ToArray());
+                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedBytesScanned - 1)), originalBuffer.Slice(result.Value).ToArray());
             }
         }
 
@@ -123,54 +100,30 @@ namespace System.IO.Pipelines.Tests
         [MemberData(nameof(SeekIteratorLimitData))]
         public void TestSeekIteratorLimitWithinSameBlock(string input, char seek, char limitAfter, int expectedReturnValue)
         {
-
-            // Arrange
-            var afterSeek = (byte)'B';
-
             var originalBuffer = Factory.CreateWithContent(input);
 
             var scan1 = originalBuffer.Start;
-            var scan2_1 = scan1;
-            var scan2_2 = scan1;
-            var scan3_1 = scan1;
-            var scan3_2 = scan1;
-            var scan3_3 = scan1;
             var buffer = originalBuffer;
 
             // Act
-            var endReturnValue = originalBuffer.Seek(out var end, (byte)limitAfter);
-            if (endReturnValue != -1)
+            var end = originalBuffer.PositionOf((byte)limitAfter);
+            if (end.HasValue)
             {
-                buffer = originalBuffer.Slice(buffer.Start, buffer.Move(end, 1));
+                buffer = originalBuffer.Slice(buffer.Start, buffer.Seek(end.Value, 1));
             }
 
-            var returnValue1 = buffer.Seek(out scan1, (byte)seek);
-            var returnValue2_1 = buffer.Seek(out scan2_1, (byte)seek, afterSeek);
-            var returnValue2_2 = buffer.Seek(out scan2_2, afterSeek, (byte)seek);
-            var returnValue3_1 = buffer.Seek(out scan3_1, (byte)seek, afterSeek, afterSeek);
-            var returnValue3_2 = buffer.Seek(out scan3_2, afterSeek, (byte)seek, afterSeek);
-            var returnValue3_3 = buffer.Seek(out scan3_3, afterSeek, afterSeek, (byte)seek);
+            var returnValue1 = buffer.PositionOf((byte)seek);
 
 
             // Assert
-            Assert.Equal(input.Contains(limitAfter) ? limitAfter : -1, endReturnValue);
-            Assert.Equal(expectedReturnValue, returnValue1);
-            Assert.Equal(expectedReturnValue, returnValue2_1);
-            Assert.Equal(expectedReturnValue, returnValue2_2);
-            Assert.Equal(expectedReturnValue, returnValue3_1);
-            Assert.Equal(expectedReturnValue, returnValue3_2);
-            Assert.Equal(expectedReturnValue, returnValue3_3);
-
+            Assert.Equal(input.Contains(limitAfter), end.HasValue);
+            
             if (expectedReturnValue != -1)
             {
                 var expectedEndIndex = input.IndexOf(seek);
 
+                Assert.NotNull(returnValue1);
                 Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)), originalBuffer.Slice(scan1).ToArray());
-                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)), originalBuffer.Slice(scan2_1).ToArray());
-                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)), originalBuffer.Slice(scan2_2).ToArray());
-                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)), originalBuffer.Slice(scan3_1).ToArray());
-                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)), originalBuffer.Slice(scan3_2).ToArray());
-                Assert.Equal(Encoding.ASCII.GetBytes(input.Substring(expectedEndIndex)), originalBuffer.Slice(scan3_3).ToArray());
             }
         }
 

--- a/tests/System.IO.Pipelines.Tests/WritableBufferWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/WritableBufferWriterFacts.cs
@@ -39,7 +39,7 @@ namespace System.IO.Pipelines.Tests
         public void ExposesSpan()
         {
             _buffer = _pipe.Writer.Alloc(1);
-            var writer = new WritableBufferWriter(_buffer);
+            var writer = new OutputWriter<>(_buffer);
             Assert.Equal(_buffer.Buffer.Length, writer.Span.Length);
             Assert.Equal(new byte[] { }, Read());
         }
@@ -50,7 +50,7 @@ namespace System.IO.Pipelines.Tests
             _buffer = _pipe.Writer.Alloc(1);
             var initialLength = _buffer.Buffer.Length;
 
-            var writer = new WritableBufferWriter(_buffer);
+            var writer = new OutputWriter<>(_buffer);
 
             writer.Write(new byte[] { 1, 2, 3 });
 
@@ -71,7 +71,7 @@ namespace System.IO.Pipelines.Tests
             _buffer = _pipe.Writer.Alloc(1);
             var initialLength = _buffer.Buffer.Length;
 
-            var writer = new WritableBufferWriter(_buffer);
+            var writer = new OutputWriter<>(_buffer);
             var array = new byte[arrayLength];
             for (int i = 0; i < array.Length; i++)
             {
@@ -108,7 +108,7 @@ namespace System.IO.Pipelines.Tests
         {
             _buffer = _pipe.Writer.Alloc(alloc);
 
-            var writer = new WritableBufferWriter(_buffer);
+            var writer = new OutputWriter<>(_buffer);
             var array = new byte[] { 1, 2, 3 };
 
             writer.Write(array, offset, length);
@@ -120,7 +120,7 @@ namespace System.IO.Pipelines.Tests
         public void CanWriteIntoHeadlessBuffer()
         {
             _buffer = _pipe.Writer.Alloc();
-            var writer = new WritableBufferWriter(_buffer);
+            var writer = new OutputWriter<>(_buffer);
 
             writer.Write(new byte[] { 1, 2, 3 });
             Assert.Equal(new byte[] { 1, 2, 3 }, Read());
@@ -130,7 +130,7 @@ namespace System.IO.Pipelines.Tests
         public void CanWriteMultipleTimes()
         {
             _buffer = _pipe.Writer.Alloc();
-            var writer = new WritableBufferWriter(_buffer);
+            var writer = new OutputWriter<>(_buffer);
 
             writer.Write(new byte[] { 1 });
             writer.Write(new byte[] { 2 });
@@ -143,7 +143,7 @@ namespace System.IO.Pipelines.Tests
         public void CanWriteEmpty()
         {
             _buffer = _pipe.Writer.Alloc();
-            var writer = new WritableBufferWriter(_buffer);
+            var writer = new OutputWriter<>(_buffer);
             var array = new byte[] { };
 
             writer.Write(array);
@@ -156,7 +156,7 @@ namespace System.IO.Pipelines.Tests
         public void CanWriteOverTheBlockLength()
         {
             _buffer = _pipe.Writer.Alloc(1);
-            var writer = new WritableBufferWriter(_buffer);
+            var writer = new OutputWriter<>(_buffer);
 
             var source = Enumerable.Range(0, _buffer.Buffer.Length).Select(i => (byte)i);
             var expectedBytes = source.Concat(source).Concat(source).ToArray();
@@ -170,7 +170,7 @@ namespace System.IO.Pipelines.Tests
         public void EnsureAllocatesSpan()
         {
             _buffer = _pipe.Writer.Alloc();
-            var writer = new WritableBufferWriter(_buffer);
+            var writer = new OutputWriter<>(_buffer);
             writer.Ensure(10);
 
             Assert.True(writer.Span.Length > 10);

--- a/tests/System.IO.Pipelines.Tests/WritableBufferWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Tests/WritableBufferWriterFacts.cs
@@ -39,7 +39,7 @@ namespace System.IO.Pipelines.Tests
         public void ExposesSpan()
         {
             _buffer = _pipe.Writer.Alloc(1);
-            var writer = new OutputWriter<>(_buffer);
+            var writer = OutputWriter.Create(_buffer);
             Assert.Equal(_buffer.Buffer.Length, writer.Span.Length);
             Assert.Equal(new byte[] { }, Read());
         }
@@ -50,7 +50,7 @@ namespace System.IO.Pipelines.Tests
             _buffer = _pipe.Writer.Alloc(1);
             var initialLength = _buffer.Buffer.Length;
 
-            var writer = new OutputWriter<>(_buffer);
+            var writer = OutputWriter.Create(_buffer);
 
             writer.Write(new byte[] { 1, 2, 3 });
 
@@ -71,7 +71,7 @@ namespace System.IO.Pipelines.Tests
             _buffer = _pipe.Writer.Alloc(1);
             var initialLength = _buffer.Buffer.Length;
 
-            var writer = new OutputWriter<>(_buffer);
+            var writer = OutputWriter.Create(_buffer);
             var array = new byte[arrayLength];
             for (int i = 0; i < array.Length; i++)
             {
@@ -108,7 +108,7 @@ namespace System.IO.Pipelines.Tests
         {
             _buffer = _pipe.Writer.Alloc(alloc);
 
-            var writer = new OutputWriter<>(_buffer);
+            var writer = OutputWriter.Create(_buffer);
             var array = new byte[] { 1, 2, 3 };
 
             writer.Write(array, offset, length);
@@ -120,7 +120,7 @@ namespace System.IO.Pipelines.Tests
         public void CanWriteIntoHeadlessBuffer()
         {
             _buffer = _pipe.Writer.Alloc();
-            var writer = new OutputWriter<>(_buffer);
+            var writer = OutputWriter.Create(_buffer);
 
             writer.Write(new byte[] { 1, 2, 3 });
             Assert.Equal(new byte[] { 1, 2, 3 }, Read());
@@ -130,7 +130,7 @@ namespace System.IO.Pipelines.Tests
         public void CanWriteMultipleTimes()
         {
             _buffer = _pipe.Writer.Alloc();
-            var writer = new OutputWriter<>(_buffer);
+            var writer = OutputWriter.Create(_buffer);
 
             writer.Write(new byte[] { 1 });
             writer.Write(new byte[] { 2 });
@@ -143,7 +143,7 @@ namespace System.IO.Pipelines.Tests
         public void CanWriteEmpty()
         {
             _buffer = _pipe.Writer.Alloc();
-            var writer = new OutputWriter<>(_buffer);
+            var writer = OutputWriter.Create(_buffer);
             var array = new byte[] { };
 
             writer.Write(array);
@@ -156,7 +156,7 @@ namespace System.IO.Pipelines.Tests
         public void CanWriteOverTheBlockLength()
         {
             _buffer = _pipe.Writer.Alloc(1);
-            var writer = new OutputWriter<>(_buffer);
+            var writer = OutputWriter.Create(_buffer);
 
             var source = Enumerable.Range(0, _buffer.Buffer.Length).Select(i => (byte)i);
             var expectedBytes = source.Concat(source).Concat(source).ToArray();
@@ -170,7 +170,7 @@ namespace System.IO.Pipelines.Tests
         public void EnsureAllocatesSpan()
         {
             _buffer = _pipe.Writer.Alloc();
-            var writer = new OutputWriter<>(_buffer);
+            var writer = OutputWriter.Create(_buffer);
             writer.Ensure(10);
 
             Assert.True(writer.Span.Length > 10);

--- a/tests/System.Text.Http.Parser.Tests/HttpParserBasicTests.cs
+++ b/tests/System.Text.Http.Parser.Tests/HttpParserBasicTests.cs
@@ -49,7 +49,7 @@ namespace System.Text.Http.Parser.Tests
                 var frontBytes = Encoding.ASCII.GetBytes(front);
                 var endBytes = Encoding.ASCII.GetBytes(back);
 
-                var (first, last) = MemoryList.Create(frontBytes, endBytes);
+                var (first, last) = BufferList.Create(frontBytes, endBytes);
                 ReadOnlyBytes buffer = new ReadOnlyBytes(first, last);
 
                 var request = new Request();


### PR DESCRIPTION
1. Make `ReadOnlyBuffer(Position, Position)` private.
2. Rename `IMemoryList<T>` to `IBufferList`.
3. Remove `CreatePosition` from `Enumerable`.
4. Remove multi-byte seek methods
5. Rename `Seek` to `PositionOf` and change signature.
6. Rename `Move` to `Seek`
7. Add `ReadOnlyBuffer(IEnumerable<Memory<byte>>)` constructor 