### PR TITLE
Rename JsonWriter to Utf8JsonWriter and add skeleton for UTF-8 specific overloads

### DIFF
--- a/samples/LowAllocationWebServer/Shared/SampleServer.cs
+++ b/samples/LowAllocationWebServer/Shared/SampleServer.cs
@@ -62,7 +62,7 @@ namespace LowAllocationWebServer
             response.AppendEoh();
 
             // write response JSON
-            var jsonWriter = new JsonWriter<TcpConnectionFormatter>(response, prettyPrint: false);
+            var jsonWriter = new Utf8JsonWriter<TcpConnectionFormatter>(response, prettyPrint: false);
             jsonWriter.WriteObjectStart();
             jsonWriter.WriteArrayStart("values");
             for (int i = 0; i < 5; i++)
@@ -95,7 +95,7 @@ namespace LowAllocationWebServer
             response.AppendEoh();
 
             // write response JSON
-            var jsonWriter = new JsonWriter<TcpConnectionFormatter>(response, prettyPrint: false);
+            var jsonWriter = new Utf8JsonWriter<TcpConnectionFormatter>(response, prettyPrint: false);
             jsonWriter.WriteObjectStart();
             jsonWriter.WriteArrayStart("values");
             for (int i = 0; i < requestedCount; i++)

--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
@@ -328,7 +328,7 @@ namespace System.Text.JsonLab
 
                 byteBuffer[idx++] = JsonConstants.Quote;
 
-                bool status= nameSpanByte.TryCopyTo(byteBuffer.Slice(idx));
+                bool status = nameSpanByte.TryCopyTo(byteBuffer.Slice(idx));
                 if (!status) return false;
 
                 idx += nameSpanByte.Length;
@@ -1533,7 +1533,7 @@ namespace System.Text.JsonLab
             }
 
             // For the new line, \r\n or \n, and the space after the colon
