### PR TITLE
Switch from case to if statements in JsonReader and code cleanup

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonConstants.cs
@@ -29,6 +29,7 @@ namespace System.Text.JsonLab
         public const byte ListSeperator = (byte)',';
         public const byte KeyValueSeperator = (byte)':';
         public const byte Quote = (byte)'"';
+        public const byte ReverseSolidus = (byte)'\\';
 
         #endregion Control characters
 

--- a/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
@@ -185,9 +185,10 @@ namespace System.Text.JsonLab
                 return false;
             }
 
+            byte ch = buffer[0];
+
             if (TokenType == JsonTokenType.StartObject)
             {
-                byte ch = buffer[0];
                 buffer = buffer.Slice(1);
                 if (ch == JsonConstants.CloseBrace)
                     EndObject();
@@ -199,22 +200,21 @@ namespace System.Text.JsonLab
             }
             else if (TokenType == JsonTokenType.StartArray)
             {
-                byte ch = buffer[0];
                 if (ch == JsonConstants.CloseBracket)
                 {
                     buffer = buffer.Slice(1);
                     EndArray();
                 }
                 else
-                    ConsumeValueUtf8(ref buffer);
+                    ConsumeValueUtf8(ref buffer, ch);
             }
             else if (TokenType == JsonTokenType.PropertyName)
             {
-                ConsumeValueUtf8(ref buffer);
+                ConsumeValueUtf8(ref buffer, ch);
             }
             else
             {
-                return ConsumeNextUtf8(ref buffer);
+                return ConsumeNextUtf8(ref buffer, ch);
             }
             return true;
         }
@@ -301,9 +301,8 @@ namespace System.Text.JsonLab
         /// This method consumes the next token regardless of whether we are inside an object or an array.
         /// For an object, it reads the next property name token. For an array, it just reads the next value.
         /// </summary>
-        private bool ConsumeNextUtf8(ref ReadOnlySpan<byte> buffer)
+        private bool ConsumeNextUtf8(ref ReadOnlySpan<byte> buffer, byte marker)
         {
-            byte marker = buffer[0];
             switch (marker)
             {
                 case JsonConstants.ListSeperator:
@@ -326,7 +325,7 @@ namespace System.Text.JsonLab
                                 return false;
                             }
 
-                            ConsumeValueUtf8(ref buffer);
+                            ConsumeValueUtf8(ref buffer, buffer[0]);
                         }
                         else
                         {
@@ -412,10 +411,10 @@ namespace System.Text.JsonLab
         /// This method contains the logic for processing the next value token and determining
         /// what type of data it is.
         /// </summary>
-        private void ConsumeValueUtf8(ref ReadOnlySpan<byte> buffer)
+        private void ConsumeValueUtf8(ref ReadOnlySpan<byte> buffer, byte marker)
         {
             TokenType = JsonTokenType.Value;
-            byte marker = buffer[0];
+
             if (marker == JsonConstants.Quote)
             {
                 buffer = buffer.Slice(1);

--- a/src/System.Text.JsonLab/System/Text/Json/JsonTokenType.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonTokenType.cs
@@ -13,7 +13,5 @@ namespace System.Text.JsonLab
         PropertyName,
         Comment,
         Value,
-        Null,
-        Undefined,
     }
 }

--- a/tests/System.Text.JsonLab.Tests/JsonParserTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonParserTests.cs
@@ -273,7 +273,6 @@ namespace System.Text.JsonLab.Tests
             }
 
             var jsonReader = new Utf8JsonReader(Encoding.UTF8.GetBytes(jsonString));
-            jsonReader.Read();
             switch (jsonReader.TokenType)
             {
                 case JsonTokenType.StartArray:

--- a/tests/System.Text.JsonLab.Tests/JsonParserTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonParserTests.cs
@@ -273,6 +273,7 @@ namespace System.Text.JsonLab.Tests
             }
 
             var jsonReader = new Utf8JsonReader(Encoding.UTF8.GetBytes(jsonString));
+            jsonReader.Read();
             switch (jsonReader.TokenType)
             {
                 case JsonTokenType.StartArray:

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -123,10 +123,6 @@ namespace System.Text.JsonLab.Tests
                         break;
                     case JsonTokenType.Comment:
                         break;
-                    case JsonTokenType.Null:
-                        break;
-                    case JsonTokenType.Undefined:
-                        break;
                     default:
                         throw new ArgumentException();
                 }


### PR DESCRIPTION
**Before (master):**

|                               Method |   TestCase |          Mean |        Error |       StdDev | Allocated |
|------------------------------------- |----------- |--------------:|-------------:|-------------:|----------:|
| **ReaderSystemTextJsonLabSpanEmptyLoop** |  **BasicJson** |     **544.87 ns** |    **10.637 ns** |    **15.921 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** | **HelloWorld** |      **63.93 ns** |     **2.413 ns** |     **2.015 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |   **Json400B** |     **818.72 ns** |    **16.023 ns** |    **17.810 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |  **Json400KB** | **867,947.02 ns** | **9,080.293 ns** | **7,089.295 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |   **Json40KB** |  **83,159.31 ns** | **1,855.172 ns** | **2,208.450 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |    **Json4KB** |   **6,730.59 ns** |   **131.063 ns** |   **165.753 ns** |       **0 B** |


