### PR TITLE
I2C support and samples using Bme280 sensor and LCD

### DIFF
--- a/src/System.Devices.Gpio/System.Devices.Gpio.Samples/Bme280.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio.Samples/Bme280.cs
@@ -87,20 +87,27 @@ namespace System.Devices.Gpio.Samples
         private I2cDevice _i2cDevice;
 
         private readonly ConnectionProtocol _protocol;
-        private Pin _csPin;
+        private readonly Pin _csPin;
+        private readonly byte[] _buffer;
 
         public Bme280(Pin chipSelectLine, SpiConnectionSettings spiSettings)
+            : this(chipSelectLine)
         {
-            _csPin = chipSelectLine ?? throw new ArgumentNullException(nameof(chipSelectLine));
             _spiSettings = spiSettings ?? throw new ArgumentNullException(nameof(spiSettings));
             _protocol = ConnectionProtocol.Spi;
         }
 
         public Bme280(Pin chipSelectLine, I2cConnectionSettings i2cSettings)
+            : this(chipSelectLine)
         {
-            _csPin = chipSelectLine ?? throw new ArgumentNullException(nameof(chipSelectLine));
             _i2cSettings = i2cSettings ?? throw new ArgumentNullException(nameof(i2cSettings));
             _protocol = ConnectionProtocol.I2c;
+        }
+
+        private Bme280(Pin chipSelectLine)
+        {
+            _csPin = chipSelectLine ?? throw new ArgumentNullException(nameof(chipSelectLine));
+            _buffer = new byte[1];
         }
 
         public void Dispose()
