### PR TITLE
 Add UTf8Json library to JsonWriter performance benchmarks

### DIFF
--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -45,7 +45,9 @@ namespace System.Text.JsonLab.Benchmarks
             _streamWriter = new StreamWriter(_memoryStream, new UTF8Encoding(false), BufferSize, true);
             _arrayFormatterWrapper = new ArrayFormatterWrapper(BufferSize, SymbolTable.InvariantUtf8);
 
-            _output = new byte[BufferSize];
+            // To pass an initialBuffer to Utf8Json:
+            // _output = new byte[BufferSize];
+            _output = null;
         }
 
         [Benchmark]


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.10.14.534-nightly, OS=Windows 10.0.14393.2312 (1607/AnniversaryUpdate/Redstone1)
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
Frequency=3328126 Hz, Resolution=300.4694 ns, Timer=TSC
.NET Core SDK=2.1.301
  [Host]     : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT


```
|                         Method | Formatted | size |         Mean |      Error |     StdDev |       Median |  Gen 0 | Allocated |
|------------------------------- |---------- |----- |-------------:|-----------:|-----------:|-------------:|-------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |     **False** |    **1** |     **75.61 ns** |   **1.542 ns** |   **2.857 ns** |     **75.25 ns** |      **-** |       **0 B** |
|        WriterUtf8JsonArrayOnly |     False |    1 |     92.04 ns |   1.709 ns |   1.515 ns |     91.94 ns | 0.0743 |     312 B |
|  **WriterSystemTextJsonArrayOnly** |     **False** |   **10** |    **173.15 ns** |   **3.279 ns** |   **7.920 ns** |    **173.25 ns** |      **-** |       **0 B** |
|        WriterUtf8JsonArrayOnly |     False |   10 |    204.80 ns |   1.644 ns |   1.538 ns |    204.40 ns | 0.0739 |     312 B |
|  **WriterSystemTextJsonArrayOnly** |     **False** | **1000** | **13,167.82 ns** | **266.380 ns** | **601.263 ns** | **13,023.37 ns** |      **-** |       **0 B** |
|        WriterUtf8JsonArrayOnly |     False | 1000 | 18,814.25 ns | 370.423 ns | 468.467 ns | 18,833.06 ns | 3.8757 |   16304 B |
|      **WriterSystemTextJsonBasic** |     **False** |    **?** |    **768.34 ns** |  **15.074 ns** |  **27.940 ns** |    **767.44 ns** |      **-** |       **0 B** |
|          WriterNewtonsoftBasic |     False |    ? |  1,341.13 ns |  27.920 ns |  71.066 ns |  1,325.24 ns | 0.0973 |     416 B |
|            WriterUtf8JsonBasic |     False |    ? |    709.96 ns |  14.153 ns |  28.590 ns |    706.21 ns | 0.0734 |     312 B |
| WriterSystemTextJsonHelloWorld |     False |    ? |     97.01 ns |   1.936 ns |   3.235 ns |     96.74 ns |      - |       0 B |
|     WriterNewtonsoftHelloWorld |     False |    ? |    237.21 ns |   4.585 ns |   3.829 ns |    236.91 ns | 0.0608 |     256 B |
|       WriterUtf8JsonHelloWorld |     False |    ? |    109.13 ns |   4.005 ns |  11.296 ns |    104.81 ns | 0.0741 |     312 B |
