### PR TITLE
Responded to API review feedback 

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/BufferSequence.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/BufferSequence.cs
@@ -33,9 +33,9 @@ namespace Microsoft.Net
 
         public int WrittenByteCount => _written;
 
-        public long VirtualIndex => throw new NotImplementedException();
+        public long RunningIndex => throw new NotImplementedException();
 
-        public Position First => new Position(this, 0);
+        public SequencePosition First => new SequencePosition(this, 0);
 
         public int CopyTo(Span<byte> buffer)
         {
@@ -48,7 +48,7 @@ namespace Microsoft.Net
             return buffer.Length;
         }
 
-        public bool TryGet(ref Position position, out Memory<byte> item, bool advance = true)
+        public bool TryGet(ref SequencePosition position, out Memory<byte> item, bool advance = true)
         {
             if (position == default) {
                 item = default;
@@ -57,11 +57,11 @@ namespace Microsoft.Net
 
             var (buffer, index) = position.Get<BufferSequence>();
             item = buffer.Memory.Slice(index, buffer._written - index);
-            if (advance) { position = new Position(buffer._next, 0); }
+            if (advance) { position = new SequencePosition(buffer._next, 0); }
             return true;
         }
 
-        public bool TryGet(ref Position position, out ReadOnlyMemory<byte> item, bool advance = true)
+        public bool TryGet(ref SequencePosition position, out ReadOnlyMemory<byte> item, bool advance = true)
         {
             if (position == default)
             {
@@ -71,7 +71,7 @@ namespace Microsoft.Net
 
             var (buffer, index) = position.Get<BufferSequence>();
             item = buffer.WrittenMemory.Slice(index);
-            if (advance) { position = new Position(buffer._next, 0); }
+            if (advance) { position = new SequencePosition(buffer._next, 0); }
             return true;
         }
 

--- a/samples/System.IO.Pipelines.Samples/Framing/Codec.cs
+++ b/samples/System.IO.Pipelines.Samples/Framing/Codec.cs
@@ -118,7 +118,7 @@ namespace System.IO.Pipelines.Samples.Framing
     {
         public bool TryDecode(ref ReadOnlyBuffer<byte> input, out Line frame)
         {
-            if (input.TrySliceTo((byte)'\r', (byte)'\n', out ReadOnlyBuffer<byte> slice, out Position cursor))
+            if (input.TrySliceTo((byte)'\r', (byte)'\n', out ReadOnlyBuffer<byte> slice, out SequencePosition cursor))
             {
                 frame = new Line { Data = slice.GetUtf8Span() };
                 input = input.Slice(cursor).Slice(1);

--- a/samples/System.IO.Pipelines.Samples/HttpClient/PipelineHttpClientHandler.cs
+++ b/samples/System.IO.Pipelines.Samples/HttpClient/PipelineHttpClientHandler.cs
@@ -106,7 +106,7 @@ namespace System.IO.Pipelines.Samples
                     {
                         break;
                     }
-                    if (!responseBuffer.TrySliceTo((byte)'\r', (byte)'\n', out ReadOnlyBuffer<byte> responseLine, out Position delim))
+                    if (!responseBuffer.TrySliceTo((byte)'\r', (byte)'\n', out ReadOnlyBuffer<byte> responseLine, out SequencePosition delim))
                     {
                         continue;
                     }
@@ -285,7 +285,7 @@ namespace System.IO.Pipelines.Samples
         {
             public Task<IPipeConnection> ConnectionTask { get; set; }
             public int PreviousContentLength { get; set; }
-            public Position Consumed { get; set; }
+            public SequencePosition Consumed { get; set; }
         }
     }
 }

--- a/samples/System.IO.Pipelines.Samples/HttpServer/FormReader.cs
+++ b/samples/System.IO.Pipelines.Samples/HttpServer/FormReader.cs
@@ -32,7 +32,7 @@ namespace System.IO.Pipelines.Samples.Http
             while (!buffer.IsEmpty && _contentLength > 0)
             {
                 var next = buffer;
-                if (!next.TrySliceTo((byte)'=', out ReadOnlyBuffer<byte> key, out Position delim))
+                if (!next.TrySliceTo((byte)'=', out ReadOnlyBuffer<byte> key, out SequencePosition delim))
                 {
                     break;
                 }

--- a/samples/System.IO.Pipelines.Samples/HttpServer/HttpRequestParser.cs
+++ b/samples/System.IO.Pipelines.Samples/HttpServer/HttpRequestParser.cs
@@ -23,14 +23,14 @@ namespace System.IO.Pipelines.Samples
 
         public RequestHeaderDictionary RequestHeaders = new RequestHeaderDictionary();
 
-        public ParseResult ParseRequest(ReadOnlyBuffer<byte> buffer, out Position consumed, out Position examined)
+        public ParseResult ParseRequest(ReadOnlyBuffer<byte> buffer, out SequencePosition consumed, out SequencePosition examined)
         {
             consumed = buffer.Start;
             examined = buffer.Start;
 
             if (_state == ParsingState.StartLine)
             {
-                if (!buffer.TrySliceTo((byte)'\r', (byte)'\n', out ReadOnlyBuffer<byte> startLine, out Position delim))
+                if (!buffer.TrySliceTo((byte)'\r', (byte)'\n', out ReadOnlyBuffer<byte> startLine, out SequencePosition delim))
                 {
                     return ParseResult.Incomplete;
                 }
@@ -77,7 +77,7 @@ namespace System.IO.Pipelines.Samples
             while (!buffer.IsEmpty)
             {
                 var headerValue = default(ReadOnlyBuffer<byte>);
-                if (!buffer.TrySliceTo((byte)'\r', (byte)'\n', out ReadOnlyBuffer<byte> headerPair, out Position delim))
+                if (!buffer.TrySliceTo((byte)'\r', (byte)'\n', out ReadOnlyBuffer<byte> headerPair, out SequencePosition delim))
                 {
                     return ParseResult.Incomplete;
                 }

--- a/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferExtensions.cs
@@ -50,13 +50,13 @@ namespace System.Buffers
             return copied;
         }
 
-        public static Position? PositionOf(this IBufferList<byte> list, byte value)
+        public static SequencePosition? PositionOf(this IBufferList<byte> list, byte value)
         {
             while (list != null)
             {
                 var current = list.Memory.Span;
                 var index = current.IndexOf(value);
-                if (index != -1) return new Position(list, index);
+                if (index != -1) return new SequencePosition(list, index);
                 list = list.Next;
             }
             return null;
@@ -135,7 +135,7 @@ namespace System.Buffers
             ReadOnlySpan<byte> remainder = stackalloc byte[0];
             Span<byte> stackSpan = stackalloc byte[stackLength];
 
-            Position poisition = default;
+            SequencePosition poisition = default;
             while (source.TryGet(ref poisition, out var sourceBuffer))
             {
                 Span<byte> outputSpan = destination.GetSpan();

--- a/src/System.Buffers.Experimental/System/Buffers/BufferReader_search.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferReader_search.cs
@@ -7,7 +7,7 @@ namespace System.Buffers
 {
     public interface ISlicable
     {
-        ReadOnlyBuffer<byte> Slice(Position start, Position end);
+        ReadOnlyBuffer<byte> Slice(SequencePosition start, SequencePosition end);
     }
 
     // TODO: the TryReadUntill methods are very inneficient. We need to fix that.
@@ -20,7 +20,7 @@ namespace System.Buffers
             var start = reader.Position;
             while (!reader.End)
             {
-                Position end = reader.Position;
+                SequencePosition end = reader.Position;
                 if (reader.Take() == delimiter)
                 {
                     bytes = reader.Sequence.Slice(start, end);

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/BufferList.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/BufferList.cs
@@ -37,14 +37,14 @@ namespace System.Buffers
 
         public IBufferList<byte> Next => _next;
 
-        public long VirtualIndex => _virtualIndex;
+        public long RunningIndex => _virtualIndex;
 
-        public Position First => new Position(this, 0);
+        public SequencePosition First => new SequencePosition(this, 0);
 
         public int CopyTo(Span<byte> buffer)
         {
             int copied = 0;
-            Position position = default;
+            SequencePosition position = default;
             var free = buffer;
             while (TryGet(ref position, out ReadOnlyMemory<byte> segment, true))
             {
@@ -64,14 +64,14 @@ namespace System.Buffers
             return copied;
         }
 
-        public bool TryGet(ref Position position, out ReadOnlyMemory<byte> item, bool advance = true)
+        public bool TryGet(ref SequencePosition position, out ReadOnlyMemory<byte> item, bool advance = true)
         {
             var result = TryGet(ref position, out Memory<byte> memory, advance);
             item = memory;
             return result;
         }
 
-        public bool TryGet(ref Position position, out Memory<byte> item, bool advance = true)
+        public bool TryGet(ref SequencePosition position, out Memory<byte> item, bool advance = true)
         {
             if (position == default)
             {
@@ -81,7 +81,7 @@ namespace System.Buffers
             
             var (list, index) = position.Get<BufferList>();
             item = list._data.Slice(index);
-            if (advance) { position = new Position(list._next, 0); }
+            if (advance) { position = new SequencePosition(list._next, 0); }
             return true;
         }
 

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadWriteBytes.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/ReadWriteBytes.cs
@@ -50,7 +50,7 @@ namespace System.Buffers
             Validate();
         }
 
-        public ReadWriteBytes(Position first, Position last)
+        public ReadWriteBytes(SequencePosition first, SequencePosition last)
         {
             (_start, _startIndex) = first.Get<object>();
             (_end, _endIndex) = last.Get<object>();
@@ -130,7 +130,7 @@ namespace System.Buffers
         public ReadWriteBytes Slice(int index)
             => Slice((long)index);
 
-        public ReadWriteBytes Slice(Position position)
+        public ReadWriteBytes Slice(SequencePosition position)
         {
             var kind = Kind;
             switch (kind)
@@ -139,12 +139,12 @@ namespace System.Buffers
                     var (array, index) = position.Get<byte[]>();
                     return new ReadWriteBytes(array, index, array.Length - index);
                 case Type.MemoryList:
-                    return Slice(position, new Position((IBufferList<byte>)_end, _endIndex));
+                    return Slice(position, new SequencePosition((IBufferList<byte>)_end, _endIndex));
                 default: throw new NotImplementedException();
             }
         }
 
-        public ReadWriteBytes Slice(Position start, Position end)
+        public ReadWriteBytes Slice(SequencePosition start, SequencePosition end)
         {
             var kind = Kind;
             switch (kind)
@@ -199,7 +199,7 @@ namespace System.Buffers
                     case Type.MemoryList:
                         var sl = (IBufferList<byte>)_start;
                         var el = (IBufferList<byte>)_end;
-                        return (el.VirtualIndex + _endIndex) - (sl.VirtualIndex + _startIndex);
+                        return (el.RunningIndex + _endIndex) - (sl.RunningIndex + _startIndex);
                     default:
                         throw new NotImplementedException();
                 }
@@ -233,7 +233,7 @@ namespace System.Buffers
             }
         }
 
-        public Position Start => new Position(_start, _startIndex);
+        public SequencePosition Start => new SequencePosition(_start, _startIndex);
 
         public int CopyTo(Span<byte> buffer)
         {
@@ -267,7 +267,7 @@ namespace System.Buffers
             return array;
         }
 
-        public bool TryGet(ref Position position, out Memory<byte> item, bool advance = true)
+        public bool TryGet(ref SequencePosition position, out Memory<byte> item, bool advance = true)
         {
             if (position == default)
             {
@@ -296,7 +296,7 @@ namespace System.Buffers
                 }
                 else
                 {
-                    if (advance) position = new Position(node.Next, 0);
+                    if (advance) position = new SequencePosition(node.Next, 0);
                 }
                 return true;
             }
@@ -304,7 +304,7 @@ namespace System.Buffers
             throw new NotImplementedException();
         }
 
-        public Position Seek(Position origin, long offset)
+        public SequencePosition Seek(SequencePosition origin, long offset)
         {
             if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset));
 
@@ -320,7 +320,7 @@ namespace System.Buffers
                 else
                 {
                     var (segment, index) = origin.Get<IBufferList<byte>>();
-                    return new Position(segment, (int)(index + offset));
+                    return new SequencePosition(segment, (int)(index + offset));
                 }
             }
             throw new ArgumentOutOfRangeException(nameof(offset));

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/SequenceExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/SequenceExtensions.cs
@@ -11,7 +11,7 @@ namespace System.Buffers
     {
         public static ReadOnlySpan<byte> ToSpan<T>(this T sequence) where T : ISequence<ReadOnlyMemory<byte>>
         {
-            Position position = sequence.Start;
+            SequencePosition position = sequence.Start;
             ResizableArray<byte> array = new ResizableArray<byte>(1024);
             while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> buffer))
             {
@@ -26,7 +26,7 @@ namespace System.Buffers
         // be used as a type parameter.
         public static long IndexOf<TSequence>(TSequence sequence, byte value) where TSequence : ISequence<ReadOnlyMemory<byte>>
         {
-            Position position = sequence.Start;
+            SequencePosition position = sequence.Start;
             int totalIndex = 0;
             while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> memory))
             {
@@ -39,7 +39,7 @@ namespace System.Buffers
 
         public static long IndexOf<TSequence>(TSequence sequence, byte v1, byte v2) where TSequence : ISequence<ReadOnlyMemory<byte>>
         {
-            Position position = sequence.Start;
+            SequencePosition position = sequence.Start;
             int totalIndex = 0;
             while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> memory))
             {
@@ -68,12 +68,12 @@ namespace System.Buffers
             return -1;
         }
 
-        public static Position? PositionOf<TSequence>(this TSequence sequence, byte value) where TSequence : ISequence<ReadOnlyMemory<byte>>
+        public static SequencePosition? PositionOf<TSequence>(this TSequence sequence, byte value) where TSequence : ISequence<ReadOnlyMemory<byte>>
         {
             if (sequence == null) return null;
 
-            Position position = sequence.Start;
-            Position result = position;
+            SequencePosition position = sequence.Start;
+            SequencePosition result = position;
             while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> memory))
             {
                 var index = MemoryExtensions.IndexOf(memory.Span, value);
@@ -87,12 +87,12 @@ namespace System.Buffers
             return null;
         }
 
-        public static Position? PositionAt<TSequence>(this TSequence sequence, long index) where TSequence : ISequence<ReadOnlyMemory<byte>>
+        public static SequencePosition? PositionAt<TSequence>(this TSequence sequence, long index) where TSequence : ISequence<ReadOnlyMemory<byte>>
         {
             if (sequence == null) return null;
 
-            Position position = sequence.Start;
-            Position result = position;
+            SequencePosition position = sequence.Start;
+            SequencePosition result = position;
             while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> memory))
             {
                 var span = memory.Span;
@@ -123,7 +123,7 @@ namespace System.Buffers
             return copied;
         }
 
-        public static int Copy<TSequence>(TSequence sequence, Position from, Span<byte> buffer) where TSequence : ISequence<ReadOnlyMemory<byte>>
+        public static int Copy<TSequence>(TSequence sequence, SequencePosition from, Span<byte> buffer) where TSequence : ISequence<ReadOnlyMemory<byte>>
         {
             int copied = 0;
             while (sequence.TryGet(ref from, out ReadOnlyMemory<byte> memory, true))
@@ -162,7 +162,7 @@ namespace System.Buffers
             return false;
         }
 
-        public static bool TryParse<TSequence>(TSequence sequence, out int value, out Position consumed) where TSequence : ISequence<ReadOnlyMemory<byte>>
+        public static bool TryParse<TSequence>(TSequence sequence, out int value, out SequencePosition consumed) where TSequence : ISequence<ReadOnlyMemory<byte>>
         {
             if(!TryParse(sequence, out value, out int consumedBytes))
             {

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBufferReader.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBufferReader.cs
@@ -24,8 +24,8 @@ namespace System.Buffers
         private int _index;
 
         private TSequence _sequence;
-        private Position _currentPosition;
-        private Position _nextPosition;
+        private SequencePosition _currentPosition;
+        private SequencePosition _nextPosition;
 
         private int _consumedBytes;
         private bool _end;
@@ -48,7 +48,7 @@ namespace System.Buffers
 
         public TSequence Sequence => _sequence;
 
-        public Position Position => _sequence.Seek(_currentPosition, _index);
+        public SequencePosition Position => _sequence.Seek(_currentPosition, _index);
 
         public ReadOnlySpan<byte> CurrentSegment => _currentSpan;
 

--- a/src/System.Buffers.Primitives/System/Buffers/ThrowHelper.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ThrowHelper.cs
@@ -28,9 +28,9 @@ namespace System.Buffers
             throw GetNotSupportedException();
         }
         
-        public static void ThrowCursorOutOfBoundsException()
+        public static void ThrowPositionOutOfBoundsException()
         {
-            throw GetCursorOutOfBoundsException();
+            throw GetPositionOutOfBoundsException();
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -58,9 +58,9 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static Exception GetCursorOutOfBoundsException()
+        private static Exception GetPositionOutOfBoundsException()
         {
-            return new InvalidOperationException("Cursor is out of bounds");
+            return new InvalidOperationException("Position is out of bounds");
         }
 
         private static string GetArgumentName(ExceptionArgument argument)
@@ -83,8 +83,8 @@ namespace System.Buffers
                 case ExceptionResource.UnexpectedSegmentType:
                     resourceString = "Unexpected segment type";
                     break;
-                case ExceptionResource.EndCursorNotReached:
-                    resourceString = "Segment chain ended without reaching end cursor location";
+                case ExceptionResource.EndPositionNotReached:
+                    resourceString = "Segment chain ended without reaching end position location";
                     break;
             }
 
@@ -106,6 +106,6 @@ namespace System.Buffers
     internal enum ExceptionResource
     {
         UnexpectedSegmentType,
-        EndCursorNotReached
+        EndPositionNotReached
     }
 }

--- a/src/System.Buffers.Primitives/System/Collections/IBufferList.cs
+++ b/src/System.Buffers.Primitives/System/Collections/IBufferList.cs
@@ -9,6 +9,6 @@ namespace System.Collections.Sequences
 
         IBufferList<T> Next { get; }
 
-        long VirtualIndex { get; }
+        long RunningIndex { get; }
     }
 }

--- a/src/System.Buffers.Primitives/System/Collections/ISequence.cs
+++ b/src/System.Buffers.Primitives/System/Collections/ISequence.cs
@@ -13,10 +13,10 @@ namespace System.Collections.Sequences
         /// <param name="advance"></param>
         /// <returns></returns>
         /// <remarks></remarks>
-        bool TryGet(ref Position position, out T item, bool advance = true);
+        bool TryGet(ref SequencePosition position, out T item, bool advance = true);
 
-        Position Seek(Position origin, long offset);
+        SequencePosition Seek(SequencePosition origin, long offset);
 
-        Position Start { get; }
+        SequencePosition Start { get; }
     }
 }

--- a/src/System.Buffers.Primitives/System/Collections/Position.cs
+++ b/src/System.Buffers.Primitives/System/Collections/Position.cs
@@ -1,25 +1,23 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Buffers;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace System.Collections.Sequences
 {
-    public readonly struct Position : IEquatable<Position>
+    public readonly struct SequencePosition : IEquatable<SequencePosition>
     {
         readonly object _segment;
         readonly int _index;
 
-        public Position(object segment, int index)
+        public SequencePosition(object segment, int index)
         {
             _segment = segment;
             _index = index;
         }
 
-        public Position(object segment)
+        public SequencePosition(object segment)
         {
             _segment = segment;
             _index = 0;
@@ -28,7 +26,7 @@ namespace System.Collections.Sequences
         public object Segment => _segment;
         public int Index => _index;
 
-        public static explicit operator int(Position position) => position._index;
+        public static explicit operator int(SequencePosition position) => position._index;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public (T segment, int index) Get<T>()
@@ -37,15 +35,15 @@ namespace System.Collections.Sequences
             return (segment, _index);
         }
 
-        public static bool operator ==(Position left, Position right) => left._index == right._index && left._segment == right._segment;
-        public static bool operator !=(Position left, Position right) => left._index != right._index || left._segment != right._segment;
+        public static bool operator ==(SequencePosition left, SequencePosition right) => left._index == right._index && left._segment == right._segment;
+        public static bool operator !=(SequencePosition left, SequencePosition right) => left._index != right._index || left._segment != right._segment;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool Equals(Position position) => this == position;
+        public bool Equals(SequencePosition position) => this == position;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object obj) =>
-            obj is Position ? this == (Position)obj : false;
+            obj is SequencePosition ? this == (SequencePosition)obj : false;
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()

--- a/src/System.Collections.Sequences/System/Collections/Sequences/ArrayList.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/ArrayList.cs
@@ -15,7 +15,7 @@ namespace System.Collections.Sequences
 
         public int Length => _items.Count;
 
-        public Position Start => default;
+        public SequencePosition Start => default;
 
         public T this[int index] => _items[index];
 
@@ -23,14 +23,14 @@ namespace System.Collections.Sequences
 
         public SequenceEnumerator<T> GetEnumerator() => new SequenceEnumerator<T>(this);
 
-        public bool TryGet(ref Position position, out T item, bool advance = true) =>
+        public bool TryGet(ref SequencePosition position, out T item, bool advance = true) =>
             _items.TryGet(ref position, out item, advance);
 
-        public Position Seek(Position origin, long offset)
+        public SequencePosition Seek(SequencePosition origin, long offset)
         {
             long index = (int)origin + offset;
             if (index < 0 || index >= Length) throw new ArgumentOutOfRangeException(nameof(offset));
-            return new Position(null, (int)index);
+            return new SequencePosition(null, (int)index);
         }
     }
 }

