### PR TITLE
Adding Utf8Json to Json Reader performance tests

### DIFF
--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -40,7 +40,7 @@ namespace System.Text.JsonLab.Benchmarks
         private MemoryStream _stream;
         private StreamReader _reader;
 
-        [Params(true, false)]
+        [Params(true)]
         public bool IsUTF8Encoded;
 
         [ParamsSource(nameof(TestCaseValues))]
@@ -116,6 +116,52 @@ namespace System.Text.JsonLab.Benchmarks
                     JsonLabReturnBytesHelper(_dataUtf16, SymbolTable.InvariantUtf16, 2);
         }
 
+        [Benchmark]
+        public void ReaderUtf8JsonEmptyLoop()
+        {
+            Utf8Json.JsonReader json = new Utf8Json.JsonReader(_dataUtf8);
+
+            while (json.GetCurrentJsonToken() != Utf8Json.JsonToken.None)
+            {
+                json.ReadNext();
+            }
+        }
+
+        [Benchmark]
+        public byte[] ReaderUtf8JsonReturnBytes()
+        {
+            Utf8Json.JsonReader json = new Utf8Json.JsonReader(_dataUtf8);
+
+            byte[] outputArray = new byte[_dataUtf8.Length * 2];
+            Span<byte> destination = outputArray;
+            
+            Utf8Json.JsonToken token = json.GetCurrentJsonToken();
+            while (token != Utf8Json.JsonToken.None)
+            {
+                json.ReadNext();
+                token = json.GetCurrentJsonToken();
+
+                switch (token)
+                {
+                    case Utf8Json.JsonToken.String:
+                    case Utf8Json.JsonToken.Number:
+                    case Utf8Json.JsonToken.True:
+                    case Utf8Json.JsonToken.False:
+                    case Utf8Json.JsonToken.Null:
+                        ReadOnlySpan<byte> valueSpan = json.ReadNextBlockSegment();
+                        valueSpan.CopyTo(destination);
+                        destination[valueSpan.Length] = (byte)',';
+                        destination[valueSpan.Length + 1] = (byte)' ';
+                        destination = destination.Slice(valueSpan.Length + 2);
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            return outputArray;
+        }
+
         private string NewtonsoftReturnStringHelper(TextReader reader)
         {
             StringBuilder sb = new StringBuilder();
@@ -133,7 +179,7 @@ namespace System.Text.JsonLab.Benchmarks
 
         private byte[] JsonLabReturnBytesHelper(byte[] data, SymbolTable symbolTable, int utf16Multiplier = 1)
         {
-            byte[] outputArray = new byte[data.Length];
+            byte[] outputArray = new byte[data.Length * 2];
 
             Span<byte> destination = outputArray;
             var json = new JsonReader(data, symbolTable);

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -29,7 +29,7 @@ namespace System.Text.JsonLab.Benchmarks
         Json400KB
     }
 
-    // Since there are 120 tests here (4 * 2 * 15), setting low values for the warmupCount, targetCount, and invocationCount
+    // Since there are 90 tests here (6 * 15), setting low values for the warmupCount, targetCount, and invocationCount
     [SimpleJob(-1, 3, 5, 1024)]
     [MemoryDiagnoser]
     public class JsonReaderPerf


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.10.14.683-nightly, OS=Windows 10.0.17713
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.2.100-preview1-009015
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT


```
|                             Method | IsUTF8Encoded |   TestCase |         Mean |      Error |     StdDev |       Median |  Gen 0 | Allocated |
|----------------------------------- |-------------- |----------- |-------------:|-----------:|-----------:|-------------:|-------:|----------:|
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** |  **BasicJson** |    **485.22 ns** |   **9.660 ns** |  **22.770 ns** |    **479.89 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True |  BasicJson |    595.67 ns |  12.456 ns |  27.341 ns |    589.12 ns | 0.1230 |     520 B |
|            ReaderUtf8JsonEmptyLoop |          True |  BasicJson |    943.96 ns |  18.724 ns |  23.680 ns |    949.45 ns |      - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True |  BasicJson |  1,162.38 ns |  22.264 ns |  20.826 ns |  1,154.38 ns | 0.1221 |     520 B |
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** | **HelloWorld** |     **90.66 ns** |   **4.006 ns** |  **11.810 ns** |     **85.41 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True | HelloWorld |     95.91 ns |   1.323 ns |   1.238 ns |     95.51 ns | 0.0209 |      88 B |
|            ReaderUtf8JsonEmptyLoop |          True | HelloWorld |     92.76 ns |   1.724 ns |   1.440 ns |     92.66 ns |      - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True | HelloWorld |    145.33 ns |   3.648 ns |  10.525 ns |    143.05 ns | 0.0207 |      88 B |
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** |   **Json400B** |    **740.58 ns** |  **16.829 ns** |  **46.634 ns** |    **724.21 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True |   Json400B |    869.68 ns |   7.951 ns |   6.640 ns |    871.09 ns | 0.2146 |     904 B |
|            ReaderUtf8JsonEmptyLoop |          True |   Json400B |  1,388.52 ns |  26.943 ns |  27.668 ns |  1,386.58 ns |      - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True |   Json400B |  1,628.70 ns |  24.201 ns |  21.454 ns |  1,635.69 ns | 0.2136 |     904 B |
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** |    **Json4KB** |  **6,482.77 ns** | **135.540 ns** | **337.542 ns** |  **6,361.17 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True |    Json4KB |  7,677.38 ns |  72.810 ns |  64.544 ns |  7,651.31 ns | 2.1057 |    8856 B |
|            ReaderUtf8JsonEmptyLoop |          True |    Json4KB | 12,211.81 ns | 241.403 ns | 648.513 ns | 12,103.22 ns |      - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True |    Json4KB | 14,546.91 ns | 294.664 ns | 776.262 ns | 14,111.82 ns | 2.1057 |    8856 B |




``` ini

BenchmarkDotNet=v0.10.14.683-nightly, OS=Windows 10.0.17713
Intel Core i7-6700 CPU 3.40GHz (Max: 3.00GHz) (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.2.100-preview1-009015
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  Job-YFJZPO : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT

InvocationCount=1024  IterationCount=5  WarmupCount=3  

```
|                             Method | IsUTF8Encoded |        TestCase |           Mean |         Error |       StdDev |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|----------------------------------- |-------------- |---------------- |---------------:|--------------:|-------------:|---------:|---------:|---------:|----------:|
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** |   **BasicLargeNum** |       **499.5 ns** |     **173.40 ns** |     **45.04 ns** |        **-** |        **-** |        **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True |   BasicLargeNum |       795.6 ns |     808.44 ns |    209.99 ns |        - |        - |        - |     408 B |
|            ReaderUtf8JsonEmptyLoop |          True |   BasicLargeNum |     1,169.3 ns |     978.80 ns |    254.24 ns |        - |        - |        - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True |   BasicLargeNum |     1,798.1 ns |   1,335.76 ns |    346.96 ns |        - |        - |        - |     408 B |
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** |       **BroadTree** |    **12,109.5 ns** |  **18,697.45 ns** |  **4,856.59 ns** |        **-** |        **-** |        **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True |       BroadTree |    12,705.3 ns |  11,786.16 ns |  3,061.41 ns |   1.9531 |        - |        - |    9600 B |
|            ReaderUtf8JsonEmptyLoop |          True |       BroadTree |    21,520.1 ns |  21,031.72 ns |  5,462.91 ns |        - |        - |        - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True |       BroadTree |    21,130.6 ns |   1,801.42 ns |    467.91 ns |   1.9531 |        - |        - |    9600 B |
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** |        **DeepTree** |     **6,668.9 ns** |   **1,279.42 ns** |    **332.33 ns** |        **-** |        **-** |        **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True |        DeepTree |     8,543.6 ns |   5,291.40 ns |  1,374.42 ns |   1.9531 |        - |        - |    8704 B |
|            ReaderUtf8JsonEmptyLoop |          True |        DeepTree |    11,730.8 ns |   5,172.55 ns |  1,343.55 ns |        - |        - |        - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True |        DeepTree |    17,924.2 ns |  13,057.77 ns |  3,391.71 ns |   1.9531 |        - |        - |    8704 B |
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** |     **FullSchema1** |     **1,093.4 ns** |      **43.24 ns** |     **11.23 ns** |        **-** |        **-** |        **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True |     FullSchema1 |     1,745.0 ns |     447.90 ns |    116.34 ns |        - |        - |        - |     880 B |
|            ReaderUtf8JsonEmptyLoop |          True |     FullSchema1 |     2,722.6 ns |   1,079.34 ns |    280.35 ns |        - |        - |        - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True |     FullSchema1 |     6,150.9 ns |   3,045.70 ns |    791.11 ns |        - |        - |        - |     880 B |
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** |     **FullSchema2** |     **1,624.2 ns** |     **158.70 ns** |     **41.22 ns** |        **-** |        **-** |        **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True |     FullSchema2 |     2,277.6 ns |     443.84 ns |    115.29 ns |        - |        - |        - |    1240 B |
|            ReaderUtf8JsonEmptyLoop |          True |     FullSchema2 |     3,772.6 ns |     923.78 ns |    239.95 ns |        - |        - |        - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True |     FullSchema2 |     5,217.0 ns |   4,630.27 ns |  1,202.70 ns |        - |        - |        - |    1240 B |
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** |       **Json400KB** |   **712,127.6 ns** | **174,682.61 ns** | **45,373.16 ns** |        **-** |        **-** |        **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True |       Json400KB |   997,233.7 ns | 110,059.72 ns | 28,587.60 ns | 198.2422 | 198.2422 | 198.2422 |  855976 B |
|            ReaderUtf8JsonEmptyLoop |          True |       Json400KB | 1,208,502.1 ns |  78,819.40 ns | 20,473.04 ns |        - |        - |        - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True |       Json400KB | 1,552,023.2 ns | 277,564.56 ns | 72,096.36 ns | 198.2422 | 198.2422 | 198.2422 |  855976 B |
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** |        **Json40KB** |    **88,435.8 ns** |  **27,940.64 ns** |  **7,257.48 ns** |        **-** |        **-** |        **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True |        Json40KB |   107,700.6 ns | 106,397.81 ns | 27,636.43 ns |  19.5313 |        - |        - |   84264 B |
|            ReaderUtf8JsonEmptyLoop |          True |        Json40KB |   125,712.8 ns |  10,297.10 ns |  2,674.63 ns |        - |        - |        - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True |        Json40KB |   179,117.6 ns | 100,744.96 ns | 26,168.13 ns |  19.5313 |        - |        - |   84264 B |
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** |   **LotsOfNumbers** |     **2,275.3 ns** |   **2,011.34 ns** |    **522.44 ns** |        **-** |        **-** |        **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True |   LotsOfNumbers |     2,552.9 ns |     628.47 ns |    163.24 ns |        - |        - |        - |    1872 B |
|            ReaderUtf8JsonEmptyLoop |          True |   LotsOfNumbers |     4,616.7 ns |   1,022.97 ns |    265.71 ns |        - |        - |        - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True |   LotsOfNumbers |     5,774.4 ns |   1,912.17 ns |    496.68 ns |        - |        - |        - |    1872 B |
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** |   **LotsOfStrings** |     **2,558.7 ns** |   **4,668.40 ns** |  **1,212.60 ns** |        **-** |        **-** |        **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True |   LotsOfStrings |     1,957.6 ns |     248.23 ns |     64.48 ns |        - |        - |        - |    1576 B |
|            ReaderUtf8JsonEmptyLoop |          True |   LotsOfStrings |     3,876.9 ns |   7,906.27 ns |  2,053.62 ns |        - |        - |        - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True |   LotsOfStrings |     3,576.3 ns |     776.59 ns |    201.72 ns |        - |        - |        - |    1576 B |
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** | **ProjectLockJson** |   **309,985.6 ns** |  **81,312.76 ns** | **21,120.69 ns** |        **-** |        **-** |        **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True | ProjectLockJson |   394,629.9 ns | 147,515.17 ns | 38,316.52 ns | 110.3516 | 110.3516 | 110.3516 |  417128 B |
|            ReaderUtf8JsonEmptyLoop |          True | ProjectLockJson |   490,077.3 ns |  70,192.22 ns | 18,232.17 ns |        - |        - |        - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True | ProjectLockJson |   553,138.5 ns |  33,101.26 ns |  8,597.93 ns | 110.3516 | 110.3516 | 110.3516 |  417128 B |
|   **ReaderSystemTextJsonLabEmptyLoop** |          **True** |  **SpecialNumForm** |       **876.0 ns** |     **151.89 ns** |     **39.45 ns** |        **-** |        **-** |        **-** |       **0 B** |
| ReaderSystemTextJsonLabReturnBytes |          True |  SpecialNumForm |     1,419.2 ns |     598.49 ns |    155.46 ns |        - |        - |        - |    1224 B |
|            ReaderUtf8JsonEmptyLoop |          True |  SpecialNumForm |     2,220.7 ns |   1,414.33 ns |    367.37 ns |        - |        - |        - |       0 B |
|          ReaderUtf8JsonReturnBytes |          True |  SpecialNumForm |     2,776.4 ns |   1,021.61 ns |    265.36 ns |        - |        - |        - |    1224 B |
