### PR TITLE
Add JsonSerializer (to string) tests and fix data generator

### DIFF
--- a/tests/Benchmarks/System.Text.JsonLab/Comparison/DataGenerator.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/Comparison/DataGenerator.cs
@@ -43,7 +43,24 @@ namespace JsonBenchmarks
             };
 
         private static IndexViewModel CreateIndexViewModel()
-            => new IndexViewModel
+        {
+            var events = new List<ActiveOrUpcomingEvent>();
+            for (int i = 0; i < 20; i++)
+            {
+                events.Add(new ActiveOrUpcomingEvent
+                {
+                    Id = 10,
+                    CampaignManagedOrganizerName = "Name FamiltyName",
+                    CampaignName = "The very new campaing",
+                    Description = "The .NET Foundation works with Microsoft and the broader industry to increase the exposure of open source projects in the .NET community and the .NET Foundation. The .NET Foundation provides access to these resources to projects and looks to promote the activities of our communities.",
+                    EndDate = DateTime.UtcNow.AddYears(1),
+                    Name = "Just a name",
+                    ImageUrl = "https://www.dotnetfoundation.org/theme/img/carousel/foundation-diagram-content.png",
+                    StartDate = DateTime.UtcNow
+                });
+            }
+
+            return new IndexViewModel
             {
                 IsNewAccount = false,
                 FeaturedCampaign = new CampaignSummaryViewModel
@@ -55,31 +72,56 @@ namespace JsonBenchmarks
                     ImageUrl = "https://www.dotnetfoundation.org/theme/img/carousel/foundation-diagram-content.png",
                     Title = "Promoting Open Source"
                 },
-                ActiveOrUpcomingEvents = Enumerable.Repeat(
-                    new ActiveOrUpcomingEvent
-                    {
-                        Id = 10,
-                        CampaignManagedOrganizerName = "Name FamiltyName",
-                        CampaignName = "The very new campaing",
-                        Description = "The .NET Foundation works with Microsoft and the broader industry to increase the exposure of open source projects in the .NET community and the .NET Foundation. The .NET Foundation provides access to these resources to projects and looks to promote the activities of our communities.",
-                        EndDate = DateTime.UtcNow.AddYears(1),
-                        Name = "Just a name",
-                        ImageUrl = "https://www.dotnetfoundation.org/theme/img/carousel/foundation-diagram-content.png",
-                        StartDate = DateTime.UtcNow
-                    },
-                    count: 20).ToList()
+                ActiveOrUpcomingEvents = events
             };
+        }
 
         private static MyEventsListerViewModel CreateMyEventsListerViewModel()
-            => new MyEventsListerViewModel
+        {
+            var current = new List<MyEventsListerItem>();
+
+            for (int i = 0; i < 3; i++)
             {
-                CurrentEvents = Enumerable.Repeat(CreateMyEventsListerItem(), 3).ToList(),
-                FutureEvents = Enumerable.Repeat(CreateMyEventsListerItem(), 9).ToList(),
-                PastEvents = Enumerable.Repeat(CreateMyEventsListerItem(), 60).ToList() // usually  there is a lot of historical data
+                current.Add(CreateMyEventsListerItem());
+            }
+
+            var future = new List<MyEventsListerItem>();
+
+            for (int i = 0; i < 9; i++)
+            {
+                future.Add(CreateMyEventsListerItem());
+            }
+
+            var past = new List<MyEventsListerItem>();
+
+            // usually  there is a lot of historical data
+            for (int i = 0; i < 60; i++)
+            {
+                past.Add(CreateMyEventsListerItem());
+            }
+
+            return new MyEventsListerViewModel
+            {
+                CurrentEvents = current,
+                FutureEvents = future,
+                PastEvents = past
             };
+        }
 
         private static MyEventsListerItem CreateMyEventsListerItem()
