### PR TITLE
Update JSON benchmark nuget packages

### DIFF
--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -19,19 +19,19 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="$(BenchmarkDotNetVersion)" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="$(CoreFxStableVersion)" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Jil" Version="2.15.4" />
+    <PackageReference Include="Jil" Version="2.16.0" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
     <PackageReference Include="System.Text.Json" Version="2.0.0.11" />
-    <PackageReference Include="fastJSON" Version="2.1.29" />
+    <PackageReference Include="fastJSON" Version="2.1.34" />
     <PackageReference Include="jayrock-json" Version="0.9.16530.1" />
-    <PackageReference Include="LitJson" Version="0.12.0" />
+    <PackageReference Include="LitJson" Version="0.13.0" />
     <PackageReference Include="codetitans-json" Version="1.8.3" />
-    <PackageReference Include="Manatee.Json" Version="9.8.0" />
-    <PackageReference Include="SpanJson" Version="0.1.0-rc2-5" />
+    <PackageReference Include="Manatee.Json" Version="9.9.1" />
+    <PackageReference Include="SpanJson" Version="1.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Azure.Experimental\System.Azure.Experimental.csproj" />

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -30,8 +30,8 @@
     <PackageReference Include="jayrock-json" Version="0.9.16530.1" />
     <PackageReference Include="LitJson" Version="0.13.0" />
     <PackageReference Include="codetitans-json" Version="1.8.3" />
-    <PackageReference Include="Manatee.Json" Version="9.9.1" />
-    <PackageReference Include="SpanJson" Version="1.0.3" />
+    <PackageReference Include="Manatee.Json" Version="9.9.2" />
+    <PackageReference Include="SpanJson" Version="1.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Azure.Experimental\System.Azure.Experimental.csproj" />

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="$(BenchmarkDotNetVersion)" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="$(CoreFxStableVersion)" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />


### PR DESCRIPTION
A few packages in the json benchmark were updated recently.
Notable changes:
- Jil 2.16.0 fixes a bug in the packaging related to .NET Core
- SpanJson is stable

Performance differences are not really there, deserialization in SpanJson is 20-30% faster now, for comparison.

<details>

``` ini

BenchmarkDotNet=v0.10.14.534-nightly, OS=Windows 10.0.17134
Intel Core i7-4790K CPU 4.00GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
Frequency=3906256 Hz, Resolution=255.9996 ns, Timer=TSC
.NET Core SDK=2.1.301
  [Host]     : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.1 (CoreCLR 4.6.26606.02, CoreFX 4.6.26606.05), 64bit RyuJIT
```

**Old** 

***JsonSerializerComparison_FromString_IndexViewModel*** 

|        Method |      Mean |     Error |    StdDev | Scaled |   Gen 0 |  Gen 1 | Allocated |
|-------------- |----------:|----------:|----------:|-------:|--------:|-------:|----------:|
|    Newtonsoft |  41.31 us | 0.1026 us | 0.0960 us |   1.00 | 14.4653 |      - |  59.32 KB |
|           Jil |  33.42 us | 0.0955 us | 0.0893 us |   0.81 | 13.7939 |      - |  56.65 KB |
|      Utf8Json |  34.38 us | 0.1777 us | 0.1576 us |   0.83 |  5.9814 |      - |  24.55 KB |
|      FastJson |  65.71 us | 0.0776 us | 0.0726 us |   1.59 | 19.5313 |      - |  80.56 KB |
|       Manatee | 186.52 us | 0.1608 us | 0.1504 us |   4.52 | 30.2734 | 0.4883 | 124.99 KB |
| SpanJsonUtf16 |  20.31 us | 0.0304 us | 0.0284 us |   0.49 |  5.9509 |      - |  24.41 KB |

***JsonDeserializerComparison_FromString_IndexViewModel***

|        Method |        Mean |     Error |    StdDev | Scaled | ScaledSD |   Gen 0 |   Gen 1 |  Gen 2 | Allocated |
|-------------- |------------:|----------:|----------:|-------:|---------:|--------:|--------:|-------:|----------:|
|    Newtonsoft |    68.58 us | 0.6984 us | 0.6533 us |   1.00 |     0.00 |  7.6904 |       - |      - |  31.81 KB |
|           Jil |    42.25 us | 0.1311 us | 0.1162 us |   0.62 |     0.01 |  5.7983 |       - |      - |  23.98 KB |
|      Utf8Json |    48.93 us | 0.8163 us | 0.7636 us |   0.71 |     0.01 |  8.3618 |       - |      - |  34.36 KB |
|        YSharp | 1,217.60 us | 1.2948 us | 1.2112 us |  17.76 |     0.16 | 29.2969 | 13.6719 | 1.9531 | 122.71 KB |
|      FastJson |    77.79 us | 0.1012 us | 0.0946 us |   1.13 |     0.01 | 17.7002 |       - |      - |   72.6 KB |
| SpanJsonUtf16 |    29.94 us | 0.1154 us | 0.1797 us |   0.44 |     0.00 |  5.3711 |       - |      - |  22.07 KB |

**New**

***JsonSerializerComparison_FromString_IndexViewModel***

|        Method |      Mean |     Error |    StdDev | Scaled |   Gen 0 |  Gen 1 | Allocated |
|-------------- |----------:|----------:|----------:|-------:|--------:|-------:|----------:|
|    Newtonsoft |  41.00 us | 0.0623 us | 0.0583 us |   1.00 | 14.4653 |      - |  59.34 KB |
|           Jil |  33.19 us | 0.0225 us | 0.0188 us |   0.81 | 13.7939 |      - |  56.65 KB |
|      Utf8Json |  33.34 us | 0.3268 us | 0.2897 us |   0.81 |  5.9814 |      - |  24.55 KB |
|      FastJson |  65.49 us | 0.0493 us | 0.0412 us |   1.60 | 19.5313 |      - |  80.56 KB |
|       Manatee | 181.45 us | 0.1809 us | 0.1692 us |   4.43 | 30.2734 | 0.4883 | 124.99 KB |
| SpanJsonUtf16 |  20.07 us | 0.0127 us | 0.0099 us |   0.49 |  5.9509 |      - |  24.41 KB |

***JsonDeserializerComparison_FromString_IndexViewModel***

|        Method |        Mean |     Error |    StdDev | Scaled | ScaledSD |   Gen 0 |   Gen 1 |  Gen 2 | Allocated |
|-------------- |------------:|----------:|----------:|-------:|---------:|--------:|--------:|-------:|----------:|
|    Newtonsoft |    66.62 us | 0.0386 us | 0.0361 us |   1.00 |     0.00 |  7.6904 |       - |      - |  31.81 KB |
|           Jil |    41.98 us | 0.0118 us | 0.0085 us |   0.63 |     0.00 |  5.7983 |       - |      - |  23.98 KB |
|      Utf8Json |    52.70 us | 0.0560 us | 0.0497 us |   0.79 |     0.00 |  8.3618 |       - |      - |  34.36 KB |
|        YSharp | 1,222.91 us | 8.1690 us | 7.6413 us |  18.36 |     0.11 | 29.2969 | 13.6719 | 1.9531 |  122.7 KB |
|      FastJson |    77.36 us | 0.5990 us | 0.5310 us |   1.16 |     0.01 | 17.7002 |       - |      - |   72.6 KB |
| SpanJsonUtf16 |    23.02 us | 0.0847 us | 0.0792 us |   0.35 |     0.00 |  5.3711 |       - |      - |  22.07 KB |

</details>