### PR TITLE
Using a private constant for the minimumBufferSize to indicate use default

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/Native/NativeMemoryPool.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Native/NativeMemoryPool.cs
@@ -9,6 +9,11 @@ namespace System.Buffers.Native
     {
         const int DefaultSize = 4096;
 
+        /// <summary>
+        /// This default value passed in to Rent to use the default value for the pool.
+        /// </summary>
+        private const int AnySize = -1;
+
         static NativeMemoryPool s_shared = new NativeMemoryPool(DefaultSize);
         object _lock = new object();
         bool _disposed;
@@ -43,9 +48,9 @@ namespace System.Buffers.Native
 
         public override int MaxBufferSize => 1024 * 1024 * 1024;
 
-        public override OwnedMemory<byte> Rent(int numberOfBytes = DefaultSize)
+        public override OwnedMemory<byte> Rent(int numberOfBytes = AnySize)
         {
-            if (numberOfBytes == -1) numberOfBytes = DefaultSize;
+            if (numberOfBytes == AnySize) numberOfBytes = DefaultSize;
             if (numberOfBytes < 1 || numberOfBytes > MaxBufferSize) throw new ArgumentOutOfRangeException(nameof(numberOfBytes));
             if (numberOfBytes > _bufferSize) new NotSupportedException();
 

--- a/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/Pool/MemoryPool.cs
+++ b/src/System.IO.Pipelines.Networking.Windows.RIO/Internal/Pool/MemoryPool.cs
@@ -73,9 +73,14 @@ namespace System.Buffers
             _slabDeallocationCallback = deallocationCallback;
         }
 
-        public override OwnedMemory<byte> Rent(int size = -1)
+        /// <summary>
+        /// This default value passed in to Rent to use the default value for the pool.
+        /// </summary>
+        private const int AnySize = -1;
+
+        public override OwnedMemory<byte> Rent(int size = AnySize)
         {
-            if (size == -1) size = _blockLength;
+            if (size == AnySize) size = _blockLength;
             else if (size > _blockLength)
             {
                 RioPipelinesThrowHelper.ThrowArgumentOutOfRangeException_BufferRequestTooLarge(_blockLength);

--- a/src/System.IO.Pipelines/System/Buffers/MemoryPool.cs
+++ b/src/System.IO.Pipelines/System/Buffers/MemoryPool.cs
@@ -63,9 +63,14 @@ namespace System.Buffers
         /// </summary>
         private bool _disposedValue = false; // To detect redundant calls
 
-        public override OwnedMemory<byte> Rent(int size = -1)
+        /// <summary>
+        /// This default value passed in to Rent to use the default value for the pool.
+        /// </summary>
+        private const int AnySize = -1;
+
+        public override OwnedMemory<byte> Rent(int size = AnySize)
         {
-            if (size == -1) size = _blockLength;
+            if (size == AnySize) size = _blockLength;
             else if (size > _blockLength)
             {
                 PipelinesThrowHelper.ThrowArgumentOutOfRangeException_BufferRequestTooLarge(_blockLength);


### PR DESCRIPTION
Leftover change from https://github.com/dotnet/corefxlab/pull/2086/files#r164603501