### PR TITLE
Move RangeEnumeration benchmark to appropriate folder.

### DIFF
--- a/tests/Benchmarks/System.Buffers.Experimental/RangeEnumeration.cs
+++ b/tests/Benchmarks/System.Buffers.Experimental/RangeEnumeration.cs
@@ -12,15 +12,33 @@ namespace System.Buffers.Experimental.Benchmarks
         public uint Length;
 
         private Range _range;
+        private int[] _array;
 
         [GlobalSetup]
         public void Setup()
         {
             _range = new Range(0, Length);
+            _array = new int[Length];
+        }
+
+        [Benchmark(Baseline = true)]
+        public void RegularForLoop()
+        {
+            for (int i = 0; i < Length; i++)
+            {
+            }
         }
 
         [Benchmark]
-        public void Enumeration()
+        public void EnumerationArray()
+        {
+            foreach (int value in _array)
+            {
+            }
+        }
+
+        [Benchmark]
+        public void EnumerationRange()
         {
             foreach (int value in _range)
             {


### PR DESCRIPTION
Related to https://github.com/dotnet/corefxlab/pull/2336.

Also added regular `for loop` baseline.

``` ini

BenchmarkDotNet=v0.10.14.534-nightly, OS=Windows 10.0.16299.431 (1709/FallCreatorsUpdate/Redstone3)
Intel Xeon CPU E5-1620 v2 3.70GHz, 1 CPU, 8 logical and 4 physical cores
Frequency=3604597 Hz, Resolution=277.4235 ns, Timer=TSC
.NET Core SDK=2.2.100-preview1-008958
  [Host]     : .NET Core 2.1.0-rtm-26515-03 (CoreCLR 4.6.26515.03, CoreFX 4.6.26515.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0-rtm-26515-03 (CoreCLR 4.6.26515.03, CoreFX 4.6.26515.03), 64bit RyuJIT


```
|           Method | Length |          Mean |       Error |      StdDev | Scaled | ScaledSD |
|----------------- |------- |--------------:|------------:|------------:|-------:|---------:|
|   **RegularForLoop** |     **10** |      **5.053 ns** |   **0.0878 ns** |   **0.0778 ns** |   **1.00** |     **0.00** |
|   EnumerateArray |     10 |      5.045 ns |   0.1513 ns |   0.1801 ns |   1.00 |     0.04 |
| EnumerationRange |     10 |     28.306 ns |   0.2874 ns |   0.2689 ns |   5.60 |     0.10 |
|                  |        |               |             |             |        |          |
|   **RegularForLoop** |    **100** |     **46.283 ns** |   **0.4805 ns** |   **0.4495 ns** |   **1.00** |     **0.00** |
|   EnumerateArray |    100 |     59.996 ns |   0.3576 ns |   0.3345 ns |   1.30 |     0.01 |
| EnumerationRange |    100 |    211.884 ns |   0.4950 ns |   0.3865 ns |   4.58 |     0.04 |
|                  |        |               |             |             |        |          |
|   **RegularForLoop** |   **1000** |    **309.527 ns** |   **4.9927 ns** |   **4.6701 ns** |   **1.00** |     **0.00** |
|   EnumerateArray |   1000 |    529.959 ns |   8.9753 ns |   8.3955 ns |   1.71 |     0.04 |
| EnumerationRange |   1000 |  1,935.464 ns |  27.8962 ns |  26.0941 ns |   6.25 |     0.12 |
|                  |        |               |             |             |        |          |
|   **RegularForLoop** |  **10000** |  **2,891.638 ns** |   **8.4067 ns** |   **7.0200 ns** |   **1.00** |     **0.00** |
|   EnumerateArray |  10000 |  5,251.891 ns |  71.8260 ns |  67.1861 ns |   1.82 |     0.02 |
| EnumerationRange |  10000 | 19,302.663 ns | 375.0180 ns | 385.1159 ns |   6.68 |     0.13 |

One of the intentions of Range is to support enumeration syntax like the following (and for it to be fast):
`foreach (int i in [x..y])`

**Right now, enumerating a range is significantly slower than enumerating an array (or for loop).**

cc @KrzysztofCwalina, @i3arnon