### PR TITLE
Re-enable previously disabled tests since there was a package update

### DIFF
--- a/tests/System.IO.Pipelines.Extensions.Tests/ReadableBufferFacts.cs
+++ b/tests/System.IO.Pipelines.Extensions.Tests/ReadableBufferFacts.cs
@@ -122,7 +122,7 @@ namespace System.IO.Pipelines.Tests
             _pipe.Reader.AdvanceTo(rb.End);
         }
 
-        [Fact(Skip = "Waiting for a build with the fix from https://github.com/dotnet/corefx/pull/27691")]
+        [Fact]
         public async Task TestIndexOfWorksForAllLocations()
         {
             const int Size = 5 * BlockSize; // multiple blocks

--- a/tests/System.Text.Http.Parser.Tests/HttpParserBasicTests.cs
+++ b/tests/System.Text.Http.Parser.Tests/HttpParserBasicTests.cs
@@ -35,7 +35,7 @@ namespace System.Text.Http.Parser.Tests
             Assert.Equal("V", request.Headers["N"]);
         }
 
-        [Theory(Skip = "Waiting for a build with the fix from https://github.com/dotnet/corefx/pull/27691")]
+        [Theory]
         [InlineData("GET /plaintext HTTP/1.1\r\nN: V\r\n\r\n")]
         public void HttpParserSegmentedRob(string requestText)
         {


### PR DESCRIPTION
Re-enable the tests that were disabled in https://github.com/dotnet/corefxlab/pull/2142.

cc @davidfowl, @benaadams, @pakrym 