### PR TITLE
Add new overloads to Clone() methods on subtypes of Tensor<T>

### DIFF
--- a/src/System.Numerics.Tensors/System/Numerics/CompressedSparseTensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/CompressedSparseTensor.cs
@@ -391,7 +391,7 @@ namespace System.Numerics
             return new CompressedSparseTensor<T>(values.ToArray(), compressedCounts.ToArray(), indices.ToArray(), nonZeroCount, dimensions, IsReversedStride);
         }
 
-        protected override Tensor<T> CloneTensor() => Clone();
+        protected override Tensor<T> CloneInternal() => Clone();
 
         /// <summary>
         /// Creates a new Tensor of a different type with the specified dimensions and the same layout as this tensor with elements initialized to their default value.

--- a/src/System.Numerics.Tensors/System/Numerics/CompressedSparseTensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/CompressedSparseTensor.cs
@@ -386,10 +386,12 @@ namespace System.Numerics
         /// Creates a shallow copy of this tensor, with new backing storage.
         /// </summary>
         /// <returns>A shallow copy of this tensor.</returns>
-        public override Tensor<T> Clone()
+        public new CompressedSparseTensor<T> Clone()
         {
             return new CompressedSparseTensor<T>(values.ToArray(), compressedCounts.ToArray(), indices.ToArray(), nonZeroCount, dimensions, IsReversedStride);
         }
+
+        protected override Tensor<T> CloneTensor() => Clone();
 
         /// <summary>
         /// Creates a new Tensor of a different type with the specified dimensions and the same layout as this tensor with elements initialized to their default value.

--- a/src/System.Numerics.Tensors/System/Numerics/DenseTensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/DenseTensor.cs
@@ -141,7 +141,7 @@ namespace System.Numerics
             return new DenseTensor<T>(Buffer.ToArray(), dimensions, IsReversedStride);
         }
 
-        protected override Tensor<T> CloneTensor() => Clone();
+        protected override Tensor<T> CloneInternal() => Clone();
 
         /// <summary>
         /// Creates a new Tensor of a different type with the specified dimensions and the same layout as this tensor with elements initialized to their default value.

--- a/src/System.Numerics.Tensors/System/Numerics/DenseTensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/DenseTensor.cs
@@ -136,10 +136,12 @@ namespace System.Numerics
         /// Creates a shallow copy of this tensor, with new backing storage.
         /// </summary>
         /// <returns>A shallow copy of this tensor.</returns>
-        public override Tensor<T> Clone()
+        public new DenseTensor<T> Clone()
         {
             return new DenseTensor<T>(Buffer.ToArray(), dimensions, IsReversedStride);
         }
+
+        protected override Tensor<T> CloneTensor() => Clone();
 
         /// <summary>
         /// Creates a new Tensor of a different type with the specified dimensions and the same layout as this tensor with elements initialized to their default value.

--- a/src/System.Numerics.Tensors/System/Numerics/SparseTensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/SparseTensor.cs
@@ -111,7 +111,7 @@ namespace System.Numerics
             return new SparseTensor<T>(valueCopy, dimensions, IsReversedStride);
         }
 
-        protected override Tensor<T> CloneTensor() => Clone();
+        protected override Tensor<T> CloneInternal() => Clone();
 
         /// <summary>
         /// Creates a new Tensor of a different type with the specified dimensions and the same layout as this tensor with elements initialized to their default value.

--- a/src/System.Numerics.Tensors/System/Numerics/SparseTensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/SparseTensor.cs
@@ -105,11 +105,13 @@ namespace System.Numerics
         /// Creates a shallow copy of this tensor, with new backing storage.
         /// </summary>
         /// <returns>A shallow copy of this tensor.</returns>
-        public override Tensor<T> Clone()
+        public new SparseTensor<T> Clone()
         {
             var valueCopy = new Dictionary<int, T>(values);
             return new SparseTensor<T>(valueCopy, dimensions, IsReversedStride);
         }
+
+        protected override Tensor<T> CloneTensor() => Clone();
 
         /// <summary>
         /// Creates a new Tensor of a different type with the specified dimensions and the same layout as this tensor with elements initialized to their default value.

--- a/src/System.Numerics.Tensors/System/Numerics/Tensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/Tensor.cs
@@ -462,13 +462,13 @@ namespace System.Numerics
         /// Creates a shallow copy of this tensor, with new backing storage.
         /// </summary>
         /// <returns>A shallow copy of this tensor.</returns>
