### PR TITLE
Re-enabling SocketFacts tests on linux

### DIFF
--- a/tests/System.IO.Pipelines.Extensions.Tests/SocketsFacts.cs
+++ b/tests/System.IO.Pipelines.Extensions.Tests/SocketsFacts.cs
@@ -112,7 +112,9 @@ namespace System.IO.Pipelines.Tests
 
         // Issue #1687 - The test intermittently fails on linux -
         // Reason: Unhandled Exception: System.IO.Pipelines.Networking.Libuv.Interop.UvException: Error -16 EBUSY resource busy or locked
+#if (Windows || OSX)
         [Fact]
+#endif
         public async Task RunStressPingPongTest_Libuv()
         {
             var endpoint = new IPEndPoint(IPAddress.Loopback, 5040);

--- a/tests/System.IO.Pipelines.Extensions.Tests/SocketsFacts.cs
+++ b/tests/System.IO.Pipelines.Extensions.Tests/SocketsFacts.cs
@@ -25,9 +25,7 @@ namespace System.IO.Pipelines.Tests
             Assert.Equal(0, SocketConnection.SmallBuffersInUse);
         }
 
-#if (Windows || OSX) // "The test hangs on linux"
         [Fact]
-#endif
         public async Task CanCreateWorkingEchoServer_PipelineLibuvServer_NonPipelineClient()
         {
             var endpoint = new IPEndPoint(IPAddress.Loopback, 5010);
@@ -95,9 +93,7 @@ namespace System.IO.Pipelines.Tests
             Assert.Equal(MessageToSend, reply);
         }
 
-#if (Windows || OSX) // "The test hangs on linux"
         [Fact]
-#endif
         public void CanCreateWorkingEchoServer_PipelineSocketServer_NonPipelineClient()
         {
             var endpoint = new IPEndPoint(IPAddress.Loopback, 5030);
@@ -116,9 +112,7 @@ namespace System.IO.Pipelines.Tests
 
         // Issue #1687 - The test intermittently fails on linux -
         // Reason: Unhandled Exception: System.IO.Pipelines.Networking.Libuv.Interop.UvException: Error -16 EBUSY resource busy or locked
-#if (Windows || OSX)
         [Fact]
-#endif
         public async Task RunStressPingPongTest_Libuv()
         {
             var endpoint = new IPEndPoint(IPAddress.Loopback, 5040);


### PR DESCRIPTION
Testing to see if these tests still fail on linux.
See:
https://github.com/dotnet/corefxlab/issues/1533#issuecomment-363945987
https://github.com/dotnet/corefxlab/issues/1687

cc @pakrym, @davidfowl 