### PR TITLE
Adding Bme280 class and samples using SPI and LCD

### DIFF
--- a/src/System.Devices.Gpio/System.Devices.Gpio.Samples/Bme280.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio.Samples/Bme280.cs
@@ -1,0 +1,409 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Devices.Gpio.Samples
+{
+    public class Bme280 : IDisposable
+    {
+        private const byte BME280_ADDRESS = 0x77; // Default I2C address
+
+        // Name of Registers used in the BME280
+
+        private const byte BME280_DIG_T1_REG = 0x88;
+        private const byte BME280_DIG_T2_REG = 0x8A;
+        private const byte BME280_DIG_T3_REG = 0x8C;
+        private const byte BME280_DIG_P1_REG = 0x8E;
+        private const byte BME280_DIG_P2_REG = 0x90;
+        private const byte BME280_DIG_P3_REG = 0x92;
+        private const byte BME280_DIG_P4_REG = 0x94;
+        private const byte BME280_DIG_P5_REG = 0x96;
+        private const byte BME280_DIG_P6_REG = 0x98;
+        private const byte BME280_DIG_P7_REG = 0x9A;
+        private const byte BME280_DIG_P8_REG = 0x9C;
+        private const byte BME280_DIG_P9_REG = 0x9E;
+
+        private const byte BME280_DIG_H1_REG = 0xA1;
+        private const byte BME280_DIG_H2_REG = 0xE1;
+        private const byte BME280_DIG_H3_REG = 0xE3;
+        private const byte BME280_DIG_H4_REG = 0xE4;
+        private const byte BME280_DIG_H5_REG = 0xE5;
+        private const byte BME280_DIG_H6_REG = 0xE7;
+
+        private const byte BME280_REGISTER_CHIPID = 0xD0;
+        private const byte BME280_REGISTER_VERSION = 0xD1;
+        private const byte BME280_REGISTER_SOFTRESET = 0xE0;
+        private const byte BME280_REGISTER_CAL26 = 0xE1;
+        private const byte BME280_REGISTER_CONTROLHUMID = 0xF2;
+        private const byte BME280_REGISTER_CONTROL = 0xF4;
+        private const byte BME280_REGISTER_CONFIG = 0xF5;
+        private const byte BME280_REGISTER_PRESSUREDATA = 0xF7;
+        private const byte BME280_REGISTER_TEMPDATA = 0xFA;
+        private const byte BME280_REGISTER_HUMIDDATA = 0xFD;
+
+        // Structure to hold the calibration data that is
+        // programmed into the sensor in the factory
+        // during manufacture
+        private struct Bme280_Calibration_Data
+        {
+            public ushort dig_T1;
+            public short dig_T2;
+            public short dig_T3;
+            public ushort dig_P1;
+            public short dig_P2;
+            public short dig_P3;
+            public short dig_P4;
+            public short dig_P5;
+            public short dig_P6;
+            public short dig_P7;
+            public short dig_P8;
+            public short dig_P9;
+            public byte dig_H1;
+            public short dig_H2;
+            public byte dig_H3;
+            public short dig_H4;
+            public short dig_H5;
+            public sbyte dig_H6;
+        };
+
+        private Bme280_Calibration_Data _cal_data;
+
+        private float _temperature;
+        private float _humidity;
+        private float _pressure;
+        private int _tFine;
+
+        private SpiConnectionSettings _spiSettings;
+        private SpiDevice _spiDevice;
+
+        private Pin _csPin;
+        private Pin _mosiPin;
+        private Pin _misoPin;
+        private Pin _sckPin;
+
+        /// <summary>
+        /// Use this for hardware SPI.
+        /// </summary>
+        public Bme280(Pin cs, SpiConnectionSettings spiSettings)
+        {
+            _csPin = cs;
+            _spiSettings = spiSettings;
+        }
+
+        /// <summary>
+        /// Use this for software SPI.
+        /// </summary>
+        public Bme280(Pin cs, Pin mosi, Pin miso, Pin sck)
+        {
+            _csPin = cs;
+            _mosiPin = mosi;
+            _misoPin = miso;
+            _sckPin = sck;
+        }
+
+        public void Dispose()
+        {
+            if (_spiDevice != null)
+            {
+                _spiDevice.Dispose();
+                _spiDevice = null;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the temperature calibration offset in degrees celsius.
+        /// </summary>
+        public float TemperatureCalibrationOffset { get; set; }
+
+        public void ReadSensor()
+        {
+            ReadTemperature();
+            ReadHumidity();
+            ReadPressure();
+        }
+
+        public float TemperatureInCelsius => _temperature + TemperatureCalibrationOffset;
+
+        public float TemperatureInFahrenheit => TemperatureInCelsius * 1.8f + 32;
+
+        public float Humidity => _humidity;
+
+        public float PressureInHectapascals => _pressure;
+
+        public float PressureInMillibars => PressureInHectapascals / 100.0f;
+
+        public bool Begin()
+        {
+            Dispose();
+
+            _csPin.Mode = PinMode.Output;
+            DigitalWrite(_csPin, PinValue.High);
+
+            if (_spiSettings != null)
+            {
+                // Hardware SPI
+                _spiSettings.Mode = SpiMode.Mode0;
+                _spiSettings.ClockFrequency = 500 * 1000;
+                _spiSettings.DataBitLength = 8;
+
+                _spiDevice = new UnixSpiDevice(_spiSettings);
+            }
+            else
+            {
+                // Software SPI
+                _sckPin.Mode = PinMode.Output;
+                _mosiPin.Mode = PinMode.Output;
+                _misoPin.Mode = PinMode.Input;
+            }
+
+            byte chipId = Read8(BME280_REGISTER_CHIPID);
+
+            if (chipId != 0x60)
+            {
+                //Console.WriteLine($"chipId = '{chipId:X2}'");
+                return false;
+            }
+
+            ReadSensorCoefficients();
+
+            // Set Humidity oversampling to 1
+            // Set before CONTROL (DS 5.4.3)
+            Write8(BME280_REGISTER_CONTROLHUMID, 0x01);
+            Write8(BME280_REGISTER_CONTROL, 0x3F);
+            return true;
+        }
+
+        private void ReadTemperature()
+        {
+            int var1, var2;
+
+            uint adc_T = Read24(BME280_REGISTER_TEMPDATA);
+            adc_T >>= 4;
+
+            var1 = (((int)((adc_T >> 3) - (_cal_data.dig_T1 << 1))) *
+                     _cal_data.dig_T2) >> 11;
+
+            var2 = ((((int)((adc_T >> 4) - ((int)_cal_data.dig_T1)) *
+                       (int)((adc_T >> 4) - ((int)_cal_data.dig_T1))) >> 12) *
+                     _cal_data.dig_T3) >> 14;
+
+            _tFine = var1 + var2;
+            _temperature = (_tFine * 5 + 128) >> 8;
+            _temperature = _temperature / 100;
+        }
+
+        private void ReadPressure()
+        {
+            long var1, var2, p;
+
+            uint adc_P = Read24(BME280_REGISTER_PRESSUREDATA);
+            adc_P >>= 4;
+
+            var1 = ((long)_tFine) - 128000;
+            var2 = var1 * var1 * _cal_data.dig_P6;
+            var2 = var2 + ((var1 * _cal_data.dig_P5) << 17);
+            var2 = var2 + (((long)_cal_data.dig_P4) << 35);
+            var1 = ((var1 * var1 * _cal_data.dig_P3) >> 8) +
+            ((var1 * _cal_data.dig_P2) << 12);
+
+            var1 = (((((long)1) << 47) + var1)) * _cal_data.dig_P1 >> 33;
+
+            if (var1 == 0)
+            {
+                // Avoid division by zero exception
+                _pressure = 0;
+            }
+
+            p = 1048576 - adc_P;
+            p = (((p << 31) - var2) * 3125) / var1;
+
+            var1 = (_cal_data.dig_P9 * (p >> 13) * (p >> 13)) >> 25;
+            var2 = (_cal_data.dig_P8 * p) >> 19;
+
+            p = ((p + var1 + var2) >> 8) + (((long)_cal_data.dig_P7) << 4);
+            _pressure = (float)p / 256;
+        }
+
+        private void ReadHumidity()
+        {
+            int adc_H = Read16(BME280_REGISTER_HUMIDDATA);
+            int v_x1_u32r;
+
+            v_x1_u32r = (_tFine - 76800);
+
+            v_x1_u32r = (((((adc_H << 14) - (_cal_data.dig_H4 << 20) -
+                            (_cal_data.dig_H5 * v_x1_u32r)) + 16384) >> 15) *
+                         (((((((v_x1_u32r * _cal_data.dig_H6) >> 10) *
+                              (((v_x1_u32r * _cal_data.dig_H3) >> 11) + 32768)) >> 10) +
+                            2097152) * _cal_data.dig_H2 + 8192) >> 14));
+
+            v_x1_u32r = (v_x1_u32r - (((((v_x1_u32r >> 15) * (v_x1_u32r >> 15)) >> 7) *
+                                       _cal_data.dig_H1) >> 4));
+
+            v_x1_u32r = (v_x1_u32r < 0) ? 0 : v_x1_u32r;
+            v_x1_u32r = (v_x1_u32r > 419430400) ? 419430400 : v_x1_u32r;
+
+            float h = (v_x1_u32r >> 12);
+            _humidity = h / 1024.0f;
+        }
+
+        /// <summary>
+        /// Read the values that are programmed into the sensor during manufacture
+        /// </summary>
+        private void ReadSensorCoefficients()
+        {
+            _cal_data.dig_T1 = Read16LittleEndian(BME280_DIG_T1_REG);
+            _cal_data.dig_T2 = ReadS16LittleEndian(BME280_DIG_T2_REG);
+            _cal_data.dig_T3 = ReadS16LittleEndian(BME280_DIG_T3_REG);
+            _cal_data.dig_P1 = Read16LittleEndian(BME280_DIG_P1_REG);
+            _cal_data.dig_P2 = ReadS16LittleEndian(BME280_DIG_P2_REG);
+            _cal_data.dig_P3 = ReadS16LittleEndian(BME280_DIG_P3_REG);
+            _cal_data.dig_P4 = ReadS16LittleEndian(BME280_DIG_P4_REG);
+            _cal_data.dig_P5 = ReadS16LittleEndian(BME280_DIG_P5_REG);
+            _cal_data.dig_P6 = ReadS16LittleEndian(BME280_DIG_P6_REG);
+            _cal_data.dig_P7 = ReadS16LittleEndian(BME280_DIG_P7_REG);
+            _cal_data.dig_P8 = ReadS16LittleEndian(BME280_DIG_P8_REG);
+            _cal_data.dig_P9 = ReadS16LittleEndian(BME280_DIG_P9_REG);
+            _cal_data.dig_H1 = Read8(BME280_DIG_H1_REG);
+            _cal_data.dig_H2 = ReadS16LittleEndian(BME280_DIG_H2_REG);
+            _cal_data.dig_H3 = Read8(BME280_DIG_H3_REG);
+            _cal_data.dig_H4 = (short)((Read8(BME280_DIG_H4_REG) << 4) | (Read8(BME280_DIG_H4_REG + 1) & 0xF));
+            _cal_data.dig_H5 = (short)((Read8(BME280_DIG_H5_REG + 1) << 4) | (Read8(BME280_DIG_H5_REG) >> 4));
+            _cal_data.dig_H6 = (sbyte)Read8(BME280_DIG_H6_REG);
+        }
+
+        /// <summary>
+        /// Transfers data over the SPI bus
+        /// </summary>
+        private byte SpiTransfer(byte x)
+        {
+            byte result;
+
+            if (_spiSettings != null)
+            {
+                // Hardware SPI
+                var writeBuffer = new byte[] { x };
+                var readBuffer = new byte[writeBuffer.Length];
+
+                _spiDevice.TransferFullDuplex(writeBuffer, readBuffer);
+                result = readBuffer[0];
+
+                // Console.WriteLine($"Spi transfer: {x:X2} sent, {result:X2} received");
+            }
+            else
+            {
+                // Software SPI
+                result = 0;
+
+                for (int i = 7; i >= 0; i--)
+                {
+                    result <<= 1;
+
+                    DigitalWrite(_sckPin, PinValue.Low);
+                    DigitalWrite(_mosiPin, x & (1 << i));
+                    DigitalWrite(_sckPin, PinValue.High);
+
+                    PinValue value = _misoPin.Read();
+
+                    if (value == PinValue.High)
+                    {
+                        result |= 1;
+                    }
+                }
+
+                // Console.WriteLine($"Spi transfer: {x:X2} sent, {result:X2} received");
+            }
+
+            return result;
+        }
+
+        private void Write8(byte reg, byte value)
+        {
+            DigitalWrite(_csPin, PinValue.Low);
+            SpiTransfer((byte)(reg & ~0x80)); // write, bit 7 low
+            SpiTransfer(value);
+            DigitalWrite(_csPin, PinValue.High);
+        }
+
+        private byte Read8(byte reg)
+        {
+            DigitalWrite(_csPin, PinValue.Low);
+            SpiTransfer((byte)(reg | 0x80)); // read, bit 7 high
+            byte value = SpiTransfer(0);
+            DigitalWrite(_csPin, PinValue.High);
+            return value;
+        }
+
+        private ushort Read16(byte reg)
+        {
+            ushort result = 0;
+
+            DigitalWrite(_csPin, PinValue.Low);
+            SpiTransfer((byte)(reg | 0x80)); // read, bit 7 high
+
+            for (int i = 0; i < 2; ++i)
+            {
+                byte value = SpiTransfer(0);
+                result = (ushort)((result << 8) | value);
+            }
+
+            DigitalWrite(_csPin, PinValue.High);
+            return result;
+        }
+
+        // Little endian
+        private ushort Read16LittleEndian(byte reg)
+        {
+            ushort temp = Read16(reg);
+            return (ushort)((temp >> 8) | (temp << 8));
+        }
+
+        private short ReadS16(byte reg)
+        {
+            return (short)Read16(reg);
+        }
+
+        // Little endian
+        private short ReadS16LittleEndian(byte reg)
+        {
+            return (short)Read16LittleEndian(reg);
+        }
+
+        private uint Read24(byte reg)
+        {
+            uint result = 0;
+
+            DigitalWrite(_csPin, PinValue.Low);
+            SpiTransfer((byte)(reg | 0x80)); // read, bit 7 high
+
+            for (int i = 0; i < 4; ++i)
+            {
+                byte value = SpiTransfer(0);
+                result = (result << 8) | value;
+            }
+
+            DigitalWrite(_csPin, PinValue.High);
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void DigitalWrite(Pin pin, int value)
+        {
+            PinValue state = HasFlag(value, 0x01) ? PinValue.High : PinValue.Low;
+            DigitalWrite(pin, state);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void DigitalWrite(Pin pin, PinValue state)
+        {
+            pin.Write(state);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool HasFlag(int value, int flag)
+        {
+            return (value & flag) == flag;
+        }
+    }
+}

--- a/src/System.Devices.Gpio/System.Devices.Gpio.Samples/Bme280.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio.Samples/Bme280.cs
@@ -85,21 +85,21 @@ namespace System.Devices.Gpio.Samples
         /// <summary>
         /// Use this for hardware SPI.
         /// </summary>
-        public Bme280(Pin cs, SpiConnectionSettings spiSettings)
+        public Bme280(Pin chipSelectLine, SpiConnectionSettings spiSettings)
         {
-            _csPin = cs;
+            _csPin = chipSelectLine;
             _spiSettings = spiSettings;
         }
 
         /// <summary>
         /// Use this for software SPI.
         /// </summary>
-        public Bme280(Pin cs, Pin mosi, Pin miso, Pin sck)
+        public Bme280(Pin chipSelectLine, Pin masterOutSlaveIn, Pin masterInSlaveOut, Pin serialClock)
         {
-            _csPin = cs;
-            _mosiPin = mosi;
-            _misoPin = miso;
-            _sckPin = sck;
+            _csPin = chipSelectLine;
+            _mosiPin = masterOutSlaveIn;
+            _misoPin = masterInSlaveOut;
+            _sckPin = serialClock;
         }
 
         public void Dispose()
@@ -146,8 +146,7 @@ namespace System.Devices.Gpio.Samples
             {
                 // Hardware SPI
                 _spiSettings.Mode = SpiMode.Mode0;
-                _spiSettings.ClockFrequency = 500 * 1000;
-                _spiSettings.DataBitLength = 8;
+                _spiSettings.DataBitLength = 8; // 1 byte
 
                 _spiDevice = new UnixSpiDevice(_spiSettings);
             }
@@ -170,7 +169,9 @@ namespace System.Devices.Gpio.Samples
             ReadSensorCoefficients();
 
             // Set Humidity oversampling to 1
-            // Set before CONTROL (DS 5.4.3)
+            // Set before CONTROL (DS 5.4.3):
+            // "Changes to this register only became effective
+            // after a write operation to CONTROL register."
             Write8(BME280_REGISTER_CONTROLHUMID, 0x01);
             Write8(BME280_REGISTER_CONTROL, 0x3F);
             return true;

--- a/src/System.Devices.Gpio/System.Devices.Gpio.Samples/LiquidCrystal.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio.Samples/LiquidCrystal.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace System.Devices.Gpio.Samples
@@ -76,33 +77,39 @@ namespace System.Devices.Gpio.Samples
         private byte _numLines;
         private byte[] _rowOffsets;
 
-        public LiquidCrystal(Pin rs, Pin enable, params Pin[] db4or8)
-            : this(rs, null, enable, db4or8)
+        public LiquidCrystal(Pin registerSelect, Pin enable, params Pin[] data)
+            : this(registerSelect, null, enable, data)
         {
             // Do nothing
         }
 
-        public LiquidCrystal(Pin rs, Pin rw, Pin enable, params Pin[] db)
+        public LiquidCrystal(Pin registerSelect, Pin readWrite, Pin enable, params Pin[] data)
         {
-            _rsPin = rs;
-            _rwPin = rw;
-            _enablePin = enable;
-            _dataPins = db;
+            _rwPin = readWrite;
+            _rsPin = registerSelect ?? throw new ArgumentNullException(nameof(registerSelect));
+            _enablePin = enable ?? throw new ArgumentNullException(nameof(enable));
+            _dataPins = data ?? throw new ArgumentNullException(nameof(data));
+
+            if (data.Any(pin => pin == null))
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
             _rowOffsets = new byte[4];
 
             _displayFunction = LCD_1LINE | LCD_5x8DOTS;
 
-            if (db.Length == 4)
+            if (data.Length == 4)
             {
                 _displayFunction |= LCD_4BITMODE;
             }
-            else if (db.Length == 8)
+            else if (data.Length == 8)
             {
                 _displayFunction |= LCD_8BITMODE;
             }
             else
             {
-                throw new ArgumentException($"The length of the array given to parameter {nameof(db)} must be 4 or 8");
+                throw new ArgumentException($"The length of the array given to parameter {nameof(data)} must be 4 or 8");
             }
 
             Begin(16, 1);

--- a/src/System.Devices.Gpio/System.Devices.Gpio.Samples/LiquidCrystal.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio.Samples/LiquidCrystal.cs
@@ -428,7 +428,8 @@ namespace System.Devices.Gpio.Samples
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void DigitalWrite(Pin pin, int value)
         {
-            PinValue state = HasFlag(value, 0x01) ? PinValue.High : PinValue.Low;
+            const int True = 1;
+            PinValue state = HasFlag(value, True) ? PinValue.High : PinValue.Low;
             DigitalWrite(pin, state);
         }
 

--- a/src/System.Devices.Gpio/System.Devices.Gpio.Samples/LiquidCrystal.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio.Samples/LiquidCrystal.cs
@@ -426,14 +426,14 @@ namespace System.Devices.Gpio.Samples
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void DigitalWrite(Pin pin, int value)
+        private static void DigitalWrite(Pin pin, int value)
         {
             PinValue state = HasFlag(value, 0x01) ? PinValue.High : PinValue.Low;
             DigitalWrite(pin, state);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void DigitalWrite(Pin pin, PinValue state)
+        private static void DigitalWrite(Pin pin, PinValue state)
         {
             pin.Write(state);
         }
@@ -444,7 +444,7 @@ namespace System.Devices.Gpio.Samples
             return (value & flag) == flag;
         }
 
-        private void DelayMicroseconds(int microseconds)
+        private static void DelayMicroseconds(int microseconds)
         {
             var sw = Diagnostics.Stopwatch.StartNew();
             long v = (microseconds * Diagnostics.Stopwatch.Frequency) / 1000000;

--- a/src/System.Devices.Gpio/System.Devices.Gpio.Samples/Program.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio.Samples/Program.cs
@@ -112,7 +112,11 @@ namespace System.Devices.Gpio.Samples
                         break;
 
                     case 24:
-                        SPI_Roundtrip();
+                        Spi_Roundtrip();
+                        break;
+
+                    case 25:
+                        Spi_Bme280();
                         break;
 
                     default:
@@ -174,7 +178,9 @@ namespace System.Devices.Gpio.Samples
             Console.WriteLine($"       22 -> {nameof(Unix_LiquidCrystal)}");
             Console.WriteLine($"       23 -> {nameof(RaspberryPi_LiquidCrystal)}");
             Console.WriteLine();
-            Console.WriteLine($"       24 -> {nameof(SPI_Roundtrip)}");
+            Console.WriteLine($"       24 -> {nameof(Spi_Roundtrip)}");
+            Console.WriteLine();
+            Console.WriteLine($"       25 -> {nameof(Spi_Bme280)}");
             Console.WriteLine();
         }
 
@@ -705,10 +711,10 @@ namespace System.Devices.Gpio.Samples
             }
         }
 
-        private static void SPI_Roundtrip()
+        private static void Spi_Roundtrip()
         {
             // For this sample connect SPI0 MOSI with SPI0 MISO.
-            var settings = new SpiConnectionSettings(0);
+            var settings = new SpiConnectionSettings(0, 0);
             using (var device = new UnixSpiDevice(settings))
             {
                 var writeBuffer = new byte[]
@@ -738,5 +744,62 @@ namespace System.Devices.Gpio.Samples
                 Console.WriteLine();
             }
         }
+
+        private static void Spi_Bme280()
+        {
+            var driver = new UnixDriver(RaspberryPiPinCount);
+            using (var controller = new GpioController(driver, PinNumberingScheme.BCM))
+            {
+                Pin csPin = controller.OpenPin(8);
+
+                var settings = new SpiConnectionSettings(0, 0);
+                using (var bme280 = new Bme280(csPin, settings))
+                {
+                    bool ok = bme280.Begin();
+
+                    Console.WriteLine($"Pressure\tHumdity\t\tTemp\tTemp");
+                    Console.WriteLine();
+
+                    for (var i = 0; i < 5; ++i)
+                    {
+                        bme280.ReadSensor();
+
+                        Console.WriteLine($"{bme280.PressureInHectapascals} hPa\t{bme280.PressureInMillibars} mb\t{bme280.Humidity} %\t{bme280.TemperatureInCelsius} *C\t{bme280.TemperatureInFahrenheit} *F");
+                        Thread.Sleep(1 * 1000);
+                    }
+                }
+            }
+        }
+
+        //private static void Spi_Bme280()
+        //{
+        //    var driver = new UnixDriver(RaspberryPiPinCount);
+        //    using (var controller = new GpioController(driver, PinNumberingScheme.BCM))
+        //    {
+        //        Pin csPin = controller.OpenPin(8);
+        //        Pin mosiPin = controller.OpenPin(10);
+        //        Pin misoPin = controller.OpenPin(9);
+        //        Pin sckPin = controller.OpenPin(11);
+
+        //        using (var bme280 = new Bme280(csPin, mosiPin, misoPin, sckPin))
+        //        {
+        //            bool ok = bme280.Begin();
+
+        //            Console.WriteLine($"Begin result: {ok}");
+        //            Console.WriteLine();
+        //            Console.WriteLine($"Pressure\tHumdity\tTemp\tTemp");
+        //            Console.WriteLine();
+
+        //            Stopwatch watch = Stopwatch.StartNew();
+
+        //            while (watch.Elapsed.TotalSeconds < 15)
+        //            {
+        //                bme280.ReadSensor();
+
+        //                Console.WriteLine($"{bme280.PressureInHectapascals} hPa\t{bme280.Humidity} %\t{bme280.TemperatureInCelsius} *C\t{bme280.TemperatureInFahrenheit} *F");
+        //            }
+        //        }
+        //    }
+        //}
     }
 }

--- a/src/System.Devices.Gpio/System.Devices.Gpio.Samples/Program.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio.Samples/Program.cs
@@ -24,31 +24,31 @@ namespace System.Devices.Gpio.Samples
                 switch (option)
                 {
                     case 0:
-                        Unix_BlinkingLED();
+                        Unix_BlinkingLed();
                         break;
                     case 1:
-                        Unix_ButtonLED();
+                        Unix_ButtonLed();
                         break;
 
                     case 2:
-                        RaspberryPi_BlinkingLED();
+                        RaspberryPi_BlinkingLed();
                         break;
                     case 3:
-                        RaspberryPi_ButtonLED();
+                        RaspberryPi_ButtonLed();
                         break;
 
                     case 4:
-                        UnixDriver_BlinkingLED();
+                        UnixDriver_BlinkingLed();
                         break;
                     case 5:
-                        UnixDriver_ButtonLED();
+                        UnixDriver_ButtonLed();
                         break;
 
                     case 6:
-                        RaspberryPiDriver_BlinkingLED();
+                        RaspberryPiDriver_BlinkingLed();
                         break;
                     case 7:
-                        RaspberryPiDriver_ButtonLED();
+                        RaspberryPiDriver_ButtonLed();
                         break;
 
                     case 8:
@@ -59,14 +59,14 @@ namespace System.Devices.Gpio.Samples
                         UnixDriver_DetectButton();
                         break;
                     case 10:
-                        UnixDriver_DetectButtonLED();
+                        UnixDriver_DetectButtonLed();
                         break;
 
                     case 11:
                         RaspberryPiDriver_DetectButton();
                         break;
                     case 12:
-                        RaspberryPiDriver_DetectButtonLED();
+                        RaspberryPiDriver_DetectButtonLed();
                         break;
 
                     case 13:
@@ -84,14 +84,14 @@ namespace System.Devices.Gpio.Samples
                         Unix_DetectButton();
                         break;
                     case 17:
-                        Unix_DetectButtonLED();
+                        Unix_DetectButtonLed();
                         break;
 
                     case 18:
                         RaspberryPi_DetectButton();
                         break;
                     case 19:
-                        RaspberryPi_DetectButtonLED();
+                        RaspberryPi_DetectButtonLed();
                         break;
 
                     case 20:
@@ -102,10 +102,10 @@ namespace System.Devices.Gpio.Samples
                         break;
 
                     case 22:
-                        Unix_LCD();
+                        Unix_Lcd();
                         break;
                     case 23:
-                        RaspberryPi_LCD();
+                        RaspberryPi_Lcd();
                         break;
 
                     case 24:
@@ -120,10 +120,10 @@ namespace System.Devices.Gpio.Samples
                         break;
 
                     case 27:
-                        Unix_Spi_Bme280_LCD();
+                        Unix_Spi_Bme280_Lcd();
                         break;
                     case 28:
-                        RaspberryPi_Spi_Bme280_LCD();
+                        RaspberryPi_Spi_Bme280_Lcd();
                         break;
 
                     default:
@@ -146,25 +146,25 @@ namespace System.Devices.Gpio.Samples
             Console.WriteLine($"Usage: {assemblyName} <arg>");
             Console.WriteLine("       where <arg> can be any of the following options:");
             Console.WriteLine();
-            Console.WriteLine($"        0 -> {nameof(Unix_BlinkingLED)}");
-            Console.WriteLine($"        1 -> {nameof(Unix_ButtonLED)}");
+            Console.WriteLine($"        0 -> {nameof(Unix_BlinkingLed)}");
+            Console.WriteLine($"        1 -> {nameof(Unix_ButtonLed)}");
             Console.WriteLine();
-            Console.WriteLine($"        2 -> {nameof(RaspberryPi_BlinkingLED)}");
-            Console.WriteLine($"        3 -> {nameof(RaspberryPi_ButtonLED)}");
+            Console.WriteLine($"        2 -> {nameof(RaspberryPi_BlinkingLed)}");
+            Console.WriteLine($"        3 -> {nameof(RaspberryPi_ButtonLed)}");
             Console.WriteLine();
-            Console.WriteLine($"        4 -> {nameof(UnixDriver_BlinkingLED)}");
-            Console.WriteLine($"        5 -> {nameof(UnixDriver_ButtonLED)}");
+            Console.WriteLine($"        4 -> {nameof(UnixDriver_BlinkingLed)}");
+            Console.WriteLine($"        5 -> {nameof(UnixDriver_ButtonLed)}");
             Console.WriteLine();
-            Console.WriteLine($"        6 -> {nameof(RaspberryPiDriver_BlinkingLED)}");
-            Console.WriteLine($"        7 -> {nameof(RaspberryPiDriver_ButtonLED)}");
+            Console.WriteLine($"        6 -> {nameof(RaspberryPiDriver_BlinkingLed)}");
+            Console.WriteLine($"        7 -> {nameof(RaspberryPiDriver_ButtonLed)}");
             Console.WriteLine();
             Console.WriteLine($"        8 -> {nameof(RaspberryPiDriver_ButtonPullDown)}");
             Console.WriteLine();
             Console.WriteLine($"        9 -> {nameof(UnixDriver_DetectButton)}");
-            Console.WriteLine($"       10 -> {nameof(UnixDriver_DetectButtonLED)}");
+            Console.WriteLine($"       10 -> {nameof(UnixDriver_DetectButtonLed)}");
             Console.WriteLine();
             Console.WriteLine($"       11 -> {nameof(RaspberryPiDriver_DetectButton)}");
-            Console.WriteLine($"       12 -> {nameof(RaspberryPiDriver_DetectButtonLED)}");
+            Console.WriteLine($"       12 -> {nameof(RaspberryPiDriver_DetectButtonLed)}");
             Console.WriteLine();
             Console.WriteLine($"       13 -> {nameof(UnixDriver_ButtonWait)}");
             Console.WriteLine($"       14 -> {nameof(RaspberryPiDriver_ButtonWait)}");
@@ -172,52 +172,52 @@ namespace System.Devices.Gpio.Samples
             Console.WriteLine($"       15 -> {nameof(RaspberryPi_ButtonPullDown)}");
             Console.WriteLine();
             Console.WriteLine($"       16 -> {nameof(Unix_DetectButton)}");
-            Console.WriteLine($"       17 -> {nameof(Unix_DetectButtonLED)}");
+            Console.WriteLine($"       17 -> {nameof(Unix_DetectButtonLed)}");
             Console.WriteLine();
             Console.WriteLine($"       18 -> {nameof(RaspberryPi_DetectButton)}");
-            Console.WriteLine($"       19 -> {nameof(RaspberryPi_DetectButtonLED)}");
+            Console.WriteLine($"       19 -> {nameof(RaspberryPi_DetectButtonLed)}");
             Console.WriteLine();
             Console.WriteLine($"       20 -> {nameof(Unix_ButtonWait)}");
             Console.WriteLine($"       21 -> {nameof(RaspberryPi_ButtonWait)}");
             Console.WriteLine();
-            Console.WriteLine($"       22 -> {nameof(Unix_LCD)}");
-            Console.WriteLine($"       23 -> {nameof(RaspberryPi_LCD)}");
+            Console.WriteLine($"       22 -> {nameof(Unix_Lcd)}");
+            Console.WriteLine($"       23 -> {nameof(RaspberryPi_Lcd)}");
             Console.WriteLine();
             Console.WriteLine($"       24 -> {nameof(Spi_Roundtrip)}");
             Console.WriteLine();
             Console.WriteLine($"       25 -> {nameof(Unix_Spi_Bme280)}");
             Console.WriteLine($"       26 -> {nameof(RaspberryPi_Spi_Bme280)}");
             Console.WriteLine();
-            Console.WriteLine($"       27 -> {nameof(Unix_Spi_Bme280_LCD)}");
-            Console.WriteLine($"       28 -> {nameof(RaspberryPi_Spi_Bme280_LCD)}");
+            Console.WriteLine($"       27 -> {nameof(Unix_Spi_Bme280_Lcd)}");
+            Console.WriteLine($"       28 -> {nameof(RaspberryPi_Spi_Bme280_Lcd)}");
             Console.WriteLine();
         }
 
-        private static void Unix_BlinkingLED()
+        private static void Unix_BlinkingLed()
         {
-            Console.WriteLine(nameof(Unix_BlinkingLED));
-            BlinkingLED(new UnixDriver(RaspberryPiPinCount));
+            Console.WriteLine(nameof(Unix_BlinkingLed));
+            BlinkingLed(new UnixDriver(RaspberryPiPinCount));
         }
 
-        private static void Unix_ButtonLED()
+        private static void Unix_ButtonLed()
         {
-            Console.WriteLine(nameof(Unix_ButtonLED));
-            ButtonLED(new UnixDriver(RaspberryPiPinCount));
+            Console.WriteLine(nameof(Unix_ButtonLed));
+            ButtonLed(new UnixDriver(RaspberryPiPinCount));
         }
 
-        private static void RaspberryPi_BlinkingLED()
+        private static void RaspberryPi_BlinkingLed()
         {
-            Console.WriteLine(nameof(RaspberryPi_BlinkingLED));
-            BlinkingLED(new RaspberryPiDriver());
+            Console.WriteLine(nameof(RaspberryPi_BlinkingLed));
+            BlinkingLed(new RaspberryPiDriver());
         }
 
-        private static void RaspberryPi_ButtonLED()
+        private static void RaspberryPi_ButtonLed()
         {
-            Console.WriteLine(nameof(RaspberryPi_ButtonLED));
-            ButtonLED(new RaspberryPiDriver());
+            Console.WriteLine(nameof(RaspberryPi_ButtonLed));
+            ButtonLed(new RaspberryPiDriver());
         }
 
-        private static void BlinkingLED(GpioDriver driver)
+        private static void BlinkingLed(GpioDriver driver)
         {
             using (var controller = new GpioController(driver, PinNumberingScheme.BCM))
             {
@@ -234,7 +234,7 @@ namespace System.Devices.Gpio.Samples
             }
         }
 
-        private static void ButtonLED(GpioDriver driver)
+        private static void ButtonLed(GpioDriver driver)
         {
             using (var controller = new GpioController(driver, PinNumberingScheme.BCM))
             {
@@ -251,31 +251,31 @@ namespace System.Devices.Gpio.Samples
             }
         }
 
-        private static void UnixDriver_BlinkingLED()
+        private static void UnixDriver_BlinkingLed()
         {
-            Console.WriteLine(nameof(UnixDriver_BlinkingLED));
-            Driver_BlinkingLED(new UnixDriver(RaspberryPiPinCount));
+            Console.WriteLine(nameof(UnixDriver_BlinkingLed));
+            Driver_BlinkingLed(new UnixDriver(RaspberryPiPinCount));
         }
 
-        private static void UnixDriver_ButtonLED()
+        private static void UnixDriver_ButtonLed()
         {
-            Console.WriteLine(nameof(UnixDriver_ButtonLED));
-            Driver_ButtonLED(new UnixDriver(RaspberryPiPinCount));
+            Console.WriteLine(nameof(UnixDriver_ButtonLed));
+            Driver_ButtonLed(new UnixDriver(RaspberryPiPinCount));
         }
 
-        private static void RaspberryPiDriver_BlinkingLED()
+        private static void RaspberryPiDriver_BlinkingLed()
         {
-            Console.WriteLine(nameof(RaspberryPiDriver_BlinkingLED));
-            Driver_BlinkingLED(new RaspberryPiDriver());
+            Console.WriteLine(nameof(RaspberryPiDriver_BlinkingLed));
+            Driver_BlinkingLed(new RaspberryPiDriver());
         }
 
-        private static void RaspberryPiDriver_ButtonLED()
+        private static void RaspberryPiDriver_ButtonLed()
         {
-            Console.WriteLine(nameof(RaspberryPiDriver_ButtonLED));
-            Driver_ButtonLED(new RaspberryPiDriver());
+            Console.WriteLine(nameof(RaspberryPiDriver_ButtonLed));
+            Driver_ButtonLed(new RaspberryPiDriver());
         }
 
-        private static void Driver_BlinkingLED(GpioDriver driver)
+        private static void Driver_BlinkingLed(GpioDriver driver)
         {
             const int led = 26;
 
@@ -295,7 +295,7 @@ namespace System.Devices.Gpio.Samples
             }
         }
 
-        private static void Driver_ButtonLED(GpioDriver driver)
+        private static void Driver_ButtonLed(GpioDriver driver)
         {
             const int button = 18;
             const int led = 26;
@@ -475,19 +475,19 @@ namespace System.Devices.Gpio.Samples
             s_buttonPressed = !s_buttonPressed;
         }
 
-        private static void UnixDriver_DetectButtonLED()
+        private static void UnixDriver_DetectButtonLed()
         {
-            Console.WriteLine(nameof(UnixDriver_DetectButtonLED));
-            Driver_DetectButtonLED(new UnixDriver(RaspberryPiPinCount));
+            Console.WriteLine(nameof(UnixDriver_DetectButtonLed));
+            Driver_DetectButtonLed(new UnixDriver(RaspberryPiPinCount));
         }
 
-        private static void RaspberryPiDriver_DetectButtonLED()
+        private static void RaspberryPiDriver_DetectButtonLed()
         {
-            Console.WriteLine(nameof(RaspberryPiDriver_DetectButtonLED));
-            Driver_DetectButtonLED(new RaspberryPiDriver());
+            Console.WriteLine(nameof(RaspberryPiDriver_DetectButtonLed));
+            Driver_DetectButtonLed(new RaspberryPiDriver());
         }
 
-        private static void Driver_DetectButtonLED(GpioDriver driver)
+        private static void Driver_DetectButtonLed(GpioDriver driver)
         {
             const int button = 18;
             const int led = 26;
@@ -524,19 +524,19 @@ namespace System.Devices.Gpio.Samples
             }
         }
 
