### PR TITLE
 Cache the span by using BufferWriter<T> within JsonWriter<T>

### DIFF
--- a/samples/LowAllocationWebServer/Shared/SampleServer.cs
+++ b/samples/LowAllocationWebServer/Shared/SampleServer.cs
@@ -62,7 +62,7 @@ namespace LowAllocationWebServer
             response.AppendEoh();
 
             // write response JSON
-            var jsonWriter = new JsonWriter(response, true, prettyPrint: false);
+            var jsonWriter = new JsonWriter<TcpConnectionFormatter>(response, true, prettyPrint: false);
             jsonWriter.WriteObjectStart();
             jsonWriter.WriteArrayStart("values");
             for (int i = 0; i < 5; i++)
@@ -94,7 +94,7 @@ namespace LowAllocationWebServer
             response.AppendEoh();
 
             // write response JSON
-            var jsonWriter = new JsonWriter(response, true, prettyPrint: false);
+            var jsonWriter = new JsonWriter<TcpConnectionFormatter>(response, true, prettyPrint: false);
             jsonWriter.WriteObjectStart();
             jsonWriter.WriteArrayStart("values");
             for (int i = 0; i < requestedCount; i++)

--- a/samples/LowAllocationWebServer/Shared/SampleServer.cs
+++ b/samples/LowAllocationWebServer/Shared/SampleServer.cs
@@ -71,6 +71,7 @@ namespace LowAllocationWebServer
             }
             jsonWriter.WriteArrayEnd();
             jsonWriter.WriteObjectEnd();
+            jsonWriter.Flush();
         }
 
         static void WriteResponseForPostJson(HttpRequest request, ReadOnlySequence<byte> body, TcpConnectionFormatter response)
@@ -103,6 +104,7 @@ namespace LowAllocationWebServer
             }
             jsonWriter.WriteArrayEnd();
             jsonWriter.WriteObjectEnd();
+            jsonWriter.Flush();
         }
     }
 }

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Writer/BufferWriterT.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Writer/BufferWriterT.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace System.Buffers.Writer
 {
@@ -12,17 +13,17 @@ namespace System.Buffers.Writer
         private Span<byte> _span;
         private int _buffered;
 
-        private static readonly byte[] s_newLine = new byte[] { (byte)'\r', (byte)'\n' };
+        private static readonly byte[] s_newLine = Encoding.UTF8.GetBytes(Environment.NewLine);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public BufferWriter(T output)
         {
             _buffered = 0;
             _output = output;
             _span = output.GetSpan();
-            NewLine = s_newLine;
         }
 
-        public ReadOnlySpan<byte> NewLine { get; set; }
+        private static ReadOnlySpan<byte> NewLine => s_newLine;
 
         public Span<byte> Buffer => _span;
 

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Writer/BufferWriterT_strings.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Writer/BufferWriterT_strings.cs
@@ -44,6 +44,12 @@ namespace System.Buffers.Writer
             Write(NewLine);
         }
 
+        public void WriteLine(string value, ReadOnlySpan<byte> newLine)
+        {
+            Write(value);
+            Write(newLine);
+        }
+
         //public void WriteLine(string value, TransformationFormat format);
 
         public void Write(Utf8String value) => Write(value.Bytes);
@@ -59,12 +65,18 @@ namespace System.Buffers.Writer
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Write(byte value)
         {
-            if (_span.Length >= 1)
+            if (_span.Length < 1)
             {
                 Enlarge();
             }
             _span[0] = value;
             Advance(1);
+        }
+
+        public void WriteLine(Utf8String value, ReadOnlySpan<byte> newLine)
+        {
+            Write(value.Bytes);
+            Write(newLine);
         }
 
         //public void WriteLine(Utf8String value, TransformationFormat format);

--- a/src/System.Text.JsonLab/System.Text.JsonLab.csproj
+++ b/src/System.Text.JsonLab/System.Text.JsonLab.csproj
@@ -7,11 +7,14 @@
     <PackageTags>.NET json non-allocating corefxlab</PackageTags>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?linkid=833199</PackageIconUrl>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\**\*.cs" Exclude="experiments\**\*.cs;bin\**;obj\**;**\*.xproj;packages\**" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\System.Text.Formatting\System.Text.Formatting.csproj" />
+    <ProjectReference Include="..\System.Buffers.ReaderWriter\System.Buffers.ReaderWriter.csproj" />
   </ItemGroup>
 </Project>

--- a/src/System.Text.JsonLab/System/Text/Json/JsonThrowHelper.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonThrowHelper.cs
@@ -19,6 +19,17 @@ namespace System.Text.JsonLab
             return new ArgumentException(message);
         }
 
