### PR TITLE
Optimize JsonWriter APIs by using the TryWrite approach

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
@@ -41,7 +41,6 @@ namespace System.Text.JsonLab
         /// array of other items. If this is used while inside a nested object, the property
         /// name will be missing and result in invalid JSON.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteObjectStart()
         {
             if (_prettyPrint)
@@ -122,7 +121,6 @@ namespace System.Text.JsonLab
         /// name will be written and result in invalid JSON.
         /// </summary>
         /// <param name="name">The name of the property (i.e. key) within the containing object.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteObjectStart(string name)
         {
             ReadOnlySpan<byte> nameSpan = MemoryMarshal.AsBytes(name.AsSpan());
@@ -325,7 +323,6 @@ namespace System.Text.JsonLab
         /// <summary>
         /// Writes the end tag for an object.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteObjectEnd()
         {
             _indent |= 1 << 31;
@@ -392,7 +389,6 @@ namespace System.Text.JsonLab
         /// name will be written and result in invalid JSON.
         /// </summary>
         /// <param name="name">The name of the property (i.e. key) within the containing object.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteArrayStart(string name)
         {
             ReadOnlySpan<byte> nameSpan = MemoryMarshal.AsBytes(name.AsSpan());
@@ -414,7 +410,6 @@ namespace System.Text.JsonLab
         /// <summary>
         /// Writes the end tag for an array.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteArrayEnd()
         {
             _indent |= 1 << 31;
@@ -438,7 +433,6 @@ namespace System.Text.JsonLab
         /// </summary>
         /// <param name="name">The name of the property (i.e. key) within the containing object.</param>
         /// <param name="value">The string value that will be quoted within the JSON data.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteAttribute(string name, string value)
         {
             ReadOnlySpan<byte> nameSpan = MemoryMarshal.AsBytes(name.AsSpan());
@@ -580,7 +574,6 @@ namespace System.Text.JsonLab
         /// </summary>
         /// <param name="name">The name of the property (i.e. key) within the containing object.</param>
         /// <param name="value">The signed integer value to be written to JSON data.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteAttribute(string name, long value)
         {
             ReadOnlySpan<byte> nameSpan = MemoryMarshal.AsBytes(name.AsSpan());
@@ -832,7 +825,6 @@ namespace System.Text.JsonLab
         /// Writes a quoted string value into the current array.
         /// </summary>
         /// <param name="value">The string value that will be quoted within the JSON data.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteValue(string value)
         {
             ReadOnlySpan<byte> valueSpan = MemoryMarshal.AsBytes(value.AsSpan());
@@ -947,7 +939,6 @@ namespace System.Text.JsonLab
         /// Write a signed integer value into the current array.
         /// </summary>
         /// <param name="value">The signed integer value to be written to JSON data.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteValue(long value)
         {
             if (_prettyPrint)

--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
@@ -140,7 +140,6 @@ namespace System.Text.JsonLab
 
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void WriteStartUtf8Pretty(ReadOnlySpan<byte> nameSpanByte, byte token)
         {
             // quote {name} quote colon open-brace, hence 4
@@ -631,7 +630,6 @@ namespace System.Text.JsonLab
             return true;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void WriteAttributeUtf8Pretty(ReadOnlySpan<byte> nameSpan, long value)
         {
             // quote {name} quote colon, hence 3

--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
@@ -72,7 +72,6 @@ namespace System.Text.JsonLab
             _indent++;
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void WriteStartUtf8Pretty(byte token)
         {
             int indent = _indent & RemoveFlagsBitMask;
@@ -340,7 +339,6 @@ namespace System.Text.JsonLab
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void WriteEndUtf8Pretty(byte token)
         {
             int indent = _indent & RemoveFlagsBitMask;
@@ -448,7 +446,6 @@ namespace System.Text.JsonLab
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void WriteAttributeUtf8Pretty(ReadOnlySpan<byte> nameSpan, ReadOnlySpan<byte> valueSpan)
         {
             //quote {name} quote colon quote {value} quote, hence 5
@@ -838,7 +835,6 @@ namespace System.Text.JsonLab
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void WriteValueUtf8Pretty(ReadOnlySpan<byte> valueSpanByte)
         {
             int bytesNeeded = CalculateValueBytesNeededPretty(valueSpanByte);
@@ -950,7 +946,6 @@ namespace System.Text.JsonLab
             }
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private void WriteValueUtf8Pretty(long value)
         {
             int bytesNeeded = 0;

--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriterHelper.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriterHelper.cs
@@ -103,5 +103,86 @@ namespace System.Text.JsonLab
 
             return digits;
         }
+
+        // Borrowed from https://github.com/dotnet/corefx/blob/master/src/System.Memory/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.Signed.Default.cs#L16
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryFormatInt64Default(long value, Span<byte> destination, out int bytesWritten)
+        {
+            if ((ulong)value < 10)
+            {
+                return TryFormatUInt32SingleDigit((uint)value, destination, out bytesWritten);
+            }
+
+            return TryFormatInt64MultipleDigits(value, destination, out bytesWritten);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryFormatUInt32SingleDigit(uint value, Span<byte> destination, out int bytesWritten)
+        {
+            if (destination.Length == 0)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+            destination[0] = (byte)('0' + value);
+            bytesWritten = 1;
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryFormatInt64MultipleDigits(long value, Span<byte> destination, out int bytesWritten)
+        {
+            if (value < 0)
+            {
+                value = -value;
+                int digitCount = CountDigits((ulong)value);
+                // WriteDigits does not do bounds checks
+                if (digitCount >= destination.Length)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+                destination[0] = (byte)'-';
+                bytesWritten = digitCount + 1;
+                WriteDigits((ulong)value, destination.Slice(1, digitCount));
+                return true;
+            }
+            else
+            {
+                return TryFormatUInt64MultipleDigits((ulong)value, destination, out bytesWritten);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryFormatUInt64MultipleDigits(ulong value, Span<byte> destination, out int bytesWritten)
+        {
+            int digitCount = CountDigits(value);
+            // WriteDigits does not do bounds checks
+            if (digitCount > destination.Length)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+            bytesWritten = digitCount;
+            WriteDigits(value, destination.Slice(0, digitCount));
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteDigits(ulong value, Span<byte> buffer)
+        {
+            // We can mutate the 'value' parameter since it's a copy-by-value local.
+            // It'll be used to represent the value left over after each division by 10.
+
+            for (int i = buffer.Length - 1; i >= 1; i--)
+            {
+                ulong temp = '0' + value;
+                value /= 10;
+                buffer[i] = (byte)(temp - (value * 10));
+            }
+
+            Debug.Assert(value < 10);
+            buffer[0] = (byte)('0' + value);
+        }
     }
 }

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -10,9 +10,9 @@ using System.Text.Formatting;
 
 namespace System.Text.JsonLab.Benchmarks
 {
-    [SimpleJob(-1, 5, 10, 32768)]
-    [DisassemblyDiagnoser(printAsm: true, printSource: true)]
-    [InliningDiagnoser()]
+    //[SimpleJob(-1, 5, 10, 32768)]
+    //[DisassemblyDiagnoser(printAsm: true, printSource: true)]
+    //[InliningDiagnoser()]
     [MemoryDiagnoser]
     public class JsonWriterPerf
     {
@@ -26,7 +26,7 @@ namespace System.Text.JsonLab.Benchmarks
         private int[] _data;
         private byte[] _output;
 
-        [Params(true, false)]
+        [Params(false)]
         public bool Formatted;
 
         [GlobalSetup]
@@ -51,49 +51,77 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark]
-        public void WriterSystemTextJsonBasic()
+        public void WriterSystemTextJsonBasic1()
         {
             _arrayFormatterWrapper.Clear();
-            WriterSystemTextJsonBasicUtf8(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
+            WriterSystemTextJsonBasicUtf8_1(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
         }
 
         [Benchmark]
+        public void WriterSystemTextJsonBasic2()
+        {
+            _arrayFormatterWrapper.Clear();
+            WriterSystemTextJsonBasicUtf8_2(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
+        }
+
+        [Benchmark]
+        public void WriterSystemTextJsonBasic3()
+        {
+            _arrayFormatterWrapper.Clear();
+            WriterSystemTextJsonBasicUtf8_3(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
+        }
+
+        [Benchmark]
+        public void WriterSystemTextJsonBasic4()
+        {
+            _arrayFormatterWrapper.Clear();
+            WriterSystemTextJsonBasicUtf8_4(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
+        }
+
+        [Benchmark]
+        public void WriterSystemTextJsonBasic5()
+        {
+            _arrayFormatterWrapper.Clear();
+            WriterSystemTextJsonBasicUtf8_5(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
+        }
+
+        //[Benchmark]
         public void WriterNewtonsoftBasic()
         {
             WriterNewtonsoftBasic(Formatted, GetWriter(), _data.AsSpan(0, 10));
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void WriterUtf8JsonBasic()
         {
             WriterUtf8JsonBasic(_data.AsSpan(0, 10));
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void WriterSystemTextJsonHelloWorld()
         {
             _arrayFormatterWrapper.Clear();
             WriterSystemTextJsonHelloWorldUtf8(Formatted, _arrayFormatterWrapper);
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void WriterNewtonsoftHelloWorld()
         {
             WriterNewtonsoftHelloWorld(Formatted, GetWriter());
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void WriterUtf8JsonHelloWorld()
         {
             WriterUtf8JsonHelloWorldHelper(_output);
         }
 
-        [Benchmark]
+        //[Benchmark]
         [Arguments(1)]
-        [Arguments(2)]
-        [Arguments(5)]
+        //[Arguments(2)]
+        //[Arguments(5)]
         [Arguments(10)]
-        [Arguments(100)]
+        //[Arguments(100)]
         [Arguments(1000)]
         public void WriterSystemTextJsonArrayOnly(int size)
         {
@@ -101,7 +129,7 @@ namespace System.Text.JsonLab.Benchmarks
             WriterSystemTextJsonArrayOnlyUtf8(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, size));
         }
 
-        [Benchmark]
+        //[Benchmark]
         [Arguments(1)]
         [Arguments(2)]
         [Arguments(5)]
@@ -120,6 +148,151 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         private static void WriterSystemTextJsonBasicUtf8(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
+        {
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
+
+            json.WriteObjectStart();
+            json.WriteAttribute("age", 42);
+            json.WriteAttribute("first", "John");
+            json.WriteAttribute("last", "Smith");
+            json.WriteArrayStart("phoneNumbers");
+            json.WriteValue("425-000-1212");
+            json.WriteValue("425-000-1213");
+            json.WriteArrayEnd();
+            json.WriteObjectStart("address");
+            json.WriteAttribute("street", "1 Microsoft Way");
+            json.WriteAttribute("city", "Redmond");
+            json.WriteAttribute("zip", 98052);
+            json.WriteObjectEnd();
+
+            json.WriteArrayStart("ExtraArray");
+            for (var i = 0; i < data.Length; i++)
+            {
+                json.WriteValue(data[i]);
+            }
+            json.WriteArrayEnd();
+
+            json.WriteObjectEnd();
+            json.Flush();
+        }
+
+        private static void WriterSystemTextJsonBasicUtf8_1(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
+        {
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
+
+            json.WriteObjectStart();
+            json.WriteAttribute("age", 42);
+            json.WriteAttribute("first", "John");
+            json.WriteAttribute("last", "Smith");
+            //json.WriteArrayStart("phoneNumbers");
+            //json.WriteValue("425-000-1212");
+            //json.WriteValue("425-000-1213");
+            //json.WriteArrayEnd();
+            //json.WriteObjectStart("address");
+            //json.WriteAttribute("street", "1 Microsoft Way");
+            //json.WriteAttribute("city", "Redmond");
+            //json.WriteAttribute("zip", 98052);
+            //json.WriteObjectEnd();
+
+            //json.WriteArrayStart("ExtraArray");
+            //for (var i = 0; i < data.Length; i++)
+            //{
+            //    json.WriteValue(data[i]);
+            //}
+            //json.WriteArrayEnd();
+
+            json.WriteObjectEnd();
+            json.Flush();
+        }
+
+        private static void WriterSystemTextJsonBasicUtf8_2(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
+        {
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
+
+            json.WriteObjectStart();
+            json.WriteAttribute("age", 42);
+            json.WriteAttribute("first", "John");
+            json.WriteAttribute("last", "Smith");
+            json.WriteArrayStart("phoneNumbers");
+            json.WriteValue("425-000-1212");
+            json.WriteValue("425-000-1213");
+            json.WriteArrayEnd();
+            //json.WriteObjectStart("address");
+            //json.WriteAttribute("street", "1 Microsoft Way");
+            //json.WriteAttribute("city", "Redmond");
+            //json.WriteAttribute("zip", 98052);
+            //json.WriteObjectEnd();
+
+            //json.WriteArrayStart("ExtraArray");
+            //for (var i = 0; i < data.Length; i++)
+            //{
+            //    json.WriteValue(data[i]);
+            //}
+            //json.WriteArrayEnd();
+
+            json.WriteObjectEnd();
+            json.Flush();
+        }
+
+        private static void WriterSystemTextJsonBasicUtf8_3(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
+        {
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
+
+            json.WriteObjectStart();
+            json.WriteAttribute("age", 42);
+            json.WriteAttribute("first", "John");
+            json.WriteAttribute("last", "Smith");
+            json.WriteArrayStart("phoneNumbers");
+            json.WriteValue("425-000-1212");
+            json.WriteValue("425-000-1213");
+            json.WriteArrayEnd();
+            json.WriteObjectStart("address");
+            json.WriteAttribute("street", "1 Microsoft Way");
+            json.WriteAttribute("city", "Redmond");
+            json.WriteAttribute("zip", 98052);
+            json.WriteObjectEnd();
+
+            //json.WriteArrayStart("ExtraArray");
+            //for (var i = 0; i < data.Length; i++)
+            //{
+            //    json.WriteValue(data[i]);
+            //}
+            //json.WriteArrayEnd();
+
+            json.WriteObjectEnd();
+            json.Flush();
+        }
+
+        private static void WriterSystemTextJsonBasicUtf8_4(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
+        {
+            var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
+
+            json.WriteObjectStart();
+            json.WriteAttribute("age", 42);
+            json.WriteAttribute("first", "John");
+            json.WriteAttribute("last", "Smith");
+            json.WriteArrayStart("phoneNumbers");
+            json.WriteValue("425-000-1212");
+            json.WriteValue("425-000-1213");
+            json.WriteArrayEnd();
+            json.WriteObjectStart("address");
+            json.WriteAttribute("street", "1 Microsoft Way");
+            json.WriteAttribute("city", "Redmond");
+            json.WriteAttribute("zip", 98052);
+            json.WriteObjectEnd();
+
+            json.WriteArrayStart("ExtraArray");
+            //for (var i = 0; i < data.Length; i++)
+            //{
+            //    json.WriteValue(data[i]);
+            //}
+            json.WriteArrayEnd();
+
+            json.WriteObjectEnd();
+            json.Flush();
+        }
+
+        private static void WriterSystemTextJsonBasicUtf8_5(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
         {
             var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
 

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -10,9 +10,9 @@ using System.Text.Formatting;
 
 namespace System.Text.JsonLab.Benchmarks
 {
-    //[SimpleJob(-1, 5, 10, 32768)]
-    //[DisassemblyDiagnoser(printAsm: true, printSource: true)]
-    //[InliningDiagnoser()]
+    [SimpleJob(-1, 5, 10, 32768)]
+    [DisassemblyDiagnoser(printAsm: true, printSource: true)]
+    [InliningDiagnoser()]
     [MemoryDiagnoser]
     public class JsonWriterPerf
     {
@@ -51,77 +51,49 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark]
-        public void WriterSystemTextJsonBasic1()
+        public void WriterSystemTextJsonBasic()
         {
             _arrayFormatterWrapper.Clear();
-            WriterSystemTextJsonBasicUtf8_1(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
+            WriterSystemTextJsonBasicUtf8(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
         }
 
         [Benchmark]
-        public void WriterSystemTextJsonBasic2()
-        {
-            _arrayFormatterWrapper.Clear();
-            WriterSystemTextJsonBasicUtf8_2(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
-        }
-
-        [Benchmark]
-        public void WriterSystemTextJsonBasic3()
-        {
-            _arrayFormatterWrapper.Clear();
-            WriterSystemTextJsonBasicUtf8_3(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
-        }
-
-        [Benchmark]
-        public void WriterSystemTextJsonBasic4()
-        {
-            _arrayFormatterWrapper.Clear();
-            WriterSystemTextJsonBasicUtf8_4(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
-        }
-
-        [Benchmark]
-        public void WriterSystemTextJsonBasic5()
-        {
-            _arrayFormatterWrapper.Clear();
-            WriterSystemTextJsonBasicUtf8_5(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
-        }
-
-        //[Benchmark]
         public void WriterNewtonsoftBasic()
         {
             WriterNewtonsoftBasic(Formatted, GetWriter(), _data.AsSpan(0, 10));
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void WriterUtf8JsonBasic()
         {
             WriterUtf8JsonBasic(_data.AsSpan(0, 10));
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void WriterSystemTextJsonHelloWorld()
         {
             _arrayFormatterWrapper.Clear();
             WriterSystemTextJsonHelloWorldUtf8(Formatted, _arrayFormatterWrapper);
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void WriterNewtonsoftHelloWorld()
         {
             WriterNewtonsoftHelloWorld(Formatted, GetWriter());
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void WriterUtf8JsonHelloWorld()
         {
             WriterUtf8JsonHelloWorldHelper(_output);
         }
 
-        //[Benchmark]
+        [Benchmark]
         [Arguments(1)]
-        //[Arguments(2)]
-        //[Arguments(5)]
+        [Arguments(2)]
+        [Arguments(5)]
         [Arguments(10)]
-        //[Arguments(100)]
+        [Arguments(100)]
         [Arguments(1000)]
         public void WriterSystemTextJsonArrayOnly(int size)
         {
@@ -129,7 +101,7 @@ namespace System.Text.JsonLab.Benchmarks
             WriterSystemTextJsonArrayOnlyUtf8(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, size));
         }
 
-        //[Benchmark]
+        [Benchmark]
         [Arguments(1)]
         [Arguments(2)]
         [Arguments(5)]
@@ -148,151 +120,6 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         private static void WriterSystemTextJsonBasicUtf8(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
-        {
-            var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
-
-            json.WriteObjectStart();
-            json.WriteAttribute("age", 42);
-            json.WriteAttribute("first", "John");
-            json.WriteAttribute("last", "Smith");
-            json.WriteArrayStart("phoneNumbers");
-            json.WriteValue("425-000-1212");
-            json.WriteValue("425-000-1213");
-            json.WriteArrayEnd();
-            json.WriteObjectStart("address");
-            json.WriteAttribute("street", "1 Microsoft Way");
-            json.WriteAttribute("city", "Redmond");
-            json.WriteAttribute("zip", 98052);
-            json.WriteObjectEnd();
-
-            json.WriteArrayStart("ExtraArray");
-            for (var i = 0; i < data.Length; i++)
-            {
-                json.WriteValue(data[i]);
-            }
-            json.WriteArrayEnd();
-
-            json.WriteObjectEnd();
-            json.Flush();
-        }
-
-        private static void WriterSystemTextJsonBasicUtf8_1(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
-        {
-            var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
-
-            json.WriteObjectStart();
-            json.WriteAttribute("age", 42);
-            json.WriteAttribute("first", "John");
-            json.WriteAttribute("last", "Smith");
-            //json.WriteArrayStart("phoneNumbers");
-            //json.WriteValue("425-000-1212");
-            //json.WriteValue("425-000-1213");
-            //json.WriteArrayEnd();
-            //json.WriteObjectStart("address");
-            //json.WriteAttribute("street", "1 Microsoft Way");
-            //json.WriteAttribute("city", "Redmond");
-            //json.WriteAttribute("zip", 98052);
-            //json.WriteObjectEnd();
-
-            //json.WriteArrayStart("ExtraArray");
-            //for (var i = 0; i < data.Length; i++)
-            //{
-            //    json.WriteValue(data[i]);
-            //}
-            //json.WriteArrayEnd();
-
-            json.WriteObjectEnd();
-            json.Flush();
-        }
-
-        private static void WriterSystemTextJsonBasicUtf8_2(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
-        {
-            var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
-
-            json.WriteObjectStart();
-            json.WriteAttribute("age", 42);
-            json.WriteAttribute("first", "John");
-            json.WriteAttribute("last", "Smith");
-            json.WriteArrayStart("phoneNumbers");
-            json.WriteValue("425-000-1212");
-            json.WriteValue("425-000-1213");
-            json.WriteArrayEnd();
-            //json.WriteObjectStart("address");
-            //json.WriteAttribute("street", "1 Microsoft Way");
-            //json.WriteAttribute("city", "Redmond");
-            //json.WriteAttribute("zip", 98052);
-            //json.WriteObjectEnd();
-
-            //json.WriteArrayStart("ExtraArray");
-            //for (var i = 0; i < data.Length; i++)
-            //{
-            //    json.WriteValue(data[i]);
-            //}
-            //json.WriteArrayEnd();
-
-            json.WriteObjectEnd();
-            json.Flush();
-        }
-
-        private static void WriterSystemTextJsonBasicUtf8_3(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
-        {
-            var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
-
-            json.WriteObjectStart();
-            json.WriteAttribute("age", 42);
-            json.WriteAttribute("first", "John");
-            json.WriteAttribute("last", "Smith");
-            json.WriteArrayStart("phoneNumbers");
-            json.WriteValue("425-000-1212");
-            json.WriteValue("425-000-1213");
-            json.WriteArrayEnd();
-            json.WriteObjectStart("address");
-            json.WriteAttribute("street", "1 Microsoft Way");
-            json.WriteAttribute("city", "Redmond");
-            json.WriteAttribute("zip", 98052);
-            json.WriteObjectEnd();
-
-            //json.WriteArrayStart("ExtraArray");
-            //for (var i = 0; i < data.Length; i++)
-            //{
-            //    json.WriteValue(data[i]);
-            //}
-            //json.WriteArrayEnd();
-
-            json.WriteObjectEnd();
-            json.Flush();
-        }
-
-        private static void WriterSystemTextJsonBasicUtf8_4(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
-        {
-            var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
-
-            json.WriteObjectStart();
-            json.WriteAttribute("age", 42);
-            json.WriteAttribute("first", "John");
-            json.WriteAttribute("last", "Smith");
-            json.WriteArrayStart("phoneNumbers");
-            json.WriteValue("425-000-1212");
-            json.WriteValue("425-000-1213");
-            json.WriteArrayEnd();
-            json.WriteObjectStart("address");
-            json.WriteAttribute("street", "1 Microsoft Way");
-            json.WriteAttribute("city", "Redmond");
-            json.WriteAttribute("zip", 98052);
-            json.WriteObjectEnd();
-
-            json.WriteArrayStart("ExtraArray");
-            //for (var i = 0; i < data.Length; i++)
-            //{
-            //    json.WriteValue(data[i]);
-            //}
-            json.WriteArrayEnd();
-
-            json.WriteObjectEnd();
-            json.Flush();
-        }
-
-        private static void WriterSystemTextJsonBasicUtf8_5(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
         {
             var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
 


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.10.14.534-nightly, OS=Windows 10.0.14393.2312 (1607/AnniversaryUpdate/Redstone1)
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
Frequency=3328126 Hz, Resolution=300.4694 ns, Timer=TSC
.NET Core SDK=2.1.301
  [Host]     : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT


```
**BEFORE (master):**

|                         Method | Formatted | size |         Mean |       Error |      StdDev | Allocated |
|------------------------------- |---------- |----- |-------------:|------------:|------------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |     **False** |    **1** |     **72.55 ns** |   **0.8945 ns** |   **0.7469 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** |   **10** |    **160.18 ns** |   **0.6331 ns** |   **0.5286 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** | **1000** | **12,708.05 ns** |  **76.4989 ns** |  **71.5571 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |     **False** |    **?** |    **769.99 ns** |  **15.4300 ns** |  **27.0244 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |     False |    ? |     93.48 ns |   1.9026 ns |   3.3819 ns |       0 B |
|  **WriterSystemTextJsonArrayOnly** |      **True** |    **1** |     **86.39 ns** |   **1.0231 ns** |   **0.9570 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** |   **10** |    **209.60 ns** |   **2.9768 ns** |   **2.7845 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** | **1000** | **16,923.45 ns** | **303.0954 ns** | **283.5156 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |      **True** |    **?** |    **898.10 ns** |  **10.5260 ns** |   **9.8460 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |      True |    ? |    104.96 ns |   2.4575 ns |   5.5970 ns |       0 B |

**AFTER (this PR):**

|                         Method | Formatted | size |         Mean |       Error |        StdDev | Allocated |
|------------------------------- |---------- |----- |-------------:|------------:|--------------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |     **False** |    **1** |     **53.17 ns** |   **1.0753 ns** |     **0.8979 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** |   **10** |    **124.29 ns** |   **0.6007 ns** |     **0.5325 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** | **1000** |  **9,874.39 ns** |  **65.1725 ns** |    **60.9623 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |     **False** |    **?** |  **1,061.03 ns** |  **21.1885 ns** |    **38.2072 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |     False |    ? |     69.20 ns |   1.4188 ns |     2.8006 ns |       0 B |
|  **WriterSystemTextJsonArrayOnly** |      **True** |    **1** |     **84.37 ns** |   **1.7058 ns** |     **2.3913 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** |   **10** |    **225.26 ns** |   **4.5097 ns** |     **9.1098 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** | **1000** | **18,291.06 ns** | **531.5408 ns** | **1,558.9170 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |      **True** |    **?** |    **908.00 ns** |  **18.0899 ns** |    **26.5159 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |      True |    ? |    106.37 ns |   1.5931 ns |     1.4122 ns |       0 B |

cc @benaadams, @GrabYourPitchforks 