--- a/src/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs
@@ -106,12 +106,12 @@ namespace System.Collections.Sequences
             return oldArray;
         }
 
-        public bool TryGet(ref Position position, out T item, bool advance = true)
+        public bool TryGet(ref SequencePosition position, out T item, bool advance = true)
         {
             int index = (int)position;
             if (index < _count) {
                 item = _array[index];
-                if (advance) { position = new Position(null, index+1); }
+                if (advance) { position = new SequencePosition(null, index+1); }
                 return true;
             }
 

--- a/src/System.Collections.Sequences/System/Collections/Sequences/SequenceEnumerator.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/SequenceEnumerator.cs
@@ -7,7 +7,7 @@ namespace System.Collections.Sequences
 {
     public struct SequenceEnumerator<T>
     {
-        Position _position;
+        SequencePosition _position;
         ISequence<T> _sequence;
         T _current;
 
@@ -27,7 +27,7 @@ namespace System.Collections.Sequences
     public struct SequenceEnumerator<T, TSequence>
         where TSequence : ISequence<T>
     {
-        Position _position;
+        SequencePosition _position;
         TSequence _sequence;
         T _current;
 

--- a/src/System.IO.Pipelines.Extensions/DefaultReadableBufferExtensions.cs
+++ b/src/System.IO.Pipelines.Extensions/DefaultReadableBufferExtensions.cs
@@ -13,14 +13,14 @@ namespace System.IO.Pipelines
 
         /// <summary>
         /// Searches for 2 sequential bytes in the <see cref="ReadOnlyBuffer"/> and returns a sliced <see cref="ReadOnlyBuffer"/> that
-        /// contains all data up to and excluding the first byte, and a <see cref="Position"/> that points to the second byte.
+        /// contains all data up to and excluding the first byte, and a <see cref="SequencePosition"/> that points to the second byte.
         /// </summary>
         /// <param name="b1">The first byte to search for</param>
         /// <param name="b2">The second byte to search for</param>
         /// <param name="slice">A <see cref="ReadOnlyBuffer"/> slice that contains all data up to and excluding the first byte.</param>
-        /// <param name="cursor">A <see cref="Position"/> that points to the second byte</param>
+        /// <param name="cursor">A <see cref="SequencePosition"/> that points to the second byte</param>
         /// <returns>True if the byte sequence was found, false if not found</returns>
-        public static unsafe bool TrySliceTo(this ReadOnlyBuffer<byte> buffer, byte b1, byte b2, out ReadOnlyBuffer<byte> slice, out Position cursor)
+        public static unsafe bool TrySliceTo(this ReadOnlyBuffer<byte> buffer, byte b1, byte b2, out ReadOnlyBuffer<byte> slice, out SequencePosition cursor)
         {
             // use address of ushort rather than stackalloc as the inliner won't inline functions with stackalloc
             ushort twoBytes;
@@ -32,13 +32,13 @@ namespace System.IO.Pipelines
 
         /// <summary>
         /// Searches for a span of bytes in the <see cref="ReadOnlyBuffer"/> and returns a sliced <see cref="ReadOnlyBuffer"/> that
-        /// contains all data up to and excluding the first byte of the span, and a <see cref="Position"/> that points to the last byte of the span.
+        /// contains all data up to and excluding the first byte of the span, and a <see cref="SequencePosition"/> that points to the last byte of the span.
         /// </summary>
         /// <param name="span">The <see cref="Span{Byte}"/> byte to search for</param>
         /// <param name="slice">A <see cref="ReadOnlyBuffer"/> that matches all data up to and excluding the first byte</param>
-        /// <param name="cursor">A <see cref="Position"/> that points to the second byte</param>
+        /// <param name="cursor">A <see cref="SequencePosition"/> that points to the second byte</param>
         /// <returns>True if the byte sequence was found, false if not found</returns>
-        public static bool TrySliceTo(this ReadOnlyBuffer<byte> buffer, Span<byte> span, out ReadOnlyBuffer<byte> slice, out Position cursor)
+        public static bool TrySliceTo(this ReadOnlyBuffer<byte> buffer, Span<byte> span, out ReadOnlyBuffer<byte> slice, out SequencePosition cursor)
         {
             var result = false;
             var subBuffer = buffer;
@@ -70,13 +70,13 @@ namespace System.IO.Pipelines
 
         /// <summary>
         /// Searches for a byte in the <see cref="ReadOnlyBuffer"/> and returns a sliced <see cref="ReadOnlyBuffer"/> that
-        /// contains all data up to and excluding the byte, and a <see cref="Position"/> that points to the byte.
+        /// contains all data up to and excluding the byte, and a <see cref="SequencePosition"/> that points to the byte.
         /// </summary>
         /// <param name="b1">The first byte to search for</param>
         /// <param name="slice">A <see cref="ReadOnlyBuffer"/> slice that contains all data up to and excluding the first byte.</param>
-        /// <param name="cursor">A <see cref="Position"/> that points to the second byte</param>
+        /// <param name="cursor">A <see cref="SequencePosition"/> that points to the second byte</param>
         /// <returns>True if the byte sequence was found, false if not found</returns>
-        public static bool TrySliceTo(this ReadOnlyBuffer<byte> buffer, byte b1, out ReadOnlyBuffer<byte> slice, out Position cursor)
+        public static bool TrySliceTo(this ReadOnlyBuffer<byte> buffer, byte b1, out ReadOnlyBuffer<byte> slice, out SequencePosition cursor)
         {
             if (buffer.IsEmpty)
             {

--- a/src/System.IO.Pipelines.Text.Primitives/SplitEnumerable.cs
+++ b/src/System.IO.Pipelines.Text.Primitives/SplitEnumerable.cs
@@ -38,7 +38,7 @@ namespace System.IO.Pipelines.Text.Primitives
 
             int count = 1;
             var current = _buffer;
-            while (current.TrySliceTo(_delimiter, out ReadOnlyBuffer<byte> ignore, out Position cursor))
+            while (current.TrySliceTo(_delimiter, out ReadOnlyBuffer<byte> ignore, out SequencePosition cursor))
             {
                 current = current.Slice(cursor).Slice(1);
                 count++;

--- a/src/System.IO.Pipelines.Text.Primitives/SplitEnumerator.cs
+++ b/src/System.IO.Pipelines.Text.Primitives/SplitEnumerator.cs
@@ -44,7 +44,7 @@ namespace System.IO.Pipelines.Text.Primitives
         /// </summary>
         public bool MoveNext()
         {
-            if (_remainder.TrySliceTo(_delimiter, out _current, out Position cursor))
+            if (_remainder.TrySliceTo(_delimiter, out _current, out SequencePosition cursor))
             {
                 _remainder = _remainder.Slice(cursor).Slice(1);
                 return true;

--- a/src/System.IO.Pipelines/System/IO/Pipelines/BufferSegment.cs
+++ b/src/System.IO.Pipelines/System/IO/Pipelines/BufferSegment.cs
@@ -45,7 +45,7 @@ namespace System.IO.Pipelines
         /// <summary>
         /// Combined length of all segments before this
         /// </summary>
-        public long VirtualIndex { get; private set; }
+        public long RunningIndex { get; private set; }
 
         /// <summary>
         /// The buffer being tracked if segment owns the memory
@@ -67,7 +67,7 @@ namespace System.IO.Pipelines
             AvailableMemory = _ownedMemory.Memory;
 
             ReadOnly = readOnly;
-            VirtualIndex = 0;
+            RunningIndex = 0;
             Start = start;
             End = end;
             NextSegment = null;
@@ -126,7 +126,7 @@ namespace System.IO.Pipelines
 
             while (segment.Next != null)
             {
-                segment.NextSegment.VirtualIndex = segment.VirtualIndex + segment.Length;
+                segment.NextSegment.RunningIndex = segment.RunningIndex + segment.Length;
                 segment = segment.NextSegment;
             }
         }

--- a/src/System.IO.Pipelines/System/IO/Pipelines/IPipeReader.cs
+++ b/src/System.IO.Pipelines/System/IO/Pipelines/IPipeReader.cs
@@ -34,7 +34,7 @@ namespace System.IO.Pipelines
         /// The memory for the consumed data will be released and no longer available.
         /// The examined data communicates to the pipeline when it should signal more data is available.
         /// </remarks>
-        void Advance(Position consumed);
+        void Advance(SequencePosition consumed);
 
         /// <summary>
         /// Moves forward the pipeline's read cursor to after the consumed data.
@@ -45,7 +45,7 @@ namespace System.IO.Pipelines
         /// The memory for the consumed data will be released and no longer available.
         /// The examined data communicates to the pipeline when it should signal more data is available.
         /// </remarks>
-        void Advance(Position consumed, Position examined);
+        void Advance(SequencePosition consumed, SequencePosition examined);
 
         /// <summary>
         /// Cancel to currently pending or next call to <see cref="ReadAsync"/> if none is pending, without completing the <see cref="IPipeReader"/>.

--- a/src/System.IO.Pipelines/System/IO/Pipelines/Pipe.cs
+++ b/src/System.IO.Pipelines/System/IO/Pipelines/Pipe.cs
@@ -393,12 +393,12 @@ namespace System.IO.Pipelines
         }
 
         // Reading
-        void IPipeReader.Advance(Position consumed)
+        void IPipeReader.Advance(SequencePosition consumed)
         {
             ((IPipeReader)this).Advance(consumed, consumed);
         }
 
-        void IPipeReader.Advance(Position consumed, Position examined)
+        void IPipeReader.Advance(SequencePosition consumed, SequencePosition examined)
         {
             BufferSegment returnStart = null;
             BufferSegment returnEnd = null;

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/SequenceFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/SequenceFormatter.cs
@@ -21,9 +21,9 @@ namespace System.Text.Formatting
         ISequence<Memory<byte>> _buffers;
         SymbolTable _symbolTable;
 
-        Position _currentPosition = default;
+        SequencePosition _currentPosition = default;
         int _currentWrittenBytes;
-        Position _previousPosition = default;
+        SequencePosition _previousPosition = default;
         int _previousWrittenBytes;
         int _totalWritten;
 

--- a/src/System.Text.Formatting/System/Text/Parsing/SequenceParser.cs
+++ b/src/System.Text.Formatting/System/Text/Parsing/SequenceParser.cs
@@ -15,7 +15,7 @@ namespace System.Text.Parsing
         {
             value = default;
             consumed = default;
-            Position position = default;
+            SequencePosition position = default;
 
             // Fetch the first segment
             if (!bufferSequence.TryGet(ref position, out ReadOnlyMemory<byte> first))
@@ -88,7 +88,7 @@ namespace System.Text.Parsing
         {
             value = default;
             consumed = default;
-            Position position = default;
+            SequencePosition position = default;
 
             // Fetch the first segment
             if (!bufferSequence.TryGet(ref position, out ReadOnlyMemory<byte> first))

--- a/src/System.Text.Http.Parser/HttpParser.cs
+++ b/src/System.Text.Http.Parser/HttpParser.cs
@@ -37,7 +37,7 @@ namespace System.Text.Http.Parser
             _showErrorDetails = showErrorDetails;
         }
 
-        public unsafe bool ParseRequestLine<T>(T handler, in ReadOnlyBuffer<byte> buffer, out Position consumed, out Position examined) where T : IHttpRequestLineHandler
+        public unsafe bool ParseRequestLine<T>(T handler, in ReadOnlyBuffer<byte> buffer, out SequencePosition consumed, out SequencePosition examined) where T : IHttpRequestLineHandler
         {
             consumed = buffer.Start;
             examined = buffer.End;
@@ -56,7 +56,7 @@ namespace System.Text.Http.Parser
             }
             else
             {
-                if (TryGetNewLineSpan(buffer, out Position found))
+                if (TryGetNewLineSpan(buffer, out SequencePosition found))
                 {
                     span = buffer.Slice(consumed, found).ToSpan();
                     consumed = found;
@@ -229,7 +229,7 @@ namespace System.Text.Http.Parser
             handler.OnStartLine(method, httpVersion, targetBuffer, pathBuffer, query, customMethod, pathEncoded);
         }
 
-        public unsafe bool ParseHeaders<T>(T handler, in ReadOnlyBuffer<byte> buffer, out Position consumed, out Position examined, out int consumedBytes) where T : IHttpHeadersHandler
+        public unsafe bool ParseHeaders<T>(T handler, in ReadOnlyBuffer<byte> buffer, out SequencePosition consumed, out SequencePosition examined, out int consumedBytes) where T : IHttpHeadersHandler
         {
             consumed = buffer.Start;
             examined = buffer.End;
@@ -370,7 +370,7 @@ namespace System.Text.Http.Parser
         {
             var index = 0;
             consumedBytes = 0;
-            Position position = buffer.Start;
+            SequencePosition position = buffer.Start;
 
             if(!buffer.TryGet(ref position, out ReadOnlyMemory<byte> currentMemory))
             {
@@ -647,7 +647,7 @@ namespace System.Text.Http.Parser
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static bool TryGetNewLineSpan(in ReadOnlyBuffer<byte> buffer, out Position found)
+        private static bool TryGetNewLineSpan(in ReadOnlyBuffer<byte> buffer, out SequencePosition found)
         {
             var position = buffer.PositionOf(ByteLF);
             if (position.HasValue)

--- a/src/System.Text.Http.Parser/IHttpParser.cs
+++ b/src/System.Text.Http.Parser/IHttpParser.cs
@@ -8,9 +8,9 @@ namespace System.Text.Http.Parser
 {
     public interface IHttpParser
     {
-        bool ParseRequestLine<T>(T handler, in ReadOnlyBuffer<byte> buffer, out Position consumed, out Position examined) where T : IHttpRequestLineHandler;
+        bool ParseRequestLine<T>(T handler, in ReadOnlyBuffer<byte> buffer, out SequencePosition consumed, out SequencePosition examined) where T : IHttpRequestLineHandler;
 
-        bool ParseHeaders<T>(T handler, in ReadOnlyBuffer<byte> buffer, out Position consumed, out Position examined, out int consumedBytes) where T : IHttpHeadersHandler;
+        bool ParseHeaders<T>(T handler, in ReadOnlyBuffer<byte> buffer, out SequencePosition consumed, out SequencePosition examined, out int consumedBytes) where T : IHttpHeadersHandler;
 
         void Reset();
     }

--- a/tests/Benchmarks/HttpParserBench.cs
+++ b/tests/Benchmarks/HttpParserBench.cs
@@ -37,8 +37,8 @@ public class HttpParserBench
         ReadOnlyBuffer<byte> buffer = new ReadOnlyBuffer<byte>(s_plaintextTechEmpowerRequestBytes, 0, s_plaintextTechEmpowerHeadersBytes.Length);
         var parser = new HttpParser();
         var request = new Request();
-        Position consumed = default;
-        Position read;
+        SequencePosition consumed = default;
+        SequencePosition read;
         bool success = true;
 
         foreach (var iteration in Benchmark.Iterations)
@@ -71,8 +71,8 @@ public class HttpParserBench
         ReadOnlyBuffer<byte> buffer = new ReadOnlyBuffer<byte>(s_plaintextTechEmpowerHeadersBytes);
         var parser = new HttpParser();
         var request = new Request();
-        Position consumed;
-        Position examined;
+        SequencePosition consumed;
+        SequencePosition examined;
         int consumedBytes;
         bool success = true;
 
@@ -103,8 +103,8 @@ public class HttpParserBench
         var parser = new HttpParser();
         var request = new Request();
         int consumedBytes  = 0;
-        Position examined;
-        Position consumed = buffer.Start;
+        SequencePosition examined;
+        SequencePosition consumed = buffer.Start;
         bool success = true;
 
         foreach (var iteration in Benchmark.Iterations) {

--- a/tests/System.Buffers.Experimental.Tests/BytesReaderTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/BytesReaderTests.cs
@@ -169,15 +169,15 @@ namespace System.Buffers.Tests
             _buffer = buffer;
         }
 
-        public Position Start => _buffer.Start;
+        public SequencePosition Start => _buffer.Start;
 
-        public Position Seek(Position origin, long offset)
+        public SequencePosition Seek(SequencePosition origin, long offset)
             => _buffer.Seek(origin, offset);
 
-        public ReadOnlyBuffer<byte> Slice(Position start, Position end)
+        public ReadOnlyBuffer<byte> Slice(SequencePosition start, SequencePosition end)
             => _buffer.Slice(start, end);
 
-        public bool TryGet(ref Position position, out ReadOnlyMemory<byte> item, bool advance = true)
+        public bool TryGet(ref SequencePosition position, out ReadOnlyMemory<byte> item, bool advance = true)
             => _buffer.TryGet(ref position, out item, advance);
     }
 }

--- a/tests/System.Buffers.Experimental.Tests/SequenceExtensionsTests.cs
+++ b/tests/System.Buffers.Experimental.Tests/SequenceExtensionsTests.cs
@@ -139,7 +139,7 @@ namespace System.Buffers.Tests
                 Assert.True(Sequence.TryParse(bytes, out int value, out int consumed));
                 Assert.Equal(expected, value);
 
-                Assert.True(Sequence.TryParse(bytes, out value, out Position consumedPosition));
+                Assert.True(Sequence.TryParse(bytes, out value, out SequencePosition consumedPosition));
                 Assert.Equal(expected, value);
 
                 var afterValue = bytes.Slice(consumedPosition);

--- a/tests/System.Buffers.Primitives.Tests/BufferSegment.cs
+++ b/tests/System.Buffers.Primitives.Tests/BufferSegment.cs
@@ -32,7 +32,7 @@ namespace System.IO.Pipelines.Testing
         /// <summary>
         /// Combined length of all segments before this
         /// </summary>
-        public long VirtualIndex { get; private set; }
+        public long RunningIndex { get; private set; }
 
         /// <summary>
         /// The buffer being tracked if segment owns the memory
@@ -54,7 +54,7 @@ namespace System.IO.Pipelines.Testing
             AvailableMemory = _ownedMemory.Memory;
 
             ReadOnly = readOnly;
-            VirtualIndex = 0;
+            RunningIndex = 0;
             Start = start;
             End = end;
             NextSegment = null;
@@ -113,7 +113,7 @@ namespace System.IO.Pipelines.Testing
 
             while (segment.Next != null)
             {
-                segment.NextSegment.VirtualIndex = segment.VirtualIndex + segment.Length;
+                segment.NextSegment.RunningIndex = segment.RunningIndex + segment.Length;
                 segment = segment.NextSegment;
             }
         }

--- a/tests/System.Collections.Sequences.Tests/BasicUnitTests.cs
+++ b/tests/System.Collections.Sequences.Tests/BasicUnitTests.cs
@@ -17,7 +17,7 @@ namespace System.Collections.Sequences.Tests
         {
             ArrayList<int> collection = CreateArrayList(array);
 
-            Position position = default;
+            SequencePosition position = default;
             int arrayIndex = 0;
             while (collection.TryGet(ref position, out int item))
             {
@@ -48,7 +48,7 @@ namespace System.Collections.Sequences.Tests
         {
             LinkedContainer<int> collection = CreateLinkedContainer(array);
 
-            Position position = default;
+            SequencePosition position = default;
             int arrayIndex = array.Length;
             while (collection.TryGet(ref position, out int item))
             {
@@ -72,7 +72,7 @@ namespace System.Collections.Sequences.Tests
             Hashtable<int, string> collection = CreateHashtable(array);
 
             int arrayIndex = 0;
-            Position position = default;
+            SequencePosition position = default;
             while (collection.TryGet(ref position, out KeyValuePair<int, string> item))
             {
                 Assert.Equal(array[arrayIndex++], item.Key);

--- a/tests/System.Collections.Sequences.Tests/SampleCollections/Hashtable.cs
+++ b/tests/System.Collections.Sequences.Tests/SampleCollections/Hashtable.cs
@@ -87,9 +87,9 @@ namespace System.Collections.Sequences
 
         public int Length => _count;
 
-        public Position Start => default;
+        public SequencePosition Start => default;
 
-        public bool TryGet(ref Position position, out KeyValuePair<K, V> item, bool advance = true)
+        public bool TryGet(ref SequencePosition position, out KeyValuePair<K, V> item, bool advance = true)
         {
             item = default;
 
@@ -105,7 +105,7 @@ namespace System.Collections.Sequences
                     return false;
                 }
 
-                position = new Position(null, firstOccupiedSlot);
+                position = new SequencePosition(null, firstOccupiedSlot);
             }
 
             var index = (int)position;
@@ -116,7 +116,7 @@ namespace System.Collections.Sequences
 
             if (advance) {
                 var first = FindFirstStartingAt(index + 1);
-                position = new Position(null, first);
+                position = new SequencePosition(null, first);
                 if (first == -1) {
                     position = default;
                 }
@@ -142,7 +142,7 @@ namespace System.Collections.Sequences
             return new SequenceEnumerator<KeyValuePair<K, V>>(this);
         }
 
-        public Position Seek(Position origin, long offset)
+        public SequencePosition Seek(SequencePosition origin, long offset)
         {
             if (offset<0) throw new ArgumentOutOfRangeException(nameof(offset));
             while (offset-- > 0 && TryGet(ref origin, out _));

--- a/tests/System.Collections.Sequences.Tests/SampleCollections/LinkedContainer.cs
+++ b/tests/System.Collections.Sequences.Tests/SampleCollections/LinkedContainer.cs
@@ -26,9 +26,9 @@ namespace System.Collections.Sequences
 
         public int Length => _count;
 
-        public Position Start => new Position(_head, 0);
+        public SequencePosition Start => new SequencePosition(_head, 0);
 
-        public bool TryGet(ref Position position, out T item, bool advance = true)
+        public bool TryGet(ref SequencePosition position, out T item, bool advance = true)
         {
             if(_count == 0 || position == default)
             {
@@ -44,7 +44,7 @@ namespace System.Collections.Sequences
             }
 
             item = node._item;
-            if (advance) { position = new Position(node._next, 0); }
+            if (advance) { position = new SequencePosition(node._next, 0); }
             return true;
         }
 
@@ -53,7 +53,7 @@ namespace System.Collections.Sequences
             return new SequenceEnumerator<T>(this);
         }
 
-        public Position Seek(Position origin, long offset)
+        public SequencePosition Seek(SequencePosition origin, long offset)
         {
             if (offset < 0) throw new InvalidOperationException("cannot seek backwards");
             var (node, index) = origin.Get<Node>();
@@ -68,7 +68,7 @@ namespace System.Collections.Sequences
                     throw new ArgumentOutOfRangeException(nameof(offset));
                 }
             }
-            return new Position(node, 0);
+            return new SequencePosition(node, 0);
         }
     }
 }

--- a/tests/System.IO.Pipelines.Extensions.Tests/PipelineReaderWriterFacts.cs
+++ b/tests/System.IO.Pipelines.Extensions.Tests/PipelineReaderWriterFacts.cs
@@ -37,7 +37,7 @@ namespace System.IO.Pipelines.Tests
             var result = await _pipe.Reader.ReadAsync();
             var buffer = result.Buffer;
 
-            Assert.False(buffer.TrySliceTo(10, out ReadOnlyBuffer<byte> slice, out Position cursor));
+            Assert.False(buffer.TrySliceTo(10, out ReadOnlyBuffer<byte> slice, out SequencePosition cursor));
 
             _pipe.Reader.Advance(buffer.Start, buffer.Start);
         }
@@ -57,7 +57,7 @@ namespace System.IO.Pipelines.Tests
 
             var result = await _pipe.Reader.ReadAsync();
             var buffer = result.Buffer;
-            Assert.False(buffer.TrySliceTo((byte)'R', out ReadOnlyBuffer<byte> slice, out Position cursor));
+            Assert.False(buffer.TrySliceTo((byte)'R', out ReadOnlyBuffer<byte> slice, out SequencePosition cursor));
 
             _pipe.Reader.Advance(buffer.Start, buffer.Start);
         }
@@ -78,7 +78,7 @@ namespace System.IO.Pipelines.Tests
             var result = await _pipe.Reader.ReadAsync();
             var buffer = result.Buffer;
             Assert.False(buffer.IsSingleSegment);
-            Assert.True(buffer.TrySliceTo((byte)' ', out ReadOnlyBuffer<byte> slice, out Position cursor));
+            Assert.True(buffer.TrySliceTo((byte)' ', out ReadOnlyBuffer<byte> slice, out SequencePosition cursor));
 
             slice = buffer.Slice(cursor).Slice(1);
             var array = slice.ToArray();

--- a/tests/System.IO.Pipelines.Extensions.Tests/ReadableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Extensions.Tests/ReadableBufferFacts.cs
@@ -46,7 +46,7 @@ namespace System.IO.Pipelines.Tests
         public void ReadableBufferSequenceWorks()
         {
             var readable = BufferUtilities.CreateBuffer(new byte[] { 1 }, new byte[] { 2, 2 }, new byte[] { 3, 3, 3 });
-            Position position = readable.Start;
+            SequencePosition position = readable.Start;
             int spanCount = 0;
             while (readable.TryGet(ref position, out ReadOnlyMemory<byte> memory))
             {
@@ -281,7 +281,7 @@ namespace System.IO.Pipelines.Tests
 
             var result = await _pipe.Reader.ReadAsync();
             var buffer = result.Buffer;
-            Assert.True(buffer.TrySliceTo(sliceToBytes, out ReadOnlyBuffer<byte> slice, out Position cursor));
+            Assert.True(buffer.TrySliceTo(sliceToBytes, out ReadOnlyBuffer<byte> slice, out SequencePosition cursor));
             Assert.Equal(expected, slice.GetUtf8Span());
 
             _pipe.Reader.Advance(buffer.End);
@@ -295,7 +295,7 @@ namespace System.IO.Pipelines.Tests
             // we're going to fully index the final locations of the buffer, so that we
             // can mutate etc in constant time
             var addresses = BuildPointerIndex(ref readBuffer, handles);
-            var found = readBuffer.TrySliceTo(huntValue, out ReadOnlyBuffer<byte> slice, out Position cursor);
+            var found = readBuffer.TrySliceTo(huntValue, out ReadOnlyBuffer<byte> slice, out SequencePosition cursor);
             Assert.False(found);
 
             // correctness test all values

--- a/tests/System.Text.Http.Parser.Tests/HttpParserTests.cs
+++ b/tests/System.Text.Http.Parser.Tests/HttpParserTests.cs
@@ -313,7 +313,7 @@ namespace System.Text.Http.Parser.Tests
             ReadOnlyBuffer<byte> buffer = BufferUtilities.CreateBuffer("GET ", "/");
             RequestHandler requestHandler = new RequestHandler();
 
-            bool result = parser.ParseRequestLine(requestHandler, buffer, out Position consumed, out Position examined);
+            bool result = parser.ParseRequestLine(requestHandler, buffer, out SequencePosition consumed, out SequencePosition examined);
             Assert.False(result);
             Assert.Equal(buffer.Start, consumed);
             Assert.Equal(buffer.End, examined);


### PR DESCRIPTION
- Renamed Position to SequencePosition
- Removed "cursor" terminology from public surface area
- Renamed VirtualIndex to RunningIndex

cc: @davidfowl, @pakrym, @terrajobst, @weshaggard, @steveharter, @joshfree 
