### PR TITLE
Add SpanJson to Benchmarks

### DIFF
--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="LitJson" Version="0.12.0" />
     <PackageReference Include="codetitans-json" Version="1.8.3" />
     <PackageReference Include="Manatee.Json" Version="9.8.0" />
-    <PackageReference Include="SpanJson" Version="0.1.0-rc2-3" />
+    <PackageReference Include="SpanJson" Version="0.1.0-rc2-5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Azure.Experimental\System.Azure.Experimental.csproj" />

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="LitJson" Version="0.12.0" />
     <PackageReference Include="codetitans-json" Version="1.8.3" />
     <PackageReference Include="Manatee.Json" Version="9.8.0" />
+    <PackageReference Include="SpanJson" Version="0.1.0-rc2-3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Azure.Experimental\System.Azure.Experimental.csproj" />

--- a/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonDeserializer/JsonDeserializerComparison_FromString.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonDeserializer/JsonDeserializerComparison_FromString.cs
@@ -62,7 +62,7 @@ namespace JsonBenchmarks
             return deserialized;
         }
 
-        [Benchmark(Description = "YSharp")]
+        [Benchmark]
         public T YSharp()
         {
             T deserialized = new System.Text.Json.JsonParser().Parse<T>(serialized);
@@ -70,7 +70,7 @@ namespace JsonBenchmarks
             return deserialized;
         }
 
-        [Benchmark(Description = "FastJson")]
+        [Benchmark]
         public T FastJson()
         {
             T deserialized = fastJSON.JSON.ToObject<T>(serialized);
@@ -96,7 +96,7 @@ namespace JsonBenchmarks
             return deserialized;
         }
 
-        [Benchmark(Description = "SpanJsonUtf16")]
+        [Benchmark]
         public T SpanJsonUtf16()
         {
             T deserialized = SpanJson.JsonSerializer.Generic.Utf16.Deserialize<T>(serialized);

--- a/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonDeserializer/JsonDeserializerComparison_FromString.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonDeserializer/JsonDeserializerComparison_FromString.cs
@@ -35,6 +35,9 @@ namespace JsonBenchmarks
         [IterationSetup(Target = nameof(Manatee_))]
         public void SerializeManatee() => jsonValue = Manatee.Json.JsonValue.Parse(new Manatee.Json.Serialization.JsonSerializer().Serialize(value).ToString());
 
+        [IterationSetup(Target = nameof(SpanJsonUtf16))]
+        public void SerializeSpanJsonUtf16() => serialized = SpanJson.JsonSerializer.Generic.Utf16.Serialize(value);
+
         [Benchmark(Baseline = true, Description = "Newtonsoft")]
         public T Newtonsoft_()
         {
@@ -89,6 +92,14 @@ namespace JsonBenchmarks
         public T Manatee_()
         {
             T deserialized = new Manatee.Json.Serialization.JsonSerializer().Deserialize<T>(jsonValue);
+            ((IVerifiable)deserialized).TouchEveryProperty();
+            return deserialized;
+        }
+
+        [Benchmark(Description = "SpanJsonUtf16")]
+        public T SpanJsonUtf16()
+        {
+            T deserialized = SpanJson.JsonSerializer.Generic.Utf16.Deserialize<T>(serialized);
             ((IVerifiable)deserialized).TouchEveryProperty();
             return deserialized;
         }

--- a/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonReader/JsonReaderComparison.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonReader/JsonReaderComparison.cs
@@ -88,5 +88,27 @@ namespace JsonBenchmarks
             var json = new LitJson.JsonReader(_reader);
             while (json.Read()) ;
         }
+
+        [Benchmark]
+        public void ReaderSpanJsonUtf16()
+        {
+            SpanJson.JsonReader<char> json = new SpanJson.JsonReader<char>(_str);
+            SpanJson.JsonToken token;
+            while ((token = json.ReadUtf16NextToken()) != SpanJson.JsonToken.None)
+            {
+                json.SkipNextUtf16Value(token);
+            }
+        }
+
+        [Benchmark]
+        public void ReaderSpanJsonUtf8()
+        {
+            SpanJson.JsonReader<byte> json = new SpanJson.JsonReader<byte>(_data);
+            SpanJson.JsonToken token;
+            while ((token = json.ReadUtf8NextToken()) != SpanJson.JsonToken.None)
+            {
+                json.SkipNextUtf8Value(token);
+            }
+        }
     }
 }

--- a/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonReader/JsonReaderComparison.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonReader/JsonReaderComparison.cs
@@ -90,17 +90,6 @@ namespace JsonBenchmarks
         }
 
         [Benchmark]