-            => new MyEventsListerItem
+        {
+            var tasks = new List<MyEventsListerItemTask>();
+            for (int i = 0; i < 4; i++)
+            {
+                tasks.Add(new MyEventsListerItemTask
+                {
+                    StartDate = DateTime.UtcNow,
+                    EndDate = DateTime.UtcNow.AddDays(1),
+                    Name = "A very nice task to have"
+                });
+            }
+
+            return new MyEventsListerItem
             {
                 Campaign = "A very nice campaing",
                 EndDate = DateTime.UtcNow.AddDays(7),
@@ -89,14 +131,9 @@ namespace JsonBenchmarks
                 StartDate = DateTime.UtcNow.AddDays(-7),
                 TimeZone = TimeZoneInfo.Utc.DisplayName,
                 VolunteerCount = 15,
-                Tasks = Enumerable.Repeat(
-                    new MyEventsListerItemTask
-                    {
-                        StartDate = DateTime.UtcNow,
-                        EndDate = DateTime.UtcNow.AddDays(1),
-                        Name = "A very nice task to have"
-                    }, 4).ToList()
+                Tasks = tasks
             };
+        }
     }
 
     /// <summary>

--- a/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonDeserializer/JsonDeserializerComparison_FromString.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonDeserializer/JsonDeserializerComparison_FromString.cs
@@ -6,7 +6,7 @@ using BenchmarkDotNet.Attributes;
 namespace JsonBenchmarks
 {
     [MemoryDiagnoser]
-    public class JsonDeserializerComparison_FromString<T>
+    public class JsonDeserializerComparison_FromString<T> where T : IVerifiable
     {
         private readonly T value;
         private string serialized;
@@ -36,26 +36,61 @@ namespace JsonBenchmarks
         public void SerializeManatee() => jsonValue = Manatee.Json.JsonValue.Parse(new Manatee.Json.Serialization.JsonSerializer().Serialize(value).ToString());
 
         [Benchmark(Description = "Jil")]
-        public T Jil_() => Jil.JSON.Deserialize<T>(serialized);
+        public T Jil_()
+        {
+            T deserialized = Jil.JSON.Deserialize<T>(serialized);
+            ((IVerifiable)deserialized).TouchEveryProperty();
+            return deserialized;
+        }
 
         [Benchmark(Baseline = true, Description = "Newtonsoft")]
-        public T Newtonsoft_() => Newtonsoft.Json.JsonConvert.DeserializeObject<T>(serialized);
+        public T Newtonsoft_()
+        {
+            T deserialized = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(serialized);
+            ((IVerifiable)deserialized).TouchEveryProperty();
+            return deserialized;
+        }
 
         [Benchmark(Description = "Utf8Json")]
-        public T Utf8Json_() => Utf8Json.JsonSerializer.Deserialize<T>(serialized);
+        public T Utf8Json_()
+        {
+            T deserialized = Utf8Json.JsonSerializer.Deserialize<T>(serialized);
+            ((IVerifiable)deserialized).TouchEveryProperty();
+            return deserialized;
+        }
 
         [Benchmark(Description = "YSharp")]
-        public T YSharp() => new System.Text.Json.JsonParser().Parse<T>(serialized);
+        public T YSharp()
+        {
+            T deserialized = new System.Text.Json.JsonParser().Parse<T>(serialized);
+            ((IVerifiable)deserialized).TouchEveryProperty();
+            return deserialized;
+        }
 
         [Benchmark(Description = "FastJson")]
-        public T FastJson() => fastJSON.JSON.ToObject<T>(serialized);
+        public T FastJson()
+        {
+            T deserialized = fastJSON.JSON.ToObject<T>(serialized);
+            ((IVerifiable)deserialized).TouchEveryProperty();
+            return deserialized;
+        }
 
         // This benchmarks fails to run for IndexViewModel and MyEventsListerViewModel.
         //[Benchmark(Description = "LitJson")]
-        public T LitJson_() => LitJson.JsonMapper.ToObject<T>(serialized);
+        public T LitJson_()
+        {
+            T deserialized = LitJson.JsonMapper.ToObject<T>(serialized);
+            ((IVerifiable)deserialized).TouchEveryProperty();
+            return deserialized;
+        }
 
         // This benchmarks fails to run for IndexViewModel and MyEventsListerViewModel.
         //[Benchmark(Description = "Manatee")]
-        public T Manatee_() => new Manatee.Json.Serialization.JsonSerializer().Deserialize<T>(jsonValue);
+        public T Manatee_()
+        {
+            T deserialized = new Manatee.Json.Serialization.JsonSerializer().Deserialize<T>(jsonValue);
+            ((IVerifiable)deserialized).TouchEveryProperty();
+            return deserialized;
+        }
     }
 }

