### PR TITLE
Pass BufferReader around as readonly byref

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/BufferReader_binary.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferReader_binary.cs
@@ -27,7 +27,7 @@ namespace System.Buffers
             }
 
             Span<byte> tempSpan = stackalloc byte[4];
-            var copied = BufferReader.Peek(reader, tempSpan);
+            var copied = BufferReader.Peek(in reader, tempSpan);
             if (copied < 4)
             {
                 value = default;

--- a/src/System.Buffers.Experimental/System/Buffers/BufferReader_text.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/BufferReader_text.cs
@@ -22,7 +22,7 @@ namespace System.Buffers
             }
 
             Span<byte> tempSpan = stackalloc byte[5];
-            var copied = BufferReader.Peek(reader, tempSpan);
+            var copied = BufferReader.Peek(in reader, tempSpan);
             if (Utf8Parser.TryParse(tempSpan.Slice(0, copied), out value, out consumed))
             {
                 reader.Advance(consumed);
@@ -46,7 +46,7 @@ namespace System.Buffers
             }
 
             Span<byte> tempSpan = stackalloc byte[15];
-            var copied = BufferReader.Peek(reader, tempSpan);
+            var copied = BufferReader.Peek(in reader, tempSpan);
             if (Utf8Parser.TryParse(tempSpan.Slice(0, copied), out value, out consumed))
             {
                 reader.Advance(consumed);
@@ -70,7 +70,7 @@ namespace System.Buffers
             }
 
             Span<byte> tempSpan = stackalloc byte[30];
-            var copied = BufferReader.Peek(reader, tempSpan);
+            var copied = BufferReader.Peek(in reader, tempSpan);
             if (Utf8Parser.TryParse(tempSpan.Slice(0, copied), out value, out consumed))
             {
                 reader.Advance(consumed);

--- a/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBufferReader.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/ReadOnlyBufferReader.cs
@@ -13,9 +13,9 @@ namespace System.Buffers
             return new BufferReader<TSequence>(buffer);
         }
 
-        public static int Peek<TSequence>(BufferReader<TSequence> reader, Span<byte> destination)
+        public static int Peek<TSequence>(in BufferReader<TSequence> reader, Span<byte> destination)
             where TSequence : ISequence<ReadOnlyMemory<byte>>
-            => BufferReader<TSequence>.Peek(reader, destination);
+            => BufferReader<TSequence>.Peek(in reader, destination);
     }
 
     public ref struct BufferReader<TSequence> where TSequence : ISequence<ReadOnlyMemory<byte>>
@@ -135,7 +135,7 @@ namespace System.Buffers
             }
         }
 
-        internal static int Peek(BufferReader<TSequence> bytes, Span<byte> destination)
+        internal static int Peek(in BufferReader<TSequence> bytes, Span<byte> destination)
         {
             var first = bytes.UnreadSegment;
             if (first.Length > destination.Length)


### PR DESCRIPTION
BufferReader is a big struct. Passing big structs by value produces bloated inefficient code. Now that this bloated inefficient served its purpose by finding stress bug in the runtime, we can use readonly byref that is much more appropriate in this case.