-        private static void Unix_DetectButtonLED()
+        private static void Unix_DetectButtonLed()
         {
-            Console.WriteLine(nameof(Unix_DetectButtonLED));
-            DetectButtonLED(new UnixDriver(RaspberryPiPinCount));
+            Console.WriteLine(nameof(Unix_DetectButtonLed));
+            DetectButtonLed(new UnixDriver(RaspberryPiPinCount));
         }
 
-        private static void RaspberryPi_DetectButtonLED()
+        private static void RaspberryPi_DetectButtonLed()
         {
-            Console.WriteLine(nameof(RaspberryPi_DetectButtonLED));
-            DetectButtonLED(new RaspberryPiDriver());
+            Console.WriteLine(nameof(RaspberryPi_DetectButtonLed));
+            DetectButtonLed(new RaspberryPiDriver());
         }
 
-        private static void DetectButtonLED(GpioDriver driver)
+        private static void DetectButtonLed(GpioDriver driver)
         {
             using (var controller = new GpioController(driver, PinNumberingScheme.BCM))
             {
@@ -573,7 +573,7 @@ namespace System.Devices.Gpio.Samples
             const int ledPinNumber = 26;
 
             s_currentLedValue = s_currentLedValue == PinValue.High ? PinValue.Low : PinValue.High;
-            Console.WriteLine($"Button pressed! LED value {s_currentLedValue}");
+            Console.WriteLine($"Button pressed! Led value {s_currentLedValue}");
 
             if (sender is GpioDriver)
             {
@@ -686,19 +686,19 @@ namespace System.Devices.Gpio.Samples
             }
         }
 
-        private static void Unix_LCD()
+        private static void Unix_Lcd()
         {
-            Console.WriteLine(nameof(Unix_LCD));
-            LCD(new UnixDriver(RaspberryPiPinCount));
+            Console.WriteLine(nameof(Unix_Lcd));
+            Lcd(new UnixDriver(RaspberryPiPinCount));
         }
 
-        private static void RaspberryPi_LCD()
+        private static void RaspberryPi_Lcd()
         {
-            Console.WriteLine(nameof(RaspberryPi_LCD));
-            LCD(new RaspberryPiDriver());
+            Console.WriteLine(nameof(RaspberryPi_Lcd));
+            Lcd(new RaspberryPiDriver());
         }
 
-        private static void LCD(GpioDriver driver)
+        private static void Lcd(GpioDriver driver)
         {
             using (var controller = new GpioController(driver, PinNumberingScheme.BCM))
             {
@@ -798,19 +798,19 @@ namespace System.Devices.Gpio.Samples
             }
         }
 
-        private static void Unix_Spi_Bme280_LCD()
+        private static void Unix_Spi_Bme280_Lcd()
         {
-            Console.WriteLine(nameof(Unix_Spi_Bme280_LCD));
-            Spi_Bme280_LCD(new UnixDriver(RaspberryPiPinCount));
+            Console.WriteLine(nameof(Unix_Spi_Bme280_Lcd));
+            Spi_Bme280_Lcd(new UnixDriver(RaspberryPiPinCount));
         }
 
-        private static void RaspberryPi_Spi_Bme280_LCD()
+        private static void RaspberryPi_Spi_Bme280_Lcd()
         {
-            Console.WriteLine(nameof(RaspberryPi_Spi_Bme280_LCD));
-            Spi_Bme280_LCD(new RaspberryPiDriver());
+            Console.WriteLine(nameof(RaspberryPi_Spi_Bme280_Lcd));
+            Spi_Bme280_Lcd(new RaspberryPiDriver());
         }
 
-        private static void Spi_Bme280_LCD(GpioDriver driver)
+        private static void Spi_Bme280_Lcd(GpioDriver driver)
         {
             using (var controller = new GpioController(driver, PinNumberingScheme.BCM))
             {

--- a/src/System.Devices.Gpio/System.Devices.Gpio.Samples/Program.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio.Samples/Program.cs
@@ -72,7 +72,6 @@ namespace System.Devices.Gpio.Samples
                     case 13:
                         UnixDriver_ButtonWait();
                         break;
-
                     case 14:
                         RaspberryPiDriver_ButtonWait();
                         break;
@@ -98,7 +97,6 @@ namespace System.Devices.Gpio.Samples
                     case 20:
                         Unix_ButtonWait();
                         break;
-
                     case 21:
                         RaspberryPi_ButtonWait();
                         break;
@@ -106,7 +104,6 @@ namespace System.Devices.Gpio.Samples
                     case 22:
                         Unix_LCD();
                         break;
-
                     case 23:
                         RaspberryPi_LCD();
                         break;
@@ -116,24 +113,17 @@ namespace System.Devices.Gpio.Samples
                         break;
 
                     case 25:
-                        Unix_Hardware_Spi_Bme280();
+                        Unix_Spi_Bme280();
                         break;
                     case 26:
-                        Unix_Software_Spi_Bme280();
+                        RaspberryPi_Spi_Bme280();
                         break;
 
                     case 27:
-                        RaspberryPi_Hardware_Spi_Bme280();
+                        Unix_Spi_Bme280_LCD();
                         break;
                     case 28:
-                        RaspberryPi_Software_Spi_Bme280();
-                        break;
-
-                    case 29:
-                        Unix_Hardware_Spi_Bme280_LCD();
-                        break;
-                    case 30:
-                        RaspberryPi_Hardware_Spi_Bme280_LCD();
+                        RaspberryPi_Spi_Bme280_LCD();
                         break;
 
                     default:
@@ -177,7 +167,6 @@ namespace System.Devices.Gpio.Samples
             Console.WriteLine($"       12 -> {nameof(RaspberryPiDriver_DetectButtonLED)}");
             Console.WriteLine();
             Console.WriteLine($"       13 -> {nameof(UnixDriver_ButtonWait)}");
-            Console.WriteLine();
             Console.WriteLine($"       14 -> {nameof(RaspberryPiDriver_ButtonWait)}");
             Console.WriteLine();
             Console.WriteLine($"       15 -> {nameof(RaspberryPi_ButtonPullDown)}");
@@ -189,7 +178,6 @@ namespace System.Devices.Gpio.Samples
             Console.WriteLine($"       19 -> {nameof(RaspberryPi_DetectButtonLED)}");
             Console.WriteLine();
             Console.WriteLine($"       20 -> {nameof(Unix_ButtonWait)}");
-            Console.WriteLine();
             Console.WriteLine($"       21 -> {nameof(RaspberryPi_ButtonWait)}");
             Console.WriteLine();
             Console.WriteLine($"       22 -> {nameof(Unix_LCD)}");
@@ -197,14 +185,11 @@ namespace System.Devices.Gpio.Samples
             Console.WriteLine();
             Console.WriteLine($"       24 -> {nameof(Spi_Roundtrip)}");
             Console.WriteLine();
-            Console.WriteLine($"       25 -> {nameof(Unix_Hardware_Spi_Bme280)}");
-            Console.WriteLine($"       26 -> {nameof(Unix_Software_Spi_Bme280)}");
+            Console.WriteLine($"       25 -> {nameof(Unix_Spi_Bme280)}");
+            Console.WriteLine($"       26 -> {nameof(RaspberryPi_Spi_Bme280)}");
             Console.WriteLine();
-            Console.WriteLine($"       27 -> {nameof(RaspberryPi_Hardware_Spi_Bme280)}");
-            Console.WriteLine($"       28 -> {nameof(RaspberryPi_Software_Spi_Bme280)}");
-            Console.WriteLine();
-            Console.WriteLine($"       29 -> {nameof(Unix_Hardware_Spi_Bme280_LCD)}");
-            Console.WriteLine($"       30 -> {nameof(RaspberryPi_Hardware_Spi_Bme280_LCD)}");
+            Console.WriteLine($"       27 -> {nameof(Unix_Spi_Bme280_LCD)}");
+            Console.WriteLine($"       28 -> {nameof(RaspberryPi_Spi_Bme280_LCD)}");
             Console.WriteLine();
         }
 
@@ -769,95 +754,63 @@ namespace System.Devices.Gpio.Samples
             }
         }
 
