### PR TITLE
Make scheduler private fields readonly

### DIFF
--- a/src/System.IO.Pipelines/System/Threading/Scheduler.cs
+++ b/src/System.IO.Pipelines/System/Threading/Scheduler.cs
@@ -5,8 +5,8 @@ namespace System.Threading
 {
     public abstract class Scheduler
     {
-        private static ThreadPoolScheduler _threadPoolScheduler = new ThreadPoolScheduler();
-        private static InlineScheduler _inlineScheduler = new InlineScheduler();
+        private static readonly ThreadPoolScheduler _threadPoolScheduler = new ThreadPoolScheduler();
+        private static readonly InlineScheduler _inlineScheduler = new InlineScheduler();
 
         public static Scheduler ThreadPool => _threadPoolScheduler;
         public static Scheduler Inline => _inlineScheduler;


### PR DESCRIPTION
Seeing how these fields are `private` and are not mutated, they can be `readonly`.