### PR TITLE
Bug fix in BufferWriter

### DIFF
--- a/src/System.Buffers.ReaderWriter/System/Buffers/Writer/BufferWriter_writable.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Writer/BufferWriter_writable.cs
@@ -39,12 +39,13 @@ namespace System.Buffers.Writer
 
         public bool TryWriteBytes(ReadOnlyMemory<byte> bytes, TransformationFormat format)
         {
-            if (!TryWriteBytes(bytes.Span))
+            var span = bytes.Span;
+            if (!span.TryCopyTo(Free))
             {
                 return false;
             }
+            int written = span.Length;
 
-            int written = bytes.Length;
             if (format.TryTransform(Free, ref written))
             {
                 _written += written;

--- a/tests/System.Buffers.ReaderWriter.Tests/BasicUnitTests.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/BasicUnitTests.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
+using System.Buffers.Operations;
 using System.Buffers.Text;
 using System.Buffers.Writer;
 using System.Diagnostics;
@@ -58,6 +59,17 @@ namespace System.Buffers.Tests
 
             var result = _sink.ToString();
             Assert.Equal(s_response, _sink.ToString());
+        }
+
+        [Fact]
+        public void BufferWriterTransform()
+        {
+            byte[] buffer = new byte[10];
+            var writer = BufferWriter.Create(buffer.AsSpan());
+            var transformation = new TransformationFormat(new RemoveTransformation(2));
+            ReadOnlyMemory<byte> value = new byte[] { 1, 2, 3 };
+            writer.WriteBytes(value, transformation);
+            Assert.Equal(-1, buffer.AsSpan().IndexOf((byte)2));
         }
     }
 


### PR DESCRIPTION
@ahsonkhan reported that AzCopyCore does not work on newer versions of our packages. I debugged the issue and found the culprit. The BufferWriter.WriteBytes overload that takes Memory and a transformation was not properly transforming the written bytes. 