### PR TITLE
Optimize JsonWriter APIs be separating prettyPrint code paths

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonConstants.cs
@@ -37,9 +37,6 @@ namespace System.Text.JsonLab
         public static readonly byte[] FalseValue = { (byte)'f', (byte)'a', (byte)'l', (byte)'s', (byte)'e' };
         public static readonly byte[] NullValue = { (byte)'n', (byte)'u', (byte)'l', (byte)'l' };
 
-        public static readonly byte[] NullValueUtf16LE = { (byte)'n', 0, (byte)'u', 0, (byte)'l', 0, (byte)'l', 0 };
-        public static readonly byte[] NullValueUtf16BE = { 0, (byte)'n', 0, (byte)'u', 0, (byte)'l', 0, (byte)'l' };
-
         #endregion Common values
     }
 }

--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
@@ -53,12 +53,16 @@ namespace System.Text.JsonLab
                 int bytesNeeded = 1;
 
                 if (_indent < 0)
+                {
                     bytesNeeded = 2;
+                }
 
                 Span<byte> byteBuffer = EnsureBuffer(bytesNeeded);
 
                 if (_indent < 0)
+                {
                     byteBuffer[0] = JsonConstants.ListSeperator;
+                }
 
                 byteBuffer[bytesNeeded - 1] = JsonConstants.OpenBrace;
                 _bufferWriter.Advance(bytesNeeded);
@@ -76,13 +80,17 @@ namespace System.Text.JsonLab
             int bytesNeeded = 1 + indent * 2;
 
             if (_indent < 0)
+            {
                 bytesNeeded++;
+            }
 
             Span<byte> byteBuffer = EnsureBuffer(bytesNeeded);
 
             int idx = 0;
             if (_indent < 0)
