### PR TITLE
Fix IBufferWriter: GetSpan should not go through GetMemory

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/TcpConnectionFormatter.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/TcpConnectionFormatter.cs
@@ -47,7 +47,16 @@ namespace Microsoft.Net
             return Memory<byte>.Empty;
         }
 
-        public Span<byte> GetSpan(int minimumLength) => GetMemory(minimumLength).Span;
+        public Span<byte> GetSpan(int minimumLength)
+        {
+            if (_written < 1) throw new NotImplementedException();
+            Send();
+            _written = 0;
+
+            Span<byte> buffer = _buffer.AsSpan(ChunkPrefixSize + _written);
+            if (buffer.Length > 2) return buffer.Slice(0, buffer.Length - 2);
+            return Span<byte>.Empty;
+        }
 
         public int MaxBufferSize { get; } = Int32.MaxValue;
 

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/BufferWriterFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/BufferWriterFormatter.cs
@@ -31,6 +31,9 @@ namespace System.Text.Formatting
             return _output.GetMemory(minimumLength);
         }
 
-        public Span<byte> GetSpan(int minimumLength) => GetMemory(minimumLength).Span;
+        public Span<byte> GetSpan(int minimumLength)
+        {
+            return _output.GetSpan(minimumLength);
+        }
     }
 }

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/StreamFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/StreamFormatter.cs
@@ -44,7 +44,21 @@ namespace System.Text.Formatting
             return _buffer;
         }
 
-        Span<byte> IBufferWriter<byte>.GetSpan(int minimumLength) => ((IBufferWriter<byte>) this).GetMemory(minimumLength).Span;
+        Span<byte> IBufferWriter<byte>.GetSpan(int minimumLength)
+        {
+            if (minimumLength > _buffer.Length)
+            {
+                var newSize = _buffer.Length * 2;
+                if (minimumLength != 0)
+                {
+                    newSize = minimumLength;
+                }
+                var temp = _buffer;
+                _buffer = _pool.Rent(newSize);
+                _pool.Return(temp);
+            }
+            return _buffer;
+        }
 
         // ISSUE
         // I would like to lazy write to the stream, but unfortunatelly this seems to be exclusive with this type being a struct.

--- a/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
+++ b/tests/System.Binary.Base64.Tests/BasicUnitTests.cs
@@ -106,7 +106,10 @@ namespace System.Binary.Base64Experimental.Tests
             return ((Memory<byte>)_buffer).Slice(_written);
         }
 
-        public Span<byte> GetSpan(int minimumLength) => GetMemory(minimumLength).Span;
+        public Span<byte> GetSpan(int minimumLength)
+        {
+            return ((Span<byte>)_buffer).Slice(_written);
+        }
 
         public int MaxBufferSize { get; } = Int32.MaxValue;
     }

--- a/tests/System.Buffers.Experimental.Tests/BufferWriterTests_sequence.cs
+++ b/tests/System.Buffers.Experimental.Tests/BufferWriterTests_sequence.cs
@@ -66,7 +66,15 @@ namespace System.Buffers.Tests
             return _current;
         }
 
-        public Span<byte> GetSpan(int minimumLength) => GetMemory(minimumLength).Span;
+        public Span<byte> GetSpan(int minimumLength)
+        {
+            if (minimumLength == 0) minimumLength = _current.Length + 1;
+            if (minimumLength < _current.Length) throw new InvalidOperationException();
+            var newBuffer = new byte[minimumLength];
+            _current.CopyTo(newBuffer.AsSpan());
+            _current = newBuffer;
+            return _current;
+        }
 
         public int MaxBufferSize { get; } = Int32.MaxValue;
 


### PR DESCRIPTION
Related PR: https://github.com/dotnet/corefxlab/pull/2255

cc @pakrym, @KrzysztofCwalina, @davidfowl, @JeremyKuhne 