### PR TITLE
Use Path.Join to avoid allocations and fix logging.

### DIFF
--- a/samples/AzCopyCore/AzCopyCore/Program.cs
+++ b/samples/AzCopyCore/AzCopyCore/Program.cs
@@ -104,10 +104,7 @@ static class Program
         {
             foreach (string filepath in Directory.EnumerateFiles(directoryPath))
             {
-                // TODO: Use Path.Join when it becomes available
-                // https://github.com/dotnet/corefx/issues/25536
-                // https://github.com/dotnet/corefx/issues/25539
-                var storagePath = new string(path) + "/" + Path.GetFileName(filepath);
+                string storagePath = Path.Join(path, Path.GetFileName(filepath));
 
                 // TODO (pri 3): this loop keeps going through all files, even if the key is wrong
                 if (CopyLocalFileToStorageFile(client, filepath, storagePath).Result)

--- a/samples/AzCopyCore/AzCopyCore/SocketPipe.cs
+++ b/samples/AzCopyCore/AzCopyCore/SocketPipe.cs
@@ -77,8 +77,12 @@ namespace System.Net.Experimental
                         {
                             for (SequencePosition position = buffer.Start; buffer.TryGet(ref position, out ReadOnlyMemory<byte> segment);)
                             {
-                                if (Log != null && Log.Switch.ShouldTrace(TraceEventType.Information))
-                                    Log.TraceInformation(Utf8.ToString(segment.Span));
+                                if (Log != null && Log.Switch.ShouldTrace(TraceEventType.Verbose))
+                                {
+                                    string data = Utf8.ToString(segment.Span);
+                                    if (!string.IsNullOrWhiteSpace(data))
+                                        Log.TraceInformation(data);
+                                }
 
                                 await WriteToSocketAsync(segment).ConfigureAwait(false);
                             }
@@ -120,8 +124,12 @@ namespace System.Net.Experimental
                         int readBytes = await ReadFromSocketAsync(buffer).ConfigureAwait(false);
                         if (readBytes == 0) break;
 
-                        if (Log != null && Log.Switch.ShouldTrace(TraceEventType.Information))
-                            Log.TraceInformation(Utf8.ToString(buffer.Span.Slice(0, readBytes)));
+                        if (Log != null && Log.Switch.ShouldTrace(TraceEventType.Verbose))
+                        {
+                            string data = Utf8.ToString(buffer.Span.Slice(0, readBytes));
+                            if (!string.IsNullOrWhiteSpace(data))
+                                Log.TraceInformation(data);
+                        }
 
                         writer.Advance(readBytes);
                         await writer.FlushAsync();


### PR DESCRIPTION
cc @KrzysztofCwalina 

- Saves 4832 bytes of allocation when processing 100 files.
- Cleaned up the logging, otherwise, the console was getting flooded with empty lines.

FYI, with the recent CoreRT package update, the natively compiled exe is throwing an exception at run-time:
```text
Unhandled Exception: System.InvalidOperationException: Cannot call Set on a null context
   at AzCopyCore!<BaseAddress>+0x13e749
   at AzCopyCore!<BaseAddress>+0x13deb7
   at AzCopyCore!<BaseAddress>+0x13d89f
```
