### PR TITLE
 Fix typo in TryReadUntill and optimize it and JsonReader for the common case

### DIFF
--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
@@ -153,7 +153,7 @@ namespace System.Buffers.Reader
 
             ConsumedBytes += byteCount;
 
-            if ((CurrentSegmentIndex + byteCount) < CurrentSegment.Length)
+            if (CurrentSegmentIndex < CurrentSegment.Length - byteCount)
             {
                 CurrentSegmentIndex += byteCount;
             }
@@ -169,7 +169,7 @@ namespace System.Buffers.Reader
         {
             while (!End && byteCount > 0)
             {
-                if ((CurrentSegmentIndex + byteCount) < CurrentSegment.Length)
+                if (CurrentSegmentIndex < CurrentSegment.Length - byteCount)
                 {
                     CurrentSegmentIndex += byteCount;
                     byteCount = 0;

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
@@ -1,14 +1,71 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.CompilerServices;
 
 namespace System.Buffers.Reader
 {
-    // TODO: the TryReadUntill methods are very inneficient. We need to fix that.
+    // TODO: the TryReadUntil methods are very inneficient. We need to fix that.
     public static partial class BufferReaderExtensions
     {
-        public static bool TryReadUntill(ref BufferReader reader, out ReadOnlySequence<byte> bytes, byte delimiter)
+        public static bool TryReadUntil(ref BufferReader reader, out ReadOnlySpan<byte> bytes, byte delimiter)
         {
+            int idx = reader.UnreadSegment.IndexOf(delimiter);
+            if (idx != -1)
+            {
+                bytes = reader.UnreadSegment.Slice(0, idx);
+                reader.Advance(idx + 1);
+                return true;
+            }
+            else
+            {
+                bool result = TryReadUntil(ref reader, out ReadOnlySequence<byte> sequence, delimiter);
+
+                if (sequence.IsSingleSegment)
+                {
+                    bytes = sequence.First.Span;
+                }
+                else
+                {
+                    bytes = sequence.ToArray();
+                }
+
+                return result;
+            }
+        }
+
+        public static bool TryReadUntil(ref BufferReader reader, out ReadOnlySequence<byte> bytes, byte delimiter)
+        {
+            // Option A
+            /*SequencePosition start = reader.Position;
+            int idx = reader.Sequence.Slice(start).PositionOf(delimiter);
+            if (idx != -1)
+            {
+                bytes = reader.Sequence.Slice(start, idx);
+                reader.Advance(idx + 1);
+                return true;
+            }
+            else
+            {
+                bytes = default;
+                return false;
+            }*/
+
+            // Option B
+            /*SequencePosition start = reader.Position;
+            SequencePosition? position = reader.Sequence.Slice(start).PositionOf(delimiter);
+            if (position != null)
+            {
+                bytes = reader.Sequence.Slice(start, (SequencePosition)position);
+                reader.Advance((int)bytes.Length + 1);
+                return true;
+            }
+            else
+            {
+                bytes = default;
+                return false;
+            }*/
+
             BufferReader copy = reader;
             while (!reader.End)
             {
@@ -25,7 +82,91 @@ namespace System.Buffers.Reader
             return false;
         }
 
-        public static bool TryReadUntill(ref BufferReader reader, out ReadOnlySequence<byte> bytes, ReadOnlySpan<byte> delimiter)
+        public static bool TryReadUntilAny(ref BufferReader reader, out ReadOnlySpan<byte> bytes, ReadOnlySpan<byte> delimiters)
+        {
+            int idx = reader.UnreadSegment.IndexOfAny(delimiters);
+            if (idx != -1)
+            {
+                bytes = reader.UnreadSegment.Slice(0, idx);
+                reader.Advance(idx);
+                return true;
+            }
+            else
+            {
+                bool result = TryReadUntil(ref reader, out ReadOnlySequence<byte> sequence, delimiters);
+
+                if (sequence.IsSingleSegment)
+                {
+                    bytes = sequence.First.Span;
+                }
+                else
+                {
+                    bytes = sequence.ToArray();
+                }
+
+                return result;
+            }
+        }
+
+        private static bool TryReadUntilAny(ref BufferReader reader, out ReadOnlySequence<byte> bytes, ReadOnlySpan<byte> delimiters)
+        {
+            BufferReader copy = reader;
+            while (!reader.End)
+            {
+                byte b = (byte)reader.Peek();
+                if (delimiters.IndexOf(b) != -1)
+                {
+                    bytes = reader.Sequence.Slice(copy.Position, reader.Position);
+                    return true;
+                }
+                reader.Advance(1);
+            }
+            reader = copy;
+            bytes = default;
+            return false;
+        }
+
+        /*[MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int PositionOf<T>(in this ReadOnlySequence<T> source, T value) where T : IEquatable<T>
+        {
+            if (source.IsSingleSegment)
+            {
+                return source.First.Span.IndexOf(value);
+            }
+            else
+            {
+                return PositionOfMultiSegment(source, value);
+            }
+        }
+
+        private static int PositionOfMultiSegment<T>(in ReadOnlySequence<T> source, T value) where T : IEquatable<T>
+        {
+            SequencePosition position = source.Start;
+            SequencePosition result = position;
+            int index = 0;
+            while (source.TryGet(ref position, out ReadOnlyMemory<T> memory))
+            {
+                int localIndex = memory.Span.IndexOf(value);
+                if (localIndex != -1)
+                {
+                    return index + localIndex;
+                }
+                else if (position.GetObject() == null)
+                {
+                    break;
+                }
+                else if (localIndex == -1)
+                {
+                    index += memory.Span.Length;
+                }
+
+                result = position;
+            }
+
+            return -1;
+        }*/
+
+        public static bool TryReadUntil(ref BufferReader reader, out ReadOnlySequence<byte> bytes, ReadOnlySpan<byte> delimiter)
         {
             if (delimiter.Length == 0)
             {

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime.CompilerServices;
-
 namespace System.Buffers.Reader
 {
     // TODO: the TryReadUntil methods are very inneficient. We need to fix that.
@@ -36,36 +34,6 @@ namespace System.Buffers.Reader
 
         public static bool TryReadUntil(ref BufferReader reader, out ReadOnlySequence<byte> bytes, byte delimiter)
         {
-            // Option A
-            /*SequencePosition start = reader.Position;
-            int idx = reader.Sequence.Slice(start).PositionOf(delimiter);
-            if (idx != -1)
-            {
-                bytes = reader.Sequence.Slice(start, idx);
-                reader.Advance(idx + 1);
-                return true;
-            }
-            else
-            {
-                bytes = default;
-                return false;
-            }*/
-
-            // Option B
-            /*SequencePosition start = reader.Position;
-            SequencePosition? position = reader.Sequence.Slice(start).PositionOf(delimiter);
-            if (position != null)
-            {
-                bytes = reader.Sequence.Slice(start, (SequencePosition)position);
-                reader.Advance((int)bytes.Length + 1);
-                return true;
-            }
-            else
-            {
-                bytes = default;
-                return false;
-            }*/
-
             BufferReader copy = reader;
             while (!reader.End)
             {
@@ -125,46 +93,6 @@ namespace System.Buffers.Reader
             bytes = default;
             return false;
         }
-
-        /*[MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int PositionOf<T>(in this ReadOnlySequence<T> source, T value) where T : IEquatable<T>
-        {
-            if (source.IsSingleSegment)
-            {
-                return source.First.Span.IndexOf(value);
-            }
-            else
-            {
-                return PositionOfMultiSegment(source, value);
-            }
-        }
-
-        private static int PositionOfMultiSegment<T>(in ReadOnlySequence<T> source, T value) where T : IEquatable<T>
-        {
-            SequencePosition position = source.Start;
-            SequencePosition result = position;
-            int index = 0;
-            while (source.TryGet(ref position, out ReadOnlyMemory<T> memory))
-            {
-                int localIndex = memory.Span.IndexOf(value);
-                if (localIndex != -1)
-                {
-                    return index + localIndex;
-                }
-                else if (position.GetObject() == null)
-                {
-                    break;
-                }
-                else if (localIndex == -1)
-                {
-                    index += memory.Span.Length;
-                }
-
-                result = position;
-            }
-
-            return -1;
-        }*/
 
         public static bool TryReadUntil(ref BufferReader reader, out ReadOnlySequence<byte> bytes, ReadOnlySpan<byte> delimiter)
         {

--- a/src/System.Text.JsonLab/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonConstants.cs
@@ -25,6 +25,7 @@ namespace System.Text.JsonLab
         public const byte Space = (byte)' ';
         public const byte CarriageReturn = (byte)'\r';
         public const byte LineFeed = (byte)'\n';
+        public const byte Tab = (byte)'\t';
         public const byte ListSeperator = (byte)',';
         public const byte KeyValueSeperator = (byte)':';
         public const byte Quote = (byte)'"';
@@ -36,6 +37,10 @@ namespace System.Text.JsonLab
         public static readonly byte[] TrueValue = { (byte)'t', (byte)'r', (byte)'u', (byte)'e' };
         public static readonly byte[] FalseValue = { (byte)'f', (byte)'a', (byte)'l', (byte)'s', (byte)'e' };
         public static readonly byte[] NullValue = { (byte)'n', (byte)'u', (byte)'l', (byte)'l' };
+
+        public static readonly byte[] Delimiters = { ListSeperator, CloseBrace, CloseBracket, CarriageReturn, LineFeed, Space, Tab };
+
+        public static readonly byte[] WhiteSpace = { Space, CarriageReturn, LineFeed, Tab };
 
         #endregion Common values
     }

--- a/tests/System.Buffers.ReaderWriter.Tests/BytesReaderTests.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/BytesReaderTests.cs
@@ -15,13 +15,13 @@ namespace System.Buffers.Tests
             var bytes = new ReadOnlySequence<byte>(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 });
             var reader = BufferReader.Create(bytes);
 
-            Assert.True(BufferReaderExtensions.TryReadUntill(ref reader, out var ab, 3));
+            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out var ab, 3));
             Assert.True(ab.First.SequenceEqual(new byte[] { 1, 2 }));
 
-            Assert.True(BufferReaderExtensions.TryReadUntill(ref reader, out var cd, 6));
+            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out var cd, 6));
             Assert.True(cd.First.SequenceEqual(new byte[] { 4, 5 }));
 
-            Assert.True(BufferReaderExtensions.TryReadUntill(ref reader, out var ef, new byte[] { 8, 9 }));
+            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out var ef, new byte[] { 8, 9 }));
             Assert.True(ef.First.SequenceEqual(new byte[] { 7 }));
         }
 
@@ -42,17 +42,17 @@ namespace System.Buffers.Tests
 
             var reader = BufferReader.Create(bytes);
 
-            Assert.True(BufferReaderExtensions.TryReadUntill(ref reader, out var bytesValue, 2));
+            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out var bytesValue, 2));
             var span = bytesValue.ToSpan();
             Assert.Equal(0, span[0]);
             Assert.Equal(1, span[1]);
 