+        public static void ThrowArgumentExceptionInvalidUtf8String()
+        {
+            throw GetArgumentExceptionInvalidUtf8String();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArgumentException GetArgumentExceptionInvalidUtf8String()
+        {
+            return new ArgumentException("Invalid or incomplete UTF-8 string");
+        }
+
         public static void ThrowFormatException()
         {
             throw GetFormatException();

--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
@@ -9,10 +9,10 @@ using System.Runtime.InteropServices;
 
 namespace System.Text.JsonLab
 {
-    public struct JsonWriter
+    public struct JsonWriter<T> where T : IBufferWriter<byte>
     {
         private readonly bool _prettyPrint;
-        private readonly IBufferWriter<byte> _bufferWriter;
+        private readonly T _bufferWriter;
         private readonly bool _isUtf8;
 
         private int _indent;
@@ -23,7 +23,7 @@ namespace System.Text.JsonLab
         /// </summary>
         /// <param name="bufferWriter">An instance of <see cref="ITextBufferWriter" /> used for writing bytes to an output channel.</param>
         /// <param name="prettyPrint">Specifies whether to add whitespace to the output text for user readability.</param>
-        public JsonWriter(IBufferWriter<byte> bufferWriter, bool isUtf8, bool prettyPrint = false)
+        public JsonWriter(T bufferWriter, bool isUtf8, bool prettyPrint = false)
         {
             _bufferWriter = bufferWriter;
             _prettyPrint = prettyPrint;

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -5,6 +5,8 @@
     <OutputType>Exe</OutputType>
     <Copyright>Microsoft Corporation, All rights reserved</Copyright>
     <NoWarn>$(NoWarn);CS0618</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="BenchmarkDotNet.Artifacts\**" />

--- a/tests/Benchmarks/System.IO.Pipelines/E2E.cs
+++ b/tests/Benchmarks/System.IO.Pipelines/E2E.cs
@@ -29,7 +29,8 @@ namespace System.IO.Pipelines.Benchmarks
         [Arguments(10000, 256)]
         public void TechEmpowerHelloWorldNoIO(int numberOfRequests, int concurrentConnections)
         {
-            RawInMemoryHttpServer.Run(numberOfRequests, concurrentConnections, s_genericRequest, (request, response) => {
+            RawInMemoryHttpServer.Run(numberOfRequests, concurrentConnections, s_genericRequest, (request, response) =>
+            {
                 var formatter = new BufferWriterFormatter<PipeWriter>(response, SymbolTable.InvariantUtf8);
                 formatter.Append("HTTP/1.1 200 OK");
                 formatter.Append("\r\nContent-Length: 13");
@@ -47,7 +48,8 @@ namespace System.IO.Pipelines.Benchmarks
         [Arguments(10000, 256)]
         public void TechEmpowerJsonNoIO(int numberOfRequests, int concurrentConnections)
         {
-            RawInMemoryHttpServer.Run(numberOfRequests, concurrentConnections, s_genericRequest, (request, response) => {
+            RawInMemoryHttpServer.Run(numberOfRequests, concurrentConnections, s_genericRequest, (request, response) =>
+            {
                 var formatter = new BufferWriterFormatter<PipeWriter>(response, SymbolTable.InvariantUtf8);
                 formatter.Append("HTTP/1.1 200 OK");
                 formatter.Append("\r\nContent-Length: 25");
@@ -61,6 +63,7 @@ namespace System.IO.Pipelines.Benchmarks
                 writer.WriteObjectStart();
                 writer.WriteAttribute("message", "Hello, World!");
                 writer.WriteObjectEnd();
+                writer.Flush();
             });
         }
     }

--- a/tests/Benchmarks/System.IO.Pipelines/E2E.cs
+++ b/tests/Benchmarks/System.IO.Pipelines/E2E.cs
@@ -57,7 +57,7 @@ namespace System.IO.Pipelines.Benchmarks
                 formatter.Append("\r\n\r\n");
 
                 // write body
-                var writer = new JsonWriter(formatter, true);
+                var writer = new JsonWriter<BufferWriterFormatter<PipeWriter>>(formatter, true);
                 writer.WriteObjectStart();
                 writer.WriteAttribute("message", "Hello, World!");
                 writer.WriteObjectEnd();

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -3,6 +3,7 @@
 
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Jobs;
+using BenchmarkDotNet.Diagnostics.Windows.Configs;
 using System.Buffers.Text;
 using System.IO;
 using System.Text.Formatting;
@@ -10,6 +11,8 @@ using System.Text.Formatting;
 namespace System.Text.JsonLab.Benchmarks
 {
     [SimpleJob(-1, 5, 10, 32768)]
+    [DisassemblyDiagnoser(printAsm: true, printSource: true)]
+    [InliningDiagnoser(filterByNamespace: false)]
     [MemoryDiagnoser]
     public class JsonWriterPerf
     {
@@ -144,6 +147,7 @@ namespace System.Text.JsonLab.Benchmarks
             json.WriteArrayEnd();
 
             json.WriteObjectEnd();
+            json.Flush();
         }
 
         private static void WriterSystemTextJsonBasicUtf16(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
@@ -172,6 +176,7 @@ namespace System.Text.JsonLab.Benchmarks
             json.WriteArrayEnd();
 
             json.WriteObjectEnd();
+            json.Flush();
         }
 
         private static void WriterNewtonsoftBasic(bool formatted, TextWriter writer, ReadOnlySpan<int> data)
@@ -221,6 +226,7 @@ namespace System.Text.JsonLab.Benchmarks
             json.WriteObjectStart();
             json.WriteAttribute("message", "Hello, World!");
             json.WriteObjectEnd();
+            json.Flush();
         }
 
         private static void WriterSystemTextJsonHelloWorldUtf16(bool formatted, ArrayFormatterWrapper output)
@@ -230,6 +236,7 @@ namespace System.Text.JsonLab.Benchmarks
             json.WriteObjectStart();
             json.WriteAttribute("message", "Hello, World!");
             json.WriteObjectEnd();
+            json.Flush();
         }
 
         private static void WriterNewtonsoftHelloWorld(bool formatted, TextWriter writer)
@@ -255,6 +262,7 @@ namespace System.Text.JsonLab.Benchmarks
                 json.WriteValue(data[i]);
             }
             json.WriteArrayEnd();
+            json.Flush();
         }
 
         private static void WriterSystemTextJsonArrayOnlyUtf16(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
@@ -267,6 +275,7 @@ namespace System.Text.JsonLab.Benchmarks
                 json.WriteValue(data[i]);
             }
             json.WriteArrayEnd();
+            json.Flush();
         }
     }
 }

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -16,7 +16,7 @@ namespace System.Text.JsonLab.Benchmarks
         private const int ExtraArraySize = 1000;
         private const int BufferSize = 1024 + (ExtraArraySize * 64);
 
-        private ArrayFormatterWrapper _ArrayFormatterWrapper;
+        private ArrayFormatterWrapper _arrayFormatterWrapper;
         private MemoryStream _memoryStream;
         private StreamWriter _streamWriter;
         private StringBuilder _stringBuilder;
@@ -45,23 +45,23 @@ namespace System.Text.JsonLab.Benchmarks
                 var buffer = new byte[BufferSize];
                 _memoryStream = new MemoryStream(buffer);
                 _streamWriter = new StreamWriter(_memoryStream, new UTF8Encoding(false), BufferSize, true);
-                _ArrayFormatterWrapper = new ArrayFormatterWrapper(BufferSize, SymbolTable.InvariantUtf8);
+                _arrayFormatterWrapper = new ArrayFormatterWrapper(BufferSize, SymbolTable.InvariantUtf8);
             }
             else
             {
                 _stringBuilder = new StringBuilder();
-                _ArrayFormatterWrapper = new ArrayFormatterWrapper(BufferSize, SymbolTable.InvariantUtf16);
+                _arrayFormatterWrapper = new ArrayFormatterWrapper(BufferSize, SymbolTable.InvariantUtf16);
             }
         }
 
         [Benchmark]
         public void WriterSystemTextJsonBasic()
         {
-            _ArrayFormatterWrapper.Clear();
+            _arrayFormatterWrapper.Clear();
             if (IsUTF8Encoded)
-                WriterSystemTextJsonBasicUtf8(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, 10));
+                WriterSystemTextJsonBasicUtf8(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
             else
-                WriterSystemTextJsonBasicUtf16(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, 10));
+                WriterSystemTextJsonBasicUtf16(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
         }
 
         //[Benchmark]
@@ -73,11 +73,11 @@ namespace System.Text.JsonLab.Benchmarks
         [Benchmark]
         public void WriterSystemTextJsonHelloWorld()
         {
-            _ArrayFormatterWrapper.Clear();
+            _arrayFormatterWrapper.Clear();
             if (IsUTF8Encoded)
-                WriterSystemTextJsonHelloWorldUtf8(Formatted, _ArrayFormatterWrapper);
+                WriterSystemTextJsonHelloWorldUtf8(Formatted, _arrayFormatterWrapper);
             else
-                WriterSystemTextJsonHelloWorldUtf16(Formatted, _ArrayFormatterWrapper);
+                WriterSystemTextJsonHelloWorldUtf16(Formatted, _arrayFormatterWrapper);
         }
 
         //[Benchmark]
@@ -95,11 +95,11 @@ namespace System.Text.JsonLab.Benchmarks
         [Arguments(1000)]
         public void WriterSystemTextJsonArrayOnly(int size)
         {
-            _ArrayFormatterWrapper.Clear();
+            _arrayFormatterWrapper.Clear();
             if (IsUTF8Encoded)
-                WriterSystemTextJsonArrayOnlyUtf8(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, size));
+                WriterSystemTextJsonArrayOnlyUtf8(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, size));
             else
-                WriterSystemTextJsonArrayOnlyUtf16(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, size));
+                WriterSystemTextJsonArrayOnlyUtf16(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, size));
         }
 
         private TextWriter GetWriter()

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -9,7 +9,7 @@ using System.Text.Formatting;
 
 namespace System.Text.JsonLab.Benchmarks
 {
-    //[SimpleJob(-1, 5, 10, 32768)]
+    [SimpleJob(-1, 5, 10, 32768)]
     [MemoryDiagnoser]
     public class JsonWriterPerf
     {
@@ -23,10 +23,10 @@ namespace System.Text.JsonLab.Benchmarks
 
         private int[] _data;
 
-        [Params(true)]
+        [Params(true, false)]
         public bool IsUTF8Encoded;
 
-        [Params(false)]
+        [Params(true, false)]
         public bool Formatted;
 
         [GlobalSetup]
@@ -64,7 +64,7 @@ namespace System.Text.JsonLab.Benchmarks
                 WriterSystemTextJsonBasicUtf16(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void WriterNewtonsoftBasic()
         {
             WriterNewtonsoftBasic(Formatted, GetWriter(), _data.AsSpan(0, 10));
@@ -80,7 +80,7 @@ namespace System.Text.JsonLab.Benchmarks
                 WriterSystemTextJsonHelloWorldUtf16(Formatted, _arrayFormatterWrapper);
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void WriterNewtonsoftHelloWorld()
         {
             WriterNewtonsoftHelloWorld(Formatted, GetWriter());
@@ -88,10 +88,10 @@ namespace System.Text.JsonLab.Benchmarks
 
         [Benchmark]
         [Arguments(1)]
-        //[Arguments(2)]
-        //[Arguments(5)]
+        [Arguments(2)]
+        [Arguments(5)]
         [Arguments(10)]
-        //[Arguments(100)]
+        [Arguments(100)]
         [Arguments(1000)]
         public void WriterSystemTextJsonArrayOnly(int size)
         {

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -9,24 +9,24 @@ using System.Text.Formatting;
 
 namespace System.Text.JsonLab.Benchmarks
 {
-    [SimpleJob(-1, 5, 10, 32768)]
+    //[SimpleJob(-1, 5, 10, 32768)]
     [MemoryDiagnoser]
     public class JsonWriterPerf
     {
         private const int ExtraArraySize = 1000;
         private const int BufferSize = 1024 + (ExtraArraySize * 64);
 
-        private ArrayFormatter _arrayFormatter;
+        private ArrayFormatterWrapper _ArrayFormatterWrapper;
         private MemoryStream _memoryStream;
         private StreamWriter _streamWriter;
         private StringBuilder _stringBuilder;
 
         private int[] _data;
 
-        [Params(true, false)]
+        [Params(true)]
         public bool IsUTF8Encoded;
 
-        [Params(true, false)]
+        [Params(false)]
         public bool Formatted;
 
         [GlobalSetup]
@@ -45,26 +45,26 @@ namespace System.Text.JsonLab.Benchmarks
                 var buffer = new byte[BufferSize];
                 _memoryStream = new MemoryStream(buffer);
                 _streamWriter = new StreamWriter(_memoryStream, new UTF8Encoding(false), BufferSize, true);
-                _arrayFormatter = new ArrayFormatter(BufferSize, SymbolTable.InvariantUtf8);
+                _ArrayFormatterWrapper = new ArrayFormatterWrapper(BufferSize, SymbolTable.InvariantUtf8);
             }
             else
             {
                 _stringBuilder = new StringBuilder();
-                _arrayFormatter = new ArrayFormatter(BufferSize, SymbolTable.InvariantUtf16);
+                _ArrayFormatterWrapper = new ArrayFormatterWrapper(BufferSize, SymbolTable.InvariantUtf16);
             }
         }
 
         [Benchmark]
         public void WriterSystemTextJsonBasic()
         {
-            _arrayFormatter.Clear();
+            _ArrayFormatterWrapper.Clear();
             if (IsUTF8Encoded)
-                WriterSystemTextJsonBasicUtf8(Formatted, _arrayFormatter, _data.AsSpan(0, 10));
+                WriterSystemTextJsonBasicUtf8(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, 10));
             else
-                WriterSystemTextJsonBasicUtf16(Formatted, _arrayFormatter, _data.AsSpan(0, 10));
+                WriterSystemTextJsonBasicUtf16(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, 10));
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void WriterNewtonsoftBasic()
         {
             WriterNewtonsoftBasic(Formatted, GetWriter(), _data.AsSpan(0, 10));
@@ -73,14 +73,14 @@ namespace System.Text.JsonLab.Benchmarks
         [Benchmark]
         public void WriterSystemTextJsonHelloWorld()
         {
-            _arrayFormatter.Clear();
+            _ArrayFormatterWrapper.Clear();
             if (IsUTF8Encoded)
-                WriterSystemTextJsonHelloWorldUtf8(Formatted, _arrayFormatter);
+                WriterSystemTextJsonHelloWorldUtf8(Formatted, _ArrayFormatterWrapper);
             else
-                WriterSystemTextJsonHelloWorldUtf16(Formatted, _arrayFormatter);
+                WriterSystemTextJsonHelloWorldUtf16(Formatted, _ArrayFormatterWrapper);
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void WriterNewtonsoftHelloWorld()
         {
             WriterNewtonsoftHelloWorld(Formatted, GetWriter());
@@ -88,18 +88,18 @@ namespace System.Text.JsonLab.Benchmarks
 
         [Benchmark]
         [Arguments(1)]
-        [Arguments(2)]
-        [Arguments(5)]
+        //[Arguments(2)]
+        //[Arguments(5)]
         [Arguments(10)]
-        [Arguments(100)]
+        //[Arguments(100)]
         [Arguments(1000)]
         public void WriterSystemTextJsonArrayOnly(int size)
         {
-            _arrayFormatter.Clear();
+            _ArrayFormatterWrapper.Clear();
             if (IsUTF8Encoded)
-                WriterSystemTextJsonArrayOnlyUtf8(Formatted, _arrayFormatter, _data.AsSpan(0, size));
+                WriterSystemTextJsonArrayOnlyUtf8(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, size));
             else
-                WriterSystemTextJsonArrayOnlyUtf16(Formatted, _arrayFormatter, _data.AsSpan(0, size));
+                WriterSystemTextJsonArrayOnlyUtf16(Formatted, _ArrayFormatterWrapper, _data.AsSpan(0, size));
         }
 
         private TextWriter GetWriter()
@@ -118,9 +118,9 @@ namespace System.Text.JsonLab.Benchmarks
             return writer;
         }
 
-        private static void WriterSystemTextJsonBasicUtf8(bool formatted, ArrayFormatter output, ReadOnlySpan<int> data)
+        private static void WriterSystemTextJsonBasicUtf8(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
         {
-            var json = new JsonWriter(output, true, formatted);
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, true, formatted);
 
             json.WriteObjectStart();
             json.WriteAttribute("age", 42);
@@ -146,9 +146,9 @@ namespace System.Text.JsonLab.Benchmarks
             json.WriteObjectEnd();
         }
 
-        private static void WriterSystemTextJsonBasicUtf16(bool formatted, ArrayFormatter output, ReadOnlySpan<int> data)
+        private static void WriterSystemTextJsonBasicUtf16(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
         {
-            var json = new JsonWriter(output, false, formatted);
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, false, formatted);
 
             json.WriteObjectStart();
             json.WriteAttribute("age", 42);
@@ -214,18 +214,18 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        private static void WriterSystemTextJsonHelloWorldUtf8(bool formatted, ArrayFormatter output)
+        private static void WriterSystemTextJsonHelloWorldUtf8(bool formatted, ArrayFormatterWrapper output)
         {
-            var json = new JsonWriter(output, true, formatted);
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, true, formatted);
 
             json.WriteObjectStart();
             json.WriteAttribute("message", "Hello, World!");
             json.WriteObjectEnd();
         }
 
-        private static void WriterSystemTextJsonHelloWorldUtf16(bool formatted, ArrayFormatter output)
+        private static void WriterSystemTextJsonHelloWorldUtf16(bool formatted, ArrayFormatterWrapper output)
         {
-            var json = new JsonWriter(output, false, formatted);
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, false, formatted);
 
             json.WriteObjectStart();
             json.WriteAttribute("message", "Hello, World!");
@@ -245,9 +245,9 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        private static void WriterSystemTextJsonArrayOnlyUtf8(bool formatted, ArrayFormatter output, ReadOnlySpan<int> data)
+        private static void WriterSystemTextJsonArrayOnlyUtf8(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
         {
-            var json = new JsonWriter(output, true, formatted);
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, true, formatted);
 
             json.WriteArrayStart("ExtraArray");
             for (var i = 0; i < data.Length; i++)
@@ -257,9 +257,9 @@ namespace System.Text.JsonLab.Benchmarks
             json.WriteArrayEnd();
         }
 
-        private static void WriterSystemTextJsonArrayOnlyUtf16(bool formatted, ArrayFormatter output, ReadOnlySpan<int> data)
+        private static void WriterSystemTextJsonArrayOnlyUtf16(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
         {
-            var json = new JsonWriter(output, false, formatted);
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, false, formatted);
 
             json.WriteArrayStart("ExtraArray");
             for (var i = 0; i < data.Length; i++)

--- a/tests/System.Buffers.ReaderWriter.Tests/BasicUnitTests.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/BasicUnitTests.cs
@@ -76,9 +76,9 @@ namespace System.Buffers.Tests
         {
             _sink.Reset();
             var writer = BufferWriter.Create(_sink);
-            writer.NewLine = new byte[] { (byte)'X', (byte)'Y' };
-            writer.WriteLine("hello world");
-            writer.WriteLine("!");
+            var newLine = new byte[] { (byte)'X', (byte)'Y' };
+            writer.WriteLine("hello world", newLine);
+            writer.WriteLine("!", newLine);
 
             writer.Flush();
             var result = _sink.ToString();
@@ -90,9 +90,9 @@ namespace System.Buffers.Tests
         {
             _sink.Reset();
             var writer = BufferWriter.Create(_sink);
-            writer.NewLine = new byte[] { (byte)'X', (byte)'Y' };
-            writer.WriteLine((Utf8String)"hello world");
-            writer.WriteLine((Utf8String)"!");
+            var newLine = new byte[] { (byte)'X', (byte)'Y' };
+            writer.WriteLine((Utf8String)"hello world", newLine);
+            writer.WriteLine((Utf8String)"!", newLine);
 
             writer.Flush();
             var result = _sink.ToString();

--- a/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
@@ -53,7 +53,8 @@ namespace System.Text.JsonLab.Tests
             Assert.Equal(expected, str.Replace("\r\n", "").Replace("\n", "").Replace(" ", ""));
         }
 
-        static string expected = "{\"age\":30,\"first\":\"John\",\"last\":\"Smith\",\"phoneNumbers\":[\"425-000-1212\",\"425-000-1213\",null],\"address\":{\"street\":\"1MicrosoftWay\",\"city\":\"Redmond\",\"zip\":98052},\"values\":[425121,-425122,425123]}";
+        static readonly string expected = "{\"age\":30,\"first\":\"John\",\"last\":\"Smith\",\"phoneNumbers\":[\"425-000-1212\",\"425-000-1213\",null],\"address\":{\"street\":\"1MicrosoftWay\",\"city\":\"Redmond\",\"zip\":98052},\"values\":[425121,-425122,425123]}";
+
         static void Write(ref JsonWriter<ArrayFormatterWrapper> json)
         {
             json.WriteObjectStart();
@@ -76,6 +77,7 @@ namespace System.Text.JsonLab.Tests
             json.WriteValue(425123);
             json.WriteArrayEnd();
             json.WriteObjectEnd();
+            json.Flush();
         }
 
         [Theory]
@@ -91,6 +93,7 @@ namespace System.Text.JsonLab.Tests
             jsonUtf16.WriteObjectStart();
             jsonUtf16.WriteAttribute("message", "Hello, World!");
             jsonUtf16.WriteObjectEnd();
+            jsonUtf16.Flush();
 
             ArraySegment<byte> formatted = output.Formatted;
             string actualStr = Encoding.Unicode.GetString(formatted.Array, formatted.Offset, formatted.Count);
@@ -111,6 +114,7 @@ namespace System.Text.JsonLab.Tests
             jsonUtf8.WriteObjectStart();
             jsonUtf8.WriteAttribute("message", "Hello, World!");
             jsonUtf8.WriteObjectEnd();
+            jsonUtf8.Flush();
 
             ArraySegment<byte> formatted = output.Formatted;
             string actualStr = Encoding.UTF8.GetString(formatted.Array, formatted.Offset, formatted.Count);
@@ -153,6 +157,7 @@ namespace System.Text.JsonLab.Tests
             jsonUtf16.WriteArrayEnd();
 
             jsonUtf16.WriteObjectEnd();
+            jsonUtf16.Flush();
 
             ArraySegment<byte> formatted = output.Formatted;
             string actualStr = Encoding.Unicode.GetString(formatted.Array, formatted.Offset, formatted.Count);
@@ -195,6 +200,7 @@ namespace System.Text.JsonLab.Tests
             jsonUtf8.WriteArrayEnd();
 
             jsonUtf8.WriteObjectEnd();
+            jsonUtf8.Flush();
 
             ArraySegment<byte> formatted = output.Formatted;
             string actualStr = Encoding.UTF8.GetString(formatted.Array, formatted.Offset, formatted.Count);

--- a/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
@@ -16,8 +16,8 @@ namespace System.Text.JsonLab.Tests
         [Fact]
         public void WriteJsonUtf8()
         {
-            var formatter = new ArrayFormatter(1024, SymbolTable.InvariantUtf8);
-            var json = new JsonWriter(formatter, true, prettyPrint: false);
+            var formatter = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
+            var json = new JsonWriter<ArrayFormatterWrapper>(formatter, true, prettyPrint: false);
             Write(ref json);
 
             var formatted = formatter.Formatted;
@@ -25,7 +25,7 @@ namespace System.Text.JsonLab.Tests
             Assert.Equal(expected, str.Replace(" ", ""));
 
             formatter.Clear();
-            json = new JsonWriter(formatter, true, prettyPrint: true);
+            json = new JsonWriter<ArrayFormatterWrapper>(formatter, true, prettyPrint: true);
             Write(ref json);
 
             formatted = formatter.Formatted;
@@ -36,8 +36,8 @@ namespace System.Text.JsonLab.Tests
         [Fact]
         public void WriteJsonUtf16()
         {
-            var formatter = new ArrayFormatter(1024, SymbolTable.InvariantUtf16);
-            var json = new JsonWriter(formatter, false, prettyPrint: false);
+            var formatter = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf16);
+            var json = new JsonWriter<ArrayFormatterWrapper>(formatter, false, prettyPrint: false);
             Write(ref json);
 
             var formatted = formatter.Formatted;
@@ -45,7 +45,7 @@ namespace System.Text.JsonLab.Tests
             Assert.Equal(expected, str.Replace(" ", ""));
 
             formatter.Clear();
-            json = new JsonWriter(formatter, false, prettyPrint: true);
+            json = new JsonWriter<ArrayFormatterWrapper>(formatter, false, prettyPrint: true);
             Write(ref json);
 
             formatted = formatter.Formatted;
@@ -54,7 +54,7 @@ namespace System.Text.JsonLab.Tests
         }
 
         static string expected = "{\"age\":30,\"first\":\"John\",\"last\":\"Smith\",\"phoneNumbers\":[\"425-000-1212\",\"425-000-1213\",null],\"address\":{\"street\":\"1MicrosoftWay\",\"city\":\"Redmond\",\"zip\":98052},\"values\":[425121,-425122,425123]}";
-        static void Write(ref JsonWriter json)
+        static void Write(ref JsonWriter<ArrayFormatterWrapper> json)
         {
             json.WriteObjectStart();
             json.WriteAttribute("age", 30);
@@ -85,8 +85,8 @@ namespace System.Text.JsonLab.Tests
         {
             string expectedStr = GetHelloWorldExpectedString(prettyPrint, isUtf8: false);
 
-            var output = new ArrayFormatter(1024, SymbolTable.InvariantUtf16);
-            var jsonUtf16 = new JsonWriter(output, false, prettyPrint);
+            var output = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf16);
+            var jsonUtf16 = new JsonWriter<ArrayFormatterWrapper>(output, false, prettyPrint);
 
             jsonUtf16.WriteObjectStart();
             jsonUtf16.WriteAttribute("message", "Hello, World!");
@@ -105,8 +105,8 @@ namespace System.Text.JsonLab.Tests
         {
             string expectedStr = GetHelloWorldExpectedString(prettyPrint, isUtf8: true);
 
-            var output = new ArrayFormatter(1024, SymbolTable.InvariantUtf8);
-            var jsonUtf8 = new JsonWriter(output, true, prettyPrint);
+            var output = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
+            var jsonUtf8 = new JsonWriter<ArrayFormatterWrapper>(output, true, prettyPrint);
 
             jsonUtf8.WriteObjectStart();
             jsonUtf8.WriteAttribute("message", "Hello, World!");
@@ -127,8 +127,8 @@ namespace System.Text.JsonLab.Tests
 
             string expectedStr = GetExpectedString(prettyPrint, isUtf8: false, data);
 
-            var output = new ArrayFormatter(1024, SymbolTable.InvariantUtf16);
-            var jsonUtf16 = new JsonWriter(output, false, prettyPrint);
+            var output = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf16);
+            var jsonUtf16 = new JsonWriter<ArrayFormatterWrapper>(output, false, prettyPrint);
 
             jsonUtf16.WriteObjectStart();
             jsonUtf16.WriteAttribute("age", 42);
@@ -169,8 +169,8 @@ namespace System.Text.JsonLab.Tests
 
             string expectedStr = GetExpectedString(prettyPrint, isUtf8: true, data);
 
-            var output = new ArrayFormatter(1024, SymbolTable.InvariantUtf8);
-            var jsonUtf8 = new JsonWriter(output, true, prettyPrint);
+            var output = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
+            var jsonUtf8 = new JsonWriter<ArrayFormatterWrapper>(output, true, prettyPrint);
 
             jsonUtf8.WriteObjectStart();
             jsonUtf8.WriteAttribute("age", 42);


### PR DESCRIPTION
Borrows most of the changes from https://github.com/dotnet/corefxlab/pull/2366, and supersedes https://github.com/dotnet/corefxlab/pull/2358

- Utilizing BufferWriter to cache the span being written to and add the Flush method.
- Keeping a single type for now, as it will only support UTF-8 (will remove UTF-16 support later).
- Reducing the JsonWriter struct size by utilizing the highest bit of _indent for _firstItem bool.
- Fix typo in BufferWriter.Write(byte)

**TODO:** Add helper factory convenience methods.

**Let me know if I missed anything. Any suggestions to reduce the overhead further are welcome :)**

- ~10% regression for hello world (overhead of creating BufferWriter and no benefit from caching the span)
- ~7% improvement for writing larger json payload, say 10-50 elements (overhead amortized, benefit of caching span kicks in)
- ~20% improvement for writing large json payload, say 1000 array elements

cc @benaadams, @JeremyKuhne 

``` ini

BenchmarkDotNet=v0.10.14.534-nightly, OS=Windows 10.0.14393.2312 (1607/AnniversaryUpdate/Redstone1)
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
Frequency=3328126 Hz, Resolution=300.4694 ns, Timer=TSC
.NET Core SDK=2.2.100-preview1-009015
  [Host]     : .NET Core 2.2.0-preview1-26609-02 (CoreCLR 4.6.26606.04, CoreFX 4.6.26606.04), 64bit RyuJIT
  DefaultJob : .NET Core 2.2.0-preview1-26609-02 (CoreCLR 4.6.26606.04, CoreFX 4.6.26606.04), 64bit RyuJIT


```

**BEFORE (master):**

|                         Method | IsUTF8Encoded | Formatted | size |         Mean |       Error |      StdDev | Allocated |
|------------------------------- |-------------- |---------- |----- |-------------:|------------:|------------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |    **1** |     **83.15 ns** |   **0.9320 ns** |   **0.8262 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |   **10** |    **231.66 ns** |   **4.6436 ns** |   **6.0380 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** | **1000** | **19,022.72 ns** | **369.7130 ns** | **467.5686 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |          **True** |     **False** |    **?** |    **975.70 ns** |  **19.5078 ns** |  **43.2279 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |          True |     False |    ? |    104.12 ns |   1.8728 ns |   2.0039 ns |       0 B |

**AFTER (this PR):**

|                         Method | IsUTF8Encoded | Formatted | size |         Mean |      Error |     StdDev | Allocated |
|------------------------------- |-------------- |---------- |----- |-------------:|-----------:|-----------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |    **1** |     **91.47 ns** |   **2.301 ns** |   **3.445 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** |   **10** |    **214.79 ns** |   **4.653 ns** |   **6.673 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |          **True** |     **False** | **1000** | **15,995.46 ns** | **269.920 ns** | **239.277 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |          **True** |     **False** |    **?** |    **908.57 ns** |  **17.670 ns** |  **21.035 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |          True |     False |    ? |    113.91 ns |   2.311 ns |   5.799 ns |       0 B |