+            {
                 byteBuffer[idx++] = JsonConstants.ListSeperator;
+            }
 
             while (indent-- > 0)
             {
@@ -99,7 +107,9 @@ namespace System.Text.JsonLab
             Span<byte> byteBuffer = EnsureBuffer(bytesNeeded);
 
             if (_indent < 0)
+            {
                 byteBuffer[0] = JsonConstants.ListSeperator;
+            }
 
             byteBuffer[bytesNeeded - 1] = token;
             _bufferWriter.Advance(bytesNeeded);
@@ -128,11 +138,15 @@ namespace System.Text.JsonLab
             int idx = 0;
 
             if (_indent < 0)
+            {
                 byteBuffer[idx++] = JsonConstants.ListSeperator;
+            }
 
             // \r\n versus \n, depending on OS
             if (JsonWriterHelper.NewLineUtf8.Length == 2)
+            {
                 byteBuffer[idx++] = JsonConstants.CarriageReturn;
+            }
 
             byteBuffer[idx++] = JsonConstants.LineFeed;
 
@@ -170,7 +184,9 @@ namespace System.Text.JsonLab
             int idx = 0;
 
             if (_indent < 0)
+            {
                 byteBuffer[idx++] = JsonConstants.ListSeperator;
+            }
 
             byteBuffer[idx++] = JsonConstants.Quote;
 
@@ -226,7 +242,9 @@ namespace System.Text.JsonLab
 
             // \r\n versus \n, depending on OS
             if (JsonWriterHelper.NewLineUtf8.Length == 2)
+            {
                 byteBuffer[idx++] = JsonConstants.CarriageReturn;
+            }
 
             byteBuffer[idx++] = JsonConstants.LineFeed;
 
@@ -265,7 +283,9 @@ namespace System.Text.JsonLab
 
             int bytesNeeded = 4;
             if (_indent < 0)
+            {
                 bytesNeeded++;
+            }
 
             if (Encodings.Utf16.ToUtf8Length(nameSpan, out int bytesNeededValue) != OperationStatus.Done)
             {
@@ -322,7 +342,9 @@ namespace System.Text.JsonLab
             //quote {name} quote colon quote {value} quote, hence 5
             int bytesNeeded = 5;
             if (_indent < 0)
+            {
                 bytesNeeded++;
+            }
 
             if (Encodings.Utf16.ToUtf8Length(nameSpan, out int bytesNeededName) != OperationStatus.Done)
             {
@@ -352,7 +374,9 @@ namespace System.Text.JsonLab
             int idx = 0;
 
             if (_indent < 0)
+            {
                 byteBuffer[idx++] = JsonConstants.ListSeperator;
+            }
 
             idx += AddNewLineAndIndentation(byteBuffer.Slice(idx));
 
@@ -395,7 +419,9 @@ namespace System.Text.JsonLab
             int idx = 0;
 
             if (_indent < 0)
+            {
                 byteBuffer[idx++] = JsonConstants.ListSeperator;
+            }
 
             byteBuffer[idx++] = JsonConstants.Quote;
 
@@ -464,9 +490,13 @@ namespace System.Text.JsonLab
             int bytesNeeded = CalculateStartAttributeBytesNeeded(nameSpan, sizeof(byte));
             WriteAttributeUtf8(nameSpan, bytesNeeded);
             if (value)
+            {
                 WriteJsonValueUtf8(JsonConstants.TrueValue);
+            }
             else
+            {
                 WriteJsonValueUtf8(JsonConstants.FalseValue);
+            }
         }
 
         /// <summary>
@@ -526,10 +556,14 @@ namespace System.Text.JsonLab
             int idx = 0;
 
             if (_indent < 0)
+            {
                 byteBuffer[idx++] = JsonConstants.ListSeperator;
+            }
 
             if (_prettyPrint)
+            {
                 idx += AddNewLineAndIndentation(byteBuffer.Slice(idx));
+            }
 
             byteBuffer[idx++] = JsonConstants.Quote;
 
@@ -547,7 +581,9 @@ namespace System.Text.JsonLab
             byteBuffer[idx++] = JsonConstants.KeyValueSeperator;
 
             if (_prettyPrint)
+            {
                 byteBuffer[idx++] = JsonConstants.Space;
+            }
 
             _bufferWriter.Advance(idx);
             _indent |= 1 << 31;
@@ -570,10 +606,14 @@ namespace System.Text.JsonLab
             int idx = 0;
 
             if (_indent < 0)
+            {
                 byteBuffer[idx++] = JsonConstants.ListSeperator;
+            }
 
             if (_prettyPrint)
+            {
                 idx += AddNewLineAndIndentation(byteBuffer.Slice(idx));
+            }
 
             byteBuffer[idx++] = JsonConstants.Quote;
 
@@ -602,7 +642,9 @@ namespace System.Text.JsonLab
         {
             int bytesNeeded = 0;
             if (_indent < 0)
+            {
                 bytesNeeded = 1;
+            }
 
             if (_prettyPrint)
             {
@@ -632,14 +674,18 @@ namespace System.Text.JsonLab
 
             int idx = 0;
             if (_indent < 0)
+            {
                 byteBuffer[idx++] = JsonConstants.ListSeperator;
+            }
 
             _indent |= 1 << 31;
 
             idx += AddNewLineAndIndentation(byteBuffer.Slice(idx));
 
             if (insertNegationSign)
+            {
                 byteBuffer[idx++] = (byte)'-';
+            }
 
             JsonWriterHelper.WriteDigitsUInt64D((ulong)value, byteBuffer.Slice(idx, digitCount));
 
@@ -662,12 +708,16 @@ namespace System.Text.JsonLab
 
             int idx = 0;
             if (_indent < 0)
+            {
                 byteBuffer[idx++] = JsonConstants.ListSeperator;
+            }
 
             _indent |= 1 << 31;
 
             if (insertNegationSign)
+            {
                 byteBuffer[idx++] = (byte)'-';
+            }
 
             JsonWriterHelper.WriteDigitsUInt64D((ulong)value, byteBuffer.Slice(idx, digitCount));
 
@@ -700,9 +750,13 @@ namespace System.Text.JsonLab
             WriteSpacingUtf8();
 
             if (value)
+            {
                 WriteJsonValueUtf8(JsonConstants.TrueValue);
+            }
             else
+            {
                 WriteJsonValueUtf8(JsonConstants.FalseValue);
+            }
         }
 
         /// <summary>
@@ -790,7 +844,9 @@ namespace System.Text.JsonLab
             Span<byte> buffer = _bufferWriter.Buffer;
             int written;
             while (!CustomFormatter.TryFormat(value, buffer, out written, JsonConstants.NumberFormat, SymbolTable.InvariantUtf8))
+            {
                 buffer = EnsureBuffer();
+            }
 
             _bufferWriter.Advance(written);
         }
@@ -801,7 +857,9 @@ namespace System.Text.JsonLab
             Span<byte> buffer = _bufferWriter.Buffer;
             int written;
             while (!CustomFormatter.TryFormat(value, buffer, out written, JsonConstants.NumberFormat, SymbolTable.InvariantUtf8))
+            {
                 buffer = EnsureBuffer();
+            }
 
             _bufferWriter.Advance(written);
         }
@@ -812,7 +870,9 @@ namespace System.Text.JsonLab
             Span<byte> buffer = _bufferWriter.Buffer;
             int written;
             while (!CustomFormatter.TryFormat(value, buffer, out written, JsonConstants.DateTimeFormat, SymbolTable.InvariantUtf8))
+            {
                 buffer = EnsureBuffer();
+            }
 
             _bufferWriter.Advance(written);
         }
@@ -823,7 +883,9 @@ namespace System.Text.JsonLab
             Span<byte> buffer = _bufferWriter.Buffer;
             int written;
             while (!CustomFormatter.TryFormat(value, buffer, out written, JsonConstants.DateTimeFormat, SymbolTable.InvariantUtf8))
+            {
                 buffer = EnsureBuffer();
+            }
 
             _bufferWriter.Advance(written);
         }
