### PR TITLE
Scheduler improvements

### DIFF
--- a/src/System.IO.Pipelines.Networking.Sockets/SocketConnection.cs
+++ b/src/System.IO.Pipelines.Networking.Sockets/SocketConnection.cs
@@ -86,8 +86,8 @@ namespace System.IO.Pipelines.Networking.Sockets
 
             // TODO: Make this configurable
             // Dispatch to avoid deadlocks
-            _input = new Pipe(new PipeOptions(pool, Scheduler.TaskRun, Scheduler.TaskRun));
-            _output = new Pipe(new PipeOptions(pool, Scheduler.TaskRun, Scheduler.TaskRun));
+            _input = new Pipe(new PipeOptions(pool, Scheduler.ThreadPool, Scheduler.ThreadPool));
+            _output = new Pipe(new PipeOptions(pool, Scheduler.ThreadPool, Scheduler.ThreadPool));
 
             _receiveTask = ReceiveFromSocketAndPushToWriterAsync();
             _sendTask = ReadFromReaderAndWriteToSocketAsync();

--- a/src/System.IO.Pipelines/System.IO.Pipelines.csproj
+++ b/src/System.IO.Pipelines/System.IO.Pipelines.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>An abstraction for doing efficient asynchronous IO</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFrameworks>netstandard1.1;netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>
     <!--<DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);BLOCK_LEASE_TRACKING</DefineConstants>-->

