### PR TITLE
Make JsonWriter generic to avoid struct boxing

### DIFF
--- a/samples/LowAllocationWebServer/Shared/SampleServer.cs
+++ b/samples/LowAllocationWebServer/Shared/SampleServer.cs
@@ -62,7 +62,7 @@ namespace LowAllocationWebServer
             response.AppendEoh();
 
             // write response JSON
-            var jsonWriter = new JsonWriter(response, true, prettyPrint: false);
+            var jsonWriter = new JsonWriter<TcpConnectionFormatter>(response, true, prettyPrint: false);
             jsonWriter.WriteObjectStart();
             jsonWriter.WriteArrayStart("values");
             for (int i = 0; i < 5; i++)
@@ -94,7 +94,7 @@ namespace LowAllocationWebServer
             response.AppendEoh();
 
             // write response JSON
-            var jsonWriter = new JsonWriter(response, true, prettyPrint: false);
+            var jsonWriter = new JsonWriter<TcpConnectionFormatter>(response, true, prettyPrint: false);
             jsonWriter.WriteObjectStart();
             jsonWriter.WriteArrayStart("values");
             for (int i = 0; i < requestedCount; i++)

--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
@@ -9,10 +9,10 @@ using System.Runtime.InteropServices;
 
 namespace System.Text.JsonLab
 {
-    public struct JsonWriter
+    public struct JsonWriter<T> where T : IBufferWriter<byte>
     {
         private readonly bool _prettyPrint;
-        private readonly IBufferWriter<byte> _bufferWriter;
+        private readonly T _bufferWriter;
         private readonly bool _isUtf8;
 
         private int _indent;
@@ -23,7 +23,7 @@ namespace System.Text.JsonLab
         /// </summary>
         /// <param name="bufferWriter">An instance of <see cref="ITextBufferWriter" /> used for writing bytes to an output channel.</param>
         /// <param name="prettyPrint">Specifies whether to add whitespace to the output text for user readability.</param>
-        public JsonWriter(IBufferWriter<byte> bufferWriter, bool isUtf8, bool prettyPrint = false)
+        public JsonWriter(T bufferWriter, bool isUtf8, bool prettyPrint = false)
         {
             _bufferWriter = bufferWriter;
             _prettyPrint = prettyPrint;

--- a/tests/Benchmarks/System.IO.Pipelines/E2E.cs
+++ b/tests/Benchmarks/System.IO.Pipelines/E2E.cs
@@ -57,7 +57,7 @@ namespace System.IO.Pipelines.Benchmarks
                 formatter.Append("\r\n\r\n");
 
                 // write body
-                var writer = new JsonWriter(formatter, true);
+                var writer = new JsonWriter<BufferWriterFormatter<PipeWriter>>(formatter, true);
                 writer.WriteObjectStart();
                 writer.WriteAttribute("message", "Hello, World!");
                 writer.WriteObjectEnd();

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -16,7 +16,7 @@ namespace System.Text.JsonLab.Benchmarks
         private const int ExtraArraySize = 1000;
         private const int BufferSize = 1024 + (ExtraArraySize * 64);
 
-        private ArrayFormatterWrapper _ArrayFormatterWrapper;
+        private ArrayFormatterWrapper _arrayFormatterWrapper;
         private MemoryStream _memoryStream;
         private StreamWriter _streamWriter;
         private StringBuilder _stringBuilder;
@@ -45,23 +45,23 @@ namespace System.Text.JsonLab.Benchmarks
                 var buffer = new byte[BufferSize];
                 _memoryStream = new MemoryStream(buffer);
                 _streamWriter = new StreamWriter(_memoryStream, new UTF8Encoding(false), BufferSize, true);
-                _ArrayFormatterWrapper = new ArrayFormatterWrapper(BufferSize, SymbolTable.InvariantUtf8);
+                _arrayFormatterWrapper = new ArrayFormatterWrapper(BufferSize, SymbolTable.InvariantUtf8);
             }
             else
             {
                 _stringBuilder = new StringBuilder();
-                _ArrayFormatterWrapper = new ArrayFormatterWrapper(BufferSize, SymbolTable.InvariantUtf16);
+                _arrayFormatterWrapper = new ArrayFormatterWrapper(BufferSize, SymbolTable.InvariantUtf16);
             }
         }
 
         [Benchmark]
         public void WriterSystemTextJsonBasic()
         {
-            _ArrayFormatterWrapper.Clear();
+            _arrayFormatterWrapper.Clear();
             if (IsUTF8Encoded)
-                WriterSystemTextJsonBasicUtf8(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, 10));
+                WriterSystemTextJsonBasicUtf8(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
             else
-                WriterSystemTextJsonBasicUtf16(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, 10));
+                WriterSystemTextJsonBasicUtf16(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
         }
 
         //[Benchmark]
@@ -73,11 +73,11 @@ namespace System.Text.JsonLab.Benchmarks
         [Benchmark]
         public void WriterSystemTextJsonHelloWorld()
         {
-            _ArrayFormatterWrapper.Clear();
+            _arrayFormatterWrapper.Clear();
             if (IsUTF8Encoded)
-                WriterSystemTextJsonHelloWorldUtf8(Formatted, _ArrayFormatterWrapper);
+                WriterSystemTextJsonHelloWorldUtf8(Formatted, _arrayFormatterWrapper);
             else
-                WriterSystemTextJsonHelloWorldUtf16(Formatted, _ArrayFormatterWrapper);
+                WriterSystemTextJsonHelloWorldUtf16(Formatted, _arrayFormatterWrapper);
         }
 
         //[Benchmark]
@@ -95,11 +95,11 @@ namespace System.Text.JsonLab.Benchmarks
         [Arguments(1000)]
         public void WriterSystemTextJsonArrayOnly(int size)
         {
-            _ArrayFormatterWrapper.Clear();
+            _arrayFormatterWrapper.Clear();
             if (IsUTF8Encoded)
-                WriterSystemTextJsonArrayOnlyUtf8(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, size));
+                WriterSystemTextJsonArrayOnlyUtf8(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, size));
             else
