### PR TITLE
Move statics to a separate class and add JsonWriter perf test.

### DIFF
--- a/src/System.Buffers.ReaderWriter/System/Buffers/Writer/BufferWriterT.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Writer/BufferWriterT.cs
@@ -56,12 +56,7 @@ namespace System.Buffers.Writer
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void EnsureMore(int count = 0)
         {
-            var buffered = _buffered;
-            if (buffered > 0)
-            {
-                _buffered = 0;
-                _output.Advance(buffered);
-            }
+            Flush();
             _span = _output.GetSpan(count);
         }
 

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Writer/BufferWriterT_strings.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Writer/BufferWriterT_strings.cs
@@ -56,6 +56,17 @@ namespace System.Buffers.Writer
             Write(NewLine);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Write(byte value)
+        {
+            if (_span.Length >= 1)
+            {
+                Enlarge();
+            }
+            _span[0] = value;
+            Advance(1);
+        }
+
         //public void WriteLine(Utf8String value, TransformationFormat format);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/ArrayFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/ArrayFormatter.cs
@@ -9,6 +9,44 @@ using System.Runtime.CompilerServices;
 
 namespace System.Text.Formatting
 {
+    public struct ArrayFormatterWrapper : ITextBufferWriter, IDisposable
+    {
+        private ArrayFormatter _arrayFormatter;
+
+        public ArrayFormatterWrapper(int capacity, SymbolTable symbolTable, ArrayPool<byte> pool = null)
+        {
+            _arrayFormatter = new ArrayFormatter(capacity, symbolTable, pool);
+        }
+
+        public int CommitedByteCount => _arrayFormatter.CommitedByteCount;
+
+        public void Clear()
+        {
+            _arrayFormatter.Clear();
+        }
+
+        public ArraySegment<byte> Free => _arrayFormatter.Free;
+        public ArraySegment<byte> Formatted => _arrayFormatter.Formatted;
+
+        public SymbolTable SymbolTable => _arrayFormatter.SymbolTable;
+
+        public Memory<byte> GetMemory(int minimumLength = 0) => _arrayFormatter.GetMemory(minimumLength);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<byte> GetSpan(int minimumLength = 0) => _arrayFormatter.GetSpan(minimumLength);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Advance(int bytes)
+        {
+            _arrayFormatter.Advance(bytes);
+        }
+
+        public void Dispose()
+        {
+            _arrayFormatter.Dispose();
+        }
+    }
+
     public class ArrayFormatter : ITextBufferWriter, IDisposable
     {
         ResizableArray<byte> _buffer;
@@ -30,6 +68,7 @@ namespace System.Text.Formatting
         }
 
         public ArraySegment<byte> Free => _buffer.Free;
+
         public ArraySegment<byte> Formatted => _buffer.Full;
 
         public SymbolTable SymbolTable => _symbolTable;
@@ -72,7 +111,6 @@ namespace System.Text.Formatting
                 FormatterThrowHelper.ThrowInvalidOperationException("More bytes commited than returned from FreeBuffer");
             }
         }
-        public int MaxBufferSize { get; } = Int32.MaxValue;
 
         public void Dispose()
         {

--- a/src/System.Text.Formatting/System/Text/Formatting/Formatters/ArrayFormatter.cs
+++ b/src/System.Text.Formatting/System/Text/Formatting/Formatters/ArrayFormatter.cs
@@ -20,31 +20,24 @@ namespace System.Text.Formatting
 
         public int CommitedByteCount => _arrayFormatter.CommitedByteCount;
 
-        public void Clear()
-        {
-            _arrayFormatter.Clear();
-        }
+        public void Clear() => _arrayFormatter.Clear();
 
         public ArraySegment<byte> Free => _arrayFormatter.Free;
+
         public ArraySegment<byte> Formatted => _arrayFormatter.Formatted;
 
         public SymbolTable SymbolTable => _arrayFormatter.SymbolTable;
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Memory<byte> GetMemory(int minimumLength = 0) => _arrayFormatter.GetMemory(minimumLength);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<byte> GetSpan(int minimumLength = 0) => _arrayFormatter.GetSpan(minimumLength);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Advance(int bytes)
-        {
-            _arrayFormatter.Advance(bytes);
-        }
+        public void Advance(int bytes) => _arrayFormatter.Advance(bytes);
 
-        public void Dispose()
-        {
-            _arrayFormatter.Dispose();
-        }
+        public void Dispose() => _arrayFormatter.Dispose();
     }
 
     public class ArrayFormatter : ITextBufferWriter, IDisposable