@@ -291,39 +298,37 @@ namespace System.Devices.Gpio.Samples
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private byte Read()
         {
-            var buffer = new byte[1];
-
             switch (_protocol)
             {
                 case ConnectionProtocol.Spi:
-                    _spiDevice.Read(buffer);
+                    _spiDevice.Read(_buffer);
                     break;
 
                 case ConnectionProtocol.I2c:
-                    _i2cDevice.Read(buffer);
+                    _i2cDevice.Read(_buffer);
                     break;
 
                 default:
                     throw new NotSupportedException($"Connection protocol '{_protocol}' not supported");
             }
 
-            byte result = buffer[0];
+            byte result = _buffer[0];
             return result;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void Write(byte x)
         {
-            var buffer = new byte[] { x };
+            _buffer[0] = x;
 
             switch (_protocol)
             {
                 case ConnectionProtocol.Spi:
-                    _spiDevice.Write(buffer);
+                    _spiDevice.Write(_buffer);
                     break;
 
                 case ConnectionProtocol.I2c:
-                    _i2cDevice.Write(buffer);
+                    _i2cDevice.Write(_buffer);
                     break;
 
                 default:

--- a/src/System.Devices.Gpio/System.Devices.Gpio.Samples/LiquidCrystal.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio.Samples/LiquidCrystal.cs
@@ -65,17 +65,17 @@ namespace System.Devices.Gpio.Samples
         // can't assume that its in that state when a sketch starts (and the
         // LiquidCrystal constructor is called).
 
-        private Pin _rsPin; // LOW: command.  HIGH: character.
-        private Pin _rwPin; // LOW: write to LCD.  HIGH: read from LCD.
-        private Pin _enablePin; // Activated by a HIGH pulse.
-        private Pin[] _dataPins;
+        private readonly Pin _rsPin; // LOW: command.  HIGH: character.
+        private readonly Pin _rwPin; // LOW: write to LCD.  HIGH: read from LCD.
+        private readonly Pin _enablePin; // Activated by a HIGH pulse.
+        private readonly Pin[] _dataPins;
 
         private byte _displayFunction;
         private byte _displayControl;
         private byte _displayMode;
 
         private byte _numLines;
-        private byte[] _rowOffsets;
+        private readonly byte[] _rowOffsets;
 
         public LiquidCrystal(Pin registerSelect, Pin enable, params Pin[] data)
             : this(registerSelect, null, enable, data)

--- a/src/System.Devices.Gpio/System.Devices.Gpio/I2cConnectionSettings.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/I2cConnectionSettings.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Devices.Gpio
+{
+    /// <summary>
+    /// Represents the settings for the connection with an <see cref="I2cDevice"/>.
+    /// </summary>
+    public sealed class I2cConnectionSettings
+    {
+        /// <summary>
+        /// Gets or sets the I2c bus id for this connection.
+        /// </summary>
+        public int BusId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the I2c connection device address.
+        /// </summary>
+        public int DeviceAddress { get; set; }
+
+        /// <summary>
+        /// Initializes new instance of <see cref="I2cConnectionSettings"/>.
+        /// </summary>
+        /// <param name="busId">The I2c bus id on which the connection will be made.</param>
+        /// <param name="deviceAddress">The I2c connection device address.</param>
+        public I2cConnectionSettings(int busId, int deviceAddress)
+        {
+            BusId = busId;
+            DeviceAddress = deviceAddress;
+        }
+
+        /// <summary>
+        /// Initializes new instance of <see cref="I2cConnectionSettings"/>.
+        /// </summary>
+        /// <param name="busId">The I2c bus id on which the connection will be made.</param>
+        public I2cConnectionSettings(int busId)
+        {
+            BusId = busId;
+        }
+
+        internal I2cConnectionSettings(I2cConnectionSettings other)
+        {
+            BusId = other.BusId;
+            DeviceAddress = other.DeviceAddress;
+        }
+    }
+}

--- a/src/System.Devices.Gpio/System.Devices.Gpio/I2cConnectionSettings.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/I2cConnectionSettings.cs
@@ -11,19 +11,19 @@ namespace System.Devices.Gpio
         /// <summary>
         /// Gets or sets the I2c bus id for this connection.
         /// </summary>
-        public int BusId { get; set; }
+        public uint BusId { get; set; }
 
         /// <summary>
         /// Gets or sets the I2c connection device address.
         /// </summary>
-        public int DeviceAddress { get; set; }
+        public uint DeviceAddress { get; set; }
 
         /// <summary>
         /// Initializes new instance of <see cref="I2cConnectionSettings"/>.
         /// </summary>
         /// <param name="busId">The I2c bus id on which the connection will be made.</param>
         /// <param name="deviceAddress">The I2c connection device address.</param>
-        public I2cConnectionSettings(int busId, int deviceAddress)
+        public I2cConnectionSettings(uint busId, uint deviceAddress)
         {
             BusId = busId;
             DeviceAddress = deviceAddress;
@@ -33,7 +33,7 @@ namespace System.Devices.Gpio
         /// Initializes new instance of <see cref="I2cConnectionSettings"/>.
         /// </summary>
         /// <param name="busId">The I2c bus id on which the connection will be made.</param>
-        public I2cConnectionSettings(int busId)
+        public I2cConnectionSettings(uint busId)
         {
             BusId = busId;
         }

--- a/src/System.Devices.Gpio/System.Devices.Gpio/I2cDevice.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/I2cDevice.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Devices.Gpio
+{
+    public abstract class I2cDevice : IDisposable
+    {
+        protected I2cConnectionSettings _settings;
+
+        public I2cDevice(I2cConnectionSettings settings)
+        {
+            _settings = settings;
+        }
+
+        public abstract void Dispose();
+
+        public I2cConnectionSettings GetConnectionSettings() => new I2cConnectionSettings(_settings);
+
+        public abstract void WriteRead(byte[] writeBuffer, byte[] readBuffer);
+        public abstract void Read(byte[] buffer);
+        public abstract void Write(byte[] buffer);
+    }
+}

--- a/src/System.Devices.Gpio/System.Devices.Gpio/RaspberryPiDriver.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/RaspberryPiDriver.cs
@@ -17,55 +17,55 @@ namespace System.Devices.Gpio
         {
             ///<summary>GPIO Function Select, 6x32 bits, R/W</summary>
             [FieldOffset(0x00)]
-            public fixed UInt32 GPFSEL[6];
+            public fixed uint GPFSEL[6];
 
             ///<summary>GPIO Pin Output Set, 2x32 bits, W</summary>
             [FieldOffset(0x1C)]
-            public fixed UInt32 GPSET[2];
+            public fixed uint GPSET[2];
 
             ///<summary>GPIO Pin Output Clear, 2x32 bits, W</summary>
             [FieldOffset(0x28)]
-            public fixed UInt32 GPCLR[2];
+            public fixed uint GPCLR[2];
 
             ///<summary>GPIO Pin Level, 2x32 bits, R</summary>
             [FieldOffset(0x34)]
-            public fixed UInt32 GPLEV[2];
+            public fixed uint GPLEV[2];
 
             ///<summary>GPIO Pin Event Detect Status, 2x32 bits, R/W</summary>
             [FieldOffset(0x40)]
-            public fixed UInt32 GPEDS[2];
+            public fixed uint GPEDS[2];
 
             ///<summary>GPIO Pin Rising Edge Detect Enable, 2x32 bits, R/W</summary>
             [FieldOffset(0x4C)]
-            public fixed UInt32 GPREN[2];
+            public fixed uint GPREN[2];
 
             ///<summary>GPIO Pin Falling Edge Detect Enable, 2x32 bits, R/W</summary>
             [FieldOffset(0x58)]
-            public fixed UInt32 GPFEN[2];
+            public fixed uint GPFEN[2];
 
             ///<summary>GPIO Pin High Detect Enable, 2x32 bits, R/W</summary>
             [FieldOffset(0x64)]
-            public fixed UInt32 GPHEN[2];
+            public fixed uint GPHEN[2];
 
             ///<summary>GPIO Pin Low Detect Enable, 2x32 bits, R/W</summary>
             [FieldOffset(0x70)]
-            public fixed UInt32 GPLEN[2];
+            public fixed uint GPLEN[2];
 
             ///<summary>GPIO Pin Async. Rising Edge Detect, 2x32 bits, R/W</summary>
             [FieldOffset(0x7C)]
-            public fixed UInt32 GPAREN[2];
+            public fixed uint GPAREN[2];
 
             ///<summary>GPIO Pin Async. Falling Edge Detect, 2x32 bits, R/W</summary>
             [FieldOffset(0x88)]
-            public fixed UInt32 GPAFEN[2];
+            public fixed uint GPAFEN[2];
 
             ///<summary>GPIO Pin Pull-up/down Enable, 32 bits, R/W</summary>
             [FieldOffset(0x94)]
-            public UInt32 GPPUD;
+            public uint GPPUD;
 
             ///<summary>GPIO Pin Pull-up/down Enable Clock, 2x32 bits, R/W</summary>
             [FieldOffset(0x98)]
-            public fixed UInt32 GPPUDCLK[2];
+            public fixed uint GPPUDCLK[2];
         }
 
         #endregion

--- a/src/System.Devices.Gpio/System.Devices.Gpio/SpiConnectionSettings.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/SpiConnectionSettings.cs
@@ -11,12 +11,12 @@ namespace System.Devices.Gpio
         /// <summary>
         /// Gets or sets the Spi bus id for this connection.
         /// </summary>
-        public int BusId { get; set; }
+        public uint BusId { get; set; }
 
         /// <summary>
         /// Gets or sets the chip select line for this connection.
         /// </summary>
-        public int ChipSelectLine { get; set; }
+        public uint ChipSelectLine { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="SpiMode"/> for this connection.
@@ -26,23 +26,23 @@ namespace System.Devices.Gpio
         /// <summary>
         /// Gets or sets the bit length for data on this connection.
         /// </summary>
-        public int DataBitLength { get; set; }
+        public uint DataBitLength { get; set; }
 
         /// <summary>
         /// Gets or sets the clock frequency for the connection.
         /// </summary>
-        public int ClockFrequency { get; set; }
+        public uint ClockFrequency { get; set; }
 
         private const SpiMode DefaultMode = SpiMode.Mode0;
-        private const int DefaultDataBitLength = 8; // 1 byte
-        private const int DefaultClockFrequency = 500_000; // 500 KHz
+        private const uint DefaultDataBitLength = 8; // 1 byte
+        private const uint DefaultClockFrequency = 500_000; // 500 KHz
 
         /// <summary>
         /// Initializes new instance of <see cref="SpiConnectionSettings"/>.
         /// </summary>
         /// <param name="busId">The Spi bus id on which the connection will be made.</param>
         /// <param name="chipSelectLine">The chip select line on which the connection will be made.</param>
-        public SpiConnectionSettings(int busId, int chipSelectLine)
+        public SpiConnectionSettings(uint busId, uint chipSelectLine)
         {
             BusId = busId;
             ChipSelectLine = chipSelectLine;

--- a/src/System.Devices.Gpio/System.Devices.Gpio/UnixDriver.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/UnixDriver.cs
@@ -98,10 +98,10 @@ namespace System.Devices.Gpio
         private int[] _pinValueFileDescriptors;
 
         private int _pinsToDetectEventsCount;
-        private BitArray _pinsToDetectEvents;
+        private readonly BitArray _pinsToDetectEvents;
         private Thread _eventDetectionThread;
-        private TimeSpan[] _debounceTimeouts;
-        private DateTime[] _lastEvents;
+        private readonly TimeSpan[] _debounceTimeouts;
+        private readonly DateTime[] _lastEvents;
 
         public UnixDriver(int pinCount)
         {

--- a/src/System.Devices.Gpio/System.Devices.Gpio/UnixI2CDevice.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/UnixI2CDevice.cs
@@ -1,0 +1,349 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace System.Devices.Gpio
+{
+    public class UnixI2cDevice : I2cDevice
+    {
+        #region Interop
+
+        private const string LibraryName = "libc";
+
+        [Flags]
+        private enum FileOpenFlags
+        {
+            O_RDONLY = 0x00,
+            O_NONBLOCK = 0x800,
+            O_RDWR = 0x02,
+            O_SYNC = 0x101000
+        }
+
+        [DllImport(LibraryName, SetLastError = true)]
+        private static extern int open([MarshalAs(UnmanagedType.LPStr)] string pathname, FileOpenFlags flags);
+
+        [DllImport(LibraryName, SetLastError = true)]
+        private static extern int close(int fd);
+
+        private enum I2cSettings : uint
+        {
+            /// <summary>Combined R/W transfer (one STOP only)</summary>
+            I2C_RDWR = 0x0707,
+            /// <summary>Smbus transfer</summary>
+            I2C_SMBUS = 0x0720,
+            /// <summary>Get the adapter functionality mask</summary>
+            I2C_FUNCS = 0x0705,
+            /// <summary>Use this slave address, even if it is already in use by a driver</summary>
+            I2C_SLAVE_FORCE = 0x0706
+        }
+
+        /// To determine what functionality is supported
+        [Flags]
+        private enum I2cFunctionalityFlags : ulong
+        {
+            I2C_FUNC_I2C = 0x00000001,
+            I2C_FUNC_SMBUS_BLOCK_DATA = 0x03000000
+        }
+
+        [Flags]
+        private enum I2cMessageFlags : ushort
+        {
+            /// <summary>Write data to slave</summary>
+            I2C_M_WR = 0x0000,
+            /// <summary>Read data from slave</summary>
+            I2C_M_RD = 0x0001
+        }
+
+        private unsafe struct i2c_msg
+        {
+            public ushort addr;
+            public I2cMessageFlags flags;
+            public ushort len;
+            public byte* buf;
+        };
+
+        /// <summary>Used in the <see cref="I2C_RDWR"/> <see cref="ioctl"/> call</summary>
+        private unsafe struct i2c_rdwr_ioctl_data
+        {
+            public i2c_msg* msgs;
+            public uint nmsgs;
+        };
+
+        private enum SmbusMessageFlags : byte
+        {
+            /// <summary>Write data to slave</summary>
+            I2C_SMBUS_WRITE = 0,
+            /// <summary>Read data from slave</summary>
+            I2C_SMBUS_READ = 1
+        }
+
+        private enum SmbusTransactionType : uint
+        {
+            I2C_SMBUS_BLOCK_DATA = 5
+        }
+
+        private unsafe struct i2c_smbus_ioctl_data
+        {
+            public SmbusMessageFlags read_write;
+            public SmbusTransactionType size;
+            public byte command;
+            public byte* data;
+        }
+
+        /// <summary>As specified in SMBus standard</summary>
+        private const int I2C_SMBUS_BLOCK_MAX = 32;
+
+        [StructLayout(LayoutKind.Explicit)]
+        private unsafe struct i2c_smbus_data
+        {
+            [FieldOffset(0)]
+            public byte u8;
+
+            [FieldOffset(0)]
+            public ushort word;
+
+            /// <summary>block[0] is used for length and one more for user-space compatibility</summary>
+            [FieldOffset(0)]
+            public fixed byte block[I2C_SMBUS_BLOCK_MAX + 2];
+        }
+
+        [DllImport(LibraryName, SetLastError = true)]
+        private static extern int ioctl(int fd, uint request, IntPtr argp);
+
+        [DllImport(LibraryName, SetLastError = true)]
+        private static extern int ioctl(int fd, uint request, ulong argp);
+
+        [DllImport(LibraryName, SetLastError = true)]
+        private static extern int read(int fd, IntPtr buf, int count);
+
+        [DllImport(LibraryName, SetLastError = true)]
+        private static extern int write(int fd, IntPtr buf, int count);
+
+        #endregion
+
+        private enum TrasnferKind
+        {
+            Read,
+            Write
+        }
+
+        private int _deviceFileDescriptor = -1;
+        private I2cFunctionalityFlags _functionalities;
+
+        public UnixI2cDevice(I2cConnectionSettings settings)
+            : base(settings)
+        {
+        }
+
+        public override void Dispose()
+        {
+            if (_deviceFileDescriptor >= 0)
+            {
+                close(_deviceFileDescriptor);
+                _deviceFileDescriptor = -1;
+            }
+        }
+
+        private unsafe void Initialize()
+        {
+            if (_deviceFileDescriptor >= 0)
+            {
+                return;
+            }
+
+            string devicePath = $"/dev/i2c-{_settings.BusId}";
+            _deviceFileDescriptor = open(devicePath, FileOpenFlags.O_RDWR);
+
+            if (_deviceFileDescriptor < 0)
+            {
+                throw new IOException($"Cannot open I2c device file '{devicePath}'");
+            }
+        }
+
+        public override void Read(byte[] buffer)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            Initialize();
+
+            Transfer(buffer, TrasnferKind.Read);
+        }
+
+        public override void Write(byte[] buffer)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            Initialize();
+
+            Transfer(buffer, TrasnferKind.Write);
+        }
+
+        public override unsafe void WriteRead(byte[] writeBuffer, byte[] readBuffer)
+        {
+            if (writeBuffer == null)
+            {
+                throw new ArgumentNullException(nameof(writeBuffer));
+            }
+
+            if (readBuffer == null)
+            {
+                throw new ArgumentNullException(nameof(readBuffer));
+            }
+
+            Initialize();
+
+            Transfer(writeBuffer, TrasnferKind.Write);
+            Transfer(readBuffer, TrasnferKind.Read);
+        }
+
+        private unsafe void Transfer(byte[] buffer, TrasnferKind kind)
+        {
+            if (_functionalities == 0)
+            {
+                I2cFunctionalityFlags functionalities;
+
+                int ret = ioctl(_deviceFileDescriptor, (uint)I2cSettings.I2C_FUNCS, new IntPtr(&functionalities));
+                if (ret < 0)
+                {
+                    throw new GpioException("Error performing I2c data transfer");
+                }
+
+                _functionalities = functionalities;
+            }
+
+            if (_functionalities.HasFlag(I2cFunctionalityFlags.I2C_FUNC_I2C))
+            {
+                //Console.WriteLine("I2c functionality supported");
+
+                I2cMessageFlags flags = TransferKindToI2cMessageFlags(kind);
+                I2cTransfer(buffer, flags);
+            }
+            //else if (_functionalities.HasFlag(I2cFunctionalityFlags.I2C_FUNC_SMBUS_BLOCK_DATA))
+            //{
+            //    //Console.WriteLine("Smbus functionality supported");
+
+            //    SmbusMessageFlags flags = TransferKindToSmbusMessageFlags(kind);
+            //    SmbusTransfer(buffer, flags);
+            //}
+            else
+            {
+                //Console.WriteLine("Using I2c file interface");
+
+                FileTransfer(buffer, kind);
+            }
+        }
+
+        //private SmbusMessageFlags TransferKindToSmbusMessageFlags(TrasnferKind kind)
+        //{
+        //    switch (kind)
+        //    {
+        //        case TrasnferKind.Read: return SmbusMessageFlags.I2C_SMBUS_WRITE;
+        //        case TrasnferKind.Write: return SmbusMessageFlags.I2C_SMBUS_READ;
+
+        //        default: throw new NotSupportedException();
+        //    }
+        //}
+
+        //private unsafe void SmbusTransfer(byte[] buffer, SmbusMessageFlags flags)
+        //{
+        //    int ret = ioctl(_deviceFileDescriptor, (uint)I2cSettings.I2C_SLAVE_FORCE, (ulong)_settings.DeviceAddress);
+        //    if (ret < 0)
+        //    {
+        //        throw new GpioException("Error performing I2c data transfer");
+        //    }
+
+        //    fixed (byte* txPtr = buffer)
+        //    {
+        //        var data = new i2c_smbus_ioctl_data
+        //        {
+        //            read_write = flags,
+        //            size = SmbusTransactionType.I2C_SMBUS_BLOCK_DATA,
+        //            command = regaddr,
+        //            data = txPtr,
+        //        };
+
+        //        ret = ioctl(_deviceFileDescriptor, (uint)I2cSettings.I2C_SMBUS, new IntPtr(&data));
+        //        if (ret < 0)
+        //        {
+        //            throw new GpioException("Error performing I2c data transfer");
+        //        }
+        //    }
+        //}
+
+        private unsafe void FileTransfer(byte[] buffer, TrasnferKind kind)
+        {
+            int ret = ioctl(_deviceFileDescriptor, (uint)I2cSettings.I2C_SLAVE_FORCE, (ulong)_settings.DeviceAddress);
+            if (ret < 0)
+            {
+                throw new GpioException("Error performing I2c data transfer");
+            }
+
+            fixed (byte* txPtr = buffer)
+            {
+                switch (kind)
+                {
+                    case TrasnferKind.Read:
+                        ret = read(_deviceFileDescriptor, new IntPtr(txPtr), buffer.Length);
+                    break;
+
+                    case TrasnferKind.Write:
+                        ret = write(_deviceFileDescriptor, new IntPtr(txPtr), buffer.Length);
+                        break;
+
+                    default:
+                        throw new NotSupportedException();
+                }
+
+                if (ret < 0)
+                {
+                    throw new GpioException("Error performing I2c data transfer");
+                }
+            }
+        }
+
+        private static I2cMessageFlags TransferKindToI2cMessageFlags(TrasnferKind kind)
+        {
+            switch (kind)
+            {
+                case TrasnferKind.Read: return I2cMessageFlags.I2C_M_RD;
+                case TrasnferKind.Write: return I2cMessageFlags.I2C_M_WR;
+
+                default: throw new NotSupportedException();
+            }
+        }
+
+        private unsafe void I2cTransfer(byte[] buffer, I2cMessageFlags flags)
+        {
+            fixed (byte* txPtr = buffer)
+            {
+                var message = new i2c_msg()
+                {
+                    addr = (ushort)_settings.DeviceAddress,
+                    len = (ushort)buffer.Length,
+                    buf = txPtr,
+                    flags = flags
+                };
+
+                var tr = new i2c_rdwr_ioctl_data()
+                {
+                    msgs = &message,
+                    nmsgs = 1 // 1 message
+                };
+
+                int ret = ioctl(_deviceFileDescriptor, (uint)I2cSettings.I2C_RDWR, new IntPtr(&tr));
+                if (ret < 1)
+                {
+                    throw new GpioException("Error performing I2c data transfer");
+                }
+            }
+        }
+    }
+}

--- a/src/System.Devices.Gpio/System.Devices.Gpio/UnixI2CDevice.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/UnixI2CDevice.cs
@@ -91,12 +91,15 @@ namespace System.Devices.Gpio
             Write
         }
 
+        private const string DefaultDevicePath = "/dev/i2c";
+
         private int _deviceFileDescriptor = -1;
         private I2cFunctionalityFlags _functionalities;
 
         public UnixI2cDevice(I2cConnectionSettings settings)
             : base(settings)
         {
+            DevicePath = DefaultDevicePath;
         }
 
         public override void Dispose()
@@ -108,6 +111,8 @@ namespace System.Devices.Gpio
             }
         }
 
+        public string DevicePath { get; set; }
+
         private unsafe void Initialize()
         {
             if (_deviceFileDescriptor >= 0)
@@ -115,12 +120,12 @@ namespace System.Devices.Gpio
                 return;
             }
 
-            string devicePath = $"/dev/i2c-{_settings.BusId}";
-            _deviceFileDescriptor = open(devicePath, FileOpenFlags.O_RDWR);
+            string deviceFileName = $"{DevicePath}-{_settings.BusId}";
+            _deviceFileDescriptor = open(deviceFileName, FileOpenFlags.O_RDWR);
 
             if (_deviceFileDescriptor < 0)
             {
-                throw new IOException($"Cannot open I2c device file '{devicePath}'");
+                throw new IOException($"Cannot open I2c device file '{deviceFileName}'");
             }
         }
 

--- a/src/System.Devices.Gpio/System.Devices.Gpio/UnixSpiDevice.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/UnixSpiDevice.cs
@@ -140,6 +140,11 @@ namespace System.Devices.Gpio
 
         public override unsafe void Read(byte[] buffer)
         {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
             Initialize();
 
             fixed (byte* rxPtr = buffer)
@@ -164,6 +169,11 @@ namespace System.Devices.Gpio
 
         public override unsafe void Write(byte[] buffer)
         {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
             Initialize();
 
             fixed (byte* txPtr = buffer)
@@ -188,6 +198,16 @@ namespace System.Devices.Gpio
 
         public override unsafe void TransferFullDuplex(byte[] writeBuffer, byte[] readBuffer)
         {
+            if (writeBuffer == null)
+            {
+                throw new ArgumentNullException(nameof(writeBuffer));
+            }
+
+            if (readBuffer == null)
+            {
+                throw new ArgumentNullException(nameof(readBuffer));
+            }
+
             if (writeBuffer.Length != readBuffer.Length)
             {
                 throw new ArgumentException($"Parameters '{nameof(writeBuffer)}' and '{nameof(readBuffer)}' must have the same length");

--- a/src/System.Devices.Gpio/System.Devices.Gpio/UnixSpiDevice.cs
+++ b/src/System.Devices.Gpio/System.Devices.Gpio/UnixSpiDevice.cs
@@ -82,11 +82,14 @@ namespace System.Devices.Gpio
 
         #endregion
 
+        private const string DefaultDevicePath = "/dev/spidev";
+
         private int _deviceFileDescriptor = -1;
 
         public UnixSpiDevice(SpiConnectionSettings settings)
             : base(settings)
         {
+            DevicePath = DefaultDevicePath;
         }
 
         public override void Dispose()
@@ -98,16 +101,18 @@ namespace System.Devices.Gpio
             }
         }
 
+        public string DevicePath { get; set; }
+
         private unsafe void Initialize()
         {
             if (_deviceFileDescriptor >= 0) return;
 
-            string devicePath = $"/dev/spidev{_settings.BusId}.{_settings.ChipSelectLine}";
-            _deviceFileDescriptor = open(devicePath, FileOpenFlags.O_RDWR);
+            string deviceFileName = $"{DevicePath}{_settings.BusId}.{_settings.ChipSelectLine}";
+            _deviceFileDescriptor = open(deviceFileName, FileOpenFlags.O_RDWR);
 
             if (_deviceFileDescriptor < 0)
             {
-                throw new IOException($"Cannot open Spi device file '{devicePath}'");
+                throw new IOException($"Cannot open Spi device file '{deviceFileName}'");
             }
 
             UnixSpiMode mode = SpiModeToUnixSpiMode(_settings.Mode);


### PR DESCRIPTION
This PR adds support for I2C serial protocol.
It also extends the Bme280 sensor API to allow I2C in addition to SPI.