-            Assert.True(BufferReaderExtensions.TryReadUntill(ref reader, out bytesValue, 5));
+            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out bytesValue, 5));
             span = bytesValue.ToSpan();
             Assert.Equal(3, span[0]);
             Assert.Equal(4, span[1]);
 
-            Assert.True(BufferReaderExtensions.TryReadUntill(ref reader, out bytesValue, new byte[] { 8, 8 }));
+            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out bytesValue, new byte[] { 8, 8 }));
             span = bytesValue.ToSpan();
             Assert.Equal(6, span[0]);
             Assert.Equal(7, span[1]);
@@ -69,7 +69,7 @@ namespace System.Buffers.Tests
         {
             var bytes = ReadOnlySequence<byte>.Empty;
             var reader = BufferReader.Create(bytes);
-            Assert.False(BufferReaderExtensions.TryReadUntill(ref reader, out var range, (byte)' '));
+            Assert.False(BufferReaderExtensions.TryReadUntil(ref reader, out var range, (byte)' '));
         }
 
         [Fact]

--- a/tests/System.Buffers.ReaderWriter.Tests/BytesReaderTests.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/BytesReaderTests.cs
@@ -15,13 +15,13 @@ namespace System.Buffers.Tests
             var bytes = new ReadOnlySequence<byte>(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 });
             var reader = BufferReader.Create(bytes);
 
