### PR TITLE
 Optimized the JsonWriter APIs and expanded the unit test.

### DIFF
--- a/src/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs
+++ b/src/System.Collections.Sequences/System/Collections/Sequences/ResizableArray.cs
@@ -38,11 +38,13 @@ namespace System.Collections.Sequences
 
         public T this[int index]
         {
-            get {
+            get
+            {
                 if (index > _count - 1) throw new IndexOutOfRangeException();
                 return _array[index];
             }
-            set {
+            set
+            {
                 if (index > _count - 1) throw new IndexOutOfRangeException();
                 _array[index] = value;
             }
@@ -50,7 +52,8 @@ namespace System.Collections.Sequences
 
         public void Add(T item)
         {
-            if (_array.Length == _count) {
+            if (_array.Length == _count)
+            {
                 Resize();
             }
             _array[_count++] = item;
@@ -58,7 +61,8 @@ namespace System.Collections.Sequences
 
         public void AddAll(T[] items)
         {
-            if (items.Length > _array.Length - _count) {
+            if (items.Length > _array.Length - _count)
+            {
                 Resize(items.Length + _count);
             }
             items.CopyTo(_array, _count);
@@ -67,7 +71,8 @@ namespace System.Collections.Sequences
 
         public void AddAll(ReadOnlySpan<T> items)
         {
-            if (items.Length > _array.Length - _count) {
+            if (items.Length > _array.Length - _count)
+            {
                 Resize(items.Length + _count);
             }
             items.CopyTo(new Span<T>(_array).Slice(_count));
@@ -81,27 +86,29 @@ namespace System.Collections.Sequences
 
         public T[] Resize(int newSize = -1)
         {
-            var oldArray = _array;
-            if (newSize == -1) {
-                if(_array == null || _array.Length == 0) {
+            T[] oldArray = _array;
+            if (newSize == -1)
+            {
+                if (_array == null || _array.Length == 0)
+                {
                     newSize = 4;
                 }
-                else {
+                else
+                {
                     newSize = _array.Length << 1;
                 }
             }
 
-            var newArray = new T[newSize];
-            new Span<T>(_array, 0, _count).CopyTo(newArray);
+            T[] newArray = new T[newSize];
+            _array.AsSpan(0, _count).CopyTo(newArray.AsSpan(0, _count));    // AsSpan will throw if newArray.Length < _count
             _array = newArray;
             return oldArray;
         }
 
         public T[] Resize(T[] newArray)
         {
-            if (newArray.Length < _count) throw new ArgumentOutOfRangeException(nameof(newArray));
-            var oldArray = _array;
-            Array.Copy(_array, 0, newArray, 0, _count);
+            T[] oldArray = _array;
+            _array.CopyTo(newArray.AsSpan(0, _count));  // AsSpan will throw if newArray.Length < _count
             _array = newArray;
             return oldArray;
         }
@@ -109,9 +116,10 @@ namespace System.Collections.Sequences
         public bool TryGet(ref SequencePosition position, out T item, bool advance = true)
         {
             int index = position.GetInteger();
-            if (index < _count) {
+            if (index < _count)
+            {
                 item = _array[index];
-                if (advance) { position = new SequencePosition(null, index+1); }
+                if (advance) { position = new SequencePosition(null, index + 1); }
                 return true;
             }
 
@@ -124,5 +132,11 @@ namespace System.Collections.Sequences
 
         public ArraySegment<T> Full => new ArraySegment<T>(_array, 0, _count);
         public ArraySegment<T> Free => new ArraySegment<T>(_array, _count, _array.Length - _count);
+
+        public Span<T> FreeSpan => new Span<T>(_array, _count, _array.Length - _count);
+
+        public Memory<T> FreeMemory => new Memory<T>(_array, _count, _array.Length - _count);
+
+        public int FreeCount => _array.Length - _count;
     }
 }

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/ArrayFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/ArrayFormatter.cs
@@ -5,6 +5,7 @@
 using System.Buffers;
 using System.Buffers.Text;
 using System.Collections.Sequences;
+using System.Runtime.CompilerServices;
 
 namespace System.Text.Formatting
 {
@@ -23,7 +24,8 @@ namespace System.Text.Formatting
 
         public int CommitedByteCount => _buffer.Count;
 
-        public void Clear() {
+        public void Clear()
+        {
             _buffer.Count = 0;
         }
 
@@ -35,44 +37,46 @@ namespace System.Text.Formatting
         public Memory<byte> GetMemory(int minimumLength = 0)
         {
             if (minimumLength < 1) minimumLength = 1;
-            if (minimumLength > _buffer.Free.Count)
+            if (minimumLength > _buffer.FreeCount)
             {
-                var doubleCount = _buffer.Free.Count * 2;
-                int newSize = minimumLength>doubleCount?minimumLength:doubleCount;
-                var newArray = _pool.Rent(newSize + _buffer.Count);
-                var oldArray = _buffer.Resize(newArray);
+                int doubleCount = _buffer.FreeCount * 2;
+                int newSize = minimumLength > doubleCount ? minimumLength : doubleCount;
+                byte[] newArray = _pool.Rent(newSize + _buffer.Count);
+                byte[] oldArray = _buffer.Resize(newArray);
                 _pool.Return(oldArray);
             }
-            return _buffer.Free;
+            return _buffer.FreeMemory;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<byte> GetSpan(int minimumLength = 0)
         {
             if (minimumLength < 1) minimumLength = 1;
-            if (minimumLength > _buffer.Free.Count)
+            if (minimumLength > _buffer.FreeCount)
             {
-                var doubleCount = _buffer.Free.Count * 2;
+                int doubleCount = _buffer.FreeCount * 2;
                 int newSize = minimumLength > doubleCount ? minimumLength : doubleCount;
-                var newArray = _pool.Rent(newSize + _buffer.Count);
-                var oldArray = _buffer.Resize(newArray);
+                byte[] newArray = _pool.Rent(newSize + _buffer.Count);
+                byte[] oldArray = _buffer.Resize(newArray);
                 _pool.Return(oldArray);
             }
-            return _buffer.Free;
+            return _buffer.FreeSpan;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Advance(int bytes)
         {
             _buffer.Count += bytes;
-            if(_buffer.Count > _buffer.Count)
+            if (_buffer.Count > _buffer.Capacity)
             {
-                throw new InvalidOperationException("More bytes commited than returned from FreeBuffer");
+                FormatterThrowHelper.ThrowInvalidOperationException("More bytes commited than returned from FreeBuffer");
             }
         }
         public int MaxBufferSize { get; } = Int32.MaxValue;
 
         public void Dispose()
         {
-            var array = _buffer.Items;
+            byte[] array = _buffer.Items;
             _buffer.Items = null;
             _pool.Return(array);
         }

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/FormatterThrowHelper.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/FormatterThrowHelper.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Text.Formatting
+{
+    internal static class FormatterThrowHelper
+    {
+        public static void ThrowInvalidOperationException(string message)
+        {
+            throw GetInvalidOperationException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException GetInvalidOperationException(string message)
+        {
+            return new InvalidOperationException(message);
+        }
+    }
+}

--- a/src/System.Text.JsonLab/System/Text/Json/JsonThrowHelper.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonThrowHelper.cs
@@ -8,6 +8,39 @@ namespace System.Text.JsonLab
 {
     internal static class JsonThrowHelper
     {
+        public static void ThrowArgumentException(string message)
+        {
+            throw GetArgumentException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentException GetArgumentException(string message)
+        {
+            return new ArgumentException(message);
+        }
+
+        public static void ThrowFormatException()
+        {
+            throw GetFormatException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static FormatException GetFormatException()
+        {
+            return new FormatException();
+        }
+
+        public static void ThrowOutOfMemoryException()
+        {
+            throw GetOutOfMemoryException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static OutOfMemoryException GetOutOfMemoryException()
+        {
+            return new OutOfMemoryException();
+        }
+
         public static void ThrowNotImplementedException()
         {
             throw GetNotImplementedException();

--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
@@ -5,6 +5,7 @@ using System.Buffers.Text;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text.Formatting;
+using System.Text.Utf8;
 
 namespace System.Text.JsonLab
 {
@@ -52,9 +53,24 @@ namespace System.Text.JsonLab
         /// </summary>
         public void WriteObjectStart()
         {
-            WriteItemSeperator();
-            WriteSpacing(false);
-            WriteControl(JsonConstants.OpenBrace);
+            if (UseFastUtf8)
+            {
+                WriteItemSeperatorUtf8();
+                WriteSpacingUtf8(false);
+                WriteControlUtf8(JsonConstants.OpenBrace);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteItemSeperatorUtf16();
+                WriteSpacingUtf16(false);
+                WriteControlUtf16(JsonConstants.OpenBrace);
+            }
+            else
+            {
+                WriteItemSeperatorSlow();
+                WriteSpacingSlow(false);
+                WriteControlSlow(JsonConstants.OpenBrace);
+            }
 
             _firstItem = true;
             _indent++;
@@ -68,8 +84,43 @@ namespace System.Text.JsonLab
         /// <param name="name">The name of the property (i.e. key) within the containing object.</param>
         public void WriteObjectStart(string name)
         {
-            WriteStartAttribute(name);
-            WriteControl(JsonConstants.OpenBrace);
+            if (UseFastUtf8)
+            {
+                WriteStartAttributeUtf8(name);
+                WriteControlUtf8(JsonConstants.OpenBrace);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteStartAttributeUtf16(name);
+                WriteControlUtf16(JsonConstants.OpenBrace);
+            }
+            else
+            {
+                WriteStartAttributeSlow(name);
+                WriteControlSlow(JsonConstants.OpenBrace);
+            }
+
+            _firstItem = true;
+            _indent++;
+        }
+
+        public void WriteObjectStart(Utf8String name)
+        {
+            if (UseFastUtf8)
+            {
+                WriteStartAttributeUtf8(name);
+                WriteControlUtf8(JsonConstants.OpenBrace);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteStartAttributeUtf16(name);
+                WriteControlUtf16(JsonConstants.OpenBrace);
+            }
+            else
+            {
+                WriteStartAttributeSlow(name);
+                WriteControlSlow(JsonConstants.OpenBrace);
+            }
 
             _firstItem = true;
             _indent++;
@@ -82,8 +133,22 @@ namespace System.Text.JsonLab
         {
             _firstItem = false;
             _indent--;
-            WriteSpacing();
-            WriteControl(JsonConstants.CloseBrace);
+
+            if (UseFastUtf8)
+            {
+                WriteSpacingUtf8();
+                WriteControlUtf8(JsonConstants.CloseBrace);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteSpacingUtf16();
+                WriteControlUtf16(JsonConstants.CloseBrace);
+            }
+            else
+            {
+                WriteSpacingSlow();
+                WriteControlSlow(JsonConstants.CloseBrace);
+            }
         }
 
         /// <summary>
@@ -93,9 +158,24 @@ namespace System.Text.JsonLab
         /// </summary>
         public void WriteArrayStart()
         {
-            WriteItemSeperator();
-            WriteSpacing();
-            WriteControl(JsonConstants.OpenBracket);
+            if (UseFastUtf8)
+            {
+                WriteItemSeperatorUtf8();
+                WriteSpacingUtf8(false);
+                WriteControlUtf8(JsonConstants.OpenBracket);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteItemSeperatorUtf16();
+                WriteSpacingUtf16(false);
+                WriteControlUtf16(JsonConstants.OpenBracket);
+            }
+            else
+            {
+                WriteItemSeperatorSlow();
+                WriteSpacingSlow(false);
+                WriteControlSlow(JsonConstants.OpenBracket);
+            }
 
             _firstItem = true;
             _indent++;
@@ -109,8 +189,21 @@ namespace System.Text.JsonLab
         /// <param name="name">The name of the property (i.e. key) within the containing object.</param>
         public void WriteArrayStart(string name)
         {
-            WriteStartAttribute(name);
-            WriteControl(JsonConstants.OpenBracket);
+            if (UseFastUtf8)
+            {
+                WriteStartAttributeUtf8(name);
+                WriteControlUtf8(JsonConstants.OpenBracket);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteStartAttributeUtf16(name);
+                WriteControlUtf16(JsonConstants.OpenBracket);
+            }
+            else
+            {
+                WriteStartAttributeSlow(name);
+                WriteControlSlow(JsonConstants.OpenBracket);
+            }
 
             _firstItem = true;
             _indent++;
@@ -123,8 +216,22 @@ namespace System.Text.JsonLab
         {
             _firstItem = false;
             _indent--;
-            WriteSpacing();
-            WriteControl(JsonConstants.CloseBracket);
+
+            if (UseFastUtf8)
+            {
+                WriteSpacingUtf8();
+                WriteControlUtf8(JsonConstants.CloseBracket);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteSpacingUtf16();
+                WriteControlUtf16(JsonConstants.CloseBracket);
+            }
+            else
+            {
+                WriteSpacingSlow();
+                WriteControlSlow(JsonConstants.CloseBracket);
+            }
         }
 
         /// <summary>
@@ -134,8 +241,21 @@ namespace System.Text.JsonLab
         /// <param name="value">The string value that will be quoted within the JSON data.</param>
         public void WriteAttribute(string name, string value)
         {
-            WriteStartAttribute(name);
-            WriteQuotedString(value);
+            if (UseFastUtf8)
+            {
+                WriteStartAttributeUtf8(name);
+                WriteQuotedStringUtf8(value);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteStartAttributeUtf16(name);
+                WriteQuotedStringUtf16(value);
+            }
+            else
+            {
+                WriteStartAttributeSlow(name);
+                WriteQuotedStringSlow(value);
+            }
         }
 
         /// <summary>
@@ -145,7 +265,18 @@ namespace System.Text.JsonLab
         /// <param name="value">The signed integer value to be written to JSON data.</param>
         public void WriteAttribute(string name, long value)
         {
-            WriteStartAttribute(name);
+            if (UseFastUtf8)
+            {
+                WriteStartAttributeUtf8(name);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteStartAttributeUtf16(name);
+            }
+            else
+            {
+                WriteStartAttributeSlow(name);
+            }
             WriteNumber(value);
         }
 
@@ -156,7 +287,18 @@ namespace System.Text.JsonLab
         /// <param name="value">The unsigned integer value to be written to JSON data.</param>
         public void WriteAttribute(string name, ulong value)
         {
-            WriteStartAttribute(name);
+            if (UseFastUtf8)
+            {
+                WriteStartAttributeUtf8(name);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteStartAttributeUtf16(name);
+            }
+            else
+            {
+                WriteStartAttributeSlow(name);
+            }
             WriteNumber(value);
         }
 
@@ -167,7 +309,18 @@ namespace System.Text.JsonLab
         /// <param name="value">The boolean value to be written to JSON data.</param>
         public void WriteAttribute(string name, bool value)
         {
-            WriteStartAttribute(name);
+            if (UseFastUtf8)
+            {
+                WriteStartAttributeUtf8(name);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteStartAttributeUtf16(name);
+            }
+            else
+            {
+                WriteStartAttributeSlow(name);
+            }
             if (value)
                 WriteJsonValue(JsonConstants.TrueValue);
             else
@@ -181,7 +334,18 @@ namespace System.Text.JsonLab
         /// <param name="value">The <see cref="DateTime"/> value to be written to JSON data.</param>
         public void WriteAttribute(string name, DateTime value)
         {
-            WriteStartAttribute(name);
+            if (UseFastUtf8)
+            {
+                WriteStartAttributeUtf8(name);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteStartAttributeUtf16(name);
+            }
+            else
+            {
+                WriteStartAttributeSlow(name);
+            }
             WriteDateTime(value);
         }
 
@@ -192,7 +356,18 @@ namespace System.Text.JsonLab
         /// <param name="value">The <see cref="DateTimeOffset"/> value to be written to JSON data.</param>
         public void WriteAttribute(string name, DateTimeOffset value)
         {
-            WriteStartAttribute(name);
+            if (UseFastUtf8)
+            {
+                WriteStartAttributeUtf8(name);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteStartAttributeUtf16(name);
+            }
+            else
+            {
+                WriteStartAttributeSlow(name);
+            }
             WriteDateTimeOffset(value);
         }
 
@@ -203,7 +378,18 @@ namespace System.Text.JsonLab
         /// <param name="value">The <see cref="Guid"/> value to be written to JSON data.</param>
         public void WriteAttribute(string name, Guid value)
         {
-            WriteStartAttribute(name);
+            if (UseFastUtf8)
+            {
+                WriteStartAttributeUtf8(name);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteStartAttributeUtf16(name);
+            }
+            else
+            {
+                WriteStartAttributeSlow(name);
+            }
             WriteGuid(value);
         }
 
@@ -213,7 +399,18 @@ namespace System.Text.JsonLab
         /// <param name="name">The name of the property (i.e. key) within the containing object.</param>
         public void WriteAttributeNull(string name)
         {
-            WriteStartAttribute(name);
+            if (UseFastUtf8)
+            {
+                WriteStartAttributeUtf8(name);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteStartAttributeUtf16(name);
+            }
+            else
+            {
+                WriteStartAttributeSlow(name);
+            }
             WriteJsonValue(JsonConstants.NullValue);
         }
 
@@ -223,10 +420,27 @@ namespace System.Text.JsonLab
         /// <param name="value">The string value that will be quoted within the JSON data.</param>
         public void WriteValue(string value)
         {
-            WriteItemSeperator();
-            _firstItem = false;
-            WriteSpacing();
-            WriteQuotedString(value);
+            if (UseFastUtf8)
+            {
+                WriteItemSeperatorUtf8();
+                _firstItem = false;
+                WriteSpacingUtf8();
+                WriteQuotedStringUtf8(value);
+            }
+            else if (UseFastUtf16)
+            {
+                WriteItemSeperatorUtf16();
+                _firstItem = false;
+                WriteSpacingUtf16();
+                WriteQuotedStringUtf16(value);
+            }
+            else
+            {
+                WriteItemSeperatorSlow();
+                _firstItem = false;
+                WriteSpacingSlow();
+                WriteQuotedStringSlow(value);
+            }
         }
 
         /// <summary>
@@ -235,9 +449,25 @@ namespace System.Text.JsonLab
         /// <param name="value">The signed integer value to be written to JSON data.</param>
         public void WriteValue(long value)
         {
-            WriteItemSeperator();
-            _firstItem = false;
-            WriteSpacing();
+            if (UseFastUtf8)
+            {
+                WriteItemSeperatorUtf8();
+                _firstItem = false;
+                WriteSpacingUtf8();
+            }
+            else if (UseFastUtf16)
+            {
+                WriteItemSeperatorUtf16();
+                _firstItem = false;
+                WriteSpacingUtf16();
+            }
+            else
+            {
+                WriteItemSeperatorSlow();
+                _firstItem = false;
+                WriteSpacingSlow();
+            }
+            
             WriteNumber(value);
         }
 
@@ -247,9 +477,25 @@ namespace System.Text.JsonLab
         /// <param name="value">The unsigned integer value to be written to JSON data.</param>
         public void WriteValue(ulong value)
         {
-            WriteItemSeperator();
-            _firstItem = false;
-            WriteSpacing();
+            if (UseFastUtf8)
+            {
+                WriteItemSeperatorUtf8();
+                _firstItem = false;
+                WriteSpacingUtf8();
+            }
+            else if (UseFastUtf16)
+            {
+                WriteItemSeperatorUtf16();
+                _firstItem = false;
+                WriteSpacingUtf16();
+            }
+            else
+            {
+                WriteItemSeperatorSlow();
+                _firstItem = false;
+                WriteSpacingSlow();
+            }
+
             WriteNumber(value);
         }
 
@@ -259,9 +505,25 @@ namespace System.Text.JsonLab
         /// <param name="value">The boolean value to be written to JSON data.</param>
         public void WriteValue(bool value)
         {
-            WriteItemSeperator();
-            _firstItem = false;
-            WriteSpacing();
+            if (UseFastUtf8)
+            {
+                WriteItemSeperatorUtf8();
+                _firstItem = false;
+                WriteSpacingUtf8();
+            }
+            else if (UseFastUtf16)
+            {
+                WriteItemSeperatorUtf16();
+                _firstItem = false;
+                WriteSpacingUtf16();
+            }
+            else
+            {
+                WriteItemSeperatorSlow();
+                _firstItem = false;
+                WriteSpacingSlow();
+            }
+
             if (value)
                 WriteJsonValue(JsonConstants.TrueValue);
             else
@@ -274,9 +536,25 @@ namespace System.Text.JsonLab
         /// <param name="value">The <see cref="DateTime"/> value to be written to JSON data.</param>
         public void WriteValue(DateTime value)
         {
-            WriteItemSeperator();
-            _firstItem = false;
-            WriteSpacing();
+            if (UseFastUtf8)
+            {
+                WriteItemSeperatorUtf8();
+                _firstItem = false;
+                WriteSpacingUtf8();
+            }
+            else if (UseFastUtf16)
+            {
+                WriteItemSeperatorUtf16();
+                _firstItem = false;
+                WriteSpacingUtf16();
+            }
+            else
+            {
+                WriteItemSeperatorSlow();
+                _firstItem = false;
+                WriteSpacingSlow();
+            }
+
             WriteDateTime(value);
         }
 
@@ -286,9 +564,25 @@ namespace System.Text.JsonLab
         /// <param name="value">The <see cref="DateTimeOffset"/> value to be written to JSON data.</param>
         public void WriteValue(DateTimeOffset value)
         {
-            WriteItemSeperator();
-            _firstItem = false;
-            WriteSpacing();
+            if (UseFastUtf8)
+            {
+                WriteItemSeperatorUtf8();
+                _firstItem = false;
+                WriteSpacingUtf8();
+            }
+            else if (UseFastUtf16)
+            {
+                WriteItemSeperatorUtf16();
+                _firstItem = false;
+                WriteSpacingUtf16();
+            }
+            else
+            {
+                WriteItemSeperatorSlow();
+                _firstItem = false;
+                WriteSpacingSlow();
+            }
+
             WriteDateTimeOffset(value);
         }
 
@@ -298,9 +592,25 @@ namespace System.Text.JsonLab
         /// <param name="value">The <see cref="Guid"/> value to be written to JSON data.</param>
         public void WriteValue(Guid value)
         {
-            WriteItemSeperator();
-            _firstItem = false;
-            WriteSpacing();
+            if (UseFastUtf8)
+            {
+                WriteItemSeperatorUtf8();
+                _firstItem = false;
+                WriteSpacingUtf8();
+            }
+            else if (UseFastUtf16)
+            {
+                WriteItemSeperatorUtf16();
+                _firstItem = false;
+                WriteSpacingUtf16();
+            }
+            else
+            {
+                WriteItemSeperatorSlow();
+                _firstItem = false;
+                WriteSpacingSlow();
+            }
+
             WriteGuid(value);
         }
 
@@ -309,58 +619,144 @@ namespace System.Text.JsonLab
         /// </summary>
         public void WriteNull()
         {
-            WriteItemSeperator();
-            _firstItem = false;
-            WriteSpacing();
+            if (UseFastUtf8)
+            {
+                WriteItemSeperatorUtf8();
+                _firstItem = false;
+                WriteSpacingUtf8();
+            }
+            else if (UseFastUtf16)
+            {
+                WriteItemSeperatorUtf16();
+                _firstItem = false;
+                WriteSpacingUtf16();
+            }
+            else
+            {
+                WriteItemSeperatorSlow();
+                _firstItem = false;
+                WriteSpacingSlow();
+            }
+
             WriteJsonValue(JsonConstants.NullValue);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteStartAttribute(string name)
+        private void WriteStartAttributeUtf8(Utf8String name)
         {
-            WriteItemSeperator();
+            WriteItemSeperatorUtf8();
             _firstItem = false;
 
-            WriteSpacing();
-            WriteQuotedString(name);
-            WriteControl(JsonConstants.KeyValueSeperator);
+            WriteSpacingUtf8();
+            WriteQuotedStringUtf8(name);
+            WriteControlUtf8(JsonConstants.KeyValueSeperator);
 
             if (_prettyPrint)
-                WriteControl(JsonConstants.Space);
+                WriteControlUtf8(JsonConstants.Space);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteControl(byte value)
+        private void WriteStartAttributeUtf8(string name)
         {
-            if (UseFastUtf8)
-            {
-                MemoryMarshal.GetReference(EnsureBuffer(1)) = value;
-                _bufferWriter.Advance(1);
-            }
-            else if (UseFastUtf16)
-            {
-                var buffer = EnsureBuffer(2);
-                Unsafe.As<byte, char>(ref MemoryMarshal.GetReference(buffer)) = (char)value;
-                _bufferWriter.Advance(2);
-            }
-            else
-            {
-                var buffer = _bufferWriter.GetSpan();
-                int written;
-                while (!_bufferWriter.SymbolTable.TryEncode(value, buffer, out written))
-                    buffer = EnsureBuffer();
+            WriteItemSeperatorUtf8();
+            _firstItem = false;
 
-                _bufferWriter.Advance(written);
-            }
+            WriteSpacingUtf8();
+            WriteQuotedStringUtf8(name);
+            WriteControlUtf8(JsonConstants.KeyValueSeperator);
+
+            if (_prettyPrint)
+                WriteControlUtf8(JsonConstants.Space);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteQuotedString(string value)
+        private void WriteStartAttributeUtf16(string name)
         {
-            WriteControl(JsonConstants.Quote);
+            WriteItemSeperatorUtf16();
+            _firstItem = false;
+
+            WriteSpacingUtf16();
+            WriteQuotedStringUtf16(name);
+            WriteControlUtf16(JsonConstants.KeyValueSeperator);
+
+            if (_prettyPrint)
+                WriteControlUtf16(JsonConstants.Space);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteStartAttributeSlow(string name)
+        {
+            WriteItemSeperatorSlow();
+            _firstItem = false;
+
+            WriteSpacingSlow();
+            WriteQuotedStringSlow(name);
+            WriteControlSlow(JsonConstants.KeyValueSeperator);
+
+            if (_prettyPrint)
+                WriteControlSlow(JsonConstants.Space);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteControlUtf8(byte value)
+        {
+            MemoryMarshal.GetReference(EnsureBuffer(1)) = value;
+            _bufferWriter.Advance(1);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteControlUtf16(byte value)
+        {
+            var buffer = EnsureBuffer(2);
+            Unsafe.As<byte, char>(ref MemoryMarshal.GetReference(buffer)) = (char)value;
+            _bufferWriter.Advance(2);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteControlSlow(byte value)
+        {
+            var buffer = _bufferWriter.GetSpan();
+            int written;
+            while (!_bufferWriter.SymbolTable.TryEncode(value, buffer, out written))
+                buffer = EnsureBuffer();
+
+            _bufferWriter.Advance(written);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteQuotedStringUtf8(Utf8String value)
+        {
+            WriteControlUtf8(JsonConstants.Quote);
             // TODO: We need to handle escaping.
-            Write(value.AsSpan());
-            WriteControl(JsonConstants.Quote);
+            WriteUtf8(value.Bytes);
+            WriteControlUtf8(JsonConstants.Quote);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteQuotedStringUtf8(string value)
+        {
+            WriteControlUtf8(JsonConstants.Quote);
+            // TODO: We need to handle escaping.
+            WriteUtf8(value.AsSpan());
+            WriteControlUtf8(JsonConstants.Quote);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteQuotedStringUtf16(string value)
+        {
+            WriteControlUtf16(JsonConstants.Quote);
+            // TODO: We need to handle escaping.
+            WriteUtf16(value.AsSpan());
+            WriteControlUtf16(JsonConstants.Quote);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteQuotedStringSlow(string value)
+        {
+            WriteControlSlow(JsonConstants.Quote);
+            // TODO: We need to handle escaping.
+            WriteSlow(value.AsSpan());
+            WriteControlSlow(JsonConstants.Quote);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -419,47 +815,58 @@ namespace System.Text.JsonLab
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void Write(ReadOnlySpan<char> value)
+        private void WriteUtf8(ReadOnlySpan<char> value)
         {
             ReadOnlySpan<byte> source = MemoryMarshal.AsBytes(value);
 
-            if (UseFastUtf8)
-            {
-                Span<byte> destination = _bufferWriter.GetSpan();
+            Span<byte> destination = _bufferWriter.GetSpan();
 
-                while (true)
+            while (true)
+            {
+                var status = Encodings.Utf16.ToUtf8(source, destination, out int consumed, out int written);
+                if (status == Buffers.OperationStatus.Done)
                 {
-                    var status = Encodings.Utf16.ToUtf8(source, destination, out int consumed, out int written);
-                    if (status == Buffers.OperationStatus.Done)
-                    {
-                        _bufferWriter.Advance(written);
-                        return;
-                    }
-
-                    if (status == Buffers.OperationStatus.DestinationTooSmall)
-                    {
-                        destination = EnsureBuffer();
-                        continue;
-                    }
-
-                    // This is a failure due to bad input. This shouldn't happen under normal circumstances.
-                    throw new FormatException();
+                    _bufferWriter.Advance(written);
+                    return;
                 }
-            }
-            else if (UseFastUtf16)
-            {
-                Span<byte> destination = EnsureBuffer(source.Length);
-                source.CopyTo(destination);
-                _bufferWriter.Advance(source.Length);
-            }
-            else
-            {
-                Span<byte> destination = _bufferWriter.GetSpan();
-                if (!_bufferWriter.SymbolTable.TryEncode(source, destination, out int consumed, out int written))
-                    destination = EnsureBuffer();
 
-                _bufferWriter.Advance(written);
+                if (status == Buffers.OperationStatus.DestinationTooSmall)
+                {
+                    destination = EnsureBuffer();
+                    continue;
+                }
+
+                // This is a failure due to bad input. This shouldn't happen under normal circumstances.
+                throw new FormatException();
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteUtf8(ReadOnlySpan<byte> value)
+        {
+            Span<byte> destination = EnsureBuffer(value.Length);
+            value.CopyTo(destination);
+            _bufferWriter.Advance(value.Length);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteUtf16(ReadOnlySpan<char> value)
+        {
+            ReadOnlySpan<byte> source = MemoryMarshal.AsBytes(value);
+            Span<byte> destination = EnsureBuffer(source.Length);
+            source.CopyTo(destination);
+            _bufferWriter.Advance(source.Length);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteSlow(ReadOnlySpan<char> value)
+        {
+            ReadOnlySpan<byte> source = MemoryMarshal.AsBytes(value);
+            Span<byte> destination = _bufferWriter.GetSpan();
+            if (!_bufferWriter.SymbolTable.TryEncode(source, destination, out int consumed, out int written))
+                destination = EnsureBuffer();
+
+            _bufferWriter.Advance(written);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -474,46 +881,53 @@ namespace System.Text.JsonLab
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteItemSeperator()
+        private void WriteItemSeperatorUtf8()
         {
             if (_firstItem) return;
 
-            WriteControl(JsonConstants.ListSeperator);
+            WriteControlUtf8(JsonConstants.ListSeperator);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteSpacing(bool newLine = true)
+        private void WriteItemSeperatorUtf16()
+        {
+            if (_firstItem) return;
+
+            WriteControlUtf16(JsonConstants.ListSeperator);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteItemSeperatorSlow()
+        {
+            if (_firstItem) return;
+
+            WriteControlSlow(JsonConstants.ListSeperator);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteSpacingSlow(bool newLine = true)
         {
             if (!_prettyPrint) return;
 
-            if (UseFastUtf8)
-                WriteSpacingUtf8(newLine);
-            else if (UseFastUtf16)
-                WriteSpacingUtf16(newLine);
-            else
-                WriteSpacingSlow(newLine);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteSpacingSlow(bool newLine)
-        {
             if (newLine)
             {
-                WriteControl(JsonConstants.CarriageReturn);
-                WriteControl(JsonConstants.LineFeed);
+                WriteControlSlow(JsonConstants.CarriageReturn);
+                WriteControlSlow(JsonConstants.LineFeed);
             }
 
             int indent = _indent;
             while (indent-- >= 0)
             {
-                WriteControl(JsonConstants.Space);
-                WriteControl(JsonConstants.Space);
+                WriteControlSlow(JsonConstants.Space);
+                WriteControlSlow(JsonConstants.Space);
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteSpacingUtf8(bool newline)
+        private void WriteSpacingUtf8(bool newline = true)
         {
+            if (!_prettyPrint) return;
+
             var indent = _indent;
             var bytesNeeded = newline ? 2 : 0;
             bytesNeeded += (indent + 1) * 2;
@@ -538,8 +952,10 @@ namespace System.Text.JsonLab
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void WriteSpacingUtf16(bool newline)
+        private void WriteSpacingUtf16(bool newline = true)
         {
+            if (!_prettyPrint) return;
+
             var indent = _indent;
             var bytesNeeded = newline ? 2 : 0;
             bytesNeeded += (indent + 1) * 2;

--- a/src/System.Text.Primitives/System/Text/Formatters/Formatter.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Formatter.cs
@@ -57,11 +57,6 @@ namespace System.Buffers.Text
 
         public static bool TryFormat(byte value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default, SymbolTable symbolTable = null)
         {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
             if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
                 return Utf8Formatter.TryFormat(value, buffer, out bytesWritten, format);
             else if (symbolTable == SymbolTable.InvariantUtf16)
@@ -72,11 +67,6 @@ namespace System.Buffers.Text
 
         public static bool TryFormat(sbyte value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default, SymbolTable symbolTable = null)
         {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
             if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
                 return Utf8Formatter.TryFormat(value, buffer, out bytesWritten, format);
             else if (symbolTable == SymbolTable.InvariantUtf16)
@@ -87,11 +77,6 @@ namespace System.Buffers.Text
 
         public static bool TryFormat(ushort value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default, SymbolTable symbolTable = null)
         {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
             if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
                 return Utf8Formatter.TryFormat(value, buffer, out bytesWritten, format);
             else if (symbolTable == SymbolTable.InvariantUtf16)
@@ -102,11 +87,6 @@ namespace System.Buffers.Text
 
         public static bool TryFormat(short value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default, SymbolTable symbolTable = null)
         {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
             if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
                 return Utf8Formatter.TryFormat(value, buffer, out bytesWritten, format);
             else if (symbolTable == SymbolTable.InvariantUtf16)
@@ -117,11 +97,6 @@ namespace System.Buffers.Text
 
         public static bool TryFormat(uint value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default, SymbolTable symbolTable = null)
         {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
             if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
                 return Utf8Formatter.TryFormat(value, buffer, out bytesWritten, format);
             else if (symbolTable == SymbolTable.InvariantUtf16)
@@ -132,11 +107,6 @@ namespace System.Buffers.Text
 
         public static bool TryFormat(int value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default, SymbolTable symbolTable = null)
         {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
             if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
                 return Utf8Formatter.TryFormat(value, buffer, out bytesWritten, format);
             else if (symbolTable == SymbolTable.InvariantUtf16)
@@ -147,11 +117,6 @@ namespace System.Buffers.Text
 
         public static bool TryFormat(ulong value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default, SymbolTable symbolTable = null)
         {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
             if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
                 return Utf8Formatter.TryFormat(value, buffer, out bytesWritten, format);
             else if (symbolTable == SymbolTable.InvariantUtf16)
@@ -162,11 +127,6 @@ namespace System.Buffers.Text
 
         public static bool TryFormat(long value, Span<byte> buffer, out int bytesWritten, StandardFormat format = default, SymbolTable symbolTable = null)
         {
-            if (format.IsDefault)
-            {
-                format = 'G';
-            }
-
             if (symbolTable == null || symbolTable == SymbolTable.InvariantUtf8)
                 return Utf8Formatter.TryFormat(value, buffer, out bytesWritten, format);
             else if (symbolTable == SymbolTable.InvariantUtf16)

--- a/src/System.Text.Primitives/System/Text/Formatters/Formatter_ints.cs
+++ b/src/System.Text.Primitives/System/Text/Formatters/Formatter_ints.cs
@@ -9,6 +9,11 @@ namespace System.Buffers.Text
     {
         private static bool TryFormatInt64(long value, ulong mask, Span<byte> buffer, out int bytesWritten, StandardFormat format, SymbolTable symbolTable)
         {
+            if (format.IsDefault)
+            {
+                format = 'G';
+            }
+
             if (value >= 0)
             {
                 return TryFormatUInt64(unchecked((ulong)value), buffer, out bytesWritten, format, symbolTable);
@@ -37,6 +42,11 @@ namespace System.Buffers.Text
 
         private static bool TryFormatUInt64(ulong value, Span<byte> buffer, out int bytesWritten, StandardFormat format, SymbolTable symbolTable)
         {
+            if (format.IsDefault)
+            {
+                format = 'G';
+            }
+
             switch (format.Symbol)
             {
                 case 'x':

--- a/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
@@ -34,7 +34,7 @@ namespace System.Text.JsonLab.Tests
             Assert.Equal(expected, str.Replace(" ", ""));
         }
 
-        static string expected = "{\"age\":30,\"first\":\"John\",\"last\":\"Smith\",\"phoneNumbers\":[\"425-000-1212\",\"425-000-1213\"],\"address\":{\"street\":\"1MicrosoftWay\",\"city\":\"Redmond\",\"zip\":98052}}";
+        static string expected = "{\"age\":30,\"first\":\"John\",\"last\":\"Smith\",\"phoneNumbers\":[\"425-000-1212\",\"425-000-1213\"],\"address\":{\"street\":\"1MicrosoftWay\",\"city\":\"Redmond\",\"zip\":98052},\"values\":[425121,-425122,425123]}";
         static void Write(ref JsonWriter json)
         {
             json.WriteObjectStart();
@@ -50,6 +50,11 @@ namespace System.Text.JsonLab.Tests
             json.WriteAttribute("city", "Redmond");
             json.WriteAttribute("zip", 98052);
             json.WriteObjectEnd();
+            json.WriteArrayStart("values");
+            json.WriteValue(425121);
+            json.WriteValue(-425122);
+            json.WriteValue(425123);
+            json.WriteArrayEnd();
             json.WriteObjectEnd();
         }
     }


### PR DESCRIPTION
Compared to [previous benchmark results](https://github.com/dotnet/corefxlab/pull/2254#issuecomment-386201486), we are 2-4x faster, which makes the writer faster than Newtonsoft.

**Optimizations:**
- Made ArrayFormatter GetSpan by avoiding unnecessary construction of ArrayFormatter and casts.
- Collapsed several method chains to avoid redundant IsUtf8/IsUtf16/etc. checks, and reduced calls to EnsureBuffer/Advance by pre-calculating exactly how many bytes are required.
- Added separate private methods for each encoding (utf-8, utf-16, slow), which resulted in some code duplication.
- Ported over the optimized Utf8Formatter APIs to WriteDigitsUInt64D, to make WriteValue(long) faster, and skip the StandardFormatter switch statement all together. TODO: Port this fix for all numeric overloads (mainly ulong).
- Optimized EnsureBuffer by removing unnecessary checks.
- Added ThrowHelpers to help with inlining.

**Other fixes:**
- Some code formatting clean-up and fix of `var` usage.

``` ini

BenchmarkDotNet=v0.10.14.534-nightly, OS=Windows 10.0.16299.431 (1709/FallCreatorsUpdate/Redstone3)
Intel Xeon CPU E5-1620 v2 3.70GHz, 1 CPU, 8 logical and 4 physical cores
Frequency=3604598 Hz, Resolution=277.4234 ns, Timer=TSC
.NET Core SDK=2.1.300-rtm-008838
  [Host]     : .NET Core 2.1.0-rtm-26514-02 (CoreCLR 4.6.26514.02, CoreFX 4.6.26514.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0-rtm-26514-02 (CoreCLR 4.6.26514.02, CoreFX 4.6.26514.02), 64bit RyuJIT


```
|                         Method |         Target | Formatted |        Mean |       Error |      StdDev |      Median |  Gen 0 | Allocated |
|------------------------------- |--------------- |---------- |------------:|------------:|------------:|------------:|-------:|----------:|
|      **WriterSystemTextJsonBasic** | **InvariantUtf16** |     **False** | **14,794.9 ns** | **136.8339 ns** | **114.2625 ns** | **14,760.6 ns** |      **-** |       **0 B** |
|          WriterNewtonsoftBasic | InvariantUtf16 |     False | 17,417.6 ns | 258.7934 ns | 242.0755 ns | 17,504.0 ns | 0.0610 |     416 B |
| WriterSystemTextJsonHelloWorld | InvariantUtf16 |     False |    149.4 ns |   0.2963 ns |   0.2474 ns |    149.4 ns |      - |       0 B |
|     WriterNewtonsoftHelloWorld | InvariantUtf16 |     False |    282.2 ns |   4.9845 ns |   4.6625 ns |    279.6 ns | 0.0486 |     256 B |
|      **WriterSystemTextJsonBasic** | **InvariantUtf16** |      **True** | **15,751.3 ns** | **298.0006 ns** | **292.6764 ns** | **15,703.0 ns** |      **-** |       **0 B** |
|          WriterNewtonsoftBasic | InvariantUtf16 |      True | 31,092.0 ns |  72.0731 ns |  42.8896 ns | 31,089.7 ns | 0.0916 |     584 B |
| WriterSystemTextJsonHelloWorld | InvariantUtf16 |      True |    151.3 ns |   2.9176 ns |   2.8654 ns |    153.2 ns |      - |       0 B |
|     WriterNewtonsoftHelloWorld | InvariantUtf16 |      True |    384.4 ns |   1.9225 ns |   1.3901 ns |    384.1 ns | 0.0806 |     424 B |
|      **WriterSystemTextJsonBasic** |  **InvariantUtf8** |     **False** | **15,637.4 ns** | **320.2385 ns** | **785.5505 ns** | **15,267.8 ns** |      **-** |       **0 B** |
|          WriterNewtonsoftBasic |  InvariantUtf8 |     False | 17,951.5 ns | 335.2059 ns | 313.5518 ns | 17,902.8 ns | 0.0610 |     416 B |
| WriterSystemTextJsonHelloWorld |  InvariantUtf8 |     False |    207.7 ns |   0.6127 ns |   0.4053 ns |    207.6 ns |      - |       0 B |
|     WriterNewtonsoftHelloWorld |  InvariantUtf8 |     False |    285.1 ns |   4.2451 ns |   3.5449 ns |    286.4 ns | 0.0486 |     256 B |
|      **WriterSystemTextJsonBasic** |  **InvariantUtf8** |      **True** | **16,288.8 ns** | **224.7983 ns** | **210.2764 ns** | **16,222.2 ns** |      **-** |       **0 B** |
|          WriterNewtonsoftBasic |  InvariantUtf8 |      True | 30,375.8 ns | 472.5879 ns | 442.0589 ns | 30,474.8 ns | 0.0916 |     584 B |
| WriterSystemTextJsonHelloWorld |  InvariantUtf8 |      True |    214.5 ns |   4.5213 ns |   4.6430 ns |    212.8 ns |      - |       0 B |
|     WriterNewtonsoftHelloWorld |  InvariantUtf8 |      True |    386.6 ns |   0.8402 ns |   0.7016 ns |    386.5 ns | 0.0806 |     424 B |
