### PR TITLE
Reduce OutputWriter's virtual calls and Memory slicing

### DIFF
--- a/src/System.Buffers.Primitives/System/Buffers/OutputWriter.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/OutputWriter.cs
@@ -71,7 +71,7 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void EnsureMore(int count = 1)
+        private void EnsureMore(int count = 0)
         {
             if (_buffered > 0)
             {

--- a/src/System.Buffers.Primitives/System/Buffers/OutputWriter.cs
+++ b/src/System.Buffers.Primitives/System/Buffers/OutputWriter.cs
@@ -18,9 +18,11 @@ namespace System.Buffers
     {
         private T _output;
         private Span<byte> _span;
+        private int _buffered;
 
         public OutputWriter(T output)
         {
+            _buffered = 0;
             _output = output;
             _span = output.GetSpan();
         }
@@ -28,10 +30,21 @@ namespace System.Buffers
         public Span<byte> Span => _span;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Commit()
+        {
+            var buffered = _buffered;
+            if (buffered > 0)
+            {
+                _buffered = 0;
+                _output.Advance(buffered);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Advance(int count)
         {
+            _buffered += count;
             _span = _span.Slice(count);
-            _output.Advance(count);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -48,9 +61,23 @@ namespace System.Buffers
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Ensure(int count = 1)
         {
+            if (_span.Length < count)
+            {
+                EnsureMore(count);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void EnsureMore(int count = 1)
+        {
+            if (_buffered > 0)
+            {
+                Commit();
+            }
+
             _output.GetMemory(count);
             _span = _output.GetSpan();
         }
@@ -61,7 +88,7 @@ namespace System.Buffers
             {
                 if (_span.Length == 0)
                 {
-                    Ensure();
+                    EnsureMore();
                 }
 
                 var writable = Math.Min(source.Length, _span.Length);
@@ -70,6 +97,5 @@ namespace System.Buffers
                 Advance(writable);
             }
         }
-
     }
 }

--- a/tests/System.IO.Pipelines.Tests/PipeWriterTests.cs
+++ b/tests/System.IO.Pipelines.Tests/PipeWriterTests.cs
@@ -54,6 +54,8 @@ namespace System.IO.Pipelines.Tests
             }
 
             writer.Write(new Span<byte>(array, 0, array.Length));
+            writer.Commit();
+
             Assert.Equal(array, Read());
         }
 
@@ -72,6 +74,7 @@ namespace System.IO.Pipelines.Tests
             var array = new byte[] { 1, 2, 3 };
 
             writer.Write(new Span<byte>(array, offset, length));
+            writer.Commit();
 
             Assert.Equal(array.Skip(offset).Take(length).ToArray(), Read());
         }
@@ -84,6 +87,7 @@ namespace System.IO.Pipelines.Tests
 
             writer.Write(array);
             writer.Write(new Span<byte>(array, 0, array.Length));
+            writer.Commit();
 
             Assert.Equal(array, Read());
         }
@@ -94,6 +98,8 @@ namespace System.IO.Pipelines.Tests
             OutputWriter<PipeWriter> writer = OutputWriter.Create(Pipe.Writer);
 
             writer.Write(new byte[] { 1, 2, 3 });
+            writer.Commit();
+
             Assert.Equal(new byte[] { 1, 2, 3 }, Read());
         }
 
@@ -105,6 +111,7 @@ namespace System.IO.Pipelines.Tests
             writer.Write(new byte[] { 1 });
             writer.Write(new byte[] { 2 });
             writer.Write(new byte[] { 3 });
+            writer.Commit();
 
             Assert.Equal(new byte[] { 1, 2, 3 }, Read());
         }
@@ -119,6 +126,7 @@ namespace System.IO.Pipelines.Tests
             byte[] expectedBytes = source.Concat(source).Concat(source).ToArray();
 
             writer.Write(expectedBytes);
+            writer.Commit();
 
             Assert.Equal(expectedBytes, Read());
         }
@@ -150,6 +158,7 @@ namespace System.IO.Pipelines.Tests
             OutputWriter<PipeWriter> writer = OutputWriter.Create(Pipe.Writer);
 
             writer.Write(new byte[] { 1, 2, 3 });
+            writer.Commit();
 
             Assert.Equal(initialLength - 3, writer.Span.Length);
             Assert.Equal(Pipe.Writer.GetMemory().Length, writer.Span.Length);


### PR DESCRIPTION
Currently every Write and Advance call makes a virtual call to Pipe and also Slices the underlining Memory; mostly defeating the purpose of using the Span.

This leads to the explosion of calls to `BufferSegment.set_End` via virtual `Advance` from writing output headers (once per name, once per value):

![image](https://user-images.githubusercontent.com/1142958/36064965-6670b93c-0e8b-11e8-8e2c-683b5b88c292.png)

Change to only Advance when `Commit()` is called or the Span runs out of space. 

`Commit()` must be called after a set of Writing to "flush" (Advance) any buffered data to pipe

/cc @davidfowl 