@@ -834,7 +896,9 @@ namespace System.Text.JsonLab
             Span<byte> buffer = _bufferWriter.Buffer;
             int written;
             while (!CustomFormatter.TryFormat(value, buffer, out written, JsonConstants.GuidFormat, SymbolTable.InvariantUtf8))
+            {
                 buffer = EnsureBuffer();
+            }
 
             _bufferWriter.Advance(written);
         }
@@ -845,7 +909,9 @@ namespace System.Text.JsonLab
             Span<byte> buffer = _bufferWriter.Buffer;
             int written;
             while (!SymbolTable.InvariantUtf8.TryEncode(values, buffer, out int consumed, out written))
+            {
                 buffer = EnsureBuffer();
+            }
 
             _bufferWriter.Advance(written);
         }
@@ -861,7 +927,10 @@ namespace System.Text.JsonLab
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteItemSeperatorUtf8()
         {
-            if (_indent >= 0) return;
+            if (_indent >= 0)
+            {
+                return;
+            }
 
             WriteControlUtf8(JsonConstants.ListSeperator);
         }
@@ -870,7 +939,10 @@ namespace System.Text.JsonLab
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteSpacingUtf8(bool newline = true)
         {
-            if (!_prettyPrint) return;
+            if (!_prettyPrint)
+            {
+                return;
+            }
 
             int indent = _indent & RemoveFlagsBitMask;
             int bytesNeeded = newline ? 2 : 0;
@@ -901,7 +973,9 @@ namespace System.Text.JsonLab
             _bufferWriter.Ensure(needed);
             Span<byte> buffer = _bufferWriter.Buffer;
             if (buffer.Length < needed)
+            {
                 JsonThrowHelper.ThrowOutOfMemoryException();
+            }
 
             return buffer;
         }
@@ -912,7 +986,9 @@ namespace System.Text.JsonLab
             int bytesNeeded = numBytes;
 
             if (_indent < 0)
+            {
                 bytesNeeded *= 2;
+            }
 
             return bytesNeeded;
         }