-        public void ReaderSpanJsonUtf16()
-        {
-            SpanJson.JsonReader<char> json = new SpanJson.JsonReader<char>(_str);
-            SpanJson.JsonToken token;
-            while ((token = json.ReadUtf16NextToken()) != SpanJson.JsonToken.None)
-            {
-                json.SkipNextUtf16Value(token);
-            }
-        }
-
-        [Benchmark]
         public void ReaderSpanJsonUtf8()
         {
             SpanJson.JsonReader<byte> json = new SpanJson.JsonReader<byte>(_data);

--- a/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonSerializer/JsonSerializerComparison_ToString.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonSerializer/JsonSerializerComparison_ToString.cs
@@ -22,7 +22,7 @@ namespace JsonBenchmarks
         [Benchmark(Description = "Utf8Json")]
         public string Utf8Json_() => Utf8Json.JsonSerializer.ToJsonString(value);
 
-        [Benchmark(Description = "FastJson")]
+        [Benchmark]
         public string FastJson() => fastJSON.JSON.ToJSON(value);
 
         // This benchmarks fails to run for IndexViewModel and MyEventsListerViewModel.
@@ -32,7 +32,7 @@ namespace JsonBenchmarks
         [Benchmark(Description = "Manatee")]
         public string Manatee_() => new Manatee.Json.Serialization.JsonSerializer().Serialize(value).ToString();
 
-        [Benchmark(Description = "SpanJsonUtf16")]
+        [Benchmark]
         public string SpanJsonUtf16() => SpanJson.JsonSerializer.Generic.Utf16.Serialize(value);
     }
 }

--- a/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonSerializer/JsonSerializerComparison_ToString.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/Comparison/JsonSerializer/JsonSerializerComparison_ToString.cs
@@ -31,5 +31,8 @@ namespace JsonBenchmarks
 
         [Benchmark(Description = "Manatee")]
         public string Manatee_() => new Manatee.Json.Serialization.JsonSerializer().Serialize(value).ToString();
+
+        [Benchmark(Description = "SpanJsonUtf16")]
+        public string SpanJsonUtf16() => SpanJson.JsonSerializer.Generic.Utf16.Serialize(value);
     }
 }


### PR DESCRIPTION
- Added Reference to nuget package.
- Added Utf16 Version to Serializer and Deserializer Comparison. I postfixed the name with Utf16 as this is consistent with my own tests and it's easier to add an Utf8 version later.
- Added both Utf8/Utf16 versions to JsonReaderComparison.

Benchmark results are in #2288 and below
<details>

**JsonReaderComparison**
``` ini

BenchmarkDotNet=v0.10.14.534-nightly, OS=Windows 10.0.17134
Intel Core i7-4790K CPU 4.00GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
Frequency=3906248 Hz, Resolution=256.0001 ns, Timer=TSC
.NET Core SDK=2.1.300-rtm-008823
  [Host]     : .NET Core 2.1.0-rtm-26509-04 (CoreCLR 4.6.26509.03, CoreFX 4.6.26509.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0-rtm-26509-04 (CoreCLR 4.6.26509.03, CoreFX 4.6.26509.03), 64bit RyuJIT


```
|              Method |        Target |  JsonStringName |         Mean |       Error |      StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
|-------------------- |-------------- |---------------- |-------------:|------------:|------------:|-------:|---------:|-------:|----------:|
|    **ReaderNewtonsoft** | **InvariantUtf8** | **HeavyNestedJson** | **17,399.87 ns** |  **29.3604 ns** |  **24.5173 ns** |   **1.00** |     **0.00** | **2.1057** |    **8904 B** |
|     ReaderCorefxlab | InvariantUtf8 | HeavyNestedJson |  5,501.33 ns |   7.4602 ns |   6.9782 ns |   0.32 |     0.00 |      - |       0 B |
|      ReaderUtf8Json | InvariantUtf8 | HeavyNestedJson | 11,634.98 ns |  17.9349 ns |  16.7763 ns |   0.67 |     0.00 |      - |       0 B |
|       ReaderJayrock | InvariantUtf8 | HeavyNestedJson | 41,562.38 ns | 786.3366 ns | 772.2876 ns |   2.39 |     0.04 | 4.9438 |   20880 B |
|       ReaderLitJson | InvariantUtf8 | HeavyNestedJson | 54,013.30 ns |  46.0975 ns |  43.1196 ns |   3.10 |     0.00 | 1.6479 |    6928 B |
|  ReaderSpanJsonUtf8 | InvariantUtf8 | HeavyNestedJson |  8,890.21 ns |  64.5886 ns |  60.4162 ns |   0.51 |     0.00 |      - |       0 B |
|                     |               |                 |              |             |             |        |          |        |           |
|    **ReaderNewtonsoft** | **InvariantUtf8** |      **HelloWorld** |    **378.29 ns** |   **0.4317 ns** |   **0.4038 ns** |   **1.00** |     **0.00** | **0.5641** |    **2368 B** |
|     ReaderCorefxlab | InvariantUtf8 |      HelloWorld |     64.77 ns |   0.1076 ns |   0.1006 ns |   0.17 |     0.00 |      - |       0 B |
|      ReaderUtf8Json | InvariantUtf8 |      HelloWorld |     82.64 ns |   0.0954 ns |   0.0892 ns |   0.22 |     0.00 |      - |       0 B |
|       ReaderJayrock | InvariantUtf8 |      HelloWorld |    553.50 ns |   4.2478 ns |   3.9734 ns |   1.46 |     0.01 | 0.3405 |    1432 B |
|       ReaderLitJson | InvariantUtf8 |      HelloWorld |    792.08 ns |   0.7162 ns |   0.6349 ns |   2.09 |     0.00 | 0.1764 |     744 B |
|  ReaderSpanJsonUtf8 | InvariantUtf8 |      HelloWorld |     64.87 ns |   0.2278 ns |   0.2019 ns |   0.17 |     0.00 |      - |       0 B |

