### PR TITLE
Add back Serializer Benchmarks and update JsonReaderPerf tests to use StringReader

### DIFF
--- a/tests/Benchmarks/Program.cs
+++ b/tests/Benchmarks/Program.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Text.Http.Parser.Benchmarks;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Environments;
@@ -24,11 +25,19 @@ namespace Benchmarks
 
         // BenchmarkDotNet can run generic benchmarks, if it knows what generic type arguments to use
         private static Type[] GetGenericBenchmarks()
-            => new[]
+        {
+            var types = new List<Type>
             {
                 typeof(HttpParser<Request>),
-                typeof(HttpParser<RequestStruct>),
+                typeof(HttpParser<RequestStruct>)
             };
+
+            foreach (Type type in JsonBenchmarks.SerializerBenchmarks.GetTypes())
+            {
+                types.Add(type);
+            }
+            return types.ToArray();
+        }
 
         private static IConfig CreateClrVsCoreConfig()
             => DefaultConfig.Instance

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -40,26 +40,26 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, enc, false, 1024, true);
         }
 
-        [Benchmark]
-        public void ReaderSystemTextJsonLab() => TestReaderSystemTextJsonLab(_data, _symbolTable);
-
         [Benchmark(Baseline = true)]
-        public void ReaderNewtonsoft()
+        public void ReaderNewtonsoftStringReader()
         {
-            _stream.Seek(0, SeekOrigin.Begin);
-            TestReaderNewtonsoft(_reader);
-        }
-
-        private static void TestReaderSystemTextJsonLab(ReadOnlySpan<byte> data, SymbolTable symbolTable)
-        {
-            var json = new JsonReader(data, symbolTable);
+            var json = new Newtonsoft.Json.JsonTextReader(new StringReader(JsonString));
             while (json.Read()) ;
         }
 
-        private static void TestReaderNewtonsoft(StreamReader reader)
+        [Benchmark]
+        public void ReaderNewtonsoftStreamReader()
         {
-            using (var json = new Newtonsoft.Json.JsonTextReader(reader))
+            _stream.Seek(0, SeekOrigin.Begin);
+            using (var json = new Newtonsoft.Json.JsonTextReader(_reader))
                 while (json.Read()) ;
+        }
+
+        [Benchmark]
+        public void ReaderSystemTextJsonLab()
+        {
+            var json = new JsonReader(_data, _symbolTable);
+            while (json.Read()) ;
         }
 
         private static byte[] EncodeTestData(EncoderTarget encoderTarget, string data)


### PR DESCRIPTION
Added StringReader based test and making it the baseline since that is a more fair comparison (for UTF-16 input). The StringReader is faster than StreamReader. Keeping the StreamReader based test (which is slower) since that is required for UTF-8 encoded input.

Comparing to the StringReader, JsonLab is 2-3x faster instead of 4x shown previously (when compared to StreamReader).

![image](https://user-images.githubusercontent.com/6527137/39852167-dde5190c-53cf-11e8-9708-21121096c65a.png)

cc @KrzysztofCwalina, @joshfree 