### PR TITLE
Update Roslyn compiler to latest, language version to latest

### DIFF
--- a/tools/common.props
+++ b/tools/common.props
@@ -13,9 +13,9 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Key.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
     <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(RoslynVersion)" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <CoreFxStableVersion>4.3.0</CoreFxStableVersion>
-    <RoslynVersion>2.8.2-beta6-62916-08</RoslynVersion>
+    <RoslynVersion>2.8.0-beta4</RoslynVersion>
     <SystemMemoryVersion>4.6.0-preview1-26517-01</SystemMemoryVersion>
     <SystemCompilerServicesUnsafeVersion>4.6.0-preview1-26517-01</SystemCompilerServicesUnsafeVersion>
     <SystemNumericsVectorsVersion>4.6.0-preview1-26517-01</SystemNumericsVectorsVersion>

--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <CoreFxStableVersion>4.3.0</CoreFxStableVersion>
-    <RoslynVersion>2.6.0-beta3-62316-02</RoslynVersion>
+    <RoslynVersion>2.8.2-beta6-62916-08</RoslynVersion>
     <SystemMemoryVersion>4.6.0-preview1-26517-01</SystemMemoryVersion>
     <SystemCompilerServicesUnsafeVersion>4.6.0-preview1-26517-01</SystemCompilerServicesUnsafeVersion>
     <SystemNumericsVectorsVersion>4.6.0-preview1-26517-01</SystemNumericsVectorsVersion>


### PR DESCRIPTION
Also includes a workaround where latest netcore compiler doesn't work in VS, use the one built in to VS instead if compiling from the IDE. I've confirmed that command-line build continues to work correctly, and we can now build and run tests from within VS2017 using the latest language features.

This PR replaces https://github.com/dotnet/corefxlab/pull/2161.

@agocke, we also tried the below props, but it resulted in errors at build time (only within the IDE).

```xml
  <ItemGroup Condition="'$(MSBuildRuntimeType)' == 'Core'">
    <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(RoslynVersion)" PrivateAssets="All" />
  </ItemGroup>
  <ItemGroup Condition="'$(MSBuildRuntimeType)' == 'Full'">
    <PackageReference Include="Microsoft.Net.Compilers" Version="$(RoslynVersion)" PrivateAssets="All" />
  </ItemGroup>
```

```txt
Error	MSB4062	The "Microsoft.CodeAnalysis.BuildTasks.Csc" task could not be loaded from the assembly C:\Users\levib\.nuget\packages\microsoft.net.compilers\2.8.2-beta6-62916-08\build\..\tools\Microsoft.Build.Tasks.CodeAnalysis.dll. Could not load file or assembly 'System.Runtime, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified. Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.	System.Text.JsonLab.Tests	C:\Users\levib\.nuget\packages\microsoft.net.compilers\2.8.2-beta6-62916-08\tools\Microsoft.CSharp.Core.targets	52	
```

The particular project I'm compiling targets netcoreapp2.1, so I would've assumed that the _System.Runtime_ dependency would've been normalized. Any ideas on how we can use the preferred switching on the _MSBuildRuntimeType_ property?