### PR TITLE
Add a benchmark for Range enumeration

### DIFF
--- a/src/System.Buffers.Experimental/System/Range.cs
+++ b/src/System.Buffers.Experimental/System/Range.cs
@@ -78,7 +78,6 @@ namespace System
             void IEnumerator.Reset() => throw new NotSupportedException();
         }
 
-        // TODO: write benchmark for this
         public Enumerator GetEnumerator()
         {
             if(IsBound) return new Enumerator(First, End);

--- a/tests/Benchmarks/System/RangeEnumeration.cs
+++ b/tests/Benchmarks/System/RangeEnumeration.cs
@@ -4,9 +4,9 @@
 
 using BenchmarkDotNet.Attributes;
 
-namespace System.Benchmarks
+namespace System.Buffers.Experimental.Benchmarks
 {
-    public class RangePerf
+    public class RangeEnumeration
     {
         [Params(10, 100, 1000, 10_000)]
         public uint Length;
@@ -22,9 +22,8 @@ namespace System.Benchmarks
         [Benchmark]
         public void Enumeration()
         {
-            foreach (var value in _range)
+            foreach (int value in _range)
             {
-                
             }
         }
     }

--- a/tests/Benchmarks/System/RangePerf.cs
+++ b/tests/Benchmarks/System/RangePerf.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+
+namespace System.Benchmarks
+{
+    public class RangePerf
+    {
+        [Params(10, 100, 1000, 10_000)]
+        public uint Length;
+
+        private Range _range;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _range = new Range(0, Length);
+        }
+
+        [Benchmark]
+        public void Enumeration()
+        {
+            foreach (var value in _range)
+            {
+                
+            }
+        }
+    }
+}


### PR DESCRIPTION
Addresses #2312 

Not sure there's much more to do here.

The results:

``` ini

BenchmarkDotNet=v0.10.14.534-nightly, OS=Windows 10.0.16299.431 (1709/FallCreatorsUpdate/Redstone3)
Intel Core i7-7600U CPU 2.80GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
Frequency=2835936 Hz, Resolution=352.6173 ns, Timer=TSC
.NET Core SDK=2.1.300
  [Host]     : .NET Core 2.1.0 (CoreCLR 4.6.26515.07, CoreFX 4.6.26515.06), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0 (CoreCLR 4.6.26515.07, CoreFX 4.6.26515.06), 64bit RyuJIT


```
|      Method | Length |         Mean |       Error |      StdDev |
|------------ |------- |-------------:|------------:|------------:|
| **Enumeration** |     **10** |     **21.23 ns** |   **0.0559 ns** |   **0.0496 ns** |
| **Enumeration** |    **100** |    **199.84 ns** |   **0.8654 ns** |   **0.7226 ns** |
| **Enumeration** |   **1000** |  **1,849.24 ns** |   **2.0702 ns** |   **1.8352 ns** |
| **Enumeration** |  **10000** | **18,728.23 ns** | **258.6625 ns** | **215.9949 ns** |
