### PR TITLE
 Add JsonReaderTests and update benchmarks with different json string inputs.

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
@@ -508,7 +508,9 @@ namespace System.Text.JsonLab
             while (idx < length)
             {
                 ref byte b = ref Unsafe.Add(ref src, idx);
-                if (b == JsonConstants.ListSeperator || b == JsonConstants.CloseBrace || b == JsonConstants.CloseBracket)
+                // TODO: Fix terminating condition
+                if (b == JsonConstants.ListSeperator || b == JsonConstants.CloseBrace || b == JsonConstants.CloseBracket || b == JsonConstants.CarriageReturn
+                    || b == JsonConstants.LineFeed || b == JsonConstants.Space)
                     break;
                 idx++;
             }
@@ -531,7 +533,9 @@ namespace System.Text.JsonLab
             while (idx < length)
             {
                 ref char b = ref Unsafe.Add(ref chars, idx);
-                if (b == JsonConstants.ListSeperator || b == JsonConstants.CloseBrace || b == JsonConstants.CloseBracket)
+                // TODO: Fix terminating condition
+                if (b == JsonConstants.ListSeperator || b == JsonConstants.CloseBrace || b == JsonConstants.CloseBracket || b == JsonConstants.CarriageReturn
+                    || b == JsonConstants.LineFeed || b == JsonConstants.Space)
                     break;
                 idx++;
             }