-            bytesNeeded += JsonWriterHelper.NewLineUtf8.Length + 1  + (_indent & RemoveFlagsBitMask) * 2;
+            bytesNeeded += JsonWriterHelper.NewLineUtf8.Length + 1 + (_indent & RemoveFlagsBitMask) * 2;
 
             if (Encodings.Utf16.ToUtf8Length(nameSpan, out int bytesNeededValue) != OperationStatus.Done)
             {

--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
@@ -10,7 +10,16 @@ using System.Runtime.InteropServices;
 
 namespace System.Text.JsonLab
 {
-    public ref struct JsonWriter<TBufferWriter> where TBufferWriter : IBufferWriter<byte>
+    public static class Utf8JsonWriter
+    {
+        public static Utf8JsonWriter<TBufferWriter> Create<TBufferWriter>(TBufferWriter bufferWriter, bool prettyPrint = false)
+            where TBufferWriter : IBufferWriter<byte>
+        {
+            return new Utf8JsonWriter<TBufferWriter>(bufferWriter, prettyPrint);
+        }
+    }
+
+    public ref struct Utf8JsonWriter<TBufferWriter> where TBufferWriter : IBufferWriter<byte>
     {
         private readonly bool _prettyPrint;
         private BufferWriter<TBufferWriter> _bufferWriter;
@@ -27,7 +36,7 @@ namespace System.Text.JsonLab
         /// </summary>
         /// <param name="bufferWriter">An instance of <see cref="ITextBufferWriter" /> used for writing bytes to an output channel.</param>
         /// <param name="prettyPrint">Specifies whether to add whitespace to the output text for user readability.</param>
-        public JsonWriter(TBufferWriter bufferWriter, bool prettyPrint = false)
+        public Utf8JsonWriter(TBufferWriter bufferWriter, bool prettyPrint = false)
         {
             _bufferWriter = BufferWriter.Create(bufferWriter);
             _prettyPrint = prettyPrint;
@@ -126,11 +135,11 @@ namespace System.Text.JsonLab
 
             if (_prettyPrint)
             {
-                WriteStartUtf8Pretty(nameSpan, JsonConstants.OpenBrace);
+                WriteStartUtf16Pretty(nameSpan, JsonConstants.OpenBrace);
             }
             else
             {
-                while (!TryWriteStartUtf8(nameSpan, JsonConstants.OpenBrace))
+                while (!TryWriteStartUtf16(nameSpan, JsonConstants.OpenBrace))
                     EnsureBuffer();
             }
 
@@ -140,6 +149,61 @@ namespace System.Text.JsonLab
         }
 
         private void WriteStartUtf8Pretty(ReadOnlySpan<byte> nameSpanByte, byte token)
+        {
+            // quote {name} quote colon open-brace, hence 4
+            int bytesNeeded = 4;
+            if (_indent < 0)
+            {
+                bytesNeeded++;
+            }
+
+            bytesNeeded += nameSpanByte.Length;
+
+            int indent = _indent & RemoveFlagsBitMask;
+
+            // For the new line, \r\n or \n, and the space after the colon
+            bytesNeeded += JsonWriterHelper.NewLineUtf8.Length + 1 + indent * 2;
+
+            Span<byte> byteBuffer = EnsureBuffer(bytesNeeded);
+            int idx = 0;
+
+            if (_indent < 0)
+            {
+                byteBuffer[idx++] = JsonConstants.ListSeperator;
+            }
+
+            // \r\n versus \n, depending on OS
+            if (JsonWriterHelper.NewLineUtf8.Length == 2)
+            {
+                byteBuffer[idx++] = JsonConstants.CarriageReturn;
+            }
+
+            byteBuffer[idx++] = JsonConstants.LineFeed;
+
+            while (indent-- > 0)
+            {
+                byteBuffer[idx++] = JsonConstants.Space;
+                byteBuffer[idx++] = JsonConstants.Space;
+            }
+
+            byteBuffer[idx++] = JsonConstants.Quote;
+
+            nameSpanByte.CopyTo(byteBuffer.Slice(idx));
+
+            idx += nameSpanByte.Length;
+
+            byteBuffer[idx++] = JsonConstants.Quote;
+
+            byteBuffer[idx++] = JsonConstants.KeyValueSeperator;
+
+            byteBuffer[idx++] = JsonConstants.Space;
+
+            byteBuffer[idx++] = token;
+
+            _bufferWriter.Advance(idx);
+        }
+
+        private void WriteStartUtf16Pretty(ReadOnlySpan<byte> nameSpanByte, byte token)
         {
             // quote {name} quote colon open-brace, hence 4
             int bytesNeeded = 4;
@@ -251,6 +315,40 @@ namespace System.Text.JsonLab
         }
 
         private bool TryWriteStartUtf8(ReadOnlySpan<byte> nameSpanByte, byte token)
+        {
+            int idx = 0;
+
+            try
+            {
+                Span<byte> byteBuffer = _bufferWriter.Buffer;
+                if (_indent < 0)
+                {
+                    byteBuffer[idx++] = JsonConstants.ListSeperator;
+                }
+
+                byteBuffer[idx++] = JsonConstants.Quote;
+
+                bool status= nameSpanByte.TryCopyTo(byteBuffer.Slice(idx));
+                if (!status) return false;
+
+                idx += nameSpanByte.Length;
+
+                byteBuffer[idx++] = JsonConstants.Quote;
+
+                byteBuffer[idx++] = JsonConstants.KeyValueSeperator;
+
+                byteBuffer[idx++] = token;
+            }
+            catch (IndexOutOfRangeException)
+            {
+                return false;
+            }
+
+            _bufferWriter.Advance(idx);
+            return true;
+        }
+
+        private bool TryWriteStartUtf16(ReadOnlySpan<byte> nameSpanByte, byte token)
         {
             int idx = 0;
 
@@ -392,16 +490,95 @@ namespace System.Text.JsonLab
 
             if (_prettyPrint)
             {
-                WriteStartUtf8Pretty(nameSpan, JsonConstants.OpenBracket);
+                WriteStartUtf16Pretty(nameSpan, JsonConstants.OpenBracket);
             }
             else
             {
-                while (!TryWriteStartUtf8(nameSpan, JsonConstants.OpenBracket))
+                while (!TryWriteStartUtf16(nameSpan, JsonConstants.OpenBracket))
                     EnsureBuffer();
             }
 
             _indent &= RemoveFlagsBitMask;
             _indent++;
+        }
+
+        public void WriteArrayStart(ReadOnlySpan<byte> name)
+        {
+            if (_prettyPrint)
+            {
+                WriteStartUtf8Pretty(name, JsonConstants.OpenBracket);
+            }
+            else
+            {
+                while (!TryWriteStartUtf8(name, JsonConstants.OpenBracket))
+                    EnsureBuffer();
+            }
+
+            _indent &= RemoveFlagsBitMask;
+            _indent++;
+        }
+
+        public void WriteObjectStart(ReadOnlySpan<byte> name)
+        {
+            if (_prettyPrint)
+            {
+                WriteStartUtf8Pretty(name, JsonConstants.OpenBrace);
+            }
+            else
+            {
+                while (!TryWriteStartUtf8(name, JsonConstants.OpenBrace))
+                    EnsureBuffer();
+            }
+
+            _indent &= RemoveFlagsBitMask;
+            _indent++;
+        }
+
+        //TODO: Implement UTF-8 specific overloads
+
+        public void WriteAttribute(ReadOnlySpan<byte> name, bool value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteAttribute(ReadOnlySpan<byte> name, DateTime value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteAttribute(ReadOnlySpan<byte> name, DateTimeOffset value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteAttribute(ReadOnlySpan<byte> name, Guid value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteAttribute(ReadOnlySpan<byte> name, long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteAttribute(ReadOnlySpan<byte> name, string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteAttribute(ReadOnlySpan<byte> name, ulong value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteAttributeNull(ReadOnlySpan<byte> name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(ReadOnlySpan<byte> value)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/tests/Benchmarks/System.IO.Pipelines/E2E.cs
+++ b/tests/Benchmarks/System.IO.Pipelines/E2E.cs
@@ -56,7 +56,7 @@ namespace System.IO.Pipelines.Benchmarks
                 formatter.Append("\r\n\r\n");
 
                 // write body
-                var writer = new JsonWriter<BufferWriterFormatter<PipeWriter>>(formatter);
+                var writer = new Utf8JsonWriter<BufferWriterFormatter<PipeWriter>>(formatter);
                 writer.WriteObjectStart();
                 writer.WriteAttribute("message", "Hello, World!");
                 writer.WriteObjectEnd();

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -9,9 +9,9 @@ using System.Text.Formatting;
 
 namespace System.Text.JsonLab.Benchmarks
 {
-    [SimpleJob(-1, 5, 10, 32768)]
-    [DisassemblyDiagnoser(printAsm: true, printSource: true)]
-    [InliningDiagnoser()]
+    //[SimpleJob(-1, 5, 10, 32768)]
+    //[DisassemblyDiagnoser(printAsm: true, printSource: true)]
+    //[InliningDiagnoser()]
     [MemoryDiagnoser]
     public class JsonWriterPerf
     {
@@ -25,7 +25,7 @@ namespace System.Text.JsonLab.Benchmarks
         private int[] _data;
         private byte[] _output;
 
-        [Params(true, false)]
+        [Params(false)]
         public bool Formatted;
 
         [GlobalSetup]
@@ -56,7 +56,7 @@ namespace System.Text.JsonLab.Benchmarks
             WriterSystemTextJsonBasicUtf8(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void WriterNewtonsoftBasic()
         {
             WriterNewtonsoftBasic(Formatted, GetWriter(), _data.AsSpan(0, 10));
@@ -75,7 +75,7 @@ namespace System.Text.JsonLab.Benchmarks
             WriterSystemTextJsonHelloWorldUtf8(Formatted, _arrayFormatterWrapper);
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void WriterNewtonsoftHelloWorld()
         {
             WriterNewtonsoftHelloWorld(Formatted, GetWriter());
@@ -89,11 +89,11 @@ namespace System.Text.JsonLab.Benchmarks
 
         [Benchmark]
         [Arguments(1)]
-        [Arguments(2)]
-        [Arguments(5)]
+        //[Arguments(2)]
+        //[Arguments(5)]
         [Arguments(10)]
         [Arguments(100)]
-        [Arguments(1000)]
+        //[Arguments(1000)]
         public void WriterSystemTextJsonArrayOnly(int size)
         {
             _arrayFormatterWrapper.Clear();
@@ -102,11 +102,11 @@ namespace System.Text.JsonLab.Benchmarks
 
         [Benchmark]
         [Arguments(1)]
-        [Arguments(2)]
-        [Arguments(5)]
+        //[Arguments(2)]
+        //[Arguments(5)]
         [Arguments(10)]
         [Arguments(100)]
-        [Arguments(1000)]
+        //[Arguments(1000)]
         public void WriterUtf8JsonArrayOnly(int size)
         {
             WriterUtf8JsonArrayOnly(_data.AsSpan(0, size), _output);
@@ -120,7 +120,7 @@ namespace System.Text.JsonLab.Benchmarks
 
         private static void WriterSystemTextJsonBasicUtf8(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
         {
-            var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
+            Utf8JsonWriter<ArrayFormatterWrapper> json = Utf8JsonWriter.Create(output, formatted);
 
             json.WriteObjectStart();
             json.WriteAttribute("age", 42);
@@ -237,7 +237,7 @@ namespace System.Text.JsonLab.Benchmarks
 
         private static void WriterSystemTextJsonHelloWorldUtf8(bool formatted, ArrayFormatterWrapper output)
         {
-            var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
+            Utf8JsonWriter<ArrayFormatterWrapper> json = Utf8JsonWriter.Create(output, formatted);
 
             json.WriteObjectStart();
             json.WriteAttribute("message", "Hello, World!");
@@ -270,7 +270,7 @@ namespace System.Text.JsonLab.Benchmarks
 
         private static void WriterSystemTextJsonArrayOnlyUtf8(bool formatted, ArrayFormatterWrapper output, ReadOnlySpan<int> data)
         {
-            var json = new JsonWriter<ArrayFormatterWrapper>(output, formatted);
+            Utf8JsonWriter<ArrayFormatterWrapper> json = Utf8JsonWriter.Create(output, formatted);
 
             json.WriteArrayStart("ExtraArray");
             for (var i = 0; i < data.Length; i++)

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -9,9 +9,9 @@ using System.Text.Formatting;
 
 namespace System.Text.JsonLab.Benchmarks
 {
-    //[SimpleJob(-1, 5, 10, 32768)]
-    //[DisassemblyDiagnoser(printAsm: true, printSource: true)]
-    //[InliningDiagnoser()]
+    [SimpleJob(-1, 5, 10, 32768)]
+    [DisassemblyDiagnoser(printAsm: true, printSource: true)]
+    [InliningDiagnoser()]
     [MemoryDiagnoser]
     public class JsonWriterPerf
     {
@@ -25,7 +25,7 @@ namespace System.Text.JsonLab.Benchmarks
         private int[] _data;
         private byte[] _output;
 
-        [Params(false)]
+        [Params(true, false)]
         public bool Formatted;
 
         [GlobalSetup]
@@ -56,7 +56,7 @@ namespace System.Text.JsonLab.Benchmarks
             WriterSystemTextJsonBasicUtf8(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void WriterNewtonsoftBasic()
         {
             WriterNewtonsoftBasic(Formatted, GetWriter(), _data.AsSpan(0, 10));
@@ -75,7 +75,7 @@ namespace System.Text.JsonLab.Benchmarks
             WriterSystemTextJsonHelloWorldUtf8(Formatted, _arrayFormatterWrapper);
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void WriterNewtonsoftHelloWorld()
         {
             WriterNewtonsoftHelloWorld(Formatted, GetWriter());
@@ -89,11 +89,11 @@ namespace System.Text.JsonLab.Benchmarks
 
         [Benchmark]
         [Arguments(1)]
-        //[Arguments(2)]
-        //[Arguments(5)]
+        [Arguments(2)]
+        [Arguments(5)]
         [Arguments(10)]
         [Arguments(100)]
-        //[Arguments(1000)]
+        [Arguments(1000)]
         public void WriterSystemTextJsonArrayOnly(int size)
         {
             _arrayFormatterWrapper.Clear();
@@ -102,11 +102,11 @@ namespace System.Text.JsonLab.Benchmarks
 
         [Benchmark]
         [Arguments(1)]
-        //[Arguments(2)]
-        //[Arguments(5)]
+        [Arguments(2)]
+        [Arguments(5)]
         [Arguments(10)]
         [Arguments(100)]
-        //[Arguments(1000)]
+        [Arguments(1000)]
         public void WriterUtf8JsonArrayOnly(int size)
         {
             WriterUtf8JsonArrayOnly(_data.AsSpan(0, size), _output);

--- a/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
@@ -17,7 +17,7 @@ namespace System.Text.JsonLab.Tests
         public void WriteJsonUtf8()
         {
             var formatter = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
-            var json = new JsonWriter<ArrayFormatterWrapper>(formatter, prettyPrint: false);
+            var json = new Utf8JsonWriter<ArrayFormatterWrapper>(formatter, prettyPrint: false);
             Write(ref json);
 
             var formatted = formatter.Formatted;
@@ -25,7 +25,7 @@ namespace System.Text.JsonLab.Tests
             Assert.Equal(expected, str.Replace(" ", ""));
 
             formatter.Clear();
-            json = new JsonWriter<ArrayFormatterWrapper>(formatter, prettyPrint: true);
+            json = new Utf8JsonWriter<ArrayFormatterWrapper>(formatter, prettyPrint: true);
             Write(ref json);
 
             formatted = formatter.Formatted;
@@ -35,7 +35,7 @@ namespace System.Text.JsonLab.Tests
 
         static readonly string expected = "{\"age\":30,\"first\":\"John\",\"last\":\"Smith\",\"phoneNumbers\":[\"425-000-1212\",\"425-000-1213\",null],\"address\":{\"street\":\"1MicrosoftWay\",\"city\":\"Redmond\",\"zip\":98052},\"values\":[425121,-425122,425123]}";
 
-        static void Write(ref JsonWriter<ArrayFormatterWrapper> json)
+        static void Write(ref Utf8JsonWriter<ArrayFormatterWrapper> json)
         {
             json.WriteObjectStart();
             json.WriteAttribute("age", 30);
@@ -68,7 +68,7 @@ namespace System.Text.JsonLab.Tests
             string expectedStr = GetHelloWorldExpectedString(prettyPrint, isUtf8: true);
 
             var output = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
-            var jsonUtf8 = new JsonWriter<ArrayFormatterWrapper>(output, prettyPrint);
+            var jsonUtf8 = new Utf8JsonWriter<ArrayFormatterWrapper>(output, prettyPrint);
 
             jsonUtf8.WriteObjectStart();
             jsonUtf8.WriteAttribute("message", "Hello, World!");
@@ -91,7 +91,7 @@ namespace System.Text.JsonLab.Tests
             string expectedStr = GetExpectedString(prettyPrint, isUtf8: true, data);
 
             var output = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
-            var jsonUtf8 = new JsonWriter<ArrayFormatterWrapper>(output, prettyPrint);
+            var jsonUtf8 = new Utf8JsonWriter<ArrayFormatterWrapper>(output, prettyPrint);
 
             jsonUtf8.WriteObjectStart();
             jsonUtf8.WriteAttribute("age", 42);


### PR DESCRIPTION
Also added helper factory method. However, if you don't use var, it ends up increasing how much you have to type. With use of var, you can avoid having to specify the generic type. Given our coding guidelines though, the static helper isn't very useful. Thoughts?

```C#
var json = new Utf8JsonWriter<ArrayFormatterWrapper>(formatter, prettyPrint: false);
var json = Utf8JsonWriter.Create(output, prettyPrint: false);
Utf8JsonWriter<ArrayFormatterWrapper> json = Utf8JsonWriter.Create(output, prettyPrint: false);
```

cc @GrabYourPitchforks, @benaadams 