**After (this PR, using IF):**

|                               Method |   TestCase |          Mean |         Error |        StdDev | Allocated |
|------------------------------------- |----------- |--------------:|--------------:|--------------:|----------:|
| **ReaderSystemTextJsonLabSpanEmptyLoop** |  **BasicJson** |     **567.88 ns** |     **11.212 ns** |     **17.455 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** | **HelloWorld** |      **61.11 ns** |      **1.337 ns** |      **1.690 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |   **Json400B** |     **781.97 ns** |     **13.619 ns** |     **12.073 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |  **Json400KB** | **826,756.60 ns** | **16,461.157 ns** | **19,595.837 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |   **Json40KB** |  **80,502.36 ns** |  **1,604.208 ns** |  **2,248.875 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |    **Json4KB** |   **6,573.59 ns** |    **128.986 ns** |    **225.909 ns** |       **0 B** |

**After (this PR, using CASE):**

|                               Method |   TestCase |          Mean |        Error |       StdDev | Allocated |
|------------------------------------- |----------- |--------------:|-------------:|-------------:|----------:|
| **ReaderSystemTextJsonLabSpanEmptyLoop** |  **BasicJson** |     **586.41 ns** |    **12.368 ns** |    **25.817 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** | **HelloWorld** |      **62.48 ns** |     **1.236 ns** |     **1.691 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |   **Json400B** |     **829.20 ns** |    **16.502 ns** |    **16.946 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |  **Json400KB** | **846,826.86 ns** | **8,851.177 ns** | **8,279.396 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |   **Json40KB** |  **81,657.82 ns** | **1,118.097 ns** |   **933.662 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |    **Json4KB** |   **6,833.22 ns** |   **135.511 ns** |   **294.590 ns** |       **0 B** |

**There is a ~5% performance difference if I use if statements instead of switch/case. The disassembly is 3% larger as well (101 instructions instead of 98).**
```C#
private bool ReadSingleSegmentUsingCASE(ref ReadOnlySpan<byte> buffer)
{
    SkipWhiteSpaceUtf8(ref buffer);
    if (buffer.Length < 1)
    {
        return false;
    }

    switch (TokenType)
    {
        case JsonTokenType.StartObject:
            byte ch = buffer[0];
            buffer = buffer.Slice(1);
            if (ch == JsonConstants.CloseBrace)
                EndObject();
            else
            {
                if (ch != JsonConstants.Quote) JsonThrowHelper.ThrowJsonReaderException();
                ConsumePropertyNameUtf8(ref buffer);
            }
            break;
        case JsonTokenType.StartArray:
            ch = buffer[0];
            if (ch == JsonConstants.CloseBracket)
            {
                buffer = buffer.Slice(1);
                EndArray();
            }
            else
                ConsumeValueUtf8(ref buffer);
            break;
        case JsonTokenType.PropertyName:
            ConsumeValueUtf8(ref buffer);
            break;
        default:
            return ConsumeNextUtf8(ref buffer);
    }
    return true;
}


private bool ReadSingleSegmentUsingIF(ref ReadOnlySpan<byte> buffer)
{
    SkipWhiteSpaceUtf8(ref buffer);
    if (buffer.Length < 1)
    {
        return false;
    }

    if (TokenType == JsonTokenType.StartObject)
    {
        byte ch = buffer[0];
        buffer = buffer.Slice(1);
        if (ch == JsonConstants.CloseBrace)
            EndObject();
        else
        {
            if (ch != JsonConstants.Quote) JsonThrowHelper.ThrowJsonReaderException();
            ConsumePropertyNameUtf8(ref buffer);
        }
    }
    else if (TokenType == JsonTokenType.StartArray)
    {
        byte ch = buffer[0];
        if (ch == JsonConstants.CloseBracket)
        {
            buffer = buffer.Slice(1);
            EndArray();
        }
        else
            ConsumeValueUtf8(ref buffer);
    }
    else if (TokenType == JsonTokenType.PropertyName)
    {
        ConsumeValueUtf8(ref buffer);
    }
    else
    {
        return ConsumeNextUtf8(ref buffer);
    }
    return true;
}
```
Using IF is in red (faster, 98 instructions), using CASE is in green (slower, 101 instructions):
https://www.diffchecker.com/d8CJMme6

![image](https://user-images.githubusercontent.com/6527137/43619328-1311ca68-9682-11e8-8aff-d5f3ed3a9d31.png)

cc @AndyAyersMS, @benaadams - any ideas why we are seeing this difference?