### PR TITLE
Fix ITextBufferWriter performance regression: ArrayFormatter.GetSpan should not go through GetMemory

### DIFF
--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/ArrayFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/ArrayFormatter.cs
@@ -46,7 +46,19 @@ namespace System.Text.Formatting
             return _buffer.Free;
         }
 
-        public Span<byte> GetSpan(int minimumLength) => GetMemory(minimumLength).Span;
+        public Span<byte> GetSpan(int minimumLength = 0)
+        {
+            if (minimumLength < 1) minimumLength = 1;
+            if (minimumLength > _buffer.Free.Count)
+            {
+                var doubleCount = _buffer.Free.Count * 2;
+                int newSize = minimumLength > doubleCount ? minimumLength : doubleCount;
+                var newArray = _pool.Rent(newSize + _buffer.Count);
+                var oldArray = _buffer.Resize(newArray);
+                _pool.Return(oldArray);
+            }
+            return _buffer.Free;
+        }
 
         public void Advance(int bytes)
         {


### PR DESCRIPTION
Regression observed in JsonWriter performance test: https://github.com/dotnet/corefxlab/pull/2254

**The following PR caused the regression:** https://github.com/dotnet/corefxlab/pull/2047 / https://github.com/dotnet/corefxlab/commit/4bf5f6a527c109c888a78ff8b2593ee631f33126 - Jan 17, 2018

Was there a particular reason we went through `Memory<byte>` to get the span? I am now getting the Span directly. If this is correct, we should make similar changes to all implementations of ITextBufferWriter (for example [BufferWriterFormatter](https://github.com/dotnet/corefxlab/blob/master/src/System.Text.Formatting/System/Text/Formatting/Formatters/BufferWriterFormatter.cs#L10)).

This change improves JsonWriter performance by roughly 70% (before - 115 ms, after - 67 ms).

cc @pakrym, @KrzysztofCwalina, @davidfowl, @JeremyKuhne 