### PR TITLE
Use full page for MemoryPool blocks

### DIFF
--- a/src/System.IO.Pipelines/System/Buffers/MemoryPool.cs
+++ b/src/System.IO.Pipelines/System/Buffers/MemoryPool.cs
@@ -12,17 +12,17 @@ namespace System.Buffers
     /// </summary>
     public class MemoryPool : MemoryPool<byte>
     {
+#if NETSTANDARD1_1
         /// <summary>
         /// The gap between blocks' starting address. 4096 is chosen because most operating systems are 4k pages in size and alignment.
         /// </summary>
-        private const int _blockStride = 4096;
-
+        private const int _pageSize = 4096;
+#else
         /// <summary>
-        /// The last 64 bytes of a block are unused to prevent CPU from pre-fetching the next 64 byte into it's memory cache.
-        /// See https://github.com/aspnet/KestrelHttpServer/issues/117 and https://www.youtube.com/watch?v=L7zSU9HI-6I
+        /// The gap between blocks' starting address.
         /// </summary>
-        private const int _blockUnused = 64;
-
+        private static readonly int _pageSize = Environment.SystemPageSize;
+#endif
         /// <summary>
         /// Allocating 32 contiguous blocks per slab makes the slab size 128k. This is larger than the 85k size which will place the memory
         /// in the large object heap. This means the GC will not try to relocate this array, so the fact it remains pinned does not negatively
@@ -31,20 +31,15 @@ namespace System.Buffers
         private const int _blockCount = 32;
 
         /// <summary>
-        /// 4096 - 64 gives you a blockLength of 4032 usable bytes per block.
-        /// </summary>
-        private const int _blockLength = _blockStride - _blockUnused;
-
-        /// <summary>
         /// Max allocation block size for pooled blocks,
         /// larger values can be leased but they will be disposed after use rather than returned to the pool.
         /// </summary>
-        public override int MaxBufferSize { get; } = _blockLength;
+        public override int MaxBufferSize { get; } = _pageSize;
 
         /// <summary>
         /// 4096 * 32 gives you a slabLength of 128k contiguous bytes allocated per slab
         /// </summary>
-        private const int _slabLength = _blockStride * _blockCount;
+        private static readonly int _slabLength = _pageSize * _blockCount;
 
         /// <summary>
         /// Thread-safe collection of blocks which are currently in the pool. A slab will pre-allocate all of the block tracking objects
@@ -70,10 +65,10 @@ namespace System.Buffers
 
         public override OwnedMemory<byte> Rent(int size = AnySize)
         {
-            if (size == AnySize) size = _blockLength;
-            else if (size > _blockLength)
+            if (size == AnySize) size = _pageSize;
+            else if (size > _pageSize)
             {
-                PipelinesThrowHelper.ThrowArgumentOutOfRangeException_BufferRequestTooLarge(_blockLength);
+                PipelinesThrowHelper.ThrowArgumentOutOfRangeException_BufferRequestTooLarge(_pageSize);
             }
 
             var block = Lease();
@@ -118,18 +113,20 @@ namespace System.Buffers
             _slabs.Push(slab);
 
             var basePtr = slab.NativePointer;
-            var firstOffset = (int)((_blockStride - 1) - ((ulong)(basePtr + _blockStride - 1) % _blockStride));
+            // Page align the blocks
+            var firstOffset = (int)((((ulong)basePtr + (uint)_pageSize - 1) & ~((uint)_pageSize - 1)) - (ulong)basePtr);
+            // Ensure page aligned
+            Debug.Assert((((ulong)basePtr + (uint)firstOffset) & (uint)(_pageSize - 1)) == 0);
 
-            var poolAllocationLength = _slabLength - _blockStride;
-
+            var blockAllocationLength = ((_slabLength - firstOffset) & ~(_pageSize - 1));
             var offset = firstOffset;
             for (;
-                offset + _blockLength < poolAllocationLength;
-                offset += _blockStride)
+                offset + _pageSize < blockAllocationLength;
+                offset += _pageSize)
             {
                 var block = MemoryPoolBlock.Create(
                     offset,
-                    _blockLength,
+                    _pageSize,
                     this,
                     slab);
 #if BLOCK_LEASE_TRACKING
@@ -138,10 +135,11 @@ namespace System.Buffers
                 Return(block);
             }
 
+            Debug.Assert(offset + _pageSize - firstOffset == blockAllocationLength);
             // return last block rather than adding to pool
             var newBlock = MemoryPoolBlock.Create(
                     offset,
-                    _blockLength,
+                    _pageSize,
                     this,
                     slab);
 

--- a/src/System.IO.Pipelines/System/Buffers/MemoryPoolBlock.cs
+++ b/src/System.IO.Pipelines/System/Buffers/MemoryPoolBlock.cs
@@ -47,7 +47,7 @@ namespace System.Buffers
         {
             get
             {
-                if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(nameof(MemoryPoolBlock));
+                if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(ExceptionArgument.MemoryPoolBlock);
                 return new Span<byte>(Slab.Array, _offset, _length);
             }
         }
@@ -106,7 +106,7 @@ namespace System.Buffers
 
         public override void Retain()
         {
-            if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(nameof(MemoryPoolBlock));
+            if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(ExceptionArgument.MemoryPoolBlock);
             Interlocked.Increment(ref _referenceCount);
         }
 
@@ -129,7 +129,7 @@ namespace System.Buffers
         // this method access modifiers need to be `protected internal`
         protected override bool TryGetArray(out ArraySegment<byte> arraySegment)
         {
-            if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(nameof(MemoryPoolBlock));
+            if (IsDisposed) PipelinesThrowHelper.ThrowObjectDisposedException(ExceptionArgument.MemoryPoolBlock);
             arraySegment = new ArraySegment<byte>(Slab.Array, _offset, _length);
             return true;
         }

--- a/src/System.IO.Pipelines/System/IO/Pipelines/PipelinesThrowHelper.cs
+++ b/src/System.IO.Pipelines/System/IO/Pipelines/PipelinesThrowHelper.cs
@@ -51,9 +51,9 @@ namespace System.IO.Pipelines
             throw GetArgumentOutOfRangeException_BufferRequestTooLarge(maxSize);
         }
 
