### PR TITLE
Fixed a bug in MoveNext

### DIFF
--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBufferReader.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBufferReader.cs
@@ -92,13 +92,14 @@ namespace System.Buffers
             var previous = _nextPosition;
             while (_sequence.TryGet(ref _nextPosition, out var memory, true))
             {
-                _currentPosition = previous;
                 _currentSpan = memory.Span;
-                _index = 0;
                 if (_currentSpan.Length > 0)
                 {
+                    _index = 0;
+                    _currentPosition = previous;
                     return;
                 }
+                previous = _nextPosition;
             }
             _end = true;
         }


### PR DESCRIPTION
MoveNext was not correctly updating _currentPosition if the loop moved past an empty buffer. The bug is not observable (as all other APIs would skip the empty buffer), but @pranavkm thought it would be good to fix it to ensure we have the right semantics if we ever add APIs that can observe the difference, e.g. expose CurrentPosition property