-        private static void Unix_Hardware_Spi_Bme280()
+        private static void Unix_Spi_Bme280()
         {
-            Console.WriteLine(nameof(Unix_Hardware_Spi_Bme280));
-            Hardware_Spi_Bme280(new UnixDriver(RaspberryPiPinCount));
+            Console.WriteLine(nameof(Unix_Spi_Bme280));
+            Spi_Bme280(new UnixDriver(RaspberryPiPinCount));
         }
 
-        private static void RaspberryPi_Hardware_Spi_Bme280()
+        private static void RaspberryPi_Spi_Bme280()
         {
-            Console.WriteLine(nameof(RaspberryPi_Hardware_Spi_Bme280));
-            Hardware_Spi_Bme280(new RaspberryPiDriver());
+            Console.WriteLine(nameof(RaspberryPi_Spi_Bme280));
+            Spi_Bme280(new RaspberryPiDriver());
         }
 
-        private static void Unix_Software_Spi_Bme280()
-        {
-            Console.WriteLine(nameof(Unix_Software_Spi_Bme280));
-            Software_Spi_Bme280(new UnixDriver(RaspberryPiPinCount));
-        }
-
-        private static void RaspberryPi_Software_Spi_Bme280()
-        {
-            Console.WriteLine(nameof(RaspberryPi_Software_Spi_Bme280));
-            Software_Spi_Bme280(new RaspberryPiDriver());
-        }
-
-        private static void Hardware_Spi_Bme280(GpioDriver driver)
+        private static void Spi_Bme280(GpioDriver driver)
         {
             using (var controller = new GpioController(driver, PinNumberingScheme.BCM))
             {
                 Pin csPin = controller.OpenPin(8);
 
                 var settings = new SpiConnectionSettings(0, 0);
-                var bme280 = new Bme280(csPin, settings);
-                Bme280(bme280);
-            }
-        }
-
-        private static void Software_Spi_Bme280(GpioDriver driver)
-        {
-            using (var controller = new GpioController(driver, PinNumberingScheme.BCM))
-            {
-                Pin csPin = controller.OpenPin(8);
-                Pin mosiPin = controller.OpenPin(10);
-                Pin misoPin = controller.OpenPin(9);
-                Pin sckPin = controller.OpenPin(11);
-
-                var bme280 = new Bme280(csPin, mosiPin, misoPin, sckPin);
-                Bme280(bme280);
-            }
-        }
-
-        private static void Bme280(Bme280 bme280)
-        {
-            using (bme280)
-            {
-                bool ok = bme280.Begin();
-
-                if (ok)
+                using (var bme280 = new Bme280(csPin, settings))
                 {
-                    Console.WriteLine($"Pressure (hPa/mb)\tHumdity (%)\tTemp (C)\tTemp (F)");
-                    Console.WriteLine();
+                    bool ok = bme280.Begin();
 
-                    for (var i = 0; i < 5; ++i)
+                    if (ok)
                     {
-                        bme280.ReadSensor();
+                        Console.WriteLine($"Pressure (hPa/mb)\tHumdity (%)\tTemp (C)\tTemp (F)");
+                        Console.WriteLine();
 
-                        Console.WriteLine($"{bme280.PressureInHectopascals:0.00} hPa\t\t{bme280.Humidity:0.00} %\t\t{bme280.TemperatureInCelsius:0.00} C\t\t{bme280.TemperatureInFahrenheit:0.00} F");
-                        Thread.Sleep(1 * 1000);
+                        for (var i = 0; i < 5; ++i)
+                        {
+                            bme280.ReadSensor();
+
+                            Console.WriteLine($"{bme280.PressureInHectopascals:0.00} hPa\t\t{bme280.Humidity:0.00} %\t\t{bme280.TemperatureInCelsius:0.00} C\t\t{bme280.TemperatureInFahrenheit:0.00} F");
+                            Thread.Sleep(1 * 1000);
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Error initializing sensor");
                     }
                 }
-                else
-                {
-                    Console.WriteLine($"Error initializing sensor");
-                }
             }
         }
 
-        private static void Unix_Hardware_Spi_Bme280_LCD()
+        private static void Unix_Spi_Bme280_LCD()
         {
-            Console.WriteLine(nameof(Unix_Hardware_Spi_Bme280_LCD));
-            Hardware_Spi_Bme280_LCD(new UnixDriver(RaspberryPiPinCount));
+            Console.WriteLine(nameof(Unix_Spi_Bme280_LCD));
+            Spi_Bme280_LCD(new UnixDriver(RaspberryPiPinCount));
         }
 
-        private static void RaspberryPi_Hardware_Spi_Bme280_LCD()
+        private static void RaspberryPi_Spi_Bme280_LCD()
         {
-            Console.WriteLine(nameof(RaspberryPi_Hardware_Spi_Bme280_LCD));
-            Hardware_Spi_Bme280_LCD(new RaspberryPiDriver());
+            Console.WriteLine(nameof(RaspberryPi_Spi_Bme280_LCD));
+            Spi_Bme280_LCD(new RaspberryPiDriver());
         }
 
-        private static void Hardware_Spi_Bme280_LCD(GpioDriver driver)
+        private static void Spi_Bme280_LCD(GpioDriver driver)
         {
             using (var controller = new GpioController(driver, PinNumberingScheme.BCM))
             {

--- a/src/System.Devices.Gpio/System.Devices.Gpio/GpioDriver.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/GpioDriver.cs
@@ -3,13 +3,6 @@
 
 namespace System.Devices.Gpio
 {
-    public class PinValueChangedEventArgs : EventArgs
-    {
-        public PinValueChangedEventArgs(int bcmPinNumber) => BcmPinNumber = bcmPinNumber;
-
-        public int BcmPinNumber { get; }
-    }
-
     public abstract class GpioDriver : IDisposable
     {
         public event EventHandler<PinValueChangedEventArgs> ValueChanged;

--- a/src/System.Devices.Gpio/System.Devices.Gpio/Pin.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/Pin.cs
@@ -3,42 +3,6 @@
 
 namespace System.Devices.Gpio
 {
-    public enum PinMode
-    {
-        Input,
-        Output,
-        InputPullDown,
-        InputPullUp
-    }
-
-    public enum PinValue
-    {
-        Low = 0,
-        High = 1
-    }
-
-    [Flags]
-    public enum PinEvent
-    {
-        None = 0,
-        Low = 1,
-        High = 2,
-        SyncFallingEdge = 4,
-        SyncRisingEdge = 8,
-        AsyncFallingEdge = 16,
-        AsyncRisingEdge = 32,
-
-        Both = Low | High,
-        SyncBoth = SyncFallingEdge | SyncRisingEdge,
-        AsyncBoth = AsyncFallingEdge | AsyncRisingEdge,
-    }
-
-    public enum PinNumberingScheme
-    {
-        Board,
-        BCM
-    }
-
     public class Pin : IDisposable
     {
         internal Pin(GpioController controller, int bcmNumber)

--- a/src/System.Devices.Gpio/System.Devices.Gpio/PinEvent.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/PinEvent.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Devices.Gpio
+{
+    [Flags]
+    public enum PinEvent
+    {
+        None = 0,
+        Low = 1,
+        High = 2,
+        SyncFallingEdge = 4,
+        SyncRisingEdge = 8,
+        AsyncFallingEdge = 16,
+        AsyncRisingEdge = 32,
+
+        Both = Low | High,
+        SyncBoth = SyncFallingEdge | SyncRisingEdge,
+        AsyncBoth = AsyncFallingEdge | AsyncRisingEdge,
+    }
+}

--- a/src/System.Devices.Gpio/System.Devices.Gpio/PinMode.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/PinMode.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Devices.Gpio
+{
+    public enum PinMode
+    {
+        Input,
+        Output,
+        InputPullDown,
+        InputPullUp
+    }
+}

--- a/src/System.Devices.Gpio/System.Devices.Gpio/PinNumberingScheme.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/PinNumberingScheme.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Devices.Gpio
+{
+    public enum PinNumberingScheme
+    {
+        Board,
+        BCM
+    }
+}

--- a/src/System.Devices.Gpio/System.Devices.Gpio/PinValue.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/PinValue.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Devices.Gpio
+{
+    public enum PinValue
+    {
+        Low = 0,
+        High = 1
+    }
+}

--- a/src/System.Devices.Gpio/System.Devices.Gpio/PinValueChangedEventArgs.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/PinValueChangedEventArgs.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Devices.Gpio
+{
+    public class PinValueChangedEventArgs : EventArgs
+    {
+        public PinValueChangedEventArgs(int bcmPinNumber) => BcmPinNumber = bcmPinNumber;
+
+        public int BcmPinNumber { get; }
+    }
+}

--- a/src/System.Devices.Gpio/System.Devices.Gpio/SpiConnectionSettings.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/SpiConnectionSettings.cs
@@ -27,7 +27,12 @@ namespace System.Devices.Gpio
     public sealed class SpiConnectionSettings
     {
         /// <summary>
-        /// Gets or sets the chip select line for the connection to the SPI device.
+        /// Gets or sets the Spi bus id for this connection.
+        /// </summary>
+        public int BusId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the chip select line for this connection.
         /// </summary>
         public int ChipSelectLine { get; set; }
 
@@ -53,13 +58,24 @@ namespace System.Devices.Gpio
         /// <summary>
         /// Initializes new instance of <see cref="SpiConnectionSettings"/>.
         /// </summary>
+        /// <param name="busId">The Spi bus id on which the connection will be made.</param>
         /// <param name="chipSelectLine">The chip select line on which the connection will be made.</param>
-        public SpiConnectionSettings(int chipSelectLine)
+        public SpiConnectionSettings(int busId, int chipSelectLine)
         {
+            BusId = busId;
             ChipSelectLine = chipSelectLine;
             DataBitLength = DefaultDataBitLength;
             ClockFrequency = DefaultClockFrequency;
             Mode = DefaultMode;
+        }
+
+        internal SpiConnectionSettings(SpiConnectionSettings other)
+        {
+            BusId = other.BusId;
+            ChipSelectLine = other.ChipSelectLine;
+            DataBitLength = other.DataBitLength;
+            ClockFrequency = other.ClockFrequency;
+            Mode = other.Mode;
         }
     }
 }

--- a/src/System.Devices.Gpio/System.Devices.Gpio/SpiConnectionSettings.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/SpiConnectionSettings.cs
@@ -4,24 +4,6 @@
 namespace System.Devices.Gpio
 {
     /// <summary>
-    /// Defines the SPI communication mode.
-    /// The communication mode defines the clock edge on which the master out line toggles,
-    /// the master in line samples, and the signal clock's signal steady level (named SCLK).
-    /// Each mode is defined with a pair of parameters called clock polarity (CPOL) and clock phase (CPHA).
-    /// </summary>
-    public enum SpiMode
-    {
-        /// <summary>CPOL = 0, CPHA = 0</summary>
-        Mode0 = 0,
-        /// <summary>CPOL = 0, CPHA = 1</summary>
-        Mode1 = 1,
-        /// <summary>CPOL = 1, CPHA = 0</summary>
-        Mode2 = 2,
-        /// <summary>CPOL = 1, CPHA = 1</summary>
-        Mode3 = 3
-    }
-
-    /// <summary>
     /// Represents the settings for the connection with an <see cref="SpiDevice"/>.
     /// </summary>
     public sealed class SpiConnectionSettings

--- a/src/System.Devices.Gpio/System.Devices.Gpio/SpiConnectionSettings.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/SpiConnectionSettings.cs
@@ -35,7 +35,7 @@ namespace System.Devices.Gpio
 
         private const SpiMode DefaultMode = SpiMode.Mode0;
         private const int DefaultDataBitLength = 8; // 1 byte
-        private const int DefaultClockFrequency = 500 * 1000; // 500 KHz
+        private const int DefaultClockFrequency = 500_000; // 500 KHz
 
         /// <summary>
         /// Initializes new instance of <see cref="SpiConnectionSettings"/>.

--- a/src/System.Devices.Gpio/System.Devices.Gpio/SpiDevice.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/SpiDevice.cs
@@ -5,14 +5,16 @@ namespace System.Devices.Gpio
 {
     public abstract class SpiDevice : IDisposable
     {
-        public SpiConnectionSettings ConnectionSettings { get; }
+        protected SpiConnectionSettings _settings;
 
         public SpiDevice(SpiConnectionSettings settings)
         {
-            ConnectionSettings = settings;
+            _settings = settings;
         }
 
         public abstract void Dispose();
+
+        public SpiConnectionSettings GetConnectionSettings() => new SpiConnectionSettings(_settings);
 
         public abstract void TransferFullDuplex(byte[] writeBuffer, byte[] readBuffer);
         public abstract void Read(byte[] buffer);

--- a/src/System.Devices.Gpio/System.Devices.Gpio/SpiMode.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/SpiMode.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Devices.Gpio
+{
+    /// <summary>
+    /// Defines the SPI communication mode.
+    /// The communication mode defines the clock edge on which the master out line toggles,
+    /// the master in line samples, and the signal clock's signal steady level (named SCLK).
+    /// Each mode is defined with a pair of parameters called clock polarity (CPOL) and clock phase (CPHA).
+    /// </summary>
+    public enum SpiMode
+    {
+        /// <summary>CPOL = 0, CPHA = 0</summary>
+        Mode0 = 0,
+        /// <summary>CPOL = 0, CPHA = 1</summary>
+        Mode1 = 1,
+        /// <summary>CPOL = 1, CPHA = 0</summary>
+        Mode2 = 2,
+        /// <summary>CPOL = 1, CPHA = 1</summary>
+        Mode3 = 3
+    }
+}


### PR DESCRIPTION
BME280 sensor allows to read pressure, humidity and temperature data. It supports both SPI and I2C serial protocols. The later is not yet supported by the current implementation.

I have also added an integrated sample that displays the data read from the sensor to an LCD using both SPI and GPIO pins.