### PR TITLE
Fix date formatting

### DIFF
--- a/src/System.Text.Primitives/System/Text/Formatters/Utf16Formatter_time.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Utf16Formatter_time.cs
@@ -199,17 +199,16 @@ namespace System.Buffers.Text
 
             if (kind == DateTimeKind.Local)
             {
-                int hours = offset.Hours;
                 char sign = Plus;
 
-                if (offset.Hours < 0)
+                if (offset < default(TimeSpan) /* a "const" version of TimeSpan.Zero */)
                 {
-                    hours = -offset.Hours;
+                    offset = TimeSpan.FromTicks(-offset.Ticks);
                     sign = Minus;
                 }
 
                 Unsafe.Add(ref utf16Bytes, 27) = sign;
-                FormattingHelpers.WriteDigits(hours, 2, ref utf16Bytes, 28);
+                FormattingHelpers.WriteDigits(offset.Hours, 2, ref utf16Bytes, 28);
                 Unsafe.Add(ref utf16Bytes, 30) = Colon;
                 FormattingHelpers.WriteDigits(offset.Minutes, 2, ref utf16Bytes, 31);
             }


### PR DESCRIPTION
This test was consistently failing on my Mac when I tried to repro the memory corruption. My Mac ended up with non-standard timezone offset somehow. This code was not handling non-standard timezone offsets correctly. I have just copied the logic from matching productized corefx utf8 formatter.