### PR TITLE
Update version of BenchmarkDotNet to consume latest fixes

### DIFF
--- a/tests/Benchmarks/System.IO.Pipelines/E2E.cs
+++ b/tests/Benchmarks/System.IO.Pipelines/E2E.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Text.Formatting;
 using System.Text.JsonLab;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Engines;
 
 namespace System.IO.Pipelines.Benchmarks

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Jobs;
 using Benchmarks;
 using System.Buffers.Text;
 using System.Collections.Generic;

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Attributes.Jobs;
 using BenchmarkDotNet.Diagnostics.Windows.Configs;
 using System.Buffers.Text;
 using System.IO;

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -26,7 +26,7 @@ namespace System.Text.JsonLab.Benchmarks
         private int[] _data;
         private byte[] _output;
 
-        [Params(false)]
+        [Params(true, false)]
         public bool Formatted;
 
         [GlobalSetup]

--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -11,6 +11,6 @@
     <TestSdkVersion>15.0.0</TestSdkVersion>
     <XunitVersion>2.2.0</XunitVersion>
     <XunitPerformanceVersion>1.0.0-beta-build0010</XunitPerformanceVersion>
-    <BenchmarkDotNetVersion>0.10.14.534</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.10.14.662</BenchmarkDotNetVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Also, fixed typo in benchmark from https://github.com/dotnet/corefxlab/pull/2378.