--- a/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonSerializer/JsonSerializerComparison_ToString.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonSerializer/JsonSerializerComparison_ToString.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using System;
+
+namespace JsonBenchmarks
+{
+    [MemoryDiagnoser]
+    public class JsonSerializerComparison_ToString<T> where T : IVerifiable
+    {
+        private readonly T value;
+
+        public JsonSerializerComparison_ToString() => value = DataGenerator.Generate<T>();
+
+        [Benchmark(Description = "Jil")]
+        public string Jil_() => Jil.JSON.Serialize(value);
+
+        [Benchmark(Baseline = true, Description = "Newtonsoft")]
+        public string Newtonsoft_() => Newtonsoft.Json.JsonConvert.SerializeObject(value);
+
+        [Benchmark(Description = "Utf8Json")]
+        public string Utf8Json_() => Utf8Json.JsonSerializer.ToJsonString(value);
+
+        [Benchmark(Description = "FastJson")]
+        public string FastJson() => fastJSON.JSON.ToJSON(value);
+
+        // This benchmarks fails to run for IndexViewModel and MyEventsListerViewModel.
+        //[Benchmark(Description = "LitJson")]
+        public string LitJson_() => LitJson.JsonMapper.ToJson(value);
+
+        [Benchmark(Description = "Manatee")]
+        public string Manatee_() => new Manatee.Json.Serialization.JsonSerializer().Serialize(value).ToString();
+    }
+}

--- a/tests/Benchmarks/System.Text.JsonLab/Comparison/SerializerBenchmarks.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/Comparison/SerializerBenchmarks.cs
@@ -14,6 +14,7 @@ namespace JsonBenchmarks
             => new[]
             {
                 typeof(JsonDeserializerComparison_FromString<>),
+                typeof(JsonSerializerComparison_ToString<>),
             };
 
         private static Type[] GetViewModels()

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -41,7 +41,7 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark]
-        public void ReaderSystemTextJson() => TestReaderSystemTextJson(_data, _symbolTable);
+        public void ReaderSystemTextJsonLab() => TestReaderSystemTextJsonLab(_data, _symbolTable);
 
         [Benchmark(Baseline = true)]
         public void ReaderNewtonsoft()
@@ -50,7 +50,7 @@ namespace System.Text.JsonLab.Benchmarks
             TestReaderNewtonsoft(_reader);
         }
 