**JsonDeserializerComparison_FromString_LoginViewModel**

``` ini

BenchmarkDotNet=v0.10.14.534-nightly, OS=Windows 10.0.17134
Intel Core i7-4790K CPU 4.00GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
Frequency=3906248 Hz, Resolution=256.0001 ns, Timer=TSC
.NET Core SDK=2.1.300-rtm-008823
  [Host]     : .NET Core 2.1.0-rtm-26509-04 (CoreCLR 4.6.26509.03, CoreFX 4.6.26509.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0-rtm-26509-04 (CoreCLR 4.6.26509.03, CoreFX 4.6.26509.03), 64bit RyuJIT


```
|        Method |         Mean |         Error |        StdDev | Scaled | ScaledSD |  Gen 0 |  Gen 1 |  Gen 2 | Allocated |
|-------------- |-------------:|--------------:|--------------:|-------:|---------:|-------:|-------:|-------:|----------:|
|    Newtonsoft |   1,200.3 ns |     4.8153 ns |     4.5042 ns |   1.00 |     0.00 | 0.6618 |      - |      - |    2784 B |
|           Jil |     346.5 ns |     1.1224 ns |     0.9950 ns |   0.29 |     0.00 | 0.0644 |      - |      - |     272 B |
|      Utf8Json |     469.2 ns |     1.2537 ns |     1.1114 ns |   0.39 |     0.00 | 0.0682 |      - |      - |     288 B |
|        YSharp | 360,634.0 ns | 3,711.9044 ns | 3,472.1174 ns | 300.46 |     3.00 | 9.2773 | 4.3945 | 0.4883 |   38578 B |
|      FastJson |   2,172.7 ns |     5.8238 ns |     5.4476 ns |   1.81 |     0.01 | 0.5722 |      - |      - |    2416 B |
| SpanJsonUtf16 |     200.1 ns |     0.6457 ns |     0.6040 ns |   0.17 |     0.00 | 0.0417 |      - |      - |     176 B |

**JsonSerializerComparison_ToString_LoginViewModel**

``` ini

BenchmarkDotNet=v0.10.14.534-nightly, OS=Windows 10.0.17134
Intel Core i7-4790K CPU 4.00GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
Frequency=3906248 Hz, Resolution=256.0001 ns, Timer=TSC
.NET Core SDK=2.1.300-rtm-008823
  [Host]     : .NET Core 2.1.0-rtm-26509-04 (CoreCLR 4.6.26509.03, CoreFX 4.6.26509.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0-rtm-26509-04 (CoreCLR 4.6.26509.03, CoreFX 4.6.26509.03), 64bit RyuJIT


```
|        Method |       Mean |      Error |     StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
|-------------- |-----------:|-----------:|-----------:|-------:|---------:|-------:|----------:|
|    Newtonsoft |   751.3 ns | 12.8312 ns | 11.3745 ns |   1.00 |     0.00 | 0.3605 |    1512 B |
|           Jil |   364.3 ns |  6.4239 ns |  5.3642 ns |   0.48 |     0.01 | 0.1750 |     736 B |
|      Utf8Json |   216.6 ns |  0.1600 ns |  0.1157 ns |   0.29 |     0.00 | 0.0455 |     192 B |
|      FastJson | 1,168.1 ns |  1.5533 ns |  1.3769 ns |   1.55 |     0.02 | 0.7019 |    2952 B |
|       Manatee | 4,403.8 ns |  6.8871 ns |  6.4422 ns |   5.86 |     0.08 | 1.0147 |    4272 B |
| SpanJsonUtf16 |   193.5 ns |  0.1432 ns |  0.1196 ns |   0.26 |     0.00 | 0.0455 |     192 B |

</details>