-            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out var ab, 3));
+            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out ReadOnlySequence<byte> ab, 3));
             Assert.True(ab.First.SequenceEqual(new byte[] { 1, 2 }));
 
-            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out var cd, 6));
+            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out ReadOnlySequence<byte> cd, 6));
             Assert.True(cd.First.SequenceEqual(new byte[] { 4, 5 }));
 
-            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out var ef, new byte[] { 8, 9 }));
+            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out ReadOnlySequence<byte> ef, new byte[] { 8, 9 }));
             Assert.True(ef.First.SequenceEqual(new byte[] { 7 }));
         }
 
@@ -42,7 +42,7 @@ namespace System.Buffers.Tests
 
             var reader = BufferReader.Create(bytes);
 
-            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out var bytesValue, 2));
+            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out ReadOnlySequence<byte> bytesValue, 2));
             var span = bytesValue.ToSpan();
             Assert.Equal(0, span[0]);
             Assert.Equal(1, span[1]);
@@ -69,7 +69,7 @@ namespace System.Buffers.Tests
         {
             var bytes = ReadOnlySequence<byte>.Empty;
             var reader = BufferReader.Create(bytes);
-            Assert.False(BufferReaderExtensions.TryReadUntil(ref reader, out var range, (byte)' '));
+            Assert.False(BufferReaderExtensions.TryReadUntil(ref reader, out ReadOnlySequence<byte> range, (byte)' '));
         }
 
         [Fact]