-        public static void ThrowObjectDisposedException(string objectName)
+        public static void ThrowObjectDisposedException(ExceptionArgument argument)
         {
-            throw GetObjectDisposedException(objectName);
+            throw GetObjectDisposedException(argument);
         }
 
         public static void ThrowCursorOutOfBoundsException()
@@ -93,9 +93,9 @@ namespace System.IO.Pipelines
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static ObjectDisposedException GetObjectDisposedException(string objectName)
+        private static ObjectDisposedException GetObjectDisposedException(ExceptionArgument argument)
         {
-            return new ObjectDisposedException(objectName);
+            return new ObjectDisposedException(GetArgumentName(argument));
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -200,7 +200,9 @@ namespace System.IO.Pipelines
         offset,
         length,
         data,
-        size
+        size,
+        MemoryPoolBlock,
+        DisposeTrackingBufferPool
     }
 
     internal enum ExceptionResource

--- a/tests/System.IO.Pipelines.Tests/PipePoolTests.cs
+++ b/tests/System.IO.Pipelines.Tests/PipePoolTests.cs
@@ -171,7 +171,7 @@ namespace System.IO.Pipelines.Tests
                     get
                     {
                         if (IsDisposed)
-                            PipelinesThrowHelper.ThrowObjectDisposedException(nameof(DisposeTrackingBufferPool));
+                            PipelinesThrowHelper.ThrowObjectDisposedException(ExceptionArgument.DisposeTrackingBufferPool);
                         return _array;
                     }
                 }
@@ -184,7 +184,7 @@ namespace System.IO.Pipelines.Tests
                 protected override bool TryGetArray(out ArraySegment<byte> arraySegment)
                 {
                     if (IsDisposed)
-                        PipelinesThrowHelper.ThrowObjectDisposedException(nameof(DisposeTrackingBufferPool));
+                        PipelinesThrowHelper.ThrowObjectDisposedException(ExceptionArgument.DisposeTrackingBufferPool);
                     arraySegment = new ArraySegment<byte>(_array);
                     return true;
                 }


### PR DESCRIPTION
CPUs doesn't prefetch across page boundaries so the cache line sized buffer isn't required.

Helps when reading from files which like page sized reads. 

Also uses the page size on .NET Core and .NET Standard rather than the const 4096

Resolves https://github.com/dotnet/corefxlab/issues/2098

/cc @davidfowl @pakrym @halter73 