-                WriterSystemTextJsonArrayOnlyUtf16(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, size));
+                WriterSystemTextJsonArrayOnlyUtf16(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, size));
         }
 
         private TextWriter GetWriter()

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -9,7 +9,7 @@ using System.Text.Formatting;
 
 namespace System.Text.JsonLab.Benchmarks
 {
-    //[SimpleJob(-1, 5, 10, 32768)]
+    [SimpleJob(-1, 5, 10, 32768)]
     [MemoryDiagnoser]
     public class JsonWriterPerf
     {
@@ -23,10 +23,10 @@ namespace System.Text.JsonLab.Benchmarks
 
         private int[] _data;
 
-        [Params(true)]
+        [Params(true, false)]
         public bool IsUTF8Encoded;
 
-        [Params(false)]
+        [Params(true, false)]
         public bool Formatted;
 
         [GlobalSetup]
@@ -64,7 +64,7 @@ namespace System.Text.JsonLab.Benchmarks
                 WriterSystemTextJsonBasicUtf16(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void WriterNewtonsoftBasic()
         {
             WriterNewtonsoftBasic(Formatted, GetWriter(), _data.AsSpan(0, 10));
@@ -80,7 +80,7 @@ namespace System.Text.JsonLab.Benchmarks
                 WriterSystemTextJsonHelloWorldUtf16(Formatted, _arrayFormatterWrapper);
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void WriterNewtonsoftHelloWorld()
         {
             WriterNewtonsoftHelloWorld(Formatted, GetWriter());
@@ -88,10 +88,10 @@ namespace System.Text.JsonLab.Benchmarks
 
         [Benchmark]
         [Arguments(1)]
-        //[Arguments(2)]
-        //[Arguments(5)]
+        [Arguments(2)]
+        [Arguments(5)]
         [Arguments(10)]
-        //[Arguments(100)]
+        [Arguments(100)]
         [Arguments(1000)]
         public void WriterSystemTextJsonArrayOnly(int size)
         {

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -9,24 +9,24 @@ using System.Text.Formatting;
 
 namespace System.Text.JsonLab.Benchmarks
 {
-    [SimpleJob(-1, 5, 10, 32768)]
+    //[SimpleJob(-1, 5, 10, 32768)]
     [MemoryDiagnoser]
     public class JsonWriterPerf
     {
         private const int ExtraArraySize = 1000;
         private const int BufferSize = 1024 + (ExtraArraySize * 64);
 
-        private ArrayFormatter _arrayFormatter;
+        private ArrayFormatterWrapper _ArrayFormatterWrapper;
         private MemoryStream _memoryStream;
         private StreamWriter _streamWriter;
         private StringBuilder _stringBuilder;
 
         private int[] _data;
 
-        [Params(true, false)]
+        [Params(true)]
         public bool IsUTF8Encoded;
 
-        [Params(true, false)]
+        [Params(false)]
         public bool Formatted;
 
         [GlobalSetup]
@@ -45,26 +45,26 @@ namespace System.Text.JsonLab.Benchmarks
                 var buffer = new byte[BufferSize];
                 _memoryStream = new MemoryStream(buffer);
                 _streamWriter = new StreamWriter(_memoryStream, new UTF8Encoding(false), BufferSize, true);
-                _arrayFormatter = new ArrayFormatter(BufferSize, SymbolTable.InvariantUtf8);
+                _ArrayFormatterWrapper = new ArrayFormatterWrapper(BufferSize, SymbolTable.InvariantUtf8);
             }
             else
             {
                 _stringBuilder = new StringBuilder();
-                _arrayFormatter = new ArrayFormatter(BufferSize, SymbolTable.InvariantUtf16);
+                _ArrayFormatterWrapper = new ArrayFormatterWrapper(BufferSize, SymbolTable.InvariantUtf16);
             }
         }
 
         [Benchmark]
         public void WriterSystemTextJsonBasic()
         {
-            _arrayFormatter.Clear();
+            _ArrayFormatterWrapper.Clear();
             if (IsUTF8Encoded)
-                WriterSystemTextJsonBasicUtf8(Formatted, _arrayFormatter, _data.AsSpan(0, 10));
+                WriterSystemTextJsonBasicUtf8(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, 10));
             else
-                WriterSystemTextJsonBasicUtf16(Formatted, _arrayFormatter, _data.AsSpan(0, 10));
+                WriterSystemTextJsonBasicUtf16(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, 10));
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void WriterNewtonsoftBasic()
         {
             WriterNewtonsoftBasic(Formatted, GetWriter(), _data.AsSpan(0, 10));
@@ -73,14 +73,14 @@ namespace System.Text.JsonLab.Benchmarks
         [Benchmark]
         public void WriterSystemTextJsonHelloWorld()
         {
-            _arrayFormatter.Clear();
+            _ArrayFormatterWrapper.Clear();
             if (IsUTF8Encoded)
-                WriterSystemTextJsonHelloWorldUtf8(Formatted, _arrayFormatter);
+                WriterSystemTextJsonHelloWorldUtf8(Formatted, _ArrayFormatterWrapper);
             else
-                WriterSystemTextJsonHelloWorldUtf16(Formatted, _arrayFormatter);
+                WriterSystemTextJsonHelloWorldUtf16(Formatted, _ArrayFormatterWrapper);
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void WriterNewtonsoftHelloWorld()
         {
             WriterNewtonsoftHelloWorld(Formatted, GetWriter());
@@ -88,18 +88,18 @@ namespace System.Text.JsonLab.Benchmarks
 
         [Benchmark]
         [Arguments(1)]
-        [Arguments(2)]
-        [Arguments(5)]
+        //[Arguments(2)]
+        //[Arguments(5)]
         [Arguments(10)]
-        [Arguments(100)]
+        //[Arguments(100)]
         [Arguments(1000)]
         public void WriterSystemTextJsonArrayOnly(int size)
         {
-            _arrayFormatter.Clear();
+            _ArrayFormatterWrapper.Clear();
             if (IsUTF8Encoded)
-                WriterSystemTextJsonArrayOnlyUtf8(Formatted, _arrayFormatter, _data.AsSpan(0, size));
+                WriterSystemTextJsonArrayOnlyUtf8(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, size));
             else
-                WriterSystemTextJsonArrayOnlyUtf16(Formatted, _arrayFormatter, _data.AsSpan(0, size));
+                WriterSystemTextJsonArrayOnlyUtf16(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, size));
         }
 
         private TextWriter GetWriter()
@@ -118,9 +118,9 @@ namespace System.Text.JsonLab.Benchmarks
             return writer;
         }
 
-        private static void WriterSystemTextJsonBasicUtf8(bool formatted, ArrayFormatter output, ReadOnlySpan<int> data)
+        private static void WriterSystemTextJsonBasicUtf8(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
         {
-            var json = new JsonWriter(output, true, formatted);
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, true, formatted);
 
             json.WriteObjectStart();
             json.WriteAttribute("age", 42);
@@ -146,9 +146,9 @@ namespace System.Text.JsonLab.Benchmarks
             json.WriteObjectEnd();
         }
 
-        private static void WriterSystemTextJsonBasicUtf16(bool formatted, ArrayFormatter output, ReadOnlySpan<int> data)
+        private static void WriterSystemTextJsonBasicUtf16(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
         {
-            var json = new JsonWriter(output, false, formatted);
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, false, formatted);
 
             json.WriteObjectStart();
             json.WriteAttribute("age", 42);
@@ -214,18 +214,18 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        private static void WriterSystemTextJsonHelloWorldUtf8(bool formatted, ArrayFormatter output)
+        private static void WriterSystemTextJsonHelloWorldUtf8(bool formatted, ArrayFormatterWrapper output)
         {
-            var json = new JsonWriter(output, true, formatted);
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, true, formatted);
 
             json.WriteObjectStart();
             json.WriteAttribute("message", "Hello, World!");
             json.WriteObjectEnd();
         }
 
-        private static void WriterSystemTextJsonHelloWorldUtf16(bool formatted, ArrayFormatter output)
+        private static void WriterSystemTextJsonHelloWorldUtf16(bool formatted, ArrayFormatterWrapper output)
         {
-            var json = new JsonWriter(output, false, formatted);
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, false, formatted);
 
             json.WriteObjectStart();
             json.WriteAttribute("message", "Hello, World!");
@@ -245,9 +245,9 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        private static void WriterSystemTextJsonArrayOnlyUtf8(bool formatted, ArrayFormatter output, ReadOnlySpan<int> data)
+        private static void WriterSystemTextJsonArrayOnlyUtf8(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
         {
-            var json = new JsonWriter(output, true, formatted);
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, true, formatted);
 
             json.WriteArrayStart("ExtraArray");
             for (var i = 0; i < data.Length; i++)
@@ -257,9 +257,9 @@ namespace System.Text.JsonLab.Benchmarks
             json.WriteArrayEnd();
         }
 
-        private static void WriterSystemTextJsonArrayOnlyUtf16(bool formatted, ArrayFormatter output, ReadOnlySpan<int> data)
+        private static void WriterSystemTextJsonArrayOnlyUtf16(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
         {
-            var json = new JsonWriter(output, false, formatted);
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, false, formatted);
 
             json.WriteArrayStart("ExtraArray");
             for (var i = 0; i < data.Length; i++)

--- a/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
@@ -16,8 +16,8 @@ namespace System.Text.JsonLab.Tests
         [Fact]
         public void WriteJsonUtf8()
         {
-            var formatter = new ArrayFormatter(1024, SymbolTable.InvariantUtf8);
-            var json = new JsonWriter(formatter, true, prettyPrint: false);
+            var formatter = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
+            var json = new JsonWriter<ArrayFormatterWrapper>(formatter, true, prettyPrint: false);
             Write(ref json);
 
             var formatted = formatter.Formatted;
@@ -25,7 +25,7 @@ namespace System.Text.JsonLab.Tests
             Assert.Equal(expected, str.Replace(" ", ""));
 
             formatter.Clear();
-            json = new JsonWriter(formatter, true, prettyPrint: true);
+            json = new JsonWriter<ArrayFormatterWrapper>(formatter, true, prettyPrint: true);
             Write(ref json);
 
             formatted = formatter.Formatted;
@@ -36,8 +36,8 @@ namespace System.Text.JsonLab.Tests
         [Fact]
         public void WriteJsonUtf16()
         {
-            var formatter = new ArrayFormatter(1024, SymbolTable.InvariantUtf16);
-            var json = new JsonWriter(formatter, false, prettyPrint: false);
+            var formatter = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf16);
+            var json = new JsonWriter<ArrayFormatterWrapper>(formatter, false, prettyPrint: false);
             Write(ref json);
 
             var formatted = formatter.Formatted;
@@ -45,7 +45,7 @@ namespace System.Text.JsonLab.Tests
             Assert.Equal(expected, str.Replace(" ", ""));
 
             formatter.Clear();
-            json = new JsonWriter(formatter, false, prettyPrint: true);
+            json = new JsonWriter<ArrayFormatterWrapper>(formatter, false, prettyPrint: true);
             Write(ref json);
 
             formatted = formatter.Formatted;
@@ -54,7 +54,7 @@ namespace System.Text.JsonLab.Tests
         }
 
         static string expected = "{\"age\":30,\"first\":\"John\",\"last\":\"Smith\",\"phoneNumbers\":[\"425-000-1212\",\"425-000-1213\",null],\"address\":{\"street\":\"1MicrosoftWay\",\"city\":\"Redmond\",\"zip\":98052},\"values\":[425121,-425122,425123]}";
-        static void Write(ref JsonWriter json)
+        static void Write(ref JsonWriter<ArrayFormatterWrapper> json)
         {
             json.WriteObjectStart();
             json.WriteAttribute("age", 30);
@@ -85,8 +85,8 @@ namespace System.Text.JsonLab.Tests
         {
             string expectedStr = GetHelloWorldExpectedString(prettyPrint, isUtf8: false);
 
-            var output = new ArrayFormatter(1024, SymbolTable.InvariantUtf16);
-            var jsonUtf16 = new JsonWriter(output, false, prettyPrint);
+            var output = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf16);
+            var jsonUtf16 = new JsonWriter<ArrayFormatterWrapper>(output, false, prettyPrint);
 
             jsonUtf16.WriteObjectStart();
             jsonUtf16.WriteAttribute("message", "Hello, World!");
@@ -105,8 +105,8 @@ namespace System.Text.JsonLab.Tests
         {
             string expectedStr = GetHelloWorldExpectedString(prettyPrint, isUtf8: true);
 
-            var output = new ArrayFormatter(1024, SymbolTable.InvariantUtf8);
-            var jsonUtf8 = new JsonWriter(output, true, prettyPrint);
+            var output = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
+            var jsonUtf8 = new JsonWriter<ArrayFormatterWrapper>(output, true, prettyPrint);
 
             jsonUtf8.WriteObjectStart();
             jsonUtf8.WriteAttribute("message", "Hello, World!");
@@ -127,8 +127,8 @@ namespace System.Text.JsonLab.Tests
 
             string expectedStr = GetExpectedString(prettyPrint, isUtf8: false, data);
 
-            var output = new ArrayFormatter(1024, SymbolTable.InvariantUtf16);
-            var jsonUtf16 = new JsonWriter(output, false, prettyPrint);
+            var output = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf16);
+            var jsonUtf16 = new JsonWriter<ArrayFormatterWrapper>(output, false, prettyPrint);
 
             jsonUtf16.WriteObjectStart();
             jsonUtf16.WriteAttribute("age", 42);
@@ -169,8 +169,8 @@ namespace System.Text.JsonLab.Tests
 
             string expectedStr = GetExpectedString(prettyPrint, isUtf8: true, data);
 
-            var output = new ArrayFormatter(1024, SymbolTable.InvariantUtf8);
-            var jsonUtf8 = new JsonWriter(output, true, prettyPrint);
+            var output = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
+            var jsonUtf8 = new JsonWriter<ArrayFormatterWrapper>(output, true, prettyPrint);
 
             jsonUtf8.WriteObjectStart();
             jsonUtf8.WriteAttribute("age", 42);


### PR DESCRIPTION
**TODO:** Add helper factory convenience methods.

Related previous PRs: https://github.com/dotnet/corefxlab/pull/2358 / https://github.com/dotnet/corefxlab/pull/2366 / https://github.com/dotnet/corefxlab/pull/2369

**I want to isolate changes and make them one at a time only. The previous PRs introduced BufferWriter/etc. which makes analysis more difficult.**

I measured the following implementations of `IBufferWriter<byte>`:
- class (ArrayFormatter)
- struct (make ArrayFormatter a struct)
- struct wrapper around a class (ArrayFormatterWrapper)

**Conclusion:**
If JsonWriter is generic, and `IBufferWriter<byte>` is implemented as a struct wrapper around a class, we get the best performance (~10% improvement compared to non-generic JsonWriter where `IBufferWriter<byte>` is a class, and ~25% if its a struct wrapper around a class). However, if JsonWriter is generic and `IBufferWriter<byte>` is implemented as just a struct, we get ~15% performance regression (compared to non-generic JsonWriter). **Should the guideline then be to never implement `IBufferWriter<byte>` as a struct but rather as a struct wrapper around a class if we are going to make JsonWriter a generic type?**

**Non-generic (original/master):**
- class (0 bytes allocated)
- struct (48 bytes allocated)
- struct wrapper around a class (24 bytes allocated)

**Generic (this PR):**
- class (0 bytes allocated)
- struct (0 bytes allocated) **[SLOWEST]**
- struct wrapper around a class (0 bytes allocated) **[FASTEST]**

![image](https://user-images.githubusercontent.com/6527137/41945266-093d12e2-7961-11e8-9fd3-b194d776ee86.png)

![image](https://user-images.githubusercontent.com/6527137/41945270-0b3f3d18-7961-11e8-8ff4-871523e4f668.png)

![image](https://user-images.githubusercontent.com/6527137/41945291-2600ec6e-7961-11e8-867c-9f120c90f082.png)

``` ini

BenchmarkDotNet=v0.10.14.534-nightly, OS=Windows 10.0.14393.2312 (1607/AnniversaryUpdate/Redstone1)
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
Frequency=3328123 Hz, Resolution=300.4697 ns, Timer=TSC
.NET Core SDK=2.2.100-preview1-009015
  [Host]     : .NET Core 2.2.0-preview1-26609-02 (CoreCLR 4.6.26606.04, CoreFX 4.6.26606.04), 64bit RyuJIT
  DefaultJob : .NET Core 2.2.0-preview1-26609-02 (CoreCLR 4.6.26606.04, CoreFX 4.6.26606.04), 64bit RyuJIT


```

**Non-generic - class:**

|                         Method | IsUTF8Encoded | Formatted | size |         Mean |       Error |      StdDev | Allocated |
|------------------------------- |-------------- |---------- |----- |-------------:|------------:|------------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |    **1** |     **95.13 ns** |   **1.8891 ns** |   **2.0997 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |   **10** |    **248.96 ns** |   **4.9069 ns** |   **5.2503 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** | **1000** | **20,855.27 ns** | **319.0868 ns** | **298.4740 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |          **True** |     **False** |    **?** |  **1,032.74 ns** |  **11.9521 ns** |   **9.9805 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |          True |     False |    ? |    105.78 ns |   0.4063 ns |   0.3602 ns |       0 B |

**Non-generic - struct:**

|                         Method | IsUTF8Encoded | Formatted | size |        Mean |       Error |        StdDev |  Gen 0 | Allocated |
|------------------------------- |-------------- |---------- |----- |------------:|------------:|--------------:|-------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |    **1** |    **119.3 ns** |   **0.7279 ns** |     **0.5263 ns** | **0.0113** |      **48 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |   **10** |    **289.6 ns** |   **3.5496 ns** |     **3.1467 ns** | **0.0110** |      **48 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** | **1000** | **23,015.4 ns** | **453.6850 ns** | **1,033.2704 ns** |      **-** |      **48 B** |
|      **WriterSystemTextJsonBasic** |          **True** |     **False** |    **?** |  **1,101.1 ns** |  **21.8697 ns** |    **30.6583 ns** | **0.0095** |      **48 B** |
| WriterSystemTextJsonHelloWorld |          True |     False |    ? |    136.8 ns |   3.0977 ns |     4.6365 ns | 0.0112 |      48 B |

**Non-generic - struct wrapping class:**

|                         Method | IsUTF8Encoded | Formatted | size |        Mean |       Error |      StdDev |  Gen 0 | Allocated |
|------------------------------- |-------------- |---------- |----- |------------:|------------:|------------:|-------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |    **1** |    **109.6 ns** |   **0.5671 ns** |   **0.4735 ns** | **0.0056** |      **24 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |   **10** |    **301.3 ns** |   **5.8269 ns** |   **7.9759 ns** | **0.0052** |      **24 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** | **1000** | **24,930.7 ns** | **486.5483 ns** | **499.6492 ns** |      **-** |      **24 B** |
|      **WriterSystemTextJsonBasic** |          **True** |     **False** |    **?** |  **1,132.1 ns** |  **22.2699 ns** |  **33.3325 ns** | **0.0038** |      **24 B** |
| WriterSystemTextJsonHelloWorld |          True |     False |    ? |    127.6 ns |   2.6712 ns |   2.6235 ns | 0.0055 |      24 B |

---

**Generic - class:**

|                         Method | IsUTF8Encoded | Formatted | size |         Mean |       Error |      StdDev | Allocated |
|------------------------------- |-------------- |---------- |----- |-------------:|------------:|------------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |    **1** |     **98.99 ns** |   **0.5284 ns** |   **0.4684 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |   **10** |    **261.88 ns** |   **1.1612 ns** |   **0.9697 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** | **1000** | **21,099.53 ns** | **159.7011 ns** | **141.5708 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |          **True** |     **False** |    **?** |  **1,066.33 ns** |  **21.7958 ns** |  **20.3878 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |          True |     False |    ? |    109.25 ns |   1.4485 ns |   1.2840 ns |       0 B |

**Generic - struct:**

|                         Method | IsUTF8Encoded | Formatted | size |        Mean |      Error |     StdDev | Allocated |
|------------------------------- |-------------- |---------- |----- |------------:|-----------:|-----------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |    **1** |    **118.5 ns** |   **2.111 ns** |   **1.974 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |   **10** |    **331.7 ns** |   **8.416 ns** |   **9.355 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** | **1000** | **26,426.9 ns** | **527.378 ns** | **647.667 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |          **True** |     **False** |    **?** |  **1,098.9 ns** |   **5.508 ns** |   **4.300 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |          True |     False |    ? |    136.5 ns |   2.714 ns |   2.904 ns |       0 B |

**Generic - struct wrapping class:**

|                         Method | IsUTF8Encoded | Formatted | size |         Mean |      Error |     StdDev |       Median | Allocated |
|------------------------------- |-------------- |---------- |----- |-------------:|-----------:|-----------:|-------------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |    **1** |     **81.62 ns** |   **1.232 ns** |   **1.028 ns** |     **81.26 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |   **10** |    **220.87 ns** |   **4.004 ns** |   **3.745 ns** |    **221.93 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** | **1000** | **18,681.24 ns** | **396.101 ns** | **389.024 ns** | **18,522.05 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |          **True** |     **False** |    **?** |    **921.26 ns** |  **16.615 ns** |  **15.542 ns** |    **927.68 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |          True |     False |    ? |    103.35 ns |   2.321 ns |   6.033 ns |    101.05 ns |       0 B |

cc @AndyAyersMS, @GrabYourPitchforks, @benaadams, @JeremyKuhne 