### PR DESCRIPTION
- Fixed potential integer overflow in BufferReader
- Also added initial implementations of some APIs from https://github.com/dotnet/corefxlab/issues/2408.

``` ini

BenchmarkDotNet=v0.10.14.683-nightly, OS=Windows 10.0.17713
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.2.100-preview1-009015
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT


```
|                                            Method |   TestCase |            Mean |         Error |        StdDev |          Median | Scaled | ScaledSD |  Gen 0 | Allocated |
|-------------------------------------------------- |----------- |----------------:|--------------:|--------------:|----------------:|-------:|---------:|-------:|----------:|
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |  **BasicJson** |       **467.02 ns** |      **2.406 ns** |      **2.250 ns** |       **467.22 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |  BasicJson |     1,552.24 ns |     91.529 ns |     85.617 ns |     1,517.03 ns |   3.32 |     0.18 | 0.0076 |      40 B |
|                                                   |            |                 |               |               |                 |        |          |        |           |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** | **HelloWorld** |        **77.57 ns** |      **1.566 ns** |      **3.055 ns** |        **76.09 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop | HelloWorld |       436.67 ns |      8.546 ns |     15.190 ns |       429.40 ns |   5.64 |     0.28 | 0.0091 |      40 B |
|                                                   |            |                 |               |               |                 |        |          |        |           |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |   **Json400B** |       **731.84 ns** |     **14.576 ns** |     **20.905 ns** |       **726.56 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |   Json400B |     2,035.42 ns |     25.197 ns |     19.672 ns |     2,032.81 ns |   2.78 |     0.08 | 0.0114 |      56 B |
|                                                   |            |                 |               |               |                 |        |          |        |           |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |  **Json400KB** |   **668,692.86 ns** |  **5,753.710 ns** |  **5,100.513 ns** |   **669,685.16 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |  Json400KB | 1,612,234.29 ns | 32,188.072 ns | 58,041.734 ns | 1,614,183.79 ns |   2.41 |     0.09 |      - |       0 B |
|                                                   |            |                 |               |               |                 |        |          |        |           |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |    **Json4KB** |     **6,610.56 ns** |    **125.760 ns** |    **117.636 ns** |     **6,585.90 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |    Json4KB |    15,389.81 ns |    250.302 ns |    221.886 ns |    15,332.40 ns |   2.33 |     0.05 | 0.0916 |     416 B |

This change improves perf for the multi-segment case by almost 2x, compared to the previous results: https://github.com/dotnet/corefxlab/pull/2407#discussion_r206368971

We are still ~3x slower than the single-segment case.

cc @JeremyKuhne, @davidfowl, @pakrym 