@@ -921,7 +997,9 @@ namespace System.Text.JsonLab
         {
             int bytesNeeded = 0;
             if (_indent < 0)
+            {
                 bytesNeeded = numBytes;
+            }
 
             if (_prettyPrint)
             {
@@ -944,7 +1022,9 @@ namespace System.Text.JsonLab
         {
             int bytesNeeded = 0;
             if (_indent < 0)
+            {
                 bytesNeeded = numBytes;
+            }
 
             bytesNeeded += numBytes * extraCharacterCount;
 
@@ -960,7 +1040,9 @@ namespace System.Text.JsonLab
         {
             int bytesNeeded = 0;
             if (_indent < 0)
+            {
                 bytesNeeded = numBytes;
+            }
 
             if (_prettyPrint)
             {
@@ -985,7 +1067,9 @@ namespace System.Text.JsonLab
             int offset = 0;
             // \r\n versus \n, depending on OS
             if (JsonWriterHelper.NewLineUtf8.Length == 2)
+            {
                 buffer[offset++] = JsonConstants.CarriageReturn;
+            }
 
             buffer[offset++] = JsonConstants.LineFeed;
 

--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
@@ -41,34 +41,67 @@ namespace System.Text.JsonLab
         /// array of other items. If this is used while inside a nested object, the property
         /// name will be missing and result in invalid JSON.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteObjectStart()
         {
-            WriteStartUtf8(CalculateStartBytesNeeded(sizeof(byte)), JsonConstants.OpenBrace);
+            if (_prettyPrint)
+            {
+                WriteStartUtf8Pretty(JsonConstants.OpenBrace);
+            }
+            else
+            {
+                int bytesNeeded = 1;
+
+                if (_indent < 0)
+                    bytesNeeded = 2;
+
+                Span<byte> byteBuffer = EnsureBuffer(bytesNeeded);
+
+                if (_indent < 0)
+                    byteBuffer[0] = JsonConstants.ListSeperator;
+
+                byteBuffer[bytesNeeded - 1] = JsonConstants.OpenBrace;
+                _bufferWriter.Advance(bytesNeeded);
+            }
 
             _indent &= RemoveFlagsBitMask;
             _indent++;
         }
 
-        private void WriteStartUtf8(int bytesNeeded, byte token)
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void WriteStartUtf8Pretty(byte token)
         {
+            int indent = _indent & RemoveFlagsBitMask;
+
+            int bytesNeeded = 1 + indent * 2;
+
+            if (_indent < 0)
+                bytesNeeded++;
+
             Span<byte> byteBuffer = EnsureBuffer(bytesNeeded);
 
             int idx = 0;
             if (_indent < 0)
                 byteBuffer[idx++] = JsonConstants.ListSeperator;
 
-            if (_prettyPrint)
+            while (indent-- > 0)
             {
-                int indent = _indent & RemoveFlagsBitMask;
-
-                while (indent-- > 0)
-                {
-                    byteBuffer[idx++] = JsonConstants.Space;
-                    byteBuffer[idx++] = JsonConstants.Space;
-                }
+                byteBuffer[idx++] = JsonConstants.Space;
+                byteBuffer[idx++] = JsonConstants.Space;
             }
 
             byteBuffer[idx] = token;
+            _bufferWriter.Advance(bytesNeeded);
+        }
+
+        private void WriteStartUtf8(int bytesNeeded, byte token)
+        {
+            Span<byte> byteBuffer = EnsureBuffer(bytesNeeded);
+
+            if (_indent < 0)
+                byteBuffer[0] = JsonConstants.ListSeperator;
+
+            byteBuffer[bytesNeeded - 1] = token;
             _bufferWriter.Advance(bytesNeeded);
         }
 
@@ -88,16 +121,26 @@ namespace System.Text.JsonLab
             _indent++;
         }
 
-        private void WriteStartUtf8(ReadOnlySpan<byte> nameSpanByte, int bytesNeeded, byte token)
+        private void WriteStartUtf8Pretty(ReadOnlySpan<byte> nameSpanByte, int bytesNeeded, byte token)
         {
+            int indent = _indent & RemoveFlagsBitMask;
             Span<byte> byteBuffer = EnsureBuffer(bytesNeeded);
             int idx = 0;
 
             if (_indent < 0)
                 byteBuffer[idx++] = JsonConstants.ListSeperator;
 
-            if (_prettyPrint)
-                idx += AddNewLineAndIndentation(byteBuffer.Slice(idx));
+            // \r\n versus \n, depending on OS
+            if (JsonWriterHelper.NewLineUtf8.Length == 2)
+                byteBuffer[idx++] = JsonConstants.CarriageReturn;
+
+            byteBuffer[idx++] = JsonConstants.LineFeed;
+
+            while (indent-- > 0)
+            {
+                byteBuffer[idx++] = JsonConstants.Space;
+                byteBuffer[idx++] = JsonConstants.Space;
+            }
 
             byteBuffer[idx++] = JsonConstants.Quote;
 
@@ -114,32 +157,84 @@ namespace System.Text.JsonLab
 
             byteBuffer[idx++] = JsonConstants.KeyValueSeperator;
 
-            if (_prettyPrint)
-                byteBuffer[idx++] = JsonConstants.Space;
+            byteBuffer[idx++] = JsonConstants.Space;
 
             byteBuffer[idx++] = token;
 
             _bufferWriter.Advance(idx);
-            _indent |= 1 << 31;
+        }
+
+        private void WriteStartUtf8(ReadOnlySpan<byte> nameSpanByte, int bytesNeeded, byte token)
+        {
+            Span<byte> byteBuffer = EnsureBuffer(bytesNeeded);
+            int idx = 0;
+
+            if (_indent < 0)
+                byteBuffer[idx++] = JsonConstants.ListSeperator;
+
+            byteBuffer[idx++] = JsonConstants.Quote;
+
+            OperationStatus status = Encodings.Utf16.ToUtf8(nameSpanByte, byteBuffer.Slice(idx), out int consumed, out int written);
+            Debug.Assert(consumed == nameSpanByte.Length);
+            if (status != OperationStatus.Done)
+            {
+                JsonThrowHelper.ThrowFormatException();
+            }
+
+            idx += written;
+
+            byteBuffer[idx++] = JsonConstants.Quote;
+
+            byteBuffer[idx++] = JsonConstants.KeyValueSeperator;
+
+            byteBuffer[idx++] = token;
+
+            _bufferWriter.Advance(idx);
         }
 
         /// <summary>
         /// Writes the end tag for an object.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteObjectEnd()
         {
             _indent |= 1 << 31;
             _indent--;
-            WriteEndUtf8(CalculateEndBytesNeeded(sizeof(byte), JsonWriterHelper.NewLineUtf8.Length), JsonConstants.CloseBrace);
+
+            if (_prettyPrint)
+            {
+                WriteEndUtf8Pretty(JsonConstants.CloseBrace);
+            }
+            else
+            {
+                Span<byte> byteBuffer = EnsureBuffer(1);
+                byteBuffer[0] = JsonConstants.CloseBrace;
+                _bufferWriter.Advance(1);
+            }
         }
 
-        private void WriteEndUtf8(int bytesNeeded, byte token)
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void WriteEndUtf8Pretty(byte token)
         {
+            int indent = _indent & RemoveFlagsBitMask;
+
+            // For the new line, \r\n or \n + indentation + }
+            int bytesNeeded = 1 + JsonWriterHelper.NewLineUtf8.Length + indent * 2;
+
             Span<byte> byteBuffer = EnsureBuffer(bytesNeeded);
             int idx = 0;
 
-            if (_prettyPrint)
-                idx += AddNewLineAndIndentation(byteBuffer.Slice(idx));
+            // \r\n versus \n, depending on OS
+            if (JsonWriterHelper.NewLineUtf8.Length == 2)
+                byteBuffer[idx++] = JsonConstants.CarriageReturn;
+
+            byteBuffer[idx++] = JsonConstants.LineFeed;
+
+            while (indent-- > 0)
+            {
+                byteBuffer[idx++] = JsonConstants.Space;
+                byteBuffer[idx++] = JsonConstants.Space;
+            }
 
             byteBuffer[idx] = token;
             _bufferWriter.Advance(bytesNeeded);
@@ -167,8 +262,27 @@ namespace System.Text.JsonLab
         public void WriteArrayStart(string name)
         {
             ReadOnlySpan<byte> nameSpan = MemoryMarshal.AsBytes(name.AsSpan());
-            int bytesNeeded = CalculateBytesNeeded(nameSpan, sizeof(byte), 4);
-            WriteStartUtf8(nameSpan, bytesNeeded, JsonConstants.OpenBracket);
+
+            int bytesNeeded = 4;
+            if (_indent < 0)
+                bytesNeeded++;
+
+            if (Encodings.Utf16.ToUtf8Length(nameSpan, out int bytesNeededValue) != OperationStatus.Done)
+            {
+                JsonThrowHelper.ThrowArgumentExceptionInvalidUtf8String();
+            }
+            bytesNeeded += bytesNeededValue;
+
+            if (_prettyPrint)
+            {
+                // For the new line, \r\n or \n, and the space after the colon
+                bytesNeeded += JsonWriterHelper.NewLineUtf8.Length + 1 + (_indent & RemoveFlagsBitMask) * 2;
+                WriteStartUtf8Pretty(nameSpan, bytesNeeded, JsonConstants.OpenBracket);
+            }
+            else
+            {
+                WriteStartUtf8(nameSpan, bytesNeeded, JsonConstants.OpenBracket);
+            }
 
             _indent &= RemoveFlagsBitMask;
             _indent++;
@@ -177,12 +291,22 @@ namespace System.Text.JsonLab
         /// <summary>
         /// Writes the end tag for an array.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteArrayEnd()
         {
             _indent |= 1 << 31;
             _indent--;
 
-            WriteEndUtf8(CalculateEndBytesNeeded(sizeof(byte), JsonWriterHelper.NewLineUtf8.Length), JsonConstants.CloseBracket);
+            if (_prettyPrint)
+            {
+                WriteEndUtf8Pretty(JsonConstants.CloseBracket);
+            }
+            else
+            {
+                Span<byte> byteBuffer = EnsureBuffer(1);
+                byteBuffer[0] = JsonConstants.CloseBracket;
+                _bufferWriter.Advance(1);
+            }
         }
 
         /// <summary>
@@ -194,11 +318,35 @@ namespace System.Text.JsonLab
         {
             ReadOnlySpan<byte> nameSpan = MemoryMarshal.AsBytes(name.AsSpan());
             ReadOnlySpan<byte> valueSpan = MemoryMarshal.AsBytes(value.AsSpan());
-            int bytesNeeded = CalculateAttributeBytesNeeded(nameSpan, valueSpan, sizeof(byte));
-            WriteAttributeUtf8(nameSpan, valueSpan, bytesNeeded);
+
+            //quote {name} quote colon quote {value} quote, hence 5
+            int bytesNeeded = 5;
+            if (_indent < 0)
+                bytesNeeded++;
+
+            if (Encodings.Utf16.ToUtf8Length(nameSpan, out int bytesNeededName) != OperationStatus.Done)
+            {
+                JsonThrowHelper.ThrowArgumentExceptionInvalidUtf8String();
+            }
+            if (Encodings.Utf16.ToUtf8Length(valueSpan, out int bytesNeededValue) != OperationStatus.Done)
+            {
+                JsonThrowHelper.ThrowArgumentExceptionInvalidUtf8String();
+            }
+            bytesNeeded += bytesNeededName;
+            bytesNeeded += bytesNeededValue;
+
+            if (_prettyPrint)
+            {
+                bytesNeeded += JsonWriterHelper.NewLineUtf8.Length + 1 + (_indent & RemoveFlagsBitMask) * 2;
+                WriteAttributeUtf8Pretty(nameSpan, valueSpan, bytesNeeded);
+            }
+            else
+            {
+                WriteAttributeUtf8(nameSpan, valueSpan, bytesNeeded);
+            }
         }
 
-        private void WriteAttributeUtf8(ReadOnlySpan<byte> nameSpanByte, ReadOnlySpan<byte> valueSpanByte, int bytesNeeded)
+        private void WriteAttributeUtf8Pretty(ReadOnlySpan<byte> nameSpanByte, ReadOnlySpan<byte> valueSpanByte, int bytesNeeded)
         {
             Span<byte> byteBuffer = EnsureBuffer(bytesNeeded);
             int idx = 0;
@@ -206,8 +354,7 @@ namespace System.Text.JsonLab
             if (_indent < 0)
                 byteBuffer[idx++] = JsonConstants.ListSeperator;
 
-            if (_prettyPrint)
-                idx += AddNewLineAndIndentation(byteBuffer.Slice(idx));
+            idx += AddNewLineAndIndentation(byteBuffer.Slice(idx));
 
             byteBuffer[idx++] = JsonConstants.Quote;
 
@@ -224,8 +371,45 @@ namespace System.Text.JsonLab
 
             byteBuffer[idx++] = JsonConstants.KeyValueSeperator;
 
-            if (_prettyPrint)
-                byteBuffer[idx++] = JsonConstants.Space;
+            byteBuffer[idx++] = JsonConstants.Space;
+
+            byteBuffer[idx++] = JsonConstants.Quote;
+
+            status = Encodings.Utf16.ToUtf8(valueSpanByte, byteBuffer.Slice(idx), out consumed, out written);
+            Debug.Assert(consumed == valueSpanByte.Length);
+            if (status != OperationStatus.Done)
+            {
+                JsonThrowHelper.ThrowFormatException();
+            }
+            idx += written;
+
+            byteBuffer[idx++] = JsonConstants.Quote;
+
+            _bufferWriter.Advance(idx);
+            _indent |= 1 << 31;
+        }
+
+        private void WriteAttributeUtf8(ReadOnlySpan<byte> nameSpanByte, ReadOnlySpan<byte> valueSpanByte, int bytesNeeded)
+        {
+            Span<byte> byteBuffer = EnsureBuffer(bytesNeeded);
+            int idx = 0;
+
+            if (_indent < 0)
+                byteBuffer[idx++] = JsonConstants.ListSeperator;
+
+            byteBuffer[idx++] = JsonConstants.Quote;
+
+            OperationStatus status = Encodings.Utf16.ToUtf8(nameSpanByte, byteBuffer.Slice(idx), out int consumed, out int written);
+            Debug.Assert(consumed == nameSpanByte.Length);
+            if (status != OperationStatus.Done)
+            {
+                JsonThrowHelper.ThrowFormatException();
+            }
+            idx += written;
+
+            byteBuffer[idx++] = JsonConstants.Quote;
+
+            byteBuffer[idx++] = JsonConstants.KeyValueSeperator;
 
             byteBuffer[idx++] = JsonConstants.Quote;
 
@@ -413,9 +597,53 @@ namespace System.Text.JsonLab
         /// Write a signed integer value into the current array.
         /// </summary>
         /// <param name="value">The signed integer value to be written to JSON data.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteValue(long value)
         {
-            WriteValueUtf8(value, CalculateValueBytesNeeded(sizeof(byte), JsonWriterHelper.NewLineUtf8.Length));
+            int bytesNeeded = 0;
+            if (_indent < 0)
+                bytesNeeded = 1;
+
+            if (_prettyPrint)
+            {
+                bytesNeeded += JsonWriterHelper.NewLineUtf8.Length + (_indent & RemoveFlagsBitMask) * 2;
+                WriteValueUtf8Pretty(value, bytesNeeded);
+            }
+            else
+            {
+                WriteValueUtf8(value, bytesNeeded);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void WriteValueUtf8Pretty(long value, int bytesNeeded)
+        {
+            bool insertNegationSign = false;
+            if (value < 0)
+            {
+                insertNegationSign = true;
+                value = -value;
+                bytesNeeded += 1;
+            }
+
+            int digitCount = JsonWriterHelper.CountDigits((ulong)value);
+            bytesNeeded += digitCount;
+            Span<byte> byteBuffer = EnsureBuffer(bytesNeeded);
+
+            int idx = 0;
+            if (_indent < 0)
+                byteBuffer[idx++] = JsonConstants.ListSeperator;
+
+            _indent |= 1 << 31;
+
+            idx += AddNewLineAndIndentation(byteBuffer.Slice(idx));
+
+            if (insertNegationSign)
+                byteBuffer[idx++] = (byte)'-';
+
+            JsonWriterHelper.WriteDigitsUInt64D((ulong)value, byteBuffer.Slice(idx, digitCount));
+
+            _bufferWriter.Advance(bytesNeeded);
         }
 
         private void WriteValueUtf8(long value, int bytesNeeded)
@@ -425,11 +653,11 @@ namespace System.Text.JsonLab
             {
                 insertNegationSign = true;
                 value = -value;
-                bytesNeeded += sizeof(byte);
+                bytesNeeded += 1;
             }
 
             int digitCount = JsonWriterHelper.CountDigits((ulong)value);
-            bytesNeeded += sizeof(byte) * digitCount;
+            bytesNeeded += digitCount;
             Span<byte> byteBuffer = EnsureBuffer(bytesNeeded);
 
             int idx = 0;
@@ -437,8 +665,6 @@ namespace System.Text.JsonLab
                 byteBuffer[idx++] = JsonConstants.ListSeperator;
 
             _indent |= 1 << 31;
-            if (_prettyPrint)
-                idx += AddNewLineAndIndentation(byteBuffer.Slice(idx));
 
             if (insertNegationSign)
                 byteBuffer[idx++] = (byte)'-';
@@ -640,7 +866,6 @@ namespace System.Text.JsonLab
             WriteControlUtf8(JsonConstants.ListSeperator);
         }
 
-
         // TODO: Once public methods are optimized, remove this.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteSpacingUtf8(bool newline = true)
@@ -670,7 +895,6 @@ namespace System.Text.JsonLab
             _bufferWriter.Advance(bytesNeeded);
         }
 
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private Span<byte> EnsureBuffer(int needed = 256)
         {
@@ -689,42 +913,6 @@ namespace System.Text.JsonLab
 
             if (_indent < 0)
                 bytesNeeded *= 2;
-
-            if (_prettyPrint)
-            {
-                int bytesNeededForPrettyPrint = _indent * 2;
-                bytesNeeded += numBytes * bytesNeededForPrettyPrint;
-            }
-            return bytesNeeded;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int CalculateEndBytesNeeded(int numBytes, int newLineLength)
-        {
-            int bytesNeeded = numBytes;
-
-            if (_prettyPrint)
-            {
-                int bytesNeededForPrettyPrint = newLineLength;  // For the new line, \r\n or \n
-                bytesNeededForPrettyPrint += _indent * 2;
-                bytesNeeded += numBytes * bytesNeededForPrettyPrint;
-            }
-            return bytesNeeded;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private int CalculateValueBytesNeeded(int numBytes, int newLineLength)
-        {
-            int bytesNeeded = 0;
-            if (_indent < 0)
-                bytesNeeded = numBytes;
-
-            if (_prettyPrint)
-            {
-                int bytesNeededForPrettyPrint = newLineLength;  // For the new line, \r\n or \n
-                bytesNeededForPrettyPrint += _indent * 2;
-                bytesNeeded += numBytes * bytesNeededForPrettyPrint;
-            }
 
             return bytesNeeded;
         }
@@ -758,13 +946,6 @@ namespace System.Text.JsonLab
             if (_indent < 0)
                 bytesNeeded = numBytes;
 
-            if (_prettyPrint)
-            {
-                int bytesNeededForPrettyPrint = JsonWriterHelper.NewLineUtf8.Length + 1;    // For the new line, \r\n or \n, and the space after the colon
-                bytesNeededForPrettyPrint += _indent * 2;
-                bytesNeeded += numBytes * bytesNeededForPrettyPrint;
-            }
-
             bytesNeeded += numBytes * extraCharacterCount;
 
             if (Encodings.Utf16.ToUtf8Length(span, out int bytesNeededValue) != OperationStatus.Done)
@@ -795,35 +976,6 @@ namespace System.Text.JsonLab
                 JsonThrowHelper.ThrowArgumentExceptionInvalidUtf8String();
             }
             bytesNeeded += bytesNeededValue;
-            return bytesNeeded;
-        }
-
-        private int CalculateAttributeBytesNeeded(ReadOnlySpan<byte> nameSpan, ReadOnlySpan<byte> valueSpan, int numBytes)
-        {
-            int bytesNeeded = 0;
-            if (_indent < 0)
-                bytesNeeded = numBytes;
-
-            if (_prettyPrint)
-            {
-                int bytesNeededForPrettyPrint = JsonWriterHelper.NewLineUtf8.Length + 1;    // For the new line, \r\n or \n,  and the space after the colon
-                bytesNeededForPrettyPrint += _indent * 2;
-                bytesNeeded += numBytes * bytesNeededForPrettyPrint;
-            }
-
-            bytesNeeded += numBytes * 5;    //quote {name} quote colon quote {value} quote, hence 5
-
-            if (Encodings.Utf16.ToUtf8Length(nameSpan, out int bytesNeededName) != OperationStatus.Done)
-            {
-                JsonThrowHelper.ThrowArgumentExceptionInvalidUtf8String();
-            }
-            if (Encodings.Utf16.ToUtf8Length(valueSpan, out int bytesNeededValue) != OperationStatus.Done)
-            {
-                JsonThrowHelper.ThrowArgumentExceptionInvalidUtf8String();
-            }
-            bytesNeeded += bytesNeededName;
-            bytesNeeded += bytesNeededValue;
-
             return bytesNeeded;
         }
 

--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriterHelper.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriterHelper.cs
@@ -9,7 +9,6 @@ namespace System.Text.JsonLab
     internal static class JsonWriterHelper
     {
         public static readonly byte[] NewLineUtf8 = Encoding.UTF8.GetBytes(Environment.NewLine);
-        public static readonly char[] NewLineUtf16 = Environment.NewLine.ToCharArray();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void WriteDigitsUInt64D(ulong value, Span<byte> buffer)

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -10,9 +10,9 @@ using System.Text.Formatting;
 
 namespace System.Text.JsonLab.Benchmarks
 {
-    [SimpleJob(-1, 5, 10, 32768)]
-    [DisassemblyDiagnoser(printAsm: true, printSource: true)]
-    [InliningDiagnoser(filterByNamespace: false)]
+    //[SimpleJob(-1, 5, 10, 32768)]
+    //[DisassemblyDiagnoser(printAsm: true, printSource: true)]
+    //[InliningDiagnoser(filterByNamespace: false)]
     [MemoryDiagnoser]
     public class JsonWriterPerf
     {
@@ -52,7 +52,7 @@ namespace System.Text.JsonLab.Benchmarks
             WriterSystemTextJsonBasicUtf8(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void WriterNewtonsoftBasic()
         {
             WriterNewtonsoftBasic(Formatted, GetWriter(), _data.AsSpan(0, 10));
@@ -65,7 +65,7 @@ namespace System.Text.JsonLab.Benchmarks
             WriterSystemTextJsonHelloWorldUtf8(Formatted, _arrayFormatterWrapper);
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void WriterNewtonsoftHelloWorld()
         {
             WriterNewtonsoftHelloWorld(Formatted, GetWriter());
@@ -73,10 +73,10 @@ namespace System.Text.JsonLab.Benchmarks
 
         [Benchmark]
         [Arguments(1)]
-        [Arguments(2)]
-        [Arguments(5)]
+        //[Arguments(2)]
+        //[Arguments(5)]
         [Arguments(10)]
-        [Arguments(100)]
+        //[Arguments(100)]
         [Arguments(1000)]
         public void WriterSystemTextJsonArrayOnly(int size)
         {


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.10.14.534-nightly, OS=Windows 10.0.14393.2312 (1607/AnniversaryUpdate/Redstone1)
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
Frequency=3328126 Hz, Resolution=300.4694 ns, Timer=TSC
.NET Core SDK=2.2.100-preview1-009015
  [Host]     : .NET Core 2.2.0-preview1-26609-02 (CoreCLR 4.6.26606.04, CoreFX 4.6.26606.04), 64bit RyuJIT
  DefaultJob : .NET Core 2.2.0-preview1-26609-02 (CoreCLR 4.6.26606.04, CoreFX 4.6.26606.04), 64bit RyuJIT


```

**Before (master):**

|                         Method | Formatted | size |         Mean |      Error |     StdDev |       Median | Allocated |
|------------------------------- |---------- |----- |-------------:|-----------:|-----------:|-------------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |     **False** |    **1** |     **79.62 ns** |   **1.593 ns** |   **2.336 ns** |     **79.02 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** |   **10** |    **170.43 ns** |   **1.966 ns** |   **1.642 ns** |    **169.84 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** | **1000** | **13,846.95 ns** | **276.462 ns** | **761.456 ns** | **13,584.43 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |     **False** |    **?** |    **825.65 ns** |  **13.743 ns** |  **12.855 ns** |    **823.55 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |     False |    ? |    105.45 ns |   2.087 ns |   2.856 ns |    105.69 ns |       0 B |
|  **WriterSystemTextJsonArrayOnly** |      **True** |    **1** |     **89.78 ns** |   **1.813 ns** |   **3.223 ns** |     **89.03 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** |   **10** |    **210.94 ns** |   **4.393 ns** |   **7.218 ns** |    **208.56 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** | **1000** | **16,035.17 ns** | **336.538 ns** | **679.823 ns** | **15,869.11 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |      **True** |    **?** |    **934.21 ns** |  **16.576 ns** |  **17.022 ns** |    **930.61 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |      True |    ? |    116.00 ns |   1.707 ns |   1.513 ns |    116.06 ns |       0 B |

**After (this PR):**

|                         Method | Formatted | size |         Mean |       Error |      StdDev | Allocated |
|------------------------------- |---------- |----- |-------------:|------------:|------------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |     **False** |    **1** |     **76.77 ns** |   **1.1029 ns** |   **1.0317 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** |   **10** |    **166.06 ns** |   **1.5836 ns** |   **1.4038 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** | **1000** | **13,767.79 ns** | **275.3813 ns** | **530.5663 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |     **False** |    **?** |    **787.15 ns** |  **15.6772 ns** |  **27.0425 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |     False |    ? |     96.45 ns |   1.9487 ns |   2.0851 ns |       0 B |
|  **WriterSystemTextJsonArrayOnly** |      **True** |    **1** |     **91.84 ns** |   **1.8149 ns** |   **1.8638 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** |   **10** |    **214.31 ns** |   **2.6148 ns** |   **2.0414 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** | **1000** | **16,959.28 ns** |  **93.3465 ns** |  **72.8788 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |      **True** |    **?** |    **907.49 ns** |  **17.3642 ns** |  **17.0539 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |      True |    ? |    108.39 ns |   0.3011 ns |   0.2816 ns |       0 B |


cc @benaadams, @GrabYourPitchforks 