### PR TITLE
Add null check to Tensor indexer and change which ToSpan method to call.

### DIFF
--- a/src/System.Numerics.Tensors/System/Numerics/Tensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/Tensor.cs
@@ -750,12 +750,20 @@ namespace System.Numerics
         {
             get
             {
+                if (indices == null)
+                {
+                    throw new ArgumentNullException(nameof(indices));
+                }
                 var span = new Span<int>(indices);
                 return this[span];
             }
 
             set
             {
+                if (indices == null)
+                {
+                    throw new ArgumentNullException(nameof(indices));
+                }
                 var span = new Span<int>(indices);
                 this[span] = value;
             }

--- a/src/System.Text.Http.Parser/HttpParser.cs
+++ b/src/System.Text.Http.Parser/HttpParser.cs
@@ -63,7 +63,7 @@ namespace System.Text.Http.Parser
             {
                 if (TryGetNewLineSpan(buffer, out SequencePosition found))
                 {
-                    span = Sequence.ToSpan(buffer.Slice(consumed, found));
+                    span = PipelineExtensions.ToSpan(buffer.Slice(consumed, found));
                     consumed = found;
                 }
                 else
@@ -102,7 +102,7 @@ namespace System.Text.Http.Parser
                     return false;
                 }
 
-                span = Sequence.ToSpan(buffer.Slice(0, eol + s_Eol.Length));
+                span = PipelineExtensions.ToSpan(buffer.Slice(0, eol + s_Eol.Length));
             }
 
             // Fix and parse the span
@@ -335,7 +335,7 @@ namespace System.Text.Http.Parser
 
                                 // Make sure LF is included in lineEnd
                                 lineEnd = subBuffer.GetPosition(lineEnd.Value, 1);
-                                var headerSpan = Sequence.ToSpan(subBuffer.Slice(current, lineEnd.Value));
+                                var headerSpan = PipelineExtensions.ToSpan(subBuffer.Slice(current, lineEnd.Value));
                                 length = headerSpan.Length;
 
                                 fixed (byte* pHeader = &MemoryMarshal.GetReference(headerSpan))
@@ -451,7 +451,7 @@ namespace System.Text.Http.Parser
                                 return false;
                             }
 
-                            var headerSpan = Sequence.ToSpan(buffer.Slice(index, end - index + 1));
+                            var headerSpan = PipelineExtensions.ToSpan(buffer.Slice(index, end - index + 1));
                             length = headerSpan.Length;
 
                             fixed (byte* pHeader = &MemoryMarshal.GetReference(headerSpan))

--- a/tests/System.Numerics.Tensors.Tests/TensorSliceTests.cs
+++ b/tests/System.Numerics.Tensors.Tests/TensorSliceTests.cs
@@ -322,6 +322,7 @@ namespace System.Numerics.Tensors.Tests
         {
             var slice = Get3DSlice(constructor);
 
+            Assert.Throws<ArgumentNullException>(() => slice[(int[])null]);
             Assert.Throws<ArgumentException>(() => slice[new int[] { }]);
             Assert.Throws<ArgumentException>(() => slice[default(ReadOnlySpan<int>)]);
             Assert.Throws<ArgumentException>(() => slice[2, 0]);


### PR DESCRIPTION
Leftover changes from https://github.com/dotnet/corefxlab/pull/2111 to address the feedback.


cc @davidfowl, @eerhardt 