--- a/src/System.IO.Pipelines/System/Threading/InlineScheduler.cs
+++ b/src/System.IO.Pipelines/System/Threading/InlineScheduler.cs
@@ -4,7 +4,7 @@
 
 namespace System.Threading
 {
-    internal class InlineScheduler : Scheduler
+    internal sealed class InlineScheduler : Scheduler
     {
         public override void Schedule(Action action)
         {

--- a/src/System.IO.Pipelines/System/Threading/Scheduler.cs
+++ b/src/System.IO.Pipelines/System/Threading/Scheduler.cs
@@ -5,8 +5,11 @@ namespace System.Threading
 {
     public abstract class Scheduler
     {
-        public static Scheduler TaskRun { get; } = new TaskRunScheduler();
-        public static Scheduler Inline { get; } = new InlineScheduler();
+        private static TaskRunScheduler _taskRunScheduler = new TaskRunScheduler();
+        private static InlineScheduler _inlineScheduler = new InlineScheduler();
+
+        public static Scheduler TaskRun => _taskRunScheduler;
+        public static Scheduler Inline => _inlineScheduler;
         
         public abstract void Schedule(Action action);
         public abstract void Schedule(Action<object> action, object state);

--- a/src/System.IO.Pipelines/System/Threading/Scheduler.cs
+++ b/src/System.IO.Pipelines/System/Threading/Scheduler.cs
@@ -5,10 +5,10 @@ namespace System.Threading
 {
     public abstract class Scheduler
     {
-        private static TaskRunScheduler _taskRunScheduler = new TaskRunScheduler();
+        private static ThreadPoolScheduler _threadPoolScheduler = new ThreadPoolScheduler();
         private static InlineScheduler _inlineScheduler = new InlineScheduler();
 
-        public static Scheduler TaskRun => _taskRunScheduler;
+        public static Scheduler ThreadPool => _threadPoolScheduler;
         public static Scheduler Inline => _inlineScheduler;
         
         public abstract void Schedule(Action action);

--- a/src/System.IO.Pipelines/System/Threading/TaskRunScheduler.cs
+++ b/src/System.IO.Pipelines/System/Threading/TaskRunScheduler.cs
@@ -10,12 +10,74 @@ namespace System.Threading
     {
         public override void Schedule(Action action)
         {
+#if NETCOREAPP2_1
+            // Queue to low contention local ThreadPool queue; rather than global queue as per Task
+            ThreadPool.QueueUserWorkItem(_actionAsTask, action, preferLocal: true);
+#elif NETSTANDARD2_0
+            ThreadPool.QueueUserWorkItem(_actionAsTask, action);
+#else
             Task.Factory.StartNew(action);
+#endif
         }
 
         public override void Schedule(Action<object> action, object state)
         {
+#if NETCOREAPP2_1
+            // Queue to low contention local ThreadPool queue; rather than global queue as per Task
+            ThreadPool.QueueUserWorkItem(_actionObjectAsTask, new ActionObjectAsTask(action, state), preferLocal: true);
+#elif NETSTANDARD2_0
+            ThreadPool.QueueUserWorkItem(_actionObjectAsTask, new ActionObjectAsTask(action, state));
+#else
             Task.Factory.StartNew(action, state);
+#endif
         }
+
+#if NETCOREAPP2_1 || NETSTANDARD2_0
+        // Catches only the exception into a failed Task, so the fire-and-forget action 
+        // can be queued directly to the ThreadPool without the extra overhead of as Task
+        private readonly static WaitCallback _actionAsTask = state =>
+        {
+            try
+            {
+                ((Action)state)();
+            }
+            catch (Exception ex)
+            {
+                // Create faulted Task for the TaskScheulder to handle exception
+                // rather than letting it escape onto the ThreadPool and crashing the process
+                Task.FromException(ex);
+            }
+        };
+
+        private readonly static WaitCallback _actionObjectAsTask = state => ((ActionObjectAsTask)state).Run();
+
+        private sealed class ActionObjectAsTask
+        {
+            private Action<object> _action;
+            private object _state;
+
+            public ActionObjectAsTask(Action<object> action, object state)
+            {
+                _action = action;
+                _state = state;
+            }
+
+            // Catches only the exception into a failed Task, so the fire-and-forget action 
+            // can be queued directly to the ThreadPool without the extra overhead of as Task
+            public void Run()
+            {
+                try
+                {
+                    _action(_state);
+                }
+                catch (Exception ex)
+                {
+                    // Create faulted Task for the TaskScheulder to handle exception
+                    // rather than letting it escape onto the ThreadPool and crashing the process
+                    Task.FromException(ex);
+                }
+            }
+        }
+#endif
     }
 }

--- a/src/System.IO.Pipelines/System/Threading/TaskRunScheduler.cs
+++ b/src/System.IO.Pipelines/System/Threading/TaskRunScheduler.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace System.Threading
 {
-    internal class TaskRunScheduler : Scheduler
+    internal sealed class TaskRunScheduler : Scheduler
     {
         public override void Schedule(Action action)
         {

--- a/src/System.IO.Pipelines/System/Threading/ThreadPoolScheduler.cs
+++ b/src/System.IO.Pipelines/System/Threading/ThreadPoolScheduler.cs
@@ -6,15 +6,15 @@ using System.Threading.Tasks;
 
 namespace System.Threading
 {
-    internal sealed class TaskRunScheduler : Scheduler
+    internal sealed class ThreadPoolScheduler : Scheduler
     {
         public override void Schedule(Action action)
         {
 #if NETCOREAPP2_1
             // Queue to low contention local ThreadPool queue; rather than global queue as per Task
-            ThreadPool.QueueUserWorkItem(_actionAsTask, action, preferLocal: true);
+            Threading.ThreadPool.QueueUserWorkItem(_actionAsTask, action, preferLocal: true);
 #elif NETSTANDARD2_0
-            ThreadPool.QueueUserWorkItem(_actionAsTask, action);
+            Threading.ThreadPool.QueueUserWorkItem(_actionAsTask, action);
 #else
             Task.Factory.StartNew(action);
 #endif
@@ -24,9 +24,9 @@ namespace System.Threading
         {
 #if NETCOREAPP2_1
             // Queue to low contention local ThreadPool queue; rather than global queue as per Task
-            ThreadPool.QueueUserWorkItem(_actionObjectAsTask, new ActionObjectAsTask(action, state), preferLocal: true);
+            Threading.ThreadPool.QueueUserWorkItem(_actionObjectAsTask, new ActionObjectAsTask(action, state), preferLocal: true);
 #elif NETSTANDARD2_0
-            ThreadPool.QueueUserWorkItem(_actionObjectAsTask, new ActionObjectAsTask(action, state));
+            Threading.ThreadPool.QueueUserWorkItem(_actionObjectAsTask, new ActionObjectAsTask(action, state));
 #else
             Task.Factory.StartNew(action, state);
 #endif


### PR DESCRIPTION
Scheduler Devirtualization
* Seal internal types `TaskRunScheduler` and `InlineScheduler`
* Maintain shared `TaskRunScheduler` and `InlineScheduler` in derived typed members; rather than base type
* Expose via base type property that will devirtualize on inlining when the Jit sees the derived types (as type is maintained above, and derived type is sealed) https://github.com/dotnet/coreclr/pull/15766

Resolves: https://github.com/dotnet/corefxlab/issues/2027

Fast Fire-and-Forget Tasks for `TaskRunScheduler`
* Queue directly to `ThreadPool`; when available, rather than have the extra overhead of a `Task` which is ignored.
* On netcoreapp2.1 use `QueueUserWorkItem(preferLocal: true)` which is lower contention and more closely matches `Task` behaviour dotnet/corefx#12442
* If the `Action` fails create a failed `Task` so it can be captured as an unobserved task exception as per `Task.Run`

Resolves: https://github.com/dotnet/corefxlab/issues/2002

Rename TaskRun -> ThreadPool https://github.com/dotnet/corefxlab/pull/2026#pullrequestreview-87068486

/cc @davidfowl @pakrym
  
  
  
  