### PR TITLE
Public sequence, long ConsumedBytes

### DIFF
--- a/src/System.Buffers.Primitives/System/Buffers/Class1.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/Class1.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Buffers
+{
+    public static class ReadOnlyBufferReaderExtensions
+    {
+        public static ReadOnlyBuffer SliceBefore(this BufferReader<ReadOnlyBuffer> reader)
+        {
+            return reader.Sequence.Slice(reader.Sequence.Start, reader.Position);
+        }
+
+        public static ReadOnlyBuffer SliceAfter(this BufferReader<ReadOnlyBuffer> reader)
+        {
+            return reader.Sequence.Slice(reader.Position);
+        }
+    }
+}

--- a/src/System.Text.Http.Parser/HttpParser.cs
+++ b/src/System.Text.Http.Parser/HttpParser.cs
@@ -356,7 +356,7 @@ namespace System.Text.Http.Parser
             finally
             {
                 consumed = reader.Position;
-                consumedBytes = reader.ConsumedBytes;
+                consumedBytes = (int)reader.ConsumedBytes;
 
                 if (done)
                 {

--- a/tests/Benchmarks/BytesReaderBench.cs
+++ b/tests/Benchmarks/BytesReaderBench.cs
@@ -84,7 +84,7 @@ public class BytesReaderBench
 
             using (iteration.StartMeasurement())
             {
-                while(Utf8Parser.TryParse(reader.Span.Slice(reader.ConsumedBytes), out int value, out int consumed)){
+                while(Utf8Parser.TryParse(reader.Span.Slice((int)reader.ConsumedBytes), out int value, out int consumed)){
                     reader.Skip(consumed + 1);
                 }
             }

--- a/tests/System.Buffers.Primitives.Tests/ReadableBufferReaderFacts.cs
+++ b/tests/System.Buffers.Primitives.Tests/ReadableBufferReaderFacts.cs
@@ -84,6 +84,34 @@ namespace System.IO.Pipelines.Tests
             reader.Take();
             Assert.True(reader.End);
         }
+        
+        [Fact]
+        public void SliceAftereWorks()
+        {
+            var reader = BufferReader.Create(Factory.CreateWithContent(new byte[] { 1, 2, 3, 4, 5 }));
+            var b1 = reader.Take();
+            var b2 = reader.Take();
+            var b3 = reader.Take();
+
+            Assert.Equal(1, b1);
+            Assert.Equal(2, b2);
+            Assert.Equal(3, b3);
+            Assert.Equal(new byte[] { 4, 5 }, reader.SliceAfter().ToArray());
+        }
+
+        [Fact]
+        public void SliceBeforeWorks()
+        {
+            var reader = BufferReader.Create(Factory.CreateWithContent(new byte[] { 1, 2, 3, 4, 5 }));
+            var b1 = reader.Take();
+            var b2 = reader.Take();
+            var b3 = reader.Take();
+
+            Assert.Equal(1, b1);
+            Assert.Equal(2, b2);
+            Assert.Equal(3, b3);
+            Assert.Equal(new byte[] { 1, 2, 3 }, reader.SliceBefore().ToArray());
+        }
 
         [Fact]
         public void CursorIsCorrectWithEmptyLastBlock()


### PR DESCRIPTION
Public `Sequence` allows some nice extension methods on `BufferReader` for example `SliceToEnd()`

https://github.com/dotnet/corefxlab/issues/2019