--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriterHelper.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriterHelper.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace System.Text.JsonLab
+{
+    internal static class JsonWriterHelper
+    {
+        public static readonly byte[] NewLineUtf8 = Encoding.UTF8.GetBytes(Environment.NewLine);
+        public static readonly char[] NewLineUtf16 = Environment.NewLine.ToCharArray();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteDigitsUInt64D(ulong value, Span<byte> buffer)
+        {
+            // We can mutate the 'value' parameter since it's a copy-by-value local.
+            // It'll be used to represent the value left over after each division by 10.
+
+            Debug.Assert(CountDigits(value) == buffer.Length);
+
+            for (int i = buffer.Length - 1; i >= 1; i--)
+            {
+                ulong temp = '0' + value;
+                value /= 10;
+                buffer[i] = (byte)(temp - (value * 10));
+            }
+
+            Debug.Assert(value < 10);
+            buffer[0] = (byte)('0' + value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteDigitsUInt64D(ulong value, Span<char> buffer)
+        {
+            // We can mutate the 'value' parameter since it's a copy-by-value local.
+            // It'll be used to represent the value left over after each division by 10.
+
+            Debug.Assert(CountDigits(value) == buffer.Length);
+
+            for (int i = buffer.Length - 1; i >= 1; i--)
+            {
+                ulong temp = '0' + value;
+                value /= 10;
+                buffer[i] = (char)(temp - (value * 10));
+            }
+
+            Debug.Assert(value < 10);
+            buffer[0] = (char)('0' + value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int CountDigits(ulong value)
+        {
+            int digits = 1;
+            uint part;
+            if (value >= 10000000)
+            {
+                if (value >= 100000000000000)
+                {
+                    part = (uint)(value / 100000000000000);
+                    digits += 14;
+                }
+                else
+                {
+                    part = (uint)(value / 10000000);
+                    digits += 7;
+                }
+            }
+            else
+            {
+                part = (uint)value;
+            }
+
+            if (part < 10)
+            {
+                // no-op
+            }
+            else if (part < 100)
+            {
+                digits += 1;
+            }
+            else if (part < 1000)
+            {
+                digits += 2;
+            }
+            else if (part < 10000)
+            {
+                digits += 3;
+            }
+            else if (part < 100000)
+            {
+                digits += 4;
+            }
+            else if (part < 1000000)
+            {
+                digits += 5;
+            }
+            else
+            {
+                Debug.Assert(part < 10000000);
+                digits += 6;
+            }
+
+            return digits;
+        }
+    }
+}

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -9,7 +9,7 @@ using System.Text.Formatting;
 
 namespace System.Text.JsonLab.Benchmarks
 {
-    [SimpleJob(-1, 5, 10, 8192)]
+    [SimpleJob(-1, 5, 10, 32768)]
     [MemoryDiagnoser]
     public class JsonWriterPerf
     {

--- a/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
@@ -16,7 +16,7 @@ namespace System.Text.JsonLab.Tests
         [Fact]
         public void WriteJsonUtf8()
         {
-            var formatter = new ArrayFormatter(1024, SymbolTable.InvariantUtf8);
+            var formatter = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
             var json = new JsonWriter(formatter, true, prettyPrint: false);
             Write(ref json);
 

--- a/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
@@ -16,7 +16,7 @@ namespace System.Text.JsonLab.Tests
         [Fact]
         public void WriteJsonUtf8()
         {
-            var formatter = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
+            var formatter = new ArrayFormatter(1024, SymbolTable.InvariantUtf8);
             var json = new JsonWriter(formatter, true, prettyPrint: false);
             Write(ref json);
 


### PR DESCRIPTION
- Add `BufferWriter.Write(byte)`
- General code clean up (use of var, explicitly add private keyword, etc.).
- Move static fields and methods to their own helper class.
- Add ArrayOnly performance test.

cc @JeremyKuhne, @adamsitnik 

Establishing a clean base-line for future changes:

``` ini

BenchmarkDotNet=v0.10.14.534-nightly, OS=Windows 10.0.14393.2312 (1607/AnniversaryUpdate/Redstone1)
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
Frequency=3328123 Hz, Resolution=300.4697 ns, Timer=TSC
.NET Core SDK=2.2.100-preview1-009015
  [Host]     : .NET Core 2.2.0-preview1-26609-02 (CoreCLR 4.6.26606.04, CoreFX 4.6.26606.04), 64bit RyuJIT
  Job-UYYLEA : .NET Core 2.2.0-preview1-26609-02 (CoreCLR 4.6.26606.04, CoreFX 4.6.26606.04), 64bit RyuJIT

InvocationCount=32768  TargetCount=10  WarmupCount=5  

```
|                         Method | IsUTF8Encoded | Formatted | size |         Mean |      Error |     StdDev |  Gen 0 | Allocated |
|------------------------------- |-------------- |---------- |----- |-------------:|-----------:|-----------:|-------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |         **False** |     **False** |    **1** |     **60.91 ns** |   **3.392 ns** |   **2.019 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |         **False** |     **False** |    **2** |     **78.60 ns** |   **4.879 ns** |   **2.552 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |         **False** |     **False** |    **5** |    **139.26 ns** |  **13.672 ns** |   **9.043 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |         **False** |     **False** |   **10** |    **237.82 ns** |  **19.225 ns** |  **12.716 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |         **False** |     **False** |  **100** |  **2,126.38 ns** |  **31.800 ns** |  **18.923 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |         **False** |     **False** | **1000** | **21,586.57 ns** | **416.679 ns** | **247.959 ns** |      **-** |       **0 B** |
|      **WriterSystemTextJsonBasic** |         **False** |     **False** |    **?** |    **736.69 ns** |  **23.357 ns** |  **13.899 ns** |      **-** |       **0 B** |
|          WriterNewtonsoftBasic |         False |     False |    ? |  1,480.28 ns |  55.310 ns |  28.928 ns | 0.0916 |     472 B |
| WriterSystemTextJsonHelloWorld |         False |     False |    ? |     56.97 ns |   3.722 ns |   2.462 ns |      - |       0 B |
|     WriterNewtonsoftHelloWorld |         False |     False |    ? |    309.05 ns |  55.034 ns |  36.402 ns | 0.0610 |     312 B |
|  **WriterSystemTextJsonArrayOnly** |         **False** |      **True** |    **1** |     **63.89 ns** |   **4.377 ns** |   **2.604 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |         **False** |      **True** |    **2** |     **90.73 ns** |   **9.277 ns** |   **6.136 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |         **False** |      **True** |    **5** |    **146.63 ns** |  **13.414 ns** |   **8.873 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |         **False** |      **True** |   **10** |    **256.78 ns** |  **23.338 ns** |  **15.437 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |         **False** |      **True** |  **100** |  **2,287.34 ns** | **174.745 ns** | **103.988 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |         **False** |      **True** | **1000** | **22,480.18 ns** | **640.267 ns** | **423.497 ns** |      **-** |       **0 B** |
|      **WriterSystemTextJsonBasic** |         **False** |      **True** |    **?** |    **934.20 ns** | **139.993 ns** |  **92.597 ns** |      **-** |       **0 B** |
|          WriterNewtonsoftBasic |         False |      True |    ? |  2,144.80 ns |  38.472 ns |  20.122 ns | 0.1221 |     632 B |
| WriterSystemTextJsonHelloWorld |         False |      True |    ? |     62.67 ns |   4.760 ns |   2.833 ns |      - |       0 B |
|     WriterNewtonsoftHelloWorld |         False |      True |    ? |    441.19 ns |  21.060 ns |  13.930 ns | 0.0916 |     472 B |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |    **1** |     **99.41 ns** |  **13.151 ns** |   **8.698 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |    **2** |    **117.11 ns** |  **11.705 ns** |   **7.742 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |    **5** |    **171.73 ns** |   **9.131 ns** |   **6.040 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |   **10** |    **274.48 ns** |  **27.708 ns** |  **18.327 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |  **100** |  **2,131.95 ns** |  **36.038 ns** |  **21.446 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** | **1000** | **20,587.48 ns** | **419.515 ns** | **277.483 ns** |      **-** |       **0 B** |
|      **WriterSystemTextJsonBasic** |          **True** |     **False** |    **?** |  **1,047.17 ns** |  **28.783 ns** |  **19.038 ns** |      **-** |       **0 B** |
|          WriterNewtonsoftBasic |          True |     False |    ? |  1,484.84 ns |  21.846 ns |  14.450 ns | 0.0916 |     416 B |
| WriterSystemTextJsonHelloWorld |          True |     False |    ? |    108.58 ns |  10.315 ns |   6.138 ns |      - |       0 B |
|     WriterNewtonsoftHelloWorld |          True |     False |    ? |    315.53 ns |  38.324 ns |  25.349 ns | 0.0305 |     256 B |
|  **WriterSystemTextJsonArrayOnly** |          **True** |      **True** |    **1** |    **107.00 ns** |  **13.591 ns** |   **8.989 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |      **True** |    **2** |    **143.66 ns** |  **32.352 ns** |  **21.399 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |      **True** |    **5** |    **192.67 ns** |  **21.361 ns** |  **14.129 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |      **True** |   **10** |    **291.00 ns** |  **13.229 ns** |   **8.750 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |      **True** |  **100** |  **2,371.10 ns** |  **79.661 ns** |  **52.691 ns** |      **-** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |      **True** | **1000** | **22,837.89 ns** | **651.197 ns** | **387.517 ns** |      **-** |       **0 B** |
|      **WriterSystemTextJsonBasic** |          **True** |      **True** |    **?** |  **1,185.59 ns** |  **23.690 ns** |  **15.669 ns** |      **-** |       **0 B** |
|          WriterNewtonsoftBasic |          True |      True |    ? |  2,125.80 ns |  49.385 ns |  32.665 ns | 0.1221 |     576 B |
| WriterSystemTextJsonHelloWorld |          True |      True |    ? |    118.78 ns |  12.369 ns |   8.181 ns |      - |       0 B |
|     WriterNewtonsoftHelloWorld |          True |      True |    ? |    468.31 ns |  28.775 ns |  19.033 ns | 0.0916 |     416 B |


|                    Method | numberOfRequests | concurrentConnections |    Mean |    Error |   StdDev |
|-------------------------- |----------------- |---------------------- |--------:|---------:|---------:|
| TechEmpowerHelloWorldNoIO |            10000 |                   256 | 2.231 s | 0.0447 s | 0.0296 s |
|       TechEmpowerJsonNoIO |            10000 |                   256 | 2.246 s | 0.0170 s | 0.0112 s |
