### PR TITLE
Fix bugs in JsonReader and add tests from SignalR

### DIFF
--- a/src/System.Devices.Gpio/System.Devices.Gpio.Samples/System.Devices.Gpio.Samples.csproj
+++ b/src/System.Devices.Gpio/System.Devices.Gpio.Samples/System.Devices.Gpio.Samples.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AssemblyOriginatorKeyFile>C:\Users\T-edzo\Repos\corefxlab\tools\Key.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>../../../tools/test_key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Initial depth was set incorrectly for the multi-segment case.

Adding several tests borrowed from SignalR, mainly from the [HandshakeProtocolTests](https://github.com/aspnet/SignalR/blob/651b39bc901bac7767fb19af6fcb256a9730e258/test/Microsoft.AspNetCore.SignalR.Common.Tests/Internal/Protocol/HandshakeProtocolTests.cs#L12).