-        public Tensor<T> Clone() => CloneTensor();
+        public Tensor<T> Clone() => CloneInternal();
 
         /// <summary>
         /// Creates a shallow copy of this tensor, with new backing storage.
         /// </summary>
         /// <returns>A shallow copy of this tensor.</returns>
-        protected abstract Tensor<T> CloneTensor();
+        protected abstract Tensor<T> CloneInternal();
 
         /// <summary>
         /// Creates a new Tensor with the same layout and dimensions as this tensor with elements initialized to their default value.

--- a/src/System.Numerics.Tensors/System/Numerics/Tensor.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/Tensor.cs
@@ -462,7 +462,13 @@ namespace System.Numerics
         /// Creates a shallow copy of this tensor, with new backing storage.
         /// </summary>
         /// <returns>A shallow copy of this tensor.</returns>
-        public abstract Tensor<T> Clone();
+        public Tensor<T> Clone() => CloneTensor();
+
+        /// <summary>
+        /// Creates a shallow copy of this tensor, with new backing storage.
+        /// </summary>
+        /// <returns>A shallow copy of this tensor.</returns>
+        protected abstract Tensor<T> CloneTensor();
 
         /// <summary>
         /// Creates a new Tensor with the same layout and dimensions as this tensor with elements initialized to their default value.

--- a/src/System.Numerics.Tensors/System/Numerics/TensorView.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/TensorView.cs
@@ -74,7 +74,7 @@ namespace System.Numerics
             this[indices] = value;
         }
 
-        protected override Tensor<T> CloneTensor()
+        protected override Tensor<T> CloneInternal()
         {
             Tensor<T> result = _backingTensor.CloneEmpty(Dimensions);
 

--- a/src/System.Numerics.Tensors/System/Numerics/TensorView.cs
+++ b/src/System.Numerics.Tensors/System/Numerics/TensorView.cs
@@ -74,7 +74,7 @@ namespace System.Numerics
             this[indices] = value;
         }
 
-        public override Tensor<T> Clone()
+        protected override Tensor<T> CloneTensor()
         {
             Tensor<T> result = _backingTensor.CloneEmpty(Dimensions);
 

--- a/tests/System.Numerics.Tensors.Tests/TensorTests.cs
+++ b/tests/System.Numerics.Tensors.Tests/TensorTests.cs
@@ -1964,6 +1964,38 @@ namespace System.Numerics.Tensors.Tests
             Assert.Equal(true, StructuralComparisons.StructuralEqualityComparer.Equals(actual, expected));
         }
 
+        [Theory]
+        [MemberData(nameof(GetSingleTensorConstructors))]
+        public void Clone(TensorConstructor constructor)
+        {
+            var arr = new[,]
+            {
+                { 1, 2, 3 },
+                { 4, 5, 6 }
+            };
+
+            var tensor = constructor.CreateFromArray<int>(arr);
+            switch (constructor.TensorType)
+            {
+                case TensorType.Dense:
+                    DenseTensor<int> denseTensor = ((DenseTensor<int>) tensor).Clone();
+                    Assert.Equal(true, StructuralComparisons.StructuralEqualityComparer.Equals(denseTensor, tensor));
+                    break;
+                case TensorType.Sparse:
+                    SparseTensor<int> sparseTensor = ((SparseTensor<int>) tensor).Clone();
+                    Assert.Equal(true, StructuralComparisons.StructuralEqualityComparer.Equals(sparseTensor, tensor));
+                    break;
+                case TensorType.CompressedSparse:
+                    CompressedSparseTensor<int> compressedSparseTensor = ((CompressedSparseTensor<int>) tensor).Clone();
+                    Assert.Equal(true, StructuralComparisons.StructuralEqualityComparer.Equals(compressedSparseTensor, tensor));
+                    break;
+                default:
+                    throw new ArgumentException(nameof(constructor.TensorType));
+            }
+
+            var clone = tensor.Clone();
+            Assert.Equal(true, StructuralComparisons.StructuralEqualityComparer.Equals(clone, tensor));
+        }
 
         [Theory]
         [MemberData(nameof(GetDualTensorConstructors))]


### PR DESCRIPTION
Addresses #1976 

Since a class can't declare 2 methods differing only in the return type I added a `protected abstract CloneTensor` to support the polymorphism.

So there are:
- `new ConcreteTensor.Clone` that returns `ConcreteTensor`
- `Tensor.Clone` that calls `ConcreteTensor.CloneTensor` that in turn calls `ConcreteTensor.Clone`

Personally I would name `CloneTensor` `CloneInternal`. Not sure what you prefer here.