--- a/tests/Benchmarks/JsonStrings.Designer.cs
+++ b/tests/Benchmarks/JsonStrings.Designer.cs
@@ -92,7 +92,23 @@ namespace Benchmarks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;_id&quot;: &quot;5af4c006873ec87e12466553&quot;,
+        ///    &quot;index&quot;: 0,
+        ///    &quot;guid&quot;: &quot;cce48618-6953-4907-b641-288a68f2bd75&quot;,
+        ///    &quot;isActive&quot;: true,
+        ///    &quot;balance&quot;: &quot;$3,677.14&quot;,
+        ///    &quot;picture&quot;: &quot;http://placehold.it/32x32&quot;,
+        ///    &quot;age&quot;: 22,
+        ///    &quot;eyeColor&quot;: &quot;blue&quot;,
+        ///    &quot;name&quot;: &quot;Hampton Guerra&quot;,
+        ///    &quot;gender&quot;: &quot;male&quot;,
+        ///    &quot;company&quot;: &quot;GAPTEC&quot;,
+        ///    &quot;email&quot;: &quot;hamptonguerra@gaptec.com&quot;,
+        ///    &quot;phone&quot;: &quot;+1 (858) 595-2071&quot;,
+        ///    &quot;address&quot;: &quot;282 Harden Street, Orason, Nebraska, 3912&quot;,
+        ///    &quot;about&quot;: &quot;Tempor ullamco eu anim d [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BroadTree {
             get {
@@ -101,7 +117,23 @@ namespace Benchmarks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;_id&quot;: &quot;5af4bfbe93ba383385d9047a&quot;,
+        ///    &quot;index&quot;: 0,
+        ///    &quot;guid&quot;: &quot;1a4244ab-960b-4937-872d-d0b00882a99d&quot;,
+        ///    &quot;isActive&quot;: true,
+        ///    &quot;balance&quot;: &quot;$3,377.20&quot;,
+        ///    &quot;picture&quot;: &quot;http://placehold.it/32x32&quot;,
+        ///    &quot;age&quot;: 30,
+        ///    &quot;eyeColor&quot;: &quot;blue&quot;,
+        ///    &quot;name&quot;: &quot;Ferguson Avery&quot;,
+        ///    &quot;gender&quot;: &quot;male&quot;,
+        ///    &quot;company&quot;: &quot;PHARMACON&quot;,
+        ///    &quot;email&quot;: &quot;fergusonavery@pharmacon.com&quot;,
+        ///    &quot;phone&quot;: &quot;+1 (904) 438-2218&quot;,
+        ///    &quot;address&quot;: &quot;732 Falmouth Street, Riviera, Mississippi, 4550&quot;,
+        ///    &quot;about&quot;: &quot;Pariatur adi [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string DeepTree {
             get {
@@ -126,7 +158,7 @@ namespace Benchmarks {
                 return ResourceManager.GetString("FullJsonSchema2", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;array&quot;:[  {    &quot;_id&quot;: &quot;56280d1abea79cfca762cd56&quot;,    &quot;index&quot;: 0,    &quot;isActive&quot;: false,    &quot;tags&quot;: [      &quot;ad&quot;,      &quot;voluptate&quot;,      &quot;ullamco&quot;,      &quot;reprehenderit&quot;,      &quot;duis&quot;,      &quot;Lorem&quot;,      &quot;anim&quot;    ],    &quot;friends&quot;: [      {        &quot;id&quot;: 0,        &quot;name&quot;: &quot;Fernandez Barr&quot;,        &quot;friends&quot;: [          {            &quot;id&quot;: 0,            &quot;name&quot;: &quot;Selena Hoover&quot;,            &quot;friends&quot;: [              {                &quot;id&quot;: 0,                &quot;name&quot;: &quot;Verna Keller&quot;,                &quot;friends&quot;: [           [rest of string was truncated]&quot;;.
         /// </summary>
@@ -146,38 +178,101 @@ namespace Benchmarks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;_id&quot;: &quot;5671eaf1eb61139592ea92ff&quot;,
+        ///    &quot;index&quot;: 0,
+        ///    &quot;guid&quot;: &quot;b825474f-3855-434e-930c-c3015f3b39ee&quot;,
+        ///    &quot;isActive&quot;: false,
+        ///    &quot;balance&quot;: &quot;$2,100.09&quot;,
+        ///    &quot;picture&quot;: &quot;http://placehold.it/32x32&quot;,
+        ///    &quot;age&quot;: 20,
+        ///    &quot;eyeColor&quot;: &quot;green&quot;,
+        ///    &quot;name&quot;: &quot;Zelma Blackburn&quot;,
+        ///    &quot;gender&quot;: &quot;female&quot;,
+        ///    &quot;company&quot;: &quot;AUTOMON&quot;,
+        ///    &quot;email&quot;: &quot;zelmablackburn@automon.com&quot;,
+        ///    &quot;phone&quot;: &quot;+1 (935) 411-3028&quot;,
+        ///    &quot;address&quot;: &quot;358 Catherine Street, Takilma, New Hampshire, 9061&quot;,
+        ///    &quot;about&quot;: &quot;Ad ea o [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string Json300B {
+        internal static string Json400KB {
             get {
-                return ResourceManager.GetString("Json300B", resourceCulture);
+                return ResourceManager.GetString("Json400KB", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;_id&quot;: &quot;5671eb0737b18866984067ac&quot;,
+        ///    &quot;index&quot;: 0,
+        ///    &quot;guid&quot;: &quot;3cfa77d7-29be-467f-a967-16bae78767e8&quot;,
+        ///    &quot;isActive&quot;: false,
+        ///    &quot;balance&quot;: &quot;$1,223.37&quot;,
+        ///    &quot;picture&quot;: &quot;http://placehold.it/32x32&quot;,
+        ///    &quot;age&quot;: 34,
+        ///    &quot;eyeColor&quot;: &quot;brown&quot;,
+        ///    &quot;name&quot;: &quot;Josephine Snider&quot;,
+        ///    &quot;gender&quot;: &quot;female&quot;,
+        ///    &quot;company&quot;: &quot;SYBIXTEX&quot;,
+        ///    &quot;email&quot;: &quot;josephinesnider@sybixtex.com&quot;,
+        ///    &quot;phone&quot;: &quot;+1 (936) 525-3324&quot;,
+        ///    &quot;address&quot;: &quot;905 Marconi Place, Motley, Oregon, 3159&quot;,
+        ///    &quot;about&quot;: &quot;Ut id id conse [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string Json300KB {
+        internal static string Json40KB {
             get {
-                return ResourceManager.GetString("Json300KB", resourceCulture);
+                return ResourceManager.GetString("Json40KB", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;_id&quot;: &quot;5671eb1b60a382ffb56b3946&quot;,
+        ///    &quot;index&quot;: 0,
+        ///    &quot;guid&quot;: &quot;8938d485-7ea7-4b57-ab02-cd7ff698a57e&quot;,
+        ///    &quot;isActive&quot;: true,
+        ///    &quot;balance&quot;: &quot;$3,138.66&quot;,
+        ///    &quot;picture&quot;: &quot;http://placehold.it/32x32&quot;,
+        ///    &quot;age&quot;: 28,
+        ///    &quot;eyeColor&quot;: &quot;blue&quot;,
+        ///    &quot;name&quot;: &quot;Susanne Wright&quot;,
+        ///    &quot;gender&quot;: &quot;female&quot;,
+        ///    &quot;company&quot;: &quot;VIXO&quot;,
+        ///    &quot;email&quot;: &quot;susannewright@vixo.com&quot;,
+        ///    &quot;phone&quot;: &quot;+1 (836) 581-2698&quot;,
+        ///    &quot;address&quot;: &quot;367 Clifford Place, Benson, Northern Mariana Islands, 4627&quot;,
+        ///    &quot;about&quot;: &quot;Irure off [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string Json30KB {
+        internal static string Json4KB {
             get {
-                return ResourceManager.GetString("Json30KB", resourceCulture);
+                return ResourceManager.GetString("Json4KB", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;_id&quot;: &quot;5671ebcfd88de5e8dac53641&quot;,
+        ///    &quot;index&quot;: 0,
+        ///    &quot;isActive&quot;: true,
+        ///    &quot;balance&quot;: &quot;$3,951.98&quot;,
+        ///    &quot;picture&quot;: &quot;http://placehold.it/32x32&quot;,
+        ///    &quot;age&quot;: 36,
+        ///    &quot;email&quot;: &quot;clementsvillarreal@daycore.com&quot;,
+        ///    &quot;phone&quot;: &quot;+1 (882) 479-2331&quot;,
+        ///    &quot;address&quot;: &quot;488 Grand Street, Hackneyville, Vermont, 5344&quot;,
+        ///    &quot;registered&quot;: &quot;2015-04-12T05:27:22 +07:00&quot;,
+        ///    &quot;latitude&quot;: -57.256693,
+        ///    &quot;longitude&quot;: 49.961028
+        ///  }
+        ///].
         /// </summary>
-        internal static string Json3KB {
+        internal static string Json400B {
             get {
-                return ResourceManager.GetString("Json3KB", resourceCulture);
+                return ResourceManager.GetString("Json400B", resourceCulture);
             }
         }
         
@@ -204,7 +299,31 @@ namespace Benchmarks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;_id1&quot;: 5957425176,
+        ///    &quot;_id2&quot;: 8643,
+        ///    &quot;_id3&quot;: 5807096065,
+        ///    &quot;_id4&quot;: 7783,
+        ///    &quot;_id5&quot;: 4472383761,
+        ///    &quot;_id6&quot;: 4732,
+        ///    &quot;_id7&quot;: 7115361679,
+        ///    &quot;_id8&quot;: 4182,
+        ///    &quot;_id9&quot;: 7135052469,
+        ///    &quot;_id10&quot;: 9529,
+        ///    &quot;_id11&quot;: 5897146321,
+        ///    &quot;_id12&quot;: 7032,
+        ///    &quot;_id13&quot;: 9662544180,
+        ///    &quot;_id14&quot;: 6889,
+        ///    &quot;_id15&quot;: 2829833657,
+        ///    &quot;_id16&quot;: 4145,
+        ///    &quot;_id17&quot;: 6358760299,
+        ///    &quot;_id18&quot;: 4908,
+        ///    &quot;_id19&quot;: 1013268274,
+        ///    &quot;_id20&quot;: 1232,
+        ///    &quot;_id21&quot;: 9736001947,
+        ///    &quot;_id22&quot;: 2862,
+        ///    &quot;_i [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string LotsOfNumbers {
             get {
@@ -213,7 +332,41 @@ namespace Benchmarks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to {
+        ///  &quot;tags&quot;: [
+        ///    &quot;culpa&quot;,
+        ///    &quot;laboris&quot;,
+        ///    &quot;nulla&quot;,
+        ///    &quot;exercitation&quot;,
+        ///    &quot;do&quot;,
+        ///    &quot;pariatur&quot;,
+        ///    &quot;occaecat&quot;,
+        ///    &quot;aliquip&quot;,
+        ///    &quot;est&quot;,
+        ///    &quot;et&quot;,
+        ///    &quot;officia&quot;,
+        ///    &quot;minim&quot;,
+        ///    &quot;quis&quot;,
+        ///    &quot;est&quot;,
+        ///    &quot;ullamco&quot;,
+        ///    &quot;consequat&quot;,
+        ///    &quot;id&quot;,
+        ///    &quot;esse&quot;,
+        ///    &quot;irure&quot;,
+        ///    &quot;reprehenderit&quot;,
+        ///    &quot;proident&quot;,
+        ///    &quot;labore&quot;,
+        ///    &quot;et&quot;,
+        ///    &quot;in&quot;,
+        ///    &quot;consequat&quot;,
+        ///    &quot;officia&quot;,
+        ///    &quot;exercitation&quot;,
+        ///    &quot;aute&quot;,
+        ///    &quot;do&quot;,
+        ///    &quot;consequat&quot;,
+        ///    &quot;laborum&quot;,
+        ///    &quot;officia&quot;,
+        ///    &quot;consectetu [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string LotsOfStrings {
             get {

--- a/tests/Benchmarks/JsonStrings.Designer.cs
+++ b/tests/Benchmarks/JsonStrings.Designer.cs
@@ -182,15 +182,6 @@ namespace Benchmarks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
-        /// </summary>
-        internal static string Json3MB {
-            get {
-                return ResourceManager.GetString("Json3MB", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {&quot;+testZero+&quot; : 0,&quot;+testSmallNum+&quot; : 0.1,&quot;+testeZero+&quot; : 0.1e0,&quot;+testENegtiveWithZero+&quot; : 0E-1,&quot;+testeNegativeWithInt+&quot; : 2155e-5,&quot;+testEPositiveWithDecimal+&quot; : 2152.1541E+2,&quot;+testePositiveWithLargeInt+&quot; : 18446744073709551615E109,&quot;+testeNegativeWithLargeDecimal+&quot; : 125125612512512.512512e-0123,&quot;-testZero-&quot; : -0,&quot;-testSmallNum-&quot; : -0.1,&quot;-testeZero-&quot; : -0.1e0,&quot;-testENegtiveWithZero-&quot; : -0E-1,&quot;-testeNegativeWithInt-&quot; : -2155e-5,&quot;-testEPositiveWithDecimal-&quot; : -2152.1541E+2,&quot;-testePositiveWithLargeInt-&quot; :-18446 [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string JsonWithSpecialNumFormat {

--- a/tests/Benchmarks/JsonStrings.Designer.cs
+++ b/tests/Benchmarks/JsonStrings.Designer.cs
@@ -85,9 +85,9 @@ namespace Benchmarks {
         /// <summary>
         ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1MicrosoftWay&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052},&quot;IDs&quot;:[425,-70,9223372036854775807]}.
         /// </summary>
-        internal static string BasicJsonWithLargeNum {
+        internal static string BasicLargeNum {
             get {
-                return ResourceManager.GetString("BasicJsonWithLargeNum", resourceCulture);
+                return ResourceManager.GetString("BasicLargeNum", resourceCulture);
             }
         }
         
@@ -144,18 +144,18 @@ namespace Benchmarks {
         /// <summary>
         ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1MicrosoftWay&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052},&quot;IDs&quot;:[425,-70,9223372036854776000],&quot;arrayWithObjects&quot;:[&quot;text&quot;,14,[],null,false,{},{&quot;time&quot;:24},[&quot;1&quot;,&quot;2&quot;,&quot;3&quot;]],&quot;boolean&quot;:false,&quot;null&quot;:null,&quot;objectName&quot;:{&quot;group&quot;:{&quot;array&quot;:[false],&quot;field&quot;:&quot;simple&quot;,&quot;anotherFieldNum&quot;:5,&quot;anotherFieldBool&quot;:true,&quot;lastField&quot;:null}},&quot;emptyObject&quot;:{}}.
         /// </summary>
-        internal static string FullJsonSchema1 {
+        internal static string FullSchema1 {
             get {
-                return ResourceManager.GetString("FullJsonSchema1", resourceCulture);
+                return ResourceManager.GetString("FullSchema1", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to {&quot;string&quot;:&quot;string&quot;,&quot;number&quot;:5,&quot;decimal&quot;:3516512.13512,&quot;long&quot;:9223372036854776000.1200,&quot;notLong&quot;:922854776000.1200,&quot;boolean&quot;:false,&quot;object&quot;:{},&quot;array&quot;:[],&quot;null&quot;:null,&quot;emptyArray&quot;:[],&quot;emptyObject&quot;:{},&quot;arrayString&quot;:[&quot;alpha&quot;,&quot;beta&quot;],&quot;arrayNum&quot;:[1,212512.01,3.00],&quot;arrayBool&quot;:[false,true,true],&quot;arrayNull&quot;:[null,null],&quot;arrayObject&quot;:[{&quot;firstName&quot;:&quot;name1&quot;,&quot;lastName&quot;:&quot;name&quot;},{&quot;firstName&quot;:&quot;name1&quot;,&quot;lastName&quot;:&quot;name&quot;},{&quot;firstName&quot;:&quot;name2&quot;,&quot;lastName&quot;:&quot;name&quot;},{&quot;firstName&quot;:&quot;name3&quot;,&quot;lastName&quot;:&quot;name1&quot;}],&quot;arrayArray&quot;:[[null,fa [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string FullJsonSchema2 {
+        internal static string FullSchema2 {
             get {
-                return ResourceManager.GetString("FullJsonSchema2", resourceCulture);
+                return ResourceManager.GetString("FullSchema2", resourceCulture);
             }
         }
         
@@ -279,9 +279,9 @@ namespace Benchmarks {
         /// <summary>
         ///   Looks up a localized string similar to {&quot;+testZero+&quot; : 0,&quot;+testSmallNum+&quot; : 0.1,&quot;+testeZero+&quot; : 0.1e0,&quot;+testENegtiveWithZero+&quot; : 0E-1,&quot;+testeNegativeWithInt+&quot; : 2155e-5,&quot;+testEPositiveWithDecimal+&quot; : 2152.1541E+2,&quot;+testePositiveWithLargeInt+&quot; : 18446744073709551615E109,&quot;+testeNegativeWithLargeDecimal+&quot; : 125125612512512.512512e-0123,&quot;-testZero-&quot; : -0,&quot;-testSmallNum-&quot; : -0.1,&quot;-testeZero-&quot; : -0.1e0,&quot;-testENegtiveWithZero-&quot; : -0E-1,&quot;-testeNegativeWithInt-&quot; : -2155e-5,&quot;-testEPositiveWithDecimal-&quot; : -2152.1541E+2,&quot;-testePositiveWithLargeInt-&quot; :-18446 [rest of string was truncated]&quot;;.
         /// </summary>
-        internal static string JsonWithSpecialNumFormat {
+        internal static string SpecialNumForm {
             get {
-                return ResourceManager.GetString("JsonWithSpecialNumFormat", resourceCulture);
+                return ResourceManager.GetString("SpecialNumForm", resourceCulture);
             }
         }
         

--- a/tests/Benchmarks/JsonStrings.Designer.cs
+++ b/tests/Benchmarks/JsonStrings.Designer.cs
@@ -83,7 +83,7 @@ namespace Benchmarks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1MicrosoftWay&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052},&quot;IDs&quot;:[0425,-70,9223372036854775807]}.
+        ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1MicrosoftWay&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052},&quot;IDs&quot;:[425,-70,9223372036854775807]}.
         /// </summary>
         internal static string BasicJsonWithLargeNum {
             get {
@@ -92,105 +92,20 @@ namespace Benchmarks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1 Microsoft Way&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052}}.
+        ///   Looks up a localized string similar to .
         /// </summary>
-        internal static string ExpectedBasicJson {
+        internal static string BroadTree {
             get {
-                return ResourceManager.GetString("ExpectedBasicJson", resourceCulture);
+                return ResourceManager.GetString("BroadTree", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1MicrosoftWay&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052},&quot;IDs&quot;:[425,-70,9.22337203685478E+18]}.
+        ///   Looks up a localized string similar to .
         /// </summary>
-        internal static string ExpectedBasicJsonWithLargeNum {
+        internal static string DeepTree {
             get {
-                return ResourceManager.GetString("ExpectedBasicJsonWithLargeNum", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1 Microsoft Way&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052}}.
-        /// </summary>
-        internal static string ExpectedCreateJson {
-            get {
-                return ResourceManager.GetString("ExpectedCreateJson", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1MicrosoftWay&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052},&quot;IDs&quot;:[425,-70,9.22337203685478E+18],&quot;arrayWithObjects&quot;:[&quot;text&quot;,14,[],null,false,{},{&quot;time&quot;:24},[&quot;1&quot;,&quot;2&quot;,&quot;3&quot;]],&quot;boolean&quot;:false,&quot;null&quot;:null,&quot;objectName&quot;:{&quot;group&quot;:{&quot;array&quot;:[false],&quot;field&quot;:&quot;simple&quot;,&quot;anotherFieldNum&quot;:5,&quot;anotherFieldBool&quot;:true,&quot;lastField&quot;:null}},&quot;emptyObject&quot;:{}}.
-        /// </summary>
-        internal static string ExpectedFullJsonSchema1 {
-            get {
-                return ResourceManager.GetString("ExpectedFullJsonSchema1", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {&quot;string&quot;:&quot;string&quot;,&quot;number&quot;:5,&quot;decimal&quot;:3516512.13512,&quot;long&quot;:9.22337203685478E+18,&quot;notLong&quot;:922854776000.12,&quot;boolean&quot;:false,&quot;object&quot;:{},&quot;array&quot;:[],&quot;null&quot;:null,&quot;emptyArray&quot;:[],&quot;emptyObject&quot;:{},&quot;arrayString&quot;:[&quot;alpha&quot;,&quot;beta&quot;],&quot;arrayNum&quot;:[1,212512.01,3],&quot;arrayBool&quot;:[false,true,true],&quot;arrayNull&quot;:[null,null],&quot;arrayObject&quot;:[{&quot;firstName&quot;:&quot;name1&quot;,&quot;lastName&quot;:&quot;name&quot;},{&quot;firstName&quot;:&quot;name1&quot;,&quot;lastName&quot;:&quot;name&quot;},{&quot;firstName&quot;:&quot;name2&quot;,&quot;lastName&quot;:&quot;name&quot;},{&quot;firstName&quot;:&quot;name3&quot;,&quot;lastName&quot;:&quot;name1&quot;}],&quot;arrayArray&quot;:[[null,false,5,&quot;-0 [rest of string was truncated]&quot;;.
-        /// </summary>
-        internal static string ExpectedFullJsonSchema2 {
-            get {
-                return ResourceManager.GetString("ExpectedFullJsonSchema2", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {&quot;array&quot;:[{&quot;_id&quot;:&quot;56280d1abea79cfca762cd56&quot;,&quot;index&quot;:0,&quot;isActive&quot;:false,&quot;tags&quot;:[&quot;ad&quot;,&quot;voluptate&quot;,&quot;ullamco&quot;,&quot;reprehenderit&quot;,&quot;duis&quot;,&quot;Lorem&quot;,&quot;anim&quot;],&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Fernandez Barr&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Selena Hoover&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Verna Keller&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Middleton Duncan&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Fitzgerald Mcbride&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Boyd Marshall&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Debbie Hess&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Larson Mcmahon&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name [rest of string was truncated]&qu....
-        /// </summary>
-        internal static string ExpectedHeavyNestedJson {
-            get {
-                return ResourceManager.GetString("ExpectedHeavyNestedJson", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to [{&quot;array&quot;:[{&quot;_id&quot;:&quot;56280d1abea79cfca762cd56&quot;,&quot;index&quot;:0,&quot;isActive&quot;:false,&quot;tags&quot;:[&quot;ad&quot;,&quot;voluptate&quot;,&quot;ullamco&quot;,&quot;reprehenderit&quot;,&quot;duis&quot;,&quot;Lorem&quot;,&quot;anim&quot;],&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Fernandez Barr&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Selena Hoover&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Verna Keller&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Middleton Duncan&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Fitzgerald Mcbride&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Boyd Marshall&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Debbie Hess&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Larson Mcmahon&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;nam [rest of string was truncated]&qu....
-        /// </summary>
-        internal static string ExpectedHeavyNestedJsonWithArray {
-            get {
-                return ResourceManager.GetString("ExpectedHeavyNestedJsonWithArray", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {&quot;+testZero+&quot;:0,&quot;+testSmallNum+&quot;:0.1,&quot;+testeZero+&quot;:0.1,&quot;+testENegtiveWithZero+&quot;:0,&quot;+testeNegativeWithInt+&quot;:0.02155,&quot;+testEPositiveWithDecimal+&quot;:215215.41,&quot;+testePositiveWithLargeInt+&quot;:1.84467440737096E+128,&quot;+testeNegativeWithLargeDecimal+&quot;:1.25125612512513E-109,&quot;-testZero-&quot;:0,&quot;-testSmallNum-&quot;:-0.1,&quot;-testeZero-&quot;:-0.1,&quot;-testENegtiveWithZero-&quot;:0,&quot;-testeNegativeWithInt-&quot;:-0.02155,&quot;-testEPositiveWithDecimal-&quot;:-215215.41,&quot;-testePositiveWithLargeInt-&quot;:-1.84467440737096E+128,&quot;-testeNegativeWithLargeDecimal-&quot;:-1.251 [rest of string was truncated]&quot;;.
-        /// </summary>
-        internal static string ExpectedJsonWithSpecialNumFormat {
-            get {
-                return ResourceManager.GetString("ExpectedJsonWithSpecialNumFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {&quot;Here is a string: \&quot;\&quot;&quot;:&quot;Here is a hex value -\u024A&quot;,&quot;Here is a back slash\\&quot;:[&quot;Multiline
-        /// String
-        ///&quot;,&quot;	Mul
-        ///tiline String&quot;,&quot;\&quot;somequote\&quot;	Mu\&quot;\&quot;l
-        ///tiline\&quot;another\&quot; String\\&quot;],&quot;str&quot;:&quot;\&quot;\&quot;&quot;}.
-        /// </summary>
-        internal static string ExpectedJsonWithSpecialStrings {
-            get {
-                return ResourceManager.GetString("ExpectedJsonWithSpecialStrings", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {&quot;test&quot;:[{&quot;_id&quot;:&quot;562704ab8c67fc70235cb3ee&quot;,&quot;index&quot;:0,&quot;guid&quot;:&quot;9e16ac89-e6cb-401d-b0bd-5cb567908ad7&quot;,&quot;isActive&quot;:false,&quot;balance&quot;:&quot;$2,222.13&quot;,&quot;picture&quot;:&quot;http://placehold.it/32x32&quot;,&quot;age&quot;:34,&quot;eyeColor&quot;:&quot;blue&quot;,&quot;name&quot;:&quot;Reba Abbott&quot;,&quot;gender&quot;:&quot;female&quot;,&quot;company&quot;:&quot;VERBUS&quot;,&quot;email&quot;:&quot;rebaabbott@verbus.com&quot;,&quot;phone&quot;:&quot;+1 (878) 506-3650&quot;,&quot;address&quot;:&quot;800 Anchorage Place, Crayne, Illinois, 9130&quot;,&quot;about&quot;:&quot;Proident ea dolor ullamco occaecat ut pariatur. Pariatur aute deserunt deserunt qui aute commodo. Dolor ipsum incididunt tempo [rest of string was truncated]&quot;;.
-        /// </summary>
-        internal static string ExpectedLargeJson {
-            get {
-                return ResourceManager.GetString("ExpectedLargeJson", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {&quot;locked&quot;:false,&quot;version&quot;:1,&quot;targets&quot;:{&quot;DNXCore,Version=v5.0&quot;:{&quot;Microsoft.CSharp/4.0.0&quot;:{&quot;dependencies&quot;:{&quot;System.Runtime&quot;:&quot;[4.0.20, )&quot;,&quot;System.Dynamic.Runtime&quot;:&quot;[4.0.0, )&quot;,&quot;System.Linq.Expressions&quot;:&quot;[4.0.0, )&quot;,&quot;System.Runtime.InteropServices&quot;:&quot;[4.0.20, )&quot;,&quot;System.Resources.ResourceManager&quot;:&quot;[4.0.0, )&quot;,&quot;System.Linq&quot;:&quot;[4.0.0, )&quot;,&quot;System.Reflection.TypeExtensions&quot;:&quot;[4.0.0, )&quot;,&quot;System.Reflection.Primitives&quot;:&quot;[4.0.0, )&quot;,&quot;System.Reflection.Extensions&quot;:&quot;[4.0.0, )&quot;,&quot;System.Collections&quot;:&quot;[4.0.10, )&quot;,&quot;System.Diagnost [rest of string was truncated]&quot;;.
-        /// </summary>
-        internal static string ExpectedProjectLockJson {
-            get {
-                return ResourceManager.GetString("ExpectedProjectLockJson", resourceCulture);
+                return ResourceManager.GetString("DeepTree", resourceCulture);
             }
         }
         
@@ -211,7 +126,7 @@ namespace Benchmarks {
                 return ResourceManager.GetString("FullJsonSchema2", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {&quot;array&quot;:[  {    &quot;_id&quot;: &quot;56280d1abea79cfca762cd56&quot;,    &quot;index&quot;: 0,    &quot;isActive&quot;: false,    &quot;tags&quot;: [      &quot;ad&quot;,      &quot;voluptate&quot;,      &quot;ullamco&quot;,      &quot;reprehenderit&quot;,      &quot;duis&quot;,      &quot;Lorem&quot;,      &quot;anim&quot;    ],    &quot;friends&quot;: [      {        &quot;id&quot;: 0,        &quot;name&quot;: &quot;Fernandez Barr&quot;,        &quot;friends&quot;: [          {            &quot;id&quot;: 0,            &quot;name&quot;: &quot;Selena Hoover&quot;,            &quot;friends&quot;: [              {                &quot;id&quot;: 0,                &quot;name&quot;: &quot;Verna Keller&quot;,                &quot;friends&quot;: [           [rest of string was truncated]&quot;;.
         /// </summary>
@@ -222,20 +137,56 @@ namespace Benchmarks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [{&quot;array&quot;:[  {    &quot;_id&quot;: &quot;56280d1abea79cfca762cd56&quot;,    &quot;index&quot;: 0,    &quot;isActive&quot;: false,    &quot;tags&quot;: [      &quot;ad&quot;,      &quot;voluptate&quot;,      &quot;ullamco&quot;,      &quot;reprehenderit&quot;,      &quot;duis&quot;,      &quot;Lorem&quot;,      &quot;anim&quot;    ],    &quot;friends&quot;: [      {        &quot;id&quot;: 0,        &quot;name&quot;: &quot;Fernandez Barr&quot;,        &quot;friends&quot;: [          {            &quot;id&quot;: 0,            &quot;name&quot;: &quot;Selena Hoover&quot;,            &quot;friends&quot;: [              {                &quot;id&quot;: 0,                &quot;name&quot;: &quot;Verna Keller&quot;,                &quot;friends&quot;: [          [rest of string was truncated]&quot;;.
-        /// </summary>
-        internal static string HeavyNestedJsonWithArray {
-            get {
-                return ResourceManager.GetString("HeavyNestedJsonWithArray", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to { &quot;message&quot;: &quot;Hello, World!&quot; }.
         /// </summary>
         internal static string HelloWorld {
             get {
                 return ResourceManager.GetString("HelloWorld", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Json300B {
+            get {
+                return ResourceManager.GetString("Json300B", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Json300KB {
+            get {
+                return ResourceManager.GetString("Json300KB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Json30KB {
+            get {
+                return ResourceManager.GetString("Json30KB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Json3KB {
+            get {
+                return ResourceManager.GetString("Json3KB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string Json3MB {
+            get {
+                return ResourceManager.GetString("Json3MB", resourceCulture);
             }
         }
         
@@ -262,35 +213,20 @@ namespace Benchmarks {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {  &quot;test&quot; : [    {      &quot;_id&quot;: &quot;562704ab8c67fc70235cb3ee&quot;,      &quot;index&quot;: 0,      &quot;guid&quot;: &quot;9e16ac89-e6cb-401d-b0bd-5cb567908ad7&quot;,      &quot;isActive&quot;: false,      &quot;balance&quot;: &quot;$2,222.13&quot;,      &quot;picture&quot;: &quot;http://placehold.it/32x32&quot;,      &quot;age&quot;: 34,      &quot;eyeColor&quot;: &quot;blue&quot;,      &quot;name&quot;: &quot;Reba Abbott&quot;,      &quot;gender&quot;: &quot;female&quot;,      &quot;company&quot;: &quot;VERBUS&quot;,      &quot;email&quot;: &quot;rebaabbott@verbus.com&quot;,      &quot;phone&quot;: &quot;+1 (878) 506-3650&quot;,      &quot;address&quot;: &quot;800 Anchorage Place, Crayne, Illinois, 9130&quot;,      &quot;about&quot;: &quot;Proident ea d [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to .
         /// </summary>
-        internal static string LargeJson {
+        internal static string LotsOfNumbers {
             get {
-                return ResourceManager.GetString("LargeJson", resourceCulture);
+                return ResourceManager.GetString("LotsOfNumbers", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [
-        ///   {
-        ///      &quot;age&quot; : 30,
-        ///      &quot;first&quot; : &quot;John&quot;,
-        ///      &quot;last&quot; : &quot;Smith&quot;,
-        ///      &quot;phoneNumbers&quot; : [
-        ///         &quot;425-000-1212&quot;,
-        ///         &quot;425-000-1213&quot;
-        ///      ],
-        ///      &quot;address&quot; : {
-        ///         &quot;street&quot; : &quot;1 Microsoft Way&quot;,
-        ///         &quot;city&quot; : &quot;Redmond&quot;,
-        ///         &quot;zip&quot; : 98052
-        ///      }
-        ///   }
-        ///].
+        ///   Looks up a localized string similar to .
         /// </summary>
-        internal static string ParseJson {
+        internal static string LotsOfStrings {
             get {
-                return ResourceManager.GetString("ParseJson", resourceCulture);
+                return ResourceManager.GetString("LotsOfStrings", resourceCulture);
             }
         }
         
@@ -300,35 +236,6 @@ namespace Benchmarks {
         internal static string ProjectLockJson {
             get {
                 return ResourceManager.GetString("ProjectLockJson", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to [
-        ///	&quot;425-214-3151&quot;,
-        ///	25
-        ///].
-        /// </summary>
-        internal static string SimpleArrayJson {
-            get {
-                return ResourceManager.GetString("SimpleArrayJson", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {
-        ///	&quot;age&quot;: 30,
-        ///	&quot;first&quot;: &quot;John&quot;,
-        ///	&quot;last&quot;: &quot;Smith&quot;,
-        ///	&quot;phoneNumber&quot;: &quot;425-214-3151&quot;,
-        ///	&quot;street&quot;: &quot;1 Microsoft Way&quot;,
-        ///	&quot;city&quot;: &quot;Redmond&quot;,
-        ///	&quot;zip&quot;: 98052
-        ///}.
-        /// </summary>
-        internal static string SimpleObjectJson {
-            get {
-                return ResourceManager.GetString("SimpleObjectJson", resourceCulture);
             }
         }
     }

--- a/tests/Benchmarks/JsonStrings.resx
+++ b/tests/Benchmarks/JsonStrings.resx
@@ -133,7 +133,7 @@
    }
 }</value>
   </data>
-  <data name="BasicJsonWithLargeNum" xml:space="preserve">
+  <data name="BasicLargeNum" xml:space="preserve">
     <value>{"age":30,"first":"John","last":"Smith","phoneNumbers":["425-000-1212","425-000-1213"],"address":{"street":"1MicrosoftWay","city":"Redmond","zip":98052},"IDs":[425,-70,9223372036854775807]}</value>
   </data>
   <data name="BroadTree" xml:space="preserve">
@@ -495,10 +495,10 @@
   }
 ]</value>
   </data>
-  <data name="FullJsonSchema1" xml:space="preserve">
+  <data name="FullSchema1" xml:space="preserve">
     <value>{"age":30,"first":"John","last":"Smith","phoneNumbers":["425-000-1212","425-000-1213"],"address":{"street":"1MicrosoftWay","city":"Redmond","zip":98052},"IDs":[425,-70,9223372036854776000],"arrayWithObjects":["text",14,[],null,false,{},{"time":24},["1","2","3"]],"boolean":false,"null":null,"objectName":{"group":{"array":[false],"field":"simple","anotherFieldNum":5,"anotherFieldBool":true,"lastField":null}},"emptyObject":{}}</value>
   </data>
-  <data name="FullJsonSchema2" xml:space="preserve">
+  <data name="FullSchema2" xml:space="preserve">
     <value>{"string":"string","number":5,"decimal":3516512.13512,"long":9223372036854776000.1200,"notLong":922854776000.1200,"boolean":false,"object":{},"array":[],"null":null,"emptyArray":[],"emptyObject":{},"arrayString":["alpha","beta"],"arrayNum":[1,212512.01,3.00],"arrayBool":[false,true,true],"arrayNull":[null,null],"arrayObject":[{"firstName":"name1","lastName":"name"},{"firstName":"name1","lastName":"name"},{"firstName":"name2","lastName":"name"},{"firstName":"name3","lastName":"name1"}],"arrayArray":[[null,false,5,"-0215.512501",9223372036854776000],[{},true,null,125651,"simple"],[{"field":null},"hi"]]}</value>
   </data>
   <data name="HeavyNestedJson" xml:space="preserve">
@@ -15522,7 +15522,7 @@
   }
 ]</value>
   </data>
-  <data name="JsonWithSpecialNumFormat" xml:space="preserve">
+  <data name="SpecialNumForm" xml:space="preserve">
     <value>{"+testZero+" : 0,"+testSmallNum+" : 0.1,"+testeZero+" : 0.1e0,"+testENegtiveWithZero+" : 0E-1,"+testeNegativeWithInt+" : 2155e-5,"+testEPositiveWithDecimal+" : 2152.1541E+2,"+testePositiveWithLargeInt+" : 18446744073709551615E109,"+testeNegativeWithLargeDecimal+" : 125125612512512.512512e-0123,"-testZero-" : -0,"-testSmallNum-" : -0.1,"-testeZero-" : -0.1e0,"-testENegtiveWithZero-" : -0E-1,"-testeNegativeWithInt-" : -2155e-5,"-testEPositiveWithDecimal-" : -2152.1541E+2,"-testePositiveWithLargeInt-" :-18446744073709551615E109,"-testeNegativeWithLargeDecimal-" : -125125612512512.512512e-0123}</value>
   </data>
   <data name="JsonWithSpecialStrings" xml:space="preserve">

--- a/tests/Benchmarks/JsonStrings.resx
+++ b/tests/Benchmarks/JsonStrings.resx
@@ -507,26 +507,8 @@
   <data name="HelloWorld" xml:space="preserve">
     <value>{ "message": "Hello, World!" }</value>
   </data>
-  <data name="Json300B" xml:space="preserve">
-        <value>[
-  {
-    "_id": "5671ebcfd88de5e8dac53641",
-    "index": 0,
-    "isActive": true,
-    "balance": "$3,951.98",
-    "picture": "http://placehold.it/32x32",
-    "age": 36,
-    "email": "clementsvillarreal@daycore.com",
-    "phone": "+1 (882) 479-2331",
-    "address": "488 Grand Street, Hackneyville, Vermont, 5344",
-    "registered": "2015-04-12T05:27:22 +07:00",
-    "latitude": -57.256693,
-    "longitude": 49.961028
-  }
-]</value>
-  </data>
-  <data name="Json300KB" xml:space="preserve">
-            <value>[
+  <data name="Json400KB" xml:space="preserve">
+    <value>[
   {
     "_id": "5671eaf1eb61139592ea92ff",
     "index": 0,
@@ -14029,8 +14011,8 @@
   }
 ]</value>
   </data>
-  <data name="Json30KB" xml:space="preserve">
-            <value>[
+  <data name="Json40KB" xml:space="preserve">
+    <value>[
   {
     "_id": "5671eb0737b18866984067ac",
     "index": 0,
@@ -15383,8 +15365,8 @@
   }
 ]</value>
   </data>
-  <data name="Json3KB" xml:space="preserve">
-        <value>[
+  <data name="Json4KB" xml:space="preserve">
+    <value>[
   {
     "_id": "5671eb1b60a382ffb56b3946",
     "index": 0,
@@ -15519,6 +15501,24 @@
     ],
     "greeting": "Hello, Oneal Weiss! You have 5 unread messages.",
     "favoriteFruit": "banana"
+  }
+]</value>
+  </data>
+  <data name="Json400B" xml:space="preserve">
+    <value>[
+  {
+    "_id": "5671ebcfd88de5e8dac53641",
+    "index": 0,
+    "isActive": true,
+    "balance": "$3,951.98",
+    "picture": "http://placehold.it/32x32",
+    "age": 36,
+    "email": "clementsvillarreal@daycore.com",
+    "phone": "+1 (882) 479-2331",
+    "address": "488 Grand Street, Hackneyville, Vermont, 5344",
+    "registered": "2015-04-12T05:27:22 +07:00",
+    "latitude": -57.256693,
+    "longitude": 49.961028
   }
 ]</value>
   </data>

--- a/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonReader/JsonReaderComparison.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonReader/JsonReaderComparison.cs
@@ -76,16 +76,14 @@ namespace JsonBenchmarks
         [Benchmark]
         public void ReaderJayrock()
         {
-            _stream.Seek(0, SeekOrigin.Begin);
-            using (var json = new JsonTextReader(_reader))
+            using (var json = new JsonTextReader(new StringReader(_str)))
                 while (json.Read()) ;
         }
 
         [Benchmark]
         public void ReaderLitJson()
         {
-            _stream.Seek(0, SeekOrigin.Begin);
-            var json = new LitJson.JsonReader(_reader);
+            var json = new LitJson.JsonReader(new StringReader(_str));
             while (json.Read()) ;
         }
     }

--- a/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonReader/JsonReaderComparison.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonReader/JsonReaderComparison.cs
@@ -76,14 +76,16 @@ namespace JsonBenchmarks
         [Benchmark]
         public void ReaderJayrock()
         {
-            using (var json = new JsonTextReader(new StringReader(_str)))
+            _stream.Seek(0, SeekOrigin.Begin);
+            using (var json = new JsonTextReader(_reader))
                 while (json.Read()) ;
         }
 
         [Benchmark]
         public void ReaderLitJson()
         {
-            var json = new LitJson.JsonReader(new StringReader(_str));
+            _stream.Seek(0, SeekOrigin.Begin);
+            var json = new LitJson.JsonReader(_reader);
             while (json.Read()) ;
         }
     }

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -26,8 +26,7 @@ namespace System.Text.JsonLab.Benchmarks
         Json300B,
         Json3KB,
         Json30KB,
-        Json300KB,
-        Json3MB,
+        Json300KB
     }
 
     [MemoryDiagnoser]
@@ -99,9 +98,6 @@ namespace System.Text.JsonLab.Benchmarks
                     break;
                 case TestCaseType.Json300KB:
                     _jsonString = JsonStrings.Json300KB;
-                    break;
-                case TestCaseType.Json3MB:
-                    _jsonString = JsonStrings.Json3MB;
                     break;
             }
 

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -24,10 +24,10 @@ namespace System.Text.JsonLab.Benchmarks
         BroadTree,
         LotsOfNumbers,
         LotsOfStrings,
-        Json300B,
-        Json3KB,
-        Json30KB,
-        Json300KB
+        Json400B,
+        Json4KB,
+        Json40KB,
+        Json400KB
     }
 
     // Since there are 120 tests here (4 * 2 * 15), setting low values for the warmupCount, targetCount, and invocationCount
@@ -87,17 +87,17 @@ namespace System.Text.JsonLab.Benchmarks
                 case TestCaseType.LotsOfStrings:
                     _jsonString = JsonStrings.LotsOfStrings;
                     break;
-                case TestCaseType.Json300B:
-                    _jsonString = JsonStrings.Json300B;
+                case TestCaseType.Json400B:
+                    _jsonString = JsonStrings.Json400B;
                     break;
-                case TestCaseType.Json3KB:
-                    _jsonString = JsonStrings.Json3KB;
+                case TestCaseType.Json4KB:
+                    _jsonString = JsonStrings.Json4KB;
                     break;
-                case TestCaseType.Json30KB:
-                    _jsonString = JsonStrings.Json30KB;
+                case TestCaseType.Json40KB:
+                    _jsonString = JsonStrings.Json40KB;
                     break;
-                case TestCaseType.Json300KB:
-                    _jsonString = JsonStrings.Json300KB;
+                case TestCaseType.Json400KB:
+                    _jsonString = JsonStrings.Json400KB;
                     break;
             }
 

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes.Jobs;
 using Benchmarks;
 using System.Buffers.Text;
 using System.Collections.Generic;
@@ -15,7 +16,7 @@ namespace System.Text.JsonLab.Benchmarks
         Basic,
         BasicLargeNum,
         SpecialNumForm,
-        SpecialStrings,
+        //SpecialStrings,
         ProjectLockJson,
         FullSchema1,
         FullSchema2,
@@ -29,6 +30,8 @@ namespace System.Text.JsonLab.Benchmarks
         Json300KB
     }
 
+    // Since there are 120 tests here (4 * 2 * 15), setting low values for the warmupCount, targetCount, and invocationCount
+    [SimpleJob(-1, 3, 5, 1024)]
     [MemoryDiagnoser]
     public class JsonReaderPerf
     {
@@ -63,9 +66,6 @@ namespace System.Text.JsonLab.Benchmarks
                 case TestCaseType.SpecialNumForm:
                     _jsonString = JsonStrings.JsonWithSpecialNumFormat;
                     break;
-                //case TestCaseType.SpecialStrings:
-                //    _jsonString = JsonStrings.JsonWithSpecialStrings;
-                //    break;
                 case TestCaseType.ProjectLockJson:
                     _jsonString = JsonStrings.ProjectLockJson;
                     break;

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -16,7 +16,6 @@ namespace System.Text.JsonLab.Benchmarks
         Basic,
         BasicLargeNum,
         SpecialNumForm,
-        //SpecialStrings,
         ProjectLockJson,
         FullSchema1,
         FullSchema2,
@@ -177,9 +176,9 @@ namespace System.Text.JsonLab.Benchmarks
         [Benchmark]
         public byte[] ReaderSystemTextJsonLabReturnBytes()
         {
+            byte[] outputArray = new byte[IsUTF8Encoded ? _dataUtf8.Length : _dataUtf16.Length]; 
             if (IsUTF8Encoded)
             {
-                byte[] outputArray = new byte[_dataUtf8.Length];
                 Span<byte> destination = outputArray;
                 var json = new JsonReader(_dataUtf8, SymbolTable.InvariantUtf8);
                 while (json.Read())
@@ -228,7 +227,6 @@ namespace System.Text.JsonLab.Benchmarks
             }
             else
             {
-                byte[] outputArray = new byte[_dataUtf16.Length];
                 Span<byte> destination = outputArray;
                 var json = new JsonReader(_dataUtf16, SymbolTable.InvariantUtf16);
                 while (json.Read())

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -7,65 +7,278 @@ using System.Buffers.Text;
 using System.Collections.Generic;
 using System.IO;
 
-using static System.Text.JsonLab.Benchmarks.Helper;
-
 namespace System.Text.JsonLab.Benchmarks
 {
+    public enum TestCaseType
+    {
+        HelloWorld,
+        Basic,
+        BasicLargeNum,
+        SpecialNumForm,
+        SpecialStrings,
+        ProjectLockJson,
+        FullSchema1,
+        FullSchema2,
+        DeepTree,
+        BroadTree,
+        LotsOfNumbers,
+        LotsOfStrings,
+        Json300B,
+        Json3KB,
+        Json30KB,
+        Json300KB,
+        Json3MB,
+    }
+
     [MemoryDiagnoser]
     public class JsonReaderPerf
     {
-        private byte[] _data;
-        private SymbolTable _symbolTable;
+        private string _jsonString;
+        private byte[] _dataUtf8;
+        private byte[] _dataUtf16;
         private MemoryStream _stream;
         private StreamReader _reader;
 
-        [Params(EncoderTarget.InvariantUtf8, EncoderTarget.InvariantUtf16)]
-        public EncoderTarget Target;
+        [Params(true, false)]
+        public bool IsUTF8Encoded;
 
-        [ParamsSource(nameof(ValuesForJsonString))]
-        public string JsonString;
+        [ParamsSource(nameof(TestCaseValues))]
+        public TestCaseType TestCase;
 
-        public static IEnumerable<string> ValuesForJsonString() => new[] { JsonStrings.HeavyNestedJson, JsonStrings.HelloWorld };
+        public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));
 
         [GlobalSetup]
         public void Setup()
         {
-            _symbolTable = GetTargetEncoder(Target);
-            _data = EncodeTestData(Target, JsonString);
+            switch (TestCase)
+            {
+                case TestCaseType.HelloWorld:
+                    _jsonString = JsonStrings.HelloWorld;
+                    break;
+                case TestCaseType.Basic:
+                    _jsonString = JsonStrings.BasicJson;
+                    break;
+                case TestCaseType.BasicLargeNum:
+                    _jsonString = JsonStrings.BasicJsonWithLargeNum;
+                    break;
+                case TestCaseType.SpecialNumForm:
+                    _jsonString = JsonStrings.JsonWithSpecialNumFormat;
+                    break;
+                //case TestCaseType.SpecialStrings:
+                //    _jsonString = JsonStrings.JsonWithSpecialStrings;
+                //    break;
+                case TestCaseType.ProjectLockJson:
+                    _jsonString = JsonStrings.ProjectLockJson;
+                    break;
+                case TestCaseType.FullSchema1:
+                    _jsonString = JsonStrings.FullJsonSchema1;
+                    break;
+                case TestCaseType.FullSchema2:
+                    _jsonString = JsonStrings.FullJsonSchema2;
+                    break;
+                case TestCaseType.DeepTree:
+                    _jsonString = JsonStrings.DeepTree;
+                    break;
+                case TestCaseType.BroadTree:
+                    _jsonString = JsonStrings.BroadTree;
+                    break;
+                case TestCaseType.LotsOfNumbers:
+                    _jsonString = JsonStrings.LotsOfNumbers;
+                    break;
+                case TestCaseType.LotsOfStrings:
+                    _jsonString = JsonStrings.LotsOfStrings;
+                    break;
+                case TestCaseType.Json300B:
+                    _jsonString = JsonStrings.Json300B;
+                    break;
+                case TestCaseType.Json3KB:
+                    _jsonString = JsonStrings.Json3KB;
+                    break;
+                case TestCaseType.Json30KB:
+                    _jsonString = JsonStrings.Json30KB;
+                    break;
+                case TestCaseType.Json300KB:
+                    _jsonString = JsonStrings.Json300KB;
+                    break;
+                case TestCaseType.Json3MB:
+                    _jsonString = JsonStrings.Json3MB;
+                    break;
+            }
 
-            _stream = new MemoryStream(_data);
-            var enc = Target == EncoderTarget.InvariantUtf8 ? Encoding.UTF8 : Encoding.Unicode;
-            _reader = new StreamReader(_stream, enc, false, 1024, true);
+            if (IsUTF8Encoded)
+            {
+                _dataUtf8 = Encoding.UTF8.GetBytes(_jsonString);
+                _stream = new MemoryStream(_dataUtf8);
+                _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
+            }
+            else
+            {
+                _dataUtf16 = Encoding.Unicode.GetBytes(_jsonString);
+            }
         }
 
         [Benchmark(Baseline = true)]
-        public void ReaderNewtonsoftStringReader()
+        public void ReaderNewtonsoftReaderEmptyLoop()
         {
-            var json = new Newtonsoft.Json.JsonTextReader(new StringReader(JsonString));
-            while (json.Read()) ;
-        }
-
-        [Benchmark]
-        public void ReaderNewtonsoftStreamReader()
-        {
-            _stream.Seek(0, SeekOrigin.Begin);
-            using (var json = new Newtonsoft.Json.JsonTextReader(_reader))
-                while (json.Read()) ;
-        }
-
-        [Benchmark]
-        public void ReaderSystemTextJsonLab()
-        {
-            var json = new JsonReader(_data, _symbolTable);
-            while (json.Read()) ;
-        }
-
-        private static byte[] EncodeTestData(EncoderTarget encoderTarget, string data)
-        {
-            if (encoderTarget == EncoderTarget.InvariantUtf16 || encoderTarget == EncoderTarget.SlowUtf16)
-                return Encoding.Unicode.GetBytes(data);
+            if (IsUTF8Encoded)
+            {
+                _stream.Seek(0, SeekOrigin.Begin);
+                using (var json = new Newtonsoft.Json.JsonTextReader(_reader))
+                    while (json.Read()) ;
+            }
             else
-                return Encoding.UTF8.GetBytes(data);
+            {
+                var json = new Newtonsoft.Json.JsonTextReader(new StringReader(_jsonString));
+                while (json.Read()) ;
+            }
+        }
+
+        [Benchmark]
+        public string ReaderNewtonsoftReaderReturnString()
+        {
+            StringBuilder sb = new StringBuilder();
+            if (IsUTF8Encoded)
+            {
+                _stream.Seek(0, SeekOrigin.Begin);
+                using (var json = new Newtonsoft.Json.JsonTextReader(_reader))
+                    while (json.Read())
+                    {
+                        if (json.Value != null)
+                        {
+                            sb.Append(json.Value + ", ");
+                        }
+                    }
+            }
+            else
+            {
+                var json = new Newtonsoft.Json.JsonTextReader(new StringReader(_jsonString));
+                while (json.Read())
+                {
+                    if (json.Value != null)
+                    {
+                        sb.Append(json.Value + ", ");
+                    }
+                }
+            }
+            return sb.ToString();
+        }
+
+        [Benchmark]
+        public void ReaderSystemTextJsonLabEmptyLoop()
+        {
+            if (IsUTF8Encoded)
+            {
+                var json = new JsonReader(_dataUtf8, SymbolTable.InvariantUtf8);
+                while (json.Read()) ;
+            }
+            else
+            {
+                var json = new JsonReader(_dataUtf16, SymbolTable.InvariantUtf16);
+                while (json.Read()) ;
+            }
+        }
+
+        [Benchmark]
+        public byte[] ReaderSystemTextJsonLabReturnBytes()
+        {
+            if (IsUTF8Encoded)
+            {
+                byte[] outputArray = new byte[_dataUtf8.Length];
+                Span<byte> destination = outputArray;
+                var json = new JsonReader(_dataUtf8, SymbolTable.InvariantUtf8);
+                while (json.Read())
+                {
+                    var tokenType = json.TokenType;
+                    switch (tokenType)
+                    {
+                        case JsonTokenType.PropertyName:
+                            json.Value.CopyTo(destination);
+                            destination[json.Value.Length] = (byte)',';
+                            destination[json.Value.Length + 1] = (byte)' ';
+                            destination = destination.Slice(json.Value.Length + 2);
+                            break;
+                        case JsonTokenType.Value:
+                            var valueType = json.ValueType;
+
+                            switch (valueType)
+                            {
+                                case JsonValueType.True:
+                                    destination[0] = (byte)'T';
+                                    destination[1] = (byte)'r';
+                                    destination[2] = (byte)'u';
+                                    destination[3] = (byte)'e';
+                                    destination = destination.Slice(4);
+                                    break;
+                                case JsonValueType.False:
+                                    destination[0] = (byte)'F';
+                                    destination[1] = (byte)'a';
+                                    destination[2] = (byte)'l';
+                                    destination[3] = (byte)'s';
+                                    destination[4] = (byte)'e';
+                                    destination = destination.Slice(5);
+                                    break;
+                            }
+
+                            json.Value.CopyTo(destination);
+                            destination[json.Value.Length] = (byte)',';
+                            destination[json.Value.Length + 1] = (byte)' ';
+                            destination = destination.Slice(json.Value.Length + 2);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                return outputArray;
+            }
+            else
+            {
+                byte[] outputArray = new byte[_dataUtf16.Length];
+                Span<byte> destination = outputArray;
+                var json = new JsonReader(_dataUtf16, SymbolTable.InvariantUtf16);
+                while (json.Read())
+                {
+                    var tokenType = json.TokenType;
+                    switch (tokenType)
+                    {
+                        case JsonTokenType.PropertyName:
+                            json.Value.CopyTo(destination);
+                            destination[json.Value.Length] = (byte)',';
+                            destination[json.Value.Length + 2] = (byte)' ';
+                            destination = destination.Slice(json.Value.Length + 4);
+                            break;
+                        case JsonTokenType.Value:
+                            var valueType = json.ValueType;
+
+                            switch (valueType)
+                            {
+                                case JsonValueType.True:
+                                    destination[0] = (byte)'T';
+                                    destination[2] = (byte)'r';
+                                    destination[4] = (byte)'u';
+                                    destination[6] = (byte)'e';
+                                    destination = destination.Slice(8);
+                                    break;
+                                case JsonValueType.False:
+                                    destination[0] = (byte)'F';
+                                    destination[2] = (byte)'a';
+                                    destination[4] = (byte)'l';
+                                    destination[6] = (byte)'s';
+                                    destination[8] = (byte)'e';
+                                    destination = destination.Slice(10);
+                                    break;
+                            }
+
+                            json.Value.CopyTo(destination);
+                            destination[json.Value.Length] = (byte)',';
+                            destination[json.Value.Length + 2] = (byte)' ';
+                            destination = destination.Slice(json.Value.Length + 4);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                return outputArray;
+            }
         }
     }
 }

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -30,10 +30,10 @@ namespace System.Text.JsonLab.Tests
                     new object[] { TestCaseType.ProjectLockJson, TestJson.ProjectLockJson},
                     //new object[] { TestCaseType.SpecialStrings, TestJson.JsonWithSpecialStrings},    // JsonLab doesn't support this yet.
                     //new object[] { TestCaseType.SpecialNumForm, TestJson.JsonWithSpecialNumFormat},    // Behavior of E-notation is different between Json.NET and JsonLab
-                    new object[] { TestCaseType.Json300B, TestJson.Json300B},
-                    new object[] { TestCaseType.Json3KB, TestJson.Json3KB},
-                    new object[] { TestCaseType.Json30KB, TestJson.Json30KB},
-                    new object[] { TestCaseType.Json300KB, TestJson.Json300KB}
+                    new object[] { TestCaseType.Json400B, TestJson.Json400B},
+                    new object[] { TestCaseType.Json4KB, TestJson.Json4KB},
+                    new object[] { TestCaseType.Json40KB, TestJson.Json40KB},
+                    new object[] { TestCaseType.Json400KB, TestJson.Json400KB}
                 };
             }
         }
@@ -52,10 +52,10 @@ namespace System.Text.JsonLab.Tests
             BroadTree,
             LotsOfNumbers,
             LotsOfStrings,
-            Json300B,
-            Json3KB,
-            Json30KB,
-            Json300KB,
+            Json400B,
+            Json4KB,
+            Json40KB,
+            Json400KB,
         }
 
         // TestCaseType is only used to give the json strings a descriptive name.

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -1,0 +1,228 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers.Text;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.JsonLab.Tests.Resources;
+using Xunit;
+
+namespace System.Text.JsonLab.Tests
+{
+    public class JsonReaderTests
+    {
+        public static IEnumerable<object[]> TestCases
+        {
+            get
+            {
+                return new List<object[]>
+                {
+                    new object[] { TestCaseType.Basic, TestJson.BasicJson},
+                    new object[] { TestCaseType.BasicLargeNum, TestJson.BasicJsonWithLargeNum}, // Json.NET treats numbers starting with 0 as octal (0425 becomes 277)
+                    new object[] { TestCaseType.BroadTree, TestJson.BroadTree}, // \r\n behavior is different between Json.NET and JsonLab
+                    new object[] { TestCaseType.DeepTree, TestJson.DeepTree},
+                    //new object[] { TestCaseType.FullSchema1, TestJson.FullJsonSchema1},   // Behavior of null values is different between Json.NET and JsonLab
+                    //new object[] { TestCaseType.FullSchema2, TestJson.FullJsonSchema2},   // Behavior of null values is different between Json.NET and JsonLab
+                    new object[] { TestCaseType.HelloWorld, TestJson.HelloWorld},
+                    new object[] { TestCaseType.LotsOfNumbers, TestJson.LotsOfNumbers},
+                    new object[] { TestCaseType.LotsOfStrings, TestJson.LotsOfStrings},
+                    new object[] { TestCaseType.ProjectLockJson, TestJson.ProjectLockJson},
+                    //new object[] { TestCaseType.SpecialStrings, TestJson.JsonWithSpecialStrings},    // JsonLab doesn't support this yet.
+                    //new object[] { TestCaseType.SpecialNumForm, TestJson.JsonWithSpecialNumFormat},    // Behavior of E-notation is different between Json.NET and JsonLab
+                    new object[] { TestCaseType.Json300B, TestJson.Json300B},
+                    new object[] { TestCaseType.Json3KB, TestJson.Json3KB},
+                    new object[] { TestCaseType.Json30KB, TestJson.Json30KB},
+                    new object[] { TestCaseType.Json300KB, TestJson.Json300KB},
+                    new object[] { TestCaseType.Json3MB, TestJson.Json3MB}
+                };
+            }
+        }
+
+        public enum TestCaseType
+        {
+            HelloWorld,
+            Basic,
+            BasicLargeNum,
+            SpecialNumForm,
+            SpecialStrings,
+            ProjectLockJson,
+            FullSchema1,
+            FullSchema2,
+            DeepTree,
+            BroadTree,
+            LotsOfNumbers,
+            LotsOfStrings,
+            Json300B,
+            Json3KB,
+            Json30KB,
+            Json300KB,
+            Json3MB,
+        }
+
+        // TestCaseType is only used to give the json strings a descriptive name.
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public static void TestJsonReaderUtf8(TestCaseType type, string jsonString)
+        {
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            byte[] result = ReaderSystemTextJsonLab(dataUtf8, out int length);
+            string str = Encoding.UTF8.GetString(result.AsSpan(0, length));
+            string newtonsoftStr = ReaderNewtonsoftReader(jsonString);
+
+            Assert.Equal(str, newtonsoftStr);
+        }
+
+        // TestCaseType is only used to give the json strings a descriptive name.
+        [Theory]
+        [MemberData(nameof(TestCases))]
+        public static void TestJsonReaderUtf16(TestCaseType type, string jsonString)
+        {
+            byte[] dataUtf16 = Encoding.Unicode.GetBytes(jsonString);
+            byte[] result = ReaderSystemTextJsonLabUtf16(dataUtf16, out int length);
+            string str = Encoding.Unicode.GetString(result.AsSpan(0, length));
+            string newtonsoftStr = ReaderNewtonsoftReaderUtf16(jsonString);
+
+            Assert.Equal(str, newtonsoftStr);
+        }
+
+        private static byte[] ReaderSystemTextJsonLab(byte[] dataUtf8, out int length)
+        {
+            byte[] outputArray = new byte[dataUtf8.Length];
+            Span<byte> destination = outputArray;
+
+            var json = new JsonReader(dataUtf8, SymbolTable.InvariantUtf8);
+            while (json.Read())
+            {
+                var tokenType = json.TokenType;
+
+                switch (tokenType)
+                {
+                    case JsonTokenType.PropertyName:
+                        json.Value.CopyTo(destination);
+                        destination[json.Value.Length] = (byte)',';
+                        destination[json.Value.Length + 1] = (byte)' ';
+                        destination = destination.Slice(json.Value.Length + 2);
+                        break;
+                    case JsonTokenType.Value:
+                        var valueType = json.ValueType;
+
+                        switch (valueType)
+                        {
+                            case JsonValueType.True:
+                                destination[0] = (byte)'T';
+                                destination[1] = (byte)'r';
+                                destination[2] = (byte)'u';
+                                destination[3] = (byte)'e';
+                                destination = destination.Slice(4);
+                                break;
+                            case JsonValueType.False:
+                                destination[0] = (byte)'F';
+                                destination[1] = (byte)'a';
+                                destination[2] = (byte)'l';
+                                destination[3] = (byte)'s';
+                                destination[4] = (byte)'e';
+                                destination = destination.Slice(5);
+                                break;
+                        }
+
+                        json.Value.CopyTo(destination);
+                        destination[json.Value.Length] = (byte)',';
+                        destination[json.Value.Length + 1] = (byte)' ';
+                        destination = destination.Slice(json.Value.Length + 2);
+                        break;
+                    default:
+                        break;
+                }
+            }
+            length = outputArray.Length - destination.Length;
+            return outputArray;
+        }
+
+        private static byte[] ReaderSystemTextJsonLabUtf16(byte[] dataUtf16, out int length)
+        {
+            byte[] outputArray = new byte[dataUtf16.Length];
+            Span<byte> destination = outputArray;
+
+            var json = new JsonReader(dataUtf16, SymbolTable.InvariantUtf16);
+            while (json.Read())
+            {
+                var tokenType = json.TokenType;
+
+                switch (tokenType)
+                {
+                    case JsonTokenType.PropertyName:
+                        json.Value.CopyTo(destination);
+                        destination[json.Value.Length] = (byte)',';
+                        destination[json.Value.Length + 2] = (byte)' ';
+                        destination = destination.Slice(json.Value.Length + 4);
+                        break;
+                    case JsonTokenType.Value:
+                        var valueType = json.ValueType;
+
+                        switch (valueType)
+                        {
+                            case JsonValueType.True:
+                                destination[0] = (byte)'T';
+                                destination[2] = (byte)'r';
+                                destination[4] = (byte)'u';
+                                destination[6] = (byte)'e';
+                                destination = destination.Slice(8);
+                                break;
+                            case JsonValueType.False:
+                                destination[0] = (byte)'F';
+                                destination[2] = (byte)'a';
+                                destination[4] = (byte)'l';
+                                destination[6] = (byte)'s';
+                                destination[8] = (byte)'e';
+                                destination = destination.Slice(10);
+                                break;
+                        }
+
+                        json.Value.CopyTo(destination);
+                        destination[json.Value.Length] = (byte)',';
+                        destination[json.Value.Length + 2] = (byte)' ';
+                        destination = destination.Slice(json.Value.Length + 4);
+                        break;
+                    default:
+                        break;
+                }
+            }
+            length = outputArray.Length - destination.Length;
+            return outputArray;
+        }
+
+        private static string ReaderNewtonsoftReader(string str)
+        {
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(str);
+            MemoryStream stream = new MemoryStream(dataUtf8);
+            StreamReader reader = new StreamReader(stream, Encoding.UTF8, false, 1024, true);
+
+            StringBuilder sb = new StringBuilder();
+            stream.Seek(0, SeekOrigin.Begin);
+            using (var json = new Newtonsoft.Json.JsonTextReader(reader))
+                while (json.Read())
+                {
+                    if (json.Value != null)
+                    {
+                        sb.Append(json.Value + ", ");
+                    }
+                }
+            return sb.ToString();
+        }
+
+        private static string ReaderNewtonsoftReaderUtf16(string str)
+        {
+            StringBuilder sb = new StringBuilder();
+            using (var json = new Newtonsoft.Json.JsonTextReader(new StringReader(str)))
+                while (json.Read())
+                {
+                    if (json.Value != null)
+                    {
+                        sb.Append(json.Value + ", ");
+                    }
+                }
+            return sb.ToString();
+        }
+    }
+}

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -33,8 +33,7 @@ namespace System.Text.JsonLab.Tests
                     new object[] { TestCaseType.Json300B, TestJson.Json300B},
                     new object[] { TestCaseType.Json3KB, TestJson.Json3KB},
                     new object[] { TestCaseType.Json30KB, TestJson.Json30KB},
-                    new object[] { TestCaseType.Json300KB, TestJson.Json300KB},
-                    new object[] { TestCaseType.Json3MB, TestJson.Json3MB}
+                    new object[] { TestCaseType.Json300KB, TestJson.Json300KB}
                 };
             }
         }
@@ -57,7 +56,6 @@ namespace System.Text.JsonLab.Tests
             Json3KB,
             Json30KB,
             Json300KB,
-            Json3MB,
         }
 
         // TestCaseType is only used to give the json strings a descriptive name.

--- a/tests/System.Text.JsonLab.Tests/Resources/TestJson.Designer.cs
+++ b/tests/System.Text.JsonLab.Tests/Resources/TestJson.Designer.cs
@@ -294,15 +294,6 @@ namespace System.Text.JsonLab.Tests.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to g.
-        /// </summary>
-        internal static string Json3MB {
-            get {
-                return ResourceManager.GetString("Json3MB", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {&quot;+testZero+&quot; : 0,&quot;+testSmallNum+&quot; : 0.1,&quot;+testeZero+&quot; : 0.1e0,&quot;+testENegtiveWithZero+&quot; : 0E-1,&quot;+testeNegativeWithInt+&quot; : 2155e-5,&quot;+testEPositiveWithDecimal+&quot; : 2152.1541E+2,&quot;+testePositiveWithLargeInt+&quot; : 18446744073709551615E109,&quot;+testeNegativeWithLargeDecimal+&quot; : 125125612512512.512512e-0123,&quot;-testZero-&quot; : -0,&quot;-testSmallNum-&quot; : -0.1,&quot;-testeZero-&quot; : -0.1e0,&quot;-testENegtiveWithZero-&quot; : -0E-1,&quot;-testeNegativeWithInt-&quot; : -2155e-5,&quot;-testEPositiveWithDecimal-&quot; : -2152.1541E+2,&quot;-testePositiveWithLargeInt-&quot; :-18446 [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string JsonWithSpecialNumFormat {

--- a/tests/System.Text.JsonLab.Tests/Resources/TestJson.Designer.cs
+++ b/tests/System.Text.JsonLab.Tests/Resources/TestJson.Designer.cs
@@ -10,9 +10,8 @@
 
 namespace System.Text.JsonLab.Tests.Resources {
     using System;
-    using System.Reflection;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -20,19 +19,19 @@ namespace System.Text.JsonLab.Tests.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class TestJson {
-
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         internal TestJson() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
@@ -40,13 +39,13 @@ namespace System.Text.JsonLab.Tests.Resources {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("System.Text.JsonLab.Tests.Resources.TestJson", typeof(TestJson).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("System.Text.JsonLab.Tests.Resources.TestJson", typeof(TestJson).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
@@ -60,7 +59,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {
         ///   &quot;age&quot; : 30,
@@ -82,16 +81,34 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("BasicJson", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1MicrosoftWay&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052},&quot;IDs&quot;:[0425,-70,9223372036854775807]}.
+        ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1MicrosoftWay&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052},&quot;IDs&quot;:[425,-70,9223372036854775807]}.
         /// </summary>
         internal static string BasicJsonWithLargeNum {
             get {
                 return ResourceManager.GetString("BasicJsonWithLargeNum", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to a.
+        /// </summary>
+        internal static string BroadTree {
+            get {
+                return ResourceManager.GetString("BroadTree", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to b.
+        /// </summary>
+        internal static string DeepTree {
+            get {
+                return ResourceManager.GetString("DeepTree", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1 Microsoft Way&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052}}.
         /// </summary>
@@ -100,7 +117,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("ExpectedBasicJson", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1MicrosoftWay&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052},&quot;IDs&quot;:[425,-70,9.22337203685478E+18]}.
         /// </summary>
@@ -109,7 +126,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("ExpectedBasicJsonWithLargeNum", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1 Microsoft Way&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052}}.
         /// </summary>
@@ -118,7 +135,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("ExpectedCreateJson", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1MicrosoftWay&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052},&quot;IDs&quot;:[425,-70,9.22337203685478E+18],&quot;arrayWithObjects&quot;:[&quot;text&quot;,14,[],null,false,{},{&quot;time&quot;:24},[&quot;1&quot;,&quot;2&quot;,&quot;3&quot;]],&quot;boolean&quot;:false,&quot;null&quot;:null,&quot;objectName&quot;:{&quot;group&quot;:{&quot;array&quot;:[false],&quot;field&quot;:&quot;simple&quot;,&quot;anotherFieldNum&quot;:5,&quot;anotherFieldBool&quot;:true,&quot;lastField&quot;:null}},&quot;emptyObject&quot;:{}}.
         /// </summary>
@@ -127,7 +144,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("ExpectedFullJsonSchema1", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;string&quot;:&quot;string&quot;,&quot;number&quot;:5,&quot;decimal&quot;:3516512.13512,&quot;long&quot;:9.22337203685478E+18,&quot;notLong&quot;:922854776000.12,&quot;boolean&quot;:false,&quot;object&quot;:{},&quot;array&quot;:[],&quot;null&quot;:null,&quot;emptyArray&quot;:[],&quot;emptyObject&quot;:{},&quot;arrayString&quot;:[&quot;alpha&quot;,&quot;beta&quot;],&quot;arrayNum&quot;:[1,212512.01,3],&quot;arrayBool&quot;:[false,true,true],&quot;arrayNull&quot;:[null,null],&quot;arrayObject&quot;:[{&quot;firstName&quot;:&quot;name1&quot;,&quot;lastName&quot;:&quot;name&quot;},{&quot;firstName&quot;:&quot;name1&quot;,&quot;lastName&quot;:&quot;name&quot;},{&quot;firstName&quot;:&quot;name2&quot;,&quot;lastName&quot;:&quot;name&quot;},{&quot;firstName&quot;:&quot;name3&quot;,&quot;lastName&quot;:&quot;name1&quot;}],&quot;arrayArray&quot;:[[null,false,5,&quot;-0 [rest of string was truncated]&quot;;.
         /// </summary>
@@ -136,7 +153,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("ExpectedFullJsonSchema2", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;array&quot;:[{&quot;_id&quot;:&quot;56280d1abea79cfca762cd56&quot;,&quot;index&quot;:0,&quot;isActive&quot;:false,&quot;tags&quot;:[&quot;ad&quot;,&quot;voluptate&quot;,&quot;ullamco&quot;,&quot;reprehenderit&quot;,&quot;duis&quot;,&quot;Lorem&quot;,&quot;anim&quot;],&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Fernandez Barr&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Selena Hoover&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Verna Keller&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Middleton Duncan&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Fitzgerald Mcbride&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Boyd Marshall&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Debbie Hess&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Larson Mcmahon&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name [rest of string was truncated]&qu....
         /// </summary>
@@ -145,7 +162,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("ExpectedHeavyNestedJson", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [{&quot;array&quot;:[{&quot;_id&quot;:&quot;56280d1abea79cfca762cd56&quot;,&quot;index&quot;:0,&quot;isActive&quot;:false,&quot;tags&quot;:[&quot;ad&quot;,&quot;voluptate&quot;,&quot;ullamco&quot;,&quot;reprehenderit&quot;,&quot;duis&quot;,&quot;Lorem&quot;,&quot;anim&quot;],&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Fernandez Barr&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Selena Hoover&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Verna Keller&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Middleton Duncan&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Fitzgerald Mcbride&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Boyd Marshall&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Debbie Hess&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;Larson Mcmahon&quot;,&quot;friends&quot;:[{&quot;id&quot;:0,&quot;nam [rest of string was truncated]&qu....
         /// </summary>
@@ -154,7 +171,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("ExpectedHeavyNestedJsonWithArray", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;+testZero+&quot;:0,&quot;+testSmallNum+&quot;:0.1,&quot;+testeZero+&quot;:0.1,&quot;+testENegtiveWithZero+&quot;:0,&quot;+testeNegativeWithInt+&quot;:0.02155,&quot;+testEPositiveWithDecimal+&quot;:215215.41,&quot;+testePositiveWithLargeInt+&quot;:1.84467440737096E+128,&quot;+testeNegativeWithLargeDecimal+&quot;:1.25125612512513E-109,&quot;-testZero-&quot;:0,&quot;-testSmallNum-&quot;:-0.1,&quot;-testeZero-&quot;:-0.1,&quot;-testENegtiveWithZero-&quot;:0,&quot;-testeNegativeWithInt-&quot;:-0.02155,&quot;-testEPositiveWithDecimal-&quot;:-215215.41,&quot;-testePositiveWithLargeInt-&quot;:-1.84467440737096E+128,&quot;-testeNegativeWithLargeDecimal-&quot;:-1.251 [rest of string was truncated]&quot;;.
         /// </summary>
@@ -163,7 +180,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("ExpectedJsonWithSpecialNumFormat", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;Here is a string: \&quot;\&quot;&quot;:&quot;Here is a hex value -\u024A&quot;,&quot;Here is a back slash\\&quot;:[&quot;Multiline
         /// String
@@ -176,7 +193,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("ExpectedJsonWithSpecialStrings", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;test&quot;:[{&quot;_id&quot;:&quot;562704ab8c67fc70235cb3ee&quot;,&quot;index&quot;:0,&quot;guid&quot;:&quot;9e16ac89-e6cb-401d-b0bd-5cb567908ad7&quot;,&quot;isActive&quot;:false,&quot;balance&quot;:&quot;$2,222.13&quot;,&quot;picture&quot;:&quot;http://placehold.it/32x32&quot;,&quot;age&quot;:34,&quot;eyeColor&quot;:&quot;blue&quot;,&quot;name&quot;:&quot;Reba Abbott&quot;,&quot;gender&quot;:&quot;female&quot;,&quot;company&quot;:&quot;VERBUS&quot;,&quot;email&quot;:&quot;rebaabbott@verbus.com&quot;,&quot;phone&quot;:&quot;+1 (878) 506-3650&quot;,&quot;address&quot;:&quot;800 Anchorage Place, Crayne, Illinois, 9130&quot;,&quot;about&quot;:&quot;Proident ea dolor ullamco occaecat ut pariatur. Pariatur aute deserunt deserunt qui aute commodo. Dolor ipsum incididunt tempo [rest of string was truncated]&quot;;.
         /// </summary>
@@ -185,7 +202,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("ExpectedLargeJson", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;locked&quot;:false,&quot;version&quot;:1,&quot;targets&quot;:{&quot;DNXCore,Version=v5.0&quot;:{&quot;Microsoft.CSharp/4.0.0&quot;:{&quot;dependencies&quot;:{&quot;System.Runtime&quot;:&quot;[4.0.20, )&quot;,&quot;System.Dynamic.Runtime&quot;:&quot;[4.0.0, )&quot;,&quot;System.Linq.Expressions&quot;:&quot;[4.0.0, )&quot;,&quot;System.Runtime.InteropServices&quot;:&quot;[4.0.20, )&quot;,&quot;System.Resources.ResourceManager&quot;:&quot;[4.0.0, )&quot;,&quot;System.Linq&quot;:&quot;[4.0.0, )&quot;,&quot;System.Reflection.TypeExtensions&quot;:&quot;[4.0.0, )&quot;,&quot;System.Reflection.Primitives&quot;:&quot;[4.0.0, )&quot;,&quot;System.Reflection.Extensions&quot;:&quot;[4.0.0, )&quot;,&quot;System.Collections&quot;:&quot;[4.0.10, )&quot;,&quot;System.Diagnost [rest of string was truncated]&quot;;.
         /// </summary>
@@ -194,7 +211,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("ExpectedProjectLockJson", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1MicrosoftWay&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052},&quot;IDs&quot;:[425,-70,9223372036854776000],&quot;arrayWithObjects&quot;:[&quot;text&quot;,14,[],null,false,{},{&quot;time&quot;:24},[&quot;1&quot;,&quot;2&quot;,&quot;3&quot;]],&quot;boolean&quot;:false,&quot;null&quot;:null,&quot;objectName&quot;:{&quot;group&quot;:{&quot;array&quot;:[false],&quot;field&quot;:&quot;simple&quot;,&quot;anotherFieldNum&quot;:5,&quot;anotherFieldBool&quot;:true,&quot;lastField&quot;:null}},&quot;emptyObject&quot;:{}}.
         /// </summary>
@@ -203,7 +220,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("FullJsonSchema1", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;string&quot;:&quot;string&quot;,&quot;number&quot;:5,&quot;decimal&quot;:3516512.13512,&quot;long&quot;:9223372036854776000.1200,&quot;notLong&quot;:922854776000.1200,&quot;boolean&quot;:false,&quot;object&quot;:{},&quot;array&quot;:[],&quot;null&quot;:null,&quot;emptyArray&quot;:[],&quot;emptyObject&quot;:{},&quot;arrayString&quot;:[&quot;alpha&quot;,&quot;beta&quot;],&quot;arrayNum&quot;:[1,212512.01,3.00],&quot;arrayBool&quot;:[false,true,true],&quot;arrayNull&quot;:[null,null],&quot;arrayObject&quot;:[{&quot;firstName&quot;:&quot;name1&quot;,&quot;lastName&quot;:&quot;name&quot;},{&quot;firstName&quot;:&quot;name1&quot;,&quot;lastName&quot;:&quot;name&quot;},{&quot;firstName&quot;:&quot;name2&quot;,&quot;lastName&quot;:&quot;name&quot;},{&quot;firstName&quot;:&quot;name3&quot;,&quot;lastName&quot;:&quot;name1&quot;}],&quot;arrayArray&quot;:[[null,fa [rest of string was truncated]&quot;;.
         /// </summary>
@@ -212,7 +229,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("FullJsonSchema2", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;array&quot;:[  {    &quot;_id&quot;: &quot;56280d1abea79cfca762cd56&quot;,    &quot;index&quot;: 0,    &quot;isActive&quot;: false,    &quot;tags&quot;: [      &quot;ad&quot;,      &quot;voluptate&quot;,      &quot;ullamco&quot;,      &quot;reprehenderit&quot;,      &quot;duis&quot;,      &quot;Lorem&quot;,      &quot;anim&quot;    ],    &quot;friends&quot;: [      {        &quot;id&quot;: 0,        &quot;name&quot;: &quot;Fernandez Barr&quot;,        &quot;friends&quot;: [          {            &quot;id&quot;: 0,            &quot;name&quot;: &quot;Selena Hoover&quot;,            &quot;friends&quot;: [              {                &quot;id&quot;: 0,                &quot;name&quot;: &quot;Verna Keller&quot;,                &quot;friends&quot;: [           [rest of string was truncated]&quot;;.
         /// </summary>
@@ -221,7 +238,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("HeavyNestedJson", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [{&quot;array&quot;:[  {    &quot;_id&quot;: &quot;56280d1abea79cfca762cd56&quot;,    &quot;index&quot;: 0,    &quot;isActive&quot;: false,    &quot;tags&quot;: [      &quot;ad&quot;,      &quot;voluptate&quot;,      &quot;ullamco&quot;,      &quot;reprehenderit&quot;,      &quot;duis&quot;,      &quot;Lorem&quot;,      &quot;anim&quot;    ],    &quot;friends&quot;: [      {        &quot;id&quot;: 0,        &quot;name&quot;: &quot;Fernandez Barr&quot;,        &quot;friends&quot;: [          {            &quot;id&quot;: 0,            &quot;name&quot;: &quot;Selena Hoover&quot;,            &quot;friends&quot;: [              {                &quot;id&quot;: 0,                &quot;name&quot;: &quot;Verna Keller&quot;,                &quot;friends&quot;: [          [rest of string was truncated]&quot;;.
         /// </summary>
@@ -230,7 +247,61 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("HeavyNestedJsonWithArray", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to { &quot;message&quot;: &quot;Hello, World!&quot; }.
+        /// </summary>
+        internal static string HelloWorld {
+            get {
+                return ResourceManager.GetString("HelloWorld", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to c.
+        /// </summary>
+        internal static string Json300B {
+            get {
+                return ResourceManager.GetString("Json300B", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to d.
+        /// </summary>
+        internal static string Json300KB {
+            get {
+                return ResourceManager.GetString("Json300KB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to e.
+        /// </summary>
+        internal static string Json30KB {
+            get {
+                return ResourceManager.GetString("Json30KB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to f.
+        /// </summary>
+        internal static string Json3KB {
+            get {
+                return ResourceManager.GetString("Json3KB", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to g.
+        /// </summary>
+        internal static string Json3MB {
+            get {
+                return ResourceManager.GetString("Json3MB", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;+testZero+&quot; : 0,&quot;+testSmallNum+&quot; : 0.1,&quot;+testeZero+&quot; : 0.1e0,&quot;+testENegtiveWithZero+&quot; : 0E-1,&quot;+testeNegativeWithInt+&quot; : 2155e-5,&quot;+testEPositiveWithDecimal+&quot; : 2152.1541E+2,&quot;+testePositiveWithLargeInt+&quot; : 18446744073709551615E109,&quot;+testeNegativeWithLargeDecimal+&quot; : 125125612512512.512512e-0123,&quot;-testZero-&quot; : -0,&quot;-testSmallNum-&quot; : -0.1,&quot;-testeZero-&quot; : -0.1e0,&quot;-testENegtiveWithZero-&quot; : -0E-1,&quot;-testeNegativeWithInt-&quot; : -2155e-5,&quot;-testEPositiveWithDecimal-&quot; : -2152.1541E+2,&quot;-testePositiveWithLargeInt-&quot; :-18446 [rest of string was truncated]&quot;;.
         /// </summary>
@@ -239,7 +310,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("JsonWithSpecialNumFormat", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {&quot;Here is a string: \&quot;\&quot;&quot;:&quot;Here is a hex value -\u024A&quot;,&quot;Here is a back slash\\&quot;:[&quot;Multiline
         /// String
@@ -252,7 +323,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("JsonWithSpecialStrings", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {  &quot;test&quot; : [    {      &quot;_id&quot;: &quot;562704ab8c67fc70235cb3ee&quot;,      &quot;index&quot;: 0,      &quot;guid&quot;: &quot;9e16ac89-e6cb-401d-b0bd-5cb567908ad7&quot;,      &quot;isActive&quot;: false,      &quot;balance&quot;: &quot;$2,222.13&quot;,      &quot;picture&quot;: &quot;http://placehold.it/32x32&quot;,      &quot;age&quot;: 34,      &quot;eyeColor&quot;: &quot;blue&quot;,      &quot;name&quot;: &quot;Reba Abbott&quot;,      &quot;gender&quot;: &quot;female&quot;,      &quot;company&quot;: &quot;VERBUS&quot;,      &quot;email&quot;: &quot;rebaabbott@verbus.com&quot;,      &quot;phone&quot;: &quot;+1 (878) 506-3650&quot;,      &quot;address&quot;: &quot;800 Anchorage Place, Crayne, Illinois, 9130&quot;,      &quot;about&quot;: &quot;Proident ea d [rest of string was truncated]&quot;;.
         /// </summary>
@@ -261,7 +332,25 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("LargeJson", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string LotsOfNumbers {
+            get {
+                return ResourceManager.GetString("LotsOfNumbers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to .
+        /// </summary>
+        internal static string LotsOfStrings {
+            get {
+                return ResourceManager.GetString("LotsOfStrings", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to [
         ///   {
@@ -285,7 +374,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("ParseJson", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {  &quot;locked&quot;: false,  &quot;version&quot;: 1,  &quot;targets&quot;: {    &quot;DNXCore,Version=v5.0&quot;: {      &quot;Microsoft.CSharp/4.0.0&quot;: {        &quot;dependencies&quot;: {          &quot;System.Runtime&quot;: &quot;[4.0.20, )&quot;,          &quot;System.Dynamic.Runtime&quot;: &quot;[4.0.0, )&quot;,          &quot;System.Linq.Expressions&quot;: &quot;[4.0.0, )&quot;,          &quot;System.Runtime.InteropServices&quot;: &quot;[4.0.20, )&quot;,          &quot;System.Resources.ResourceManager&quot;: &quot;[4.0.0, )&quot;,          &quot;System.Linq&quot;: &quot;[4.0.0, )&quot;,          &quot;System.Reflection.TypeExtensions&quot;: &quot;[4.0.0, )&quot;,          &quot;System.Reflection. [rest of string was truncated]&quot;;.
         /// </summary>
@@ -294,7 +383,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("ProjectLockJson", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [
         ///	&quot;425-214-3151&quot;,
@@ -306,7 +395,7 @@ namespace System.Text.JsonLab.Tests.Resources {
                 return ResourceManager.GetString("SimpleArrayJson", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {
         ///	&quot;age&quot;: 30,
@@ -321,15 +410,6 @@ namespace System.Text.JsonLab.Tests.Resources {
         internal static string SimpleObjectJson {
             get {
                 return ResourceManager.GetString("SimpleObjectJson", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        /// Looks up a localized string similar to { &quot;message&quot;: &quot;Hello, World!&quot; }.
-        /// </summary>
-        internal static string HelloWorld {
-            get {
-                return ResourceManager.GetString("HelloWorld", resourceCulture);
             }
         }
     }

--- a/tests/System.Text.JsonLab.Tests/Resources/TestJson.Designer.cs
+++ b/tests/System.Text.JsonLab.Tests/Resources/TestJson.Designer.cs
@@ -92,7 +92,23 @@ namespace System.Text.JsonLab.Tests.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to a.
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;_id&quot;: &quot;5af4c006873ec87e12466553&quot;,
+        ///    &quot;index&quot;: 0,
+        ///    &quot;guid&quot;: &quot;cce48618-6953-4907-b641-288a68f2bd75&quot;,
+        ///    &quot;isActive&quot;: true,
+        ///    &quot;balance&quot;: &quot;$3,677.14&quot;,
+        ///    &quot;picture&quot;: &quot;http://placehold.it/32x32&quot;,
+        ///    &quot;age&quot;: 22,
+        ///    &quot;eyeColor&quot;: &quot;blue&quot;,
+        ///    &quot;name&quot;: &quot;Hampton Guerra&quot;,
+        ///    &quot;gender&quot;: &quot;male&quot;,
+        ///    &quot;company&quot;: &quot;GAPTEC&quot;,
+        ///    &quot;email&quot;: &quot;hamptonguerra@gaptec.com&quot;,
+        ///    &quot;phone&quot;: &quot;+1 (858) 595-2071&quot;,
+        ///    &quot;address&quot;: &quot;282 Harden Street, Orason, Nebraska, 3912&quot;,
+        ///    &quot;about&quot;: &quot;Tempor ullamco eu anim d [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string BroadTree {
             get {
@@ -101,7 +117,23 @@ namespace System.Text.JsonLab.Tests.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to b.
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;_id&quot;: &quot;5af4bfbe93ba383385d9047a&quot;,
+        ///    &quot;index&quot;: 0,
+        ///    &quot;guid&quot;: &quot;1a4244ab-960b-4937-872d-d0b00882a99d&quot;,
+        ///    &quot;isActive&quot;: true,
+        ///    &quot;balance&quot;: &quot;$3,377.20&quot;,
+        ///    &quot;picture&quot;: &quot;http://placehold.it/32x32&quot;,
+        ///    &quot;age&quot;: 30,
+        ///    &quot;eyeColor&quot;: &quot;blue&quot;,
+        ///    &quot;name&quot;: &quot;Ferguson Avery&quot;,
+        ///    &quot;gender&quot;: &quot;male&quot;,
+        ///    &quot;company&quot;: &quot;PHARMACON&quot;,
+        ///    &quot;email&quot;: &quot;fergusonavery@pharmacon.com&quot;,
+        ///    &quot;phone&quot;: &quot;+1 (904) 438-2218&quot;,
+        ///    &quot;address&quot;: &quot;732 Falmouth Street, Riviera, Mississippi, 4550&quot;,
+        ///    &quot;about&quot;: &quot;Pariatur adi [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string DeepTree {
             get {
@@ -258,7 +290,22 @@ namespace System.Text.JsonLab.Tests.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to c.
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;_id&quot;: &quot;5671ebcfd88de5e8dac53641&quot;,
+        ///    &quot;index&quot;: 0,
+        ///    &quot;isActive&quot;: true,
+        ///    &quot;balance&quot;: &quot;$3,951.98&quot;,
+        ///    &quot;picture&quot;: &quot;http://placehold.it/32x32&quot;,
+        ///    &quot;age&quot;: 36,
+        ///    &quot;email&quot;: &quot;clementsvillarreal@daycore.com&quot;,
+        ///    &quot;phone&quot;: &quot;+1 (882) 479-2331&quot;,
+        ///    &quot;address&quot;: &quot;488 Grand Street, Hackneyville, Vermont, 5344&quot;,
+        ///    &quot;registered&quot;: &quot;2015-04-12T05:27:22 +07:00&quot;,
+        ///    &quot;latitude&quot;: -57.256693,
+        ///    &quot;longitude&quot;: 49.961028
+        ///  }
+        ///].
         /// </summary>
         internal static string Json400B {
             get {
@@ -267,7 +314,23 @@ namespace System.Text.JsonLab.Tests.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to d.
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;_id&quot;: &quot;5671eaf1eb61139592ea92ff&quot;,
+        ///    &quot;index&quot;: 0,
+        ///    &quot;guid&quot;: &quot;b825474f-3855-434e-930c-c3015f3b39ee&quot;,
+        ///    &quot;isActive&quot;: false,
+        ///    &quot;balance&quot;: &quot;$2,100.09&quot;,
+        ///    &quot;picture&quot;: &quot;http://placehold.it/32x32&quot;,
+        ///    &quot;age&quot;: 20,
+        ///    &quot;eyeColor&quot;: &quot;green&quot;,
+        ///    &quot;name&quot;: &quot;Zelma Blackburn&quot;,
+        ///    &quot;gender&quot;: &quot;female&quot;,
+        ///    &quot;company&quot;: &quot;AUTOMON&quot;,
+        ///    &quot;email&quot;: &quot;zelmablackburn@automon.com&quot;,
+        ///    &quot;phone&quot;: &quot;+1 (935) 411-3028&quot;,
+        ///    &quot;address&quot;: &quot;358 Catherine Street, Takilma, New Hampshire, 9061&quot;,
+        ///    &quot;about&quot;: &quot;Ad ea o [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Json400KB {
             get {
@@ -276,7 +339,23 @@ namespace System.Text.JsonLab.Tests.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to e.
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;_id&quot;: &quot;5671eb0737b18866984067ac&quot;,
+        ///    &quot;index&quot;: 0,
+        ///    &quot;guid&quot;: &quot;3cfa77d7-29be-467f-a967-16bae78767e8&quot;,
+        ///    &quot;isActive&quot;: false,
+        ///    &quot;balance&quot;: &quot;$1,223.37&quot;,
+        ///    &quot;picture&quot;: &quot;http://placehold.it/32x32&quot;,
+        ///    &quot;age&quot;: 34,
+        ///    &quot;eyeColor&quot;: &quot;brown&quot;,
+        ///    &quot;name&quot;: &quot;Josephine Snider&quot;,
+        ///    &quot;gender&quot;: &quot;female&quot;,
+        ///    &quot;company&quot;: &quot;SYBIXTEX&quot;,
+        ///    &quot;email&quot;: &quot;josephinesnider@sybixtex.com&quot;,
+        ///    &quot;phone&quot;: &quot;+1 (936) 525-3324&quot;,
+        ///    &quot;address&quot;: &quot;905 Marconi Place, Motley, Oregon, 3159&quot;,
+        ///    &quot;about&quot;: &quot;Ut id id conse [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Json40KB {
             get {
@@ -285,7 +364,23 @@ namespace System.Text.JsonLab.Tests.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to f.
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;_id&quot;: &quot;5671eb1b60a382ffb56b3946&quot;,
+        ///    &quot;index&quot;: 0,
+        ///    &quot;guid&quot;: &quot;8938d485-7ea7-4b57-ab02-cd7ff698a57e&quot;,
+        ///    &quot;isActive&quot;: true,
+        ///    &quot;balance&quot;: &quot;$3,138.66&quot;,
+        ///    &quot;picture&quot;: &quot;http://placehold.it/32x32&quot;,
+        ///    &quot;age&quot;: 28,
+        ///    &quot;eyeColor&quot;: &quot;blue&quot;,
+        ///    &quot;name&quot;: &quot;Susanne Wright&quot;,
+        ///    &quot;gender&quot;: &quot;female&quot;,
+        ///    &quot;company&quot;: &quot;VIXO&quot;,
+        ///    &quot;email&quot;: &quot;susannewright@vixo.com&quot;,
+        ///    &quot;phone&quot;: &quot;+1 (836) 581-2698&quot;,
+        ///    &quot;address&quot;: &quot;367 Clifford Place, Benson, Northern Mariana Islands, 4627&quot;,
+        ///    &quot;about&quot;: &quot;Irure off [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string Json4KB {
             get {
@@ -325,7 +420,45 @@ namespace System.Text.JsonLab.Tests.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;_id1&quot;: 1970097990,
+        ///    &quot;_id2&quot;: 9666
+        ///  },
+        ///  {
+        ///    &quot;_id1&quot;: 5632677389,
+        ///    &quot;_id2&quot;: 2356
+        ///  },
+        ///  {
+        ///    &quot;_id1&quot;: 7930277137,
+        ///    &quot;_id2&quot;: 1130
+        ///  },
+        ///  {
+        ///    &quot;_id1&quot;: 6964942657,
+        ///    &quot;_id2&quot;: 3348
+        ///  },
+        ///  {
+        ///    &quot;_id1&quot;: 2504939563,
+        ///    &quot;_id2&quot;: 3501
+        ///  },
+        ///  {
+        ///    &quot;_id1&quot;: 5993828171,
+        ///    &quot;_id2&quot;: 4462
+        ///  },
+        ///  {
+        ///    &quot;_id1&quot;: 6829429877,
+        ///    &quot;_id2&quot;: 3502
+        ///  },
+        ///  {
+        ///    &quot;_id1&quot;: 9526593666,
+        ///    &quot;_id2&quot;: 5752
+        ///  },
+        ///  {
+        ///    &quot;_id1&quot;: 7980793185,
+        ///    &quot;_id2&quot;: 9376
+        ///  },
+        ///  {
+        ///    &quot;_id1&quot;: 747666 [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string LotsOfNumbers {
             get {
@@ -334,7 +467,33 @@ namespace System.Text.JsonLab.Tests.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to [
+        ///  {
+        ///    &quot;email&quot;: &quot;3388 hooversexton@nitracyr.com 6241&quot;
+        ///  },
+        ///  {
+        ///    &quot;email&quot;: &quot;9999 hooversexton@nitracyr.com 445&quot;
+        ///  },
+        ///  {
+        ///    &quot;email&quot;: &quot;7601 hooversexton@nitracyr.com 4879&quot;
+        ///  },
+        ///  {
+        ///    &quot;email&quot;: &quot;1913 hooversexton@nitracyr.com 4301&quot;
+        ///  },
+        ///  {
+        ///    &quot;email&quot;: &quot;9541 hooversexton@nitracyr.com 403&quot;
+        ///  },
+        ///  {
+        ///    &quot;email&quot;: &quot;4363 hooversexton@nitracyr.com 9040&quot;
+        ///  },
+        ///  {
+        ///    &quot;email&quot;: &quot;7105 hooversexton@nitracyr.com 4676&quot;
+        ///  },
+        ///  {
+        ///    &quot;email&quot;: &quot;2558 hooversexton@nitracyr.com 8668&quot;
+        ///  },
+        ///  {
+        ///   [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string LotsOfStrings {
             get {

--- a/tests/System.Text.JsonLab.Tests/Resources/TestJson.Designer.cs
+++ b/tests/System.Text.JsonLab.Tests/Resources/TestJson.Designer.cs
@@ -260,36 +260,36 @@ namespace System.Text.JsonLab.Tests.Resources {
         /// <summary>
         ///   Looks up a localized string similar to c.
         /// </summary>
-        internal static string Json300B {
+        internal static string Json400B {
             get {
-                return ResourceManager.GetString("Json300B", resourceCulture);
+                return ResourceManager.GetString("Json400B", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to d.
         /// </summary>
-        internal static string Json300KB {
+        internal static string Json400KB {
             get {
-                return ResourceManager.GetString("Json300KB", resourceCulture);
+                return ResourceManager.GetString("Json400KB", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to e.
         /// </summary>
-        internal static string Json30KB {
+        internal static string Json40KB {
             get {
-                return ResourceManager.GetString("Json30KB", resourceCulture);
+                return ResourceManager.GetString("Json40KB", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to f.
         /// </summary>
-        internal static string Json3KB {
+        internal static string Json4KB {
             get {
-                return ResourceManager.GetString("Json3KB", resourceCulture);
+                return ResourceManager.GetString("Json4KB", resourceCulture);
             }
         }
         

--- a/tests/System.Text.JsonLab.Tests/Resources/TestJson.resx
+++ b/tests/System.Text.JsonLab.Tests/Resources/TestJson.resx
@@ -598,7 +598,7 @@ tiline\"another\" String\\"],"str":"\"\""}</value>
   }
 ]</value>
   </data>
-  <data name="Json300B" xml:space="preserve">
+  <data name="Json400B" xml:space="preserve">
     <value>[
   {
     "_id": "5671ebcfd88de5e8dac53641",
@@ -616,7 +616,7 @@ tiline\"another\" String\\"],"str":"\"\""}</value>
   }
 ]</value>
   </data>
-  <data name="Json300KB" xml:space="preserve">
+  <data name="Json400KB" xml:space="preserve">
             <value>[
   {
     "_id": "5671eaf1eb61139592ea92ff",
@@ -14120,7 +14120,7 @@ tiline\"another\" String\\"],"str":"\"\""}</value>
   }
 ]</value>
   </data>
-  <data name="Json30KB" xml:space="preserve">
+  <data name="Json40KB" xml:space="preserve">
     <value>[
   {
     "_id": "5671eb0737b18866984067ac",
@@ -15474,7 +15474,7 @@ tiline\"another\" String\\"],"str":"\"\""}</value>
   }
 ]</value>
   </data>
-  <data name="Json3KB" xml:space="preserve">
+  <data name="Json4KB" xml:space="preserve">
     <value>[
   {
     "_id": "5671eb1b60a382ffb56b3946",

--- a/tests/System.Text.JsonLab.Tests/System.Text.JsonLab.Tests.csproj
+++ b/tests/System.Text.JsonLab.Tests/System.Text.JsonLab.Tests.csproj
@@ -27,6 +27,19 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Text.JsonLab\System.Text.JsonLab.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Resources\TestJson.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>TestJson.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Resources\TestJson.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>TestJson.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
   <!-- register for test discovery in Visual Studio -->
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />


### PR DESCRIPTION
**See the raw results here:** https://gist.github.com/ahsonkhan/4f8dbb517e701e84c2f6d1385afff2e1

![image](https://user-images.githubusercontent.com/6527137/39951985-4e4598dc-5544-11e8-98a8-1a4b83551eff.png)

**Conclusions:**
- JsonLab Reader is 2.5-3.7x faster than Json.NET Reader, in general, across the board.
- JsonLab Reader is better at reading UTF-8 than UTF-16 when compared to Json.NET Reader (Json.NET is forced to use StreamReader which is slower than StringReader)
- When returning a copy of the data, JsonLab Reader allocates 1.1x of the input json size for UTF-8 and 2.2x for UTF-16. Json.NET Reader ends up allocating 6-7x of the input json size for both UTF-8 and UTF-16 (32 bytes more in the case of UTF-16 due to the allocation of a new StringReader).

![image](https://user-images.githubusercontent.com/6527137/39951989-533a4bd0-5544-11e8-9c60-c0df3c5fdc26.png)

![image](https://user-images.githubusercontent.com/6527137/39951992-589c436c-5544-11e8-84cb-7029fc2a38dc.png)

![image](https://user-images.githubusercontent.com/6527137/39951993-5d9aad18-5544-11e8-8bb1-b25bd245bff9.png)

![image](https://user-images.githubusercontent.com/6527137/39951996-62b3136c-5544-11e8-948c-2659009f59e2.png)

**EmptyLoop just goes through the entire json using each reader, without accessing any value or token:**
```C#
public void ReaderNewtonsoftReaderEmptyLoop()
{
    TextReader reader;
    if (IsUTF8Encoded)
    {
        _stream.Seek(0, SeekOrigin.Begin);
        reader = _reader;
    }
    else
    {
        reader = new StringReader(_jsonString);
    }
    var json = new Newtonsoft.Json.JsonTextReader(reader);
    while (json.Read()) ;
}

public void ReaderSystemTextJsonLabEmptyLoop()
{
    JsonReader json = IsUTF8Encoded ?
        new JsonReader(_dataUtf8, SymbolTable.InvariantUtf8) :
        new JsonReader(_dataUtf16, SymbolTable.InvariantUtf16);

    while (json.Read()) ;
}
```

**ReturnBytes, ReturnString get each value within the json from the reader and concat it together (either as a string output, or byte array).  The results of these loops are essentially identical (which is what our unit tests compare and assert).**
```C#
private string NewtonsoftReturnStringHelper(TextReader reader)
{
    StringBuilder sb = new StringBuilder();
    var json = new Newtonsoft.Json.JsonTextReader(reader);
    while (json.Read())
    {
        if (json.Value != null)
        {
            sb.Append(json.Value).Append(", ");
        }
    }

    return sb.ToString();
}

private byte[] JsonLabReturnBytesHelper(byte[] data, SymbolTable symbolTable, int utf16Multiplier = 1)
{
    byte[] outputArray = new byte[data.Length];

    Span<byte> destination = outputArray;
    var json = new JsonReader(data, symbolTable);
    while (json.Read())
    {
        JsonTokenType tokenType = json.TokenType;
        ReadOnlySpan<byte> valueSpan = json.Value;
        switch (tokenType)
        {
            case JsonTokenType.PropertyName:
                valueSpan.CopyTo(destination);
                destination[valueSpan.Length] = (byte)',';
                destination[valueSpan.Length + 1 * utf16Multiplier] = (byte)' ';
                destination = destination.Slice(valueSpan.Length + 2 * utf16Multiplier);
                break;
            case JsonTokenType.Value:
                var valueType = json.ValueType;

                switch (valueType)
                {
                    case JsonValueType.True:
                        destination[0] = (byte)'T';
                        destination[1 * utf16Multiplier] = (byte)'r';
                        destination[2 * utf16Multiplier] = (byte)'u';
                        destination[3 * utf16Multiplier] = (byte)'e';
                        destination = destination.Slice(4 * utf16Multiplier);
                        break;
                    case JsonValueType.False:
                        destination[0] = (byte)'F';
                        destination[1 * utf16Multiplier] = (byte)'a';
                        destination[2 * utf16Multiplier] = (byte)'l';
                        destination[3 * utf16Multiplier] = (byte)'s';
                        destination[4 * utf16Multiplier] = (byte)'e';
                        destination = destination.Slice(5 * utf16Multiplier);
                        break;
                }

                valueSpan.CopyTo(destination);
                destination[valueSpan.Length] = (byte)',';
                destination[valueSpan.Length + 1 * utf16Multiplier] = (byte)' ';
                destination = destination.Slice(valueSpan.Length + 2 * utf16Multiplier);
                break;
            default:
                break;
        }
    }
    return outputArray;
}
```

**Edit:** Updated the results and gist.

<details>
<summary>Out-dated results </summary>

!~[image](https://user-images.githubusercontent.com/6527137/39912453-9f797fd4-54b3-11e8-87a8-a07be0ebaec7.png)~

**Conclusions:**
- JsonLab is 3-4x faster than Json.NET, in general, across the board.
- JsonLab is better at reading UTF-8 than UTF-16 when compared to Json.NET (Json.NET is forced to use StreamReader which is slower than StringReader)
- When returning a copy of the data, Json.Lab allocates 1x of the input json size for UTF-8 and 2x for UTF-16. Json.NET ends up allocating 10x of the input json size for UTF-8 and 7x for UTF-16.

!~[image](https://user-images.githubusercontent.com/6527137/39912463-a6cca856-54b3-11e8-8ce7-8cc5709b7214.png)~

!~[image](https://user-images.githubusercontent.com/6527137/39912465-aa18e268-54b3-11e8-9cab-9a402f9b56ab.png)~

!~[image](https://user-images.githubusercontent.com/6527137/39912468-acff3022-54b3-11e8-8ac2-2dfe7ab41b62.png)~

!~[image](https://user-images.githubusercontent.com/6527137/39912474-b03d2870-54b3-11e8-9a93-cef82a001245.png)~
</details>

cc @adamsitnik, @KrzysztofCwalina 