### PR TITLE
Expose JsonReader depth, add Skip, and fix reading strings with embedded quotes

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
@@ -609,17 +609,24 @@ namespace System.Text.JsonLab
         /// <param name="value">The string value that will be quoted within the JSON data.</param>
         public void WriteAttribute(string name, string value)
         {
-            ReadOnlySpan<byte> nameSpan = MemoryMarshal.AsBytes(name.AsSpan());
-            ReadOnlySpan<byte> valueSpan = MemoryMarshal.AsBytes(value.AsSpan());
-
-            if (_prettyPrint)
+            if (value == null)
             {
-                WriteAttributeUtf8Pretty(nameSpan, valueSpan);
+                WriteAttributeNull(name);
             }
             else
             {
-                while (!TryWriteAttributeUtf8(nameSpan, valueSpan))
-                    EnsureBuffer();
+                ReadOnlySpan<byte> nameSpan = MemoryMarshal.AsBytes(name.AsSpan());
+                ReadOnlySpan<byte> valueSpan = MemoryMarshal.AsBytes(value.AsSpan());
+
+                if (_prettyPrint)
+                {
+                    WriteAttributeUtf8Pretty(nameSpan, valueSpan);
+                }
+                else
+                {
+                    while (!TryWriteAttributeUtf8(nameSpan, valueSpan))
+                        EnsureBuffer();
+                }
             }
         }
 

--- a/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
@@ -95,7 +95,7 @@ namespace System.Text.JsonLab.Tests
 
             jsonUtf8.WriteObjectStart();
             jsonUtf8.WriteAttribute("age", 42);
-            jsonUtf8.WriteAttribute("first", "John");
+            jsonUtf8.WriteAttribute("first", null);
             jsonUtf8.WriteAttribute("last", "Smith");
             jsonUtf8.WriteArrayStart("phoneNumbers");
             jsonUtf8.WriteValue("425-000-1212");
@@ -181,7 +181,7 @@ namespace System.Text.JsonLab.Tests
             json.WritePropertyName("age");
             json.WriteValue(42);
             json.WritePropertyName("first");
-            json.WriteValue("John");
+            json.WriteValue((string)null);
             json.WritePropertyName("last");
             json.WriteValue("Smith");
             json.WritePropertyName("phoneNumbers");


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefxlab/issues/1640

**TODO:** Optimize search for nested escaped quotes.

Also write null instead of an empty string if WriteAttribute() with null string value.