-        private static void TestReaderSystemTextJson(ReadOnlySpan<byte> data, SymbolTable symbolTable)
+        private static void TestReaderSystemTextJsonLab(ReadOnlySpan<byte> data, SymbolTable symbolTable)
         {
             var json = new JsonReader(data, symbolTable);
             while (json.Read()) ;


### PR DESCRIPTION
- We can't use Enumerable.Repeat since some JSON libraries (like FastJson) optimize for repeated values, which ends up skewing the results.

The updated results are shown below. The FastJson library was the only one that was significantly impacted by this change (previous PR https://github.com/dotnet/corefxlab/pull/2265)

``` ini

BenchmarkDotNet=v0.10.14.525-nightly, OS=Windows 10.0.16299.371 (1709/FallCreatorsUpdate/Redstone3)
Intel Xeon CPU E5-1620 v2 3.70GHz, 1 CPU, 8 logical and 4 physical cores
Frequency=3604597 Hz, Resolution=277.4235 ns, Timer=TSC
.NET Core SDK=2.1.300-rtm-008820
  [Host]     : .NET Core 2.1.0-rtm-26507-03 (CoreCLR 4.6.26507.03, CoreFX 4.6.26507.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0-rtm-26507-03 (CoreCLR 4.6.26507.03, CoreFX 4.6.26507.03), 64bit RyuJIT


```
**JsonDeserializerComparison_FromString_LoginViewModel**

|     Method |         Mean |         Error |        StdDev | Scaled | ScaledSD |  Gen 0 |  Gen 1 | Allocated |
|----------- |-------------:|--------------:|--------------:|-------:|---------:|-------:|-------:|----------:|
|        Jil |     508.9 ns |      8.061 ns |      7.541 ns |   0.28 |     0.01 | 0.0515 |      - |     272 B |
| Newtonsoft |   1,806.4 ns |     35.591 ns |     38.081 ns |   1.00 |     0.00 | 0.5302 |      - |    2784 B |
|   Utf8Json |   1,016.1 ns |     12.158 ns |     11.372 ns |   0.56 |     0.01 | 0.0534 |      - |     288 B |
|     YSharp | 539,029.1 ns | 10,608.678 ns | 10,419.139 ns | 298.53 |     8.28 | 6.8359 | 2.9297 |   38554 B |
|   FastJson |   3,066.3 ns |     10.952 ns |      9.708 ns |   1.70 |     0.04 | 0.4578 |      - |    2416 B |

**JsonDeserializerComparison_FromString_MyEventsListerViewModel**

|     Method |       Mean |      Error |     StdDev | Scaled | ScaledSD |    Gen 0 |   Gen 1 | Allocated |
|----------- |-----------:|-----------:|-----------:|-------:|---------:|---------:|--------:|----------:|
|        Jil |   430.7 us |  0.7704 us |  0.5570 us |   0.38 |     0.00 |  16.1133 |  3.9063 |  83.92 KB |
| Newtonsoft | 1,123.6 us |  7.8644 us |  7.3564 us |   1.00 |     0.00 |  29.2969 |  5.8594 |  156.7 KB |
|   Utf8Json |   551.7 us |  4.5463 us |  3.7963 us |   0.49 |     0.00 |  34.1797 |  7.8125 |  180.8 KB |
|     YSharp | 4,650.7 us | 28.4729 us | 26.6335 us |   4.14 |     0.03 |  54.6875 | 23.4375 | 292.24 KB |
|   FastJson | 1,225.4 us |  7.5132 us |  5.8658 us |   1.09 |     0.01 | 103.5156 | 39.0625 | 581.96 KB |

**JsonSerializerComparison_ToString_LoginViewModel**

|     Method |       Mean |      Error |     StdDev |     Median | Scaled | ScaledSD |  Gen 0 |  Gen 1 | Allocated |
|----------- |-----------:|-----------:|-----------:|-----------:|-------:|---------:|-------:|-------:|----------:|
|        Jil |   554.0 ns |  11.028 ns |  22.278 ns |   545.0 ns |   0.49 |     0.02 | 0.1402 |      - |     736 B |
| Newtonsoft | 1,131.5 ns |   5.489 ns |   4.583 ns | 1,132.1 ns |   1.00 |     0.00 | 0.2880 |      - |    1512 B |
|   Utf8Json |   305.3 ns |   6.145 ns |   7.547 ns |   303.7 ns |   0.27 |     0.01 | 0.0362 |      - |     192 B |
|   FastJson | 1,672.9 ns |  43.827 ns |  36.597 ns | 1,674.8 ns |   1.48 |     0.03 | 0.5627 | 0.0038 |    2952 B |
|    Manatee | 8,733.2 ns | 171.357 ns | 168.295 ns | 8,767.8 ns |   7.72 |     0.15 | 0.8087 |      - |    4272 B |

**JsonSerializerComparison_ToString_MyEventsListerViewModel**

|     Method |       Mean |     Error |    StdDev | Scaled | ScaledSD |    Gen 0 |   Gen 1 |   Gen 2 |  Allocated |
|----------- |-----------:|----------:|----------:|-------:|---------:|---------:|--------:|--------:|-----------:|
|        Jil |   841.7 us |  7.572 us |  7.083 us |   0.50 |     0.00 |  85.9375 | 42.9688 | 42.9688 |  578.98 KB |
| Newtonsoft | 1,685.3 us |  9.783 us |  8.673 us |   1.00 |     0.00 | 113.2813 | 44.9219 | 44.9219 |  624.12 KB |
|   Utf8Json | 1,105.6 us | 12.583 us | 11.770 us |   0.66 |     0.01 |  85.9375 | 85.9375 | 85.9375 |  564.93 KB |
|   FastJson | 1,464.4 us |  7.590 us |  5.926 us |   0.87 |     0.01 | 105.4688 | 35.1563 | 35.1563 |  504.73 KB |
|    Manatee | 3,845.2 us | 74.377 us | 76.380 us |   2.28 |     0.05 | 199.2188 | 66.4063 |       - | 1066.55 KB |

![image](https://user-images.githubusercontent.com/6527137/39731976-7c164d92-521f-11e8-98c5-9d9692492720.png)

![image](https://user-images.githubusercontent.com/6527137/39731977-812f2858-521f-11e8-88b4-331a58ab8d78.png)

![image](https://user-images.githubusercontent.com/6527137/39731978-844443c0-521f-11e8-8a37-6280c357a2bb.png)

![image](https://user-images.githubusercontent.com/6527137/39731981-868ccc10-521f-11e8-8d60-c2528f8b66d5.png)

