### PR TITLE
Remove unnecessary cast now that we are targeting C# 7.3 with latest compiler

### DIFF
--- a/src/System.Buffers.ReaderWriter/System/Buffers/Writer/BufferWriter_writable.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Writer/BufferWriter_writable.cs
@@ -11,10 +11,10 @@ namespace System.Buffers.Writer
     {
         #region Byte
         public bool TryWriteBytes(byte[] bytes)
-            => TryWriteBytes((ReadOnlySpan<byte>)bytes.AsSpan());
+            => TryWriteBytes(bytes.AsSpan());
 
         public void WriteBytes(byte[] bytes)
-            => WriteBytes((ReadOnlySpan<byte>)bytes.AsSpan());
+            => WriteBytes(bytes.AsSpan());
 
         public bool TryWriteBytes(ReadOnlySpan<byte> bytes)
         {

--- a/tools/common.props
+++ b/tools/common.props
@@ -15,5 +15,4 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Key.snk</AssemblyOriginatorKeyFile>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
 </Project>

--- a/tools/common.props
+++ b/tools/common.props
@@ -15,7 +15,5 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Key.snk</AssemblyOriginatorKeyFile>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
-  <ItemGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
-    <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(RoslynVersion)" PrivateAssets="All" />
-  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Leftover change from https://github.com/dotnet/corefxlab/pull/2161