### PR TITLE
Optimize TryReadUntil

### DIFF
--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
@@ -3,128 +3,179 @@
 
 namespace System.Buffers.Reader
 {
-    // TODO: the TryReadUntil methods are very inneficient. We need to fix that.
-    public static partial class BufferReaderExtensions
+    public ref partial struct BufferReader
     {
-        public static bool TryReadUntil(ref BufferReader reader, out ReadOnlySpan<byte> bytes, byte delimiter)
+        /// <summary>
+        /// Try to read everything up to the given delimiter. Will position the reader past the delimiter if found.
+        /// </summary>
+        /// <param name="span">The read data, if any.</param>
+        /// <param name="delimiter">The delimiter to look for.</param>
+        /// <returns>True if the data was found.</returns>
+        public bool TryReadUntil(out ReadOnlySpan<byte> span, byte delimiter)
         {
-            int idx = reader.UnreadSegment.IndexOf(delimiter);
-            if (idx != -1)
+            ReadOnlySpan<byte> remaining = CurrentSegmentIndex == 0 ? CurrentSegment : UnreadSegment;
+            int index = remaining.IndexOf(delimiter);
+            if (index != -1)
             {
-                bytes = reader.UnreadSegment.Slice(0, idx);
-                reader.Advance(idx + 1);
+                span = index == 0 ? default : remaining.Slice(0, index);
+                Advance(index + 1);
                 return true;
             }
-            else
-            {
-                bool result = TryReadUntil(ref reader, out ReadOnlySequence<byte> sequence, delimiter);
 
-                if (sequence.IsSingleSegment)
-                {
-                    bytes = sequence.First.Span;
-                }
-                else
-                {
-                    bytes = sequence.ToArray();
-                }
-
-                return result;
-            }
+            return TryReadUntilSlow(out span, delimiter, remaining.Length);
         }
 
-        public static bool TryReadUntil(ref BufferReader reader, out ReadOnlySequence<byte> bytes, byte delimiter)
+        private bool TryReadUntilSlow(out ReadOnlySpan<byte> span, byte delimiter, int advance)
         {
-            BufferReader copy = reader;
-            while (!reader.End)
+            Advance(advance);
+            if (End || !TryReadUntil(out ReadOnlySequence<byte> sequence, delimiter))
             {
-                if (reader.Peek() == delimiter)
+                span = default;
+                return false;
+            }
+
+            span = sequence.IsSingleSegment ? sequence.First.Span : sequence.ToArray();
+            return true;
+        }
+
+        /// <summary>
+        /// Try to read everything up to the given delimiter. Will position the reader past the delimiter if found.
+        /// </summary>
+        /// <param name="sequence">The read data, if any.</param>
+        /// <param name="delimiter">The delimiter to look for.</param>
+        /// <returns>True if the data was found.</returns>
+        public bool TryReadUntil(out ReadOnlySequence<byte> sequence, byte delimiter)
+        {
+            BufferReader copy = this;
+            ReadOnlySpan<byte> remaining = CurrentSegmentIndex == 0 ? CurrentSegment : UnreadSegment;
+
+            while (!End)
+            {
+                int index = remaining.IndexOf(delimiter);
+                if (index != -1)
                 {
-                    bytes = reader.Sequence.Slice(copy.Position, reader.Position);
-                    reader.Advance(1);
+                    // Found the delimiter. Move to it, slice, then move past it.
+                    if (index > 0)
+                    {
+                        Advance(index);
+                    }
+
+                    sequence = Sequence.Slice(copy.Position, Position);
+                    Advance(1);
                     return true;
                 }
-                reader.Advance(1);
+
+                Advance(remaining.Length);
+                remaining = CurrentSegment;
             }
-            reader = copy;
-            bytes = default;
+
+            // Didn't find anything, reset our original state.
+            this = copy;
+            sequence = default;
             return false;
         }
 
-        public static bool TryReadUntilAny(ref BufferReader reader, out ReadOnlySpan<byte> bytes, ReadOnlySpan<byte> delimiters)
+        /// <summary>
+        /// Try to read everything up to the given delimiters. Will position the reader past the delimiter if found.
+        /// </summary>
+        /// <param name="span">The read data, if any.</param>
+        /// <param name="delimiters">The delimiters to look for.</param>
+        /// <returns>True if the data was found.</returns>
+        public bool TryReadUntilAny(out ReadOnlySpan<byte> span, ReadOnlySpan<byte> delimiters)
         {
-            int idx = reader.UnreadSegment.IndexOfAny(delimiters);
-            if (idx != -1)
+            ReadOnlySpan<byte> remaining = UnreadSegment;
+            int index = remaining.IndexOfAny(delimiters);
+            if (index != -1)
             {
-                bytes = reader.UnreadSegment.Slice(0, idx);
-                reader.Advance(idx);
+                span = remaining.Slice(0, index);
+                Advance(index + 1);
                 return true;
             }
-            else
-            {
-                bool result = TryReadUntil(ref reader, out ReadOnlySequence<byte> sequence, delimiters);
 
-                if (sequence.IsSingleSegment)
-                {
-                    bytes = sequence.First.Span;
-                }
-                else
-                {
-                    bytes = sequence.ToArray();
-                }
-
-                return result;
-            }
+            return TryReadUntilAnySlow(out span, delimiters, remaining.Length);
         }
 
-        private static bool TryReadUntilAny(ref BufferReader reader, out ReadOnlySequence<byte> bytes, ReadOnlySpan<byte> delimiters)
+        private bool TryReadUntilAnySlow(out ReadOnlySpan<byte> span, ReadOnlySpan<byte> delimiters, int advance)
         {
-            BufferReader copy = reader;
-            while (!reader.End)
+            Advance(advance);
+            if (End || !TryReadUntilAny(out ReadOnlySequence<byte> sequence, delimiters))
             {
-                byte b = (byte)reader.Peek();
-                if (delimiters.IndexOf(b) != -1)
+                span = default;
+                return false;
+            }
+
+            span = sequence.IsSingleSegment ? sequence.First.Span : sequence.ToArray();
+            return true;
+        }
+
+        /// <summary>
+        /// Try to read everything up to the given delimiters. Will position the reader past the delimiter if found.
+        /// </summary>
+        /// <param name="sequence">The read data, if any.</param>
+        /// <param name="delimiters">The delimiters to look for.</param>
+        /// <returns>True if the data was found.</returns>
+        public bool TryReadUntilAny(out ReadOnlySequence<byte> sequence, ReadOnlySpan<byte> delimiters)
+        {
+            BufferReader copy = this;
+            ReadOnlySpan<byte> remaining = CurrentSegmentIndex == 0 ? CurrentSegment : UnreadSegment;
+
+            while (!End)
+            {
+                int index = remaining.IndexOfAny(delimiters);
+                if (index != -1)
                 {
-                    bytes = reader.Sequence.Slice(copy.Position, reader.Position);
+                    // Found one of the delimiters. Move to it, slice, then move past it.
+                    if (index > 0)
+                    {
+                        Advance(index);
+                    }
+
+                    sequence = Sequence.Slice(copy.Position, Position);
+                    Advance(1);
                     return true;
                 }
-                reader.Advance(1);
+
+                Advance(remaining.Length);
+                remaining = CurrentSegment;
             }
-            reader = copy;
-            bytes = default;
+
+            // Didn't find anything, reset our original state.
+            this = copy;
+            sequence = default;
             return false;
         }
 
-        public static bool TryReadUntil(ref BufferReader reader, out ReadOnlySequence<byte> bytes, ReadOnlySpan<byte> delimiter)
+        public bool TryReadUntil(out ReadOnlySequence<byte> sequence, ReadOnlySpan<byte> delimiter)
         {
             if (delimiter.Length == 0)
             {
-                bytes = default;
+                sequence = default;
                 return true;
             }
 
             int matched = 0;
-            var copy = reader;
-            var start = reader.Position;
-            var end = reader.Position;
-            while (!reader.End)
+            BufferReader copy = this;
+            SequencePosition start = Position;
+            SequencePosition end = Position;
+            while (!End)
             {
-                if (reader.Read() == delimiter[matched])
+                if (Read() == delimiter[matched])
                 {
                     matched++;
                 }
                 else
                 {
-                    end = reader.Position;
+                    end = Position;
                     matched = 0;
                 }
                 if (matched >= delimiter.Length)
                 {
-                    bytes = reader.Sequence.Slice(start, end);
+                    sequence = Sequence.Slice(start, end);
                     return true;
                 }
             }
-            reader = copy;
-            bytes = default;
+            this = copy;
+            sequence = default;
             return false;
         }
     }

--- a/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
@@ -535,7 +535,7 @@ namespace System.Text.JsonLab
 
         private int ConsumeNumberUtf8MultiSegment()
         {
-            if (!_reader.TryReadUntilAny(out ReadOnlySpan<byte> span, JsonConstants.Delimiters))
+            if (!_reader.TryReadUntilAny(out ReadOnlySpan<byte> span, JsonConstants.Delimiters, movePastDelimiter: false))
             {
                 JsonThrowHelper.ThrowJsonReaderException();
             }

--- a/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
@@ -535,7 +535,7 @@ namespace System.Text.JsonLab
 
         private int ConsumeNumberUtf8MultiSegment()
         {
-            if (!BufferReaderExtensions.TryReadUntilAny(ref _reader, out ReadOnlySpan<byte> span, JsonConstants.Delimiters))
+            if (!_reader.TryReadUntilAny(out ReadOnlySpan<byte> span, JsonConstants.Delimiters))
             {
                 JsonThrowHelper.ThrowJsonReaderException();
             }
@@ -656,7 +656,7 @@ namespace System.Text.JsonLab
 
         private void ConsumePropertyNameUtf8MultiSegment()
         {
-            if (!BufferReaderExtensions.TryReadUntil(ref _reader, out ReadOnlySpan<byte> span, JsonConstants.Quote))
+            if (!_reader.TryReadUntil(out ReadOnlySpan<byte> span, JsonConstants.Quote))
             {
                 JsonThrowHelper.ThrowJsonReaderException();
             }
@@ -691,7 +691,7 @@ namespace System.Text.JsonLab
 
         private int ConsumeStringUtf8MultiSegment()
         {
-            if (!BufferReaderExtensions.TryReadUntil(ref _reader, out ReadOnlySpan<byte> span, JsonConstants.Quote))
+            if (!_reader.TryReadUntil(out ReadOnlySpan<byte> span, JsonConstants.Quote))
             {
                 JsonThrowHelper.ThrowJsonReaderException();
             }

--- a/tests/Benchmarks/System.Buffers/Reader_Search.cs
+++ b/tests/Benchmarks/System.Buffers/Reader_Search.cs
@@ -1,0 +1,115 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using System.Buffers.Reader;
+using System.Buffers.Testing;
+using System.Buffers.Text;
+
+namespace System.Buffers.Benchmarks
+{
+    public class Reader_Search
+    {
+        private static byte[] s_array;
+        private static ReadOnlySequence<byte> s_ros;
+        private static ReadOnlySequence<byte> s_rosSplit;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            s_array = new byte[1_000_000];
+            Random r = new Random(42);
+            r.NextBytes(s_array);
+            s_ros = new ReadOnlySequence<byte>(s_array);
+            s_rosSplit = BufferUtilities.CreateSplitBuffer(s_array, 10, 100);
+        }
+
+        [Benchmark]
+        public void TryReadUntil_Sequence()
+        {
+            BufferReader reader = BufferReader.Create(s_rosSplit);
+            while (reader.TryReadUntil(out ReadOnlySequence<byte> bytes, 42))
+            {
+            }
+        }
+
+        [Benchmark]
+        public void TryReadUntilAny_2_Sequence()
+        {
+            BufferReader reader = BufferReader.Create(s_rosSplit);
+            byte[] delimiters = { 0, 255 };
+            while (reader.TryReadUntilAny(out ReadOnlySequence<byte> bytes, delimiters))
+            {
+            }
+        }
+
+        [Benchmark]
+        public void TryReadUntilAny_5_Sequence()
+        {
+            BufferReader reader = BufferReader.Create(s_rosSplit);
+            byte[] delimiters = { 2, 3, 5, 7, 11 };
+            while (reader.TryReadUntilAny(out ReadOnlySequence<byte> bytes, delimiters))
+            {
+            }
+        }
+
+        [Benchmark]
+        public void TryReadUntil_Span()
+        {
+            BufferReader reader = BufferReader.Create(s_rosSplit);
+            while (reader.TryReadUntil(out ReadOnlySpan<byte> bytes, 42))
+            {
+            }
+        }
+
+        [Benchmark]
+        public void TryReadUntil_Span_OneSegment()
+        {
+            BufferReader reader = BufferReader.Create(s_ros);
+            while (reader.TryReadUntil(out ReadOnlySpan<byte> bytes, 42))
+            {
+            }
+        }
+
+        [Benchmark]
+        public void TryReadUntilAny_2_Span()
+        {
+            BufferReader reader = BufferReader.Create(s_rosSplit);
+            byte[] delimiters = { 0, 255 };
+            while (reader.TryReadUntilAny(out ReadOnlySpan<byte> bytes, delimiters))
+            {
+            }
+        }
+
+        [Benchmark]
+        public void TryReadUntilAny_2_Span_OneSegment()
+        {
+            BufferReader reader = BufferReader.Create(s_ros);
+            byte[] delimiters = { 0, 255 };
+            while (reader.TryReadUntilAny(out ReadOnlySpan<byte> bytes, delimiters))
+            {
+            }
+        }
+
+        [Benchmark]
+        public void TryReadUntilAny_5_Span()
+        {
+            BufferReader reader = BufferReader.Create(s_rosSplit);
+            byte[] delimiters = { 2, 3, 5, 7, 11 };
+            while (reader.TryReadUntilAny(out ReadOnlySpan<byte> bytes, delimiters))
+            {
+            }
+        }
+
+        [Benchmark]
+        public void TryReadUntilAny_5_Span_OneSegment()
+        {
+            BufferReader reader = BufferReader.Create(s_ros);
+            byte[] delimiters = { 2, 3, 5, 7, 11 };
+            while (reader.TryReadUntilAny(out ReadOnlySpan<byte> bytes, delimiters))
+            {
+            }
+        }
+    }
+}

--- a/tests/System.Buffers.ReaderWriter.Tests/BytesReaderTests.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/BytesReaderTests.cs
@@ -15,13 +15,13 @@ namespace System.Buffers.Tests
             var bytes = new ReadOnlySequence<byte>(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 });
             var reader = BufferReader.Create(bytes);
 
-            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out ReadOnlySequence<byte> ab, 3));
+            Assert.True(reader.TryReadUntil(out ReadOnlySequence<byte> ab, 3));
             Assert.True(ab.First.SequenceEqual(new byte[] { 1, 2 }));
 
-            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out ReadOnlySequence<byte> cd, 6));
+            Assert.True(reader.TryReadUntil(out ReadOnlySequence<byte> cd, 6));
             Assert.True(cd.First.SequenceEqual(new byte[] { 4, 5 }));
 
-            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out ReadOnlySequence<byte> ef, new byte[] { 8, 9 }));
+            Assert.True(reader.TryReadUntil(out ReadOnlySequence<byte> ef, new byte[] { 8, 9 }));
             Assert.True(ef.First.SequenceEqual(new byte[] { 7 }));
         }
 
@@ -48,17 +48,17 @@ namespace System.Buffers.Tests
 
             var reader = BufferReader.Create(bytes);
 
-            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out ReadOnlySequence<byte> bytesValue, 2));
+            Assert.True(reader.TryReadUntil(out ReadOnlySequence<byte> bytesValue, 2));
             var span = bytesValue.ToSpan();
             Assert.Equal(0, span[0]);
             Assert.Equal(1, span[1]);
 
-            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out bytesValue, 5));
+            Assert.True(reader.TryReadUntil(out bytesValue, 5));
             span = bytesValue.ToSpan();
             Assert.Equal(3, span[0]);
             Assert.Equal(4, span[1]);
 
-            Assert.True(BufferReaderExtensions.TryReadUntil(ref reader, out bytesValue, new byte[] { 8, 8 }));
+            Assert.True(reader.TryReadUntil(out bytesValue, new byte[] { 8, 8 }));
             span = bytesValue.ToSpan();
             Assert.Equal(6, span[0]);
             Assert.Equal(7, span[1]);
@@ -87,7 +87,7 @@ namespace System.Buffers.Tests
         {
             var bytes = ReadOnlySequence<byte>.Empty;
             var reader = BufferReader.Create(bytes);
-            Assert.False(BufferReaderExtensions.TryReadUntil(ref reader, out ReadOnlySequence<byte> range, (byte)' '));
+            Assert.False(reader.TryReadUntil(out ReadOnlySequence<byte> range, (byte)' '));
         }
 
         [Fact]


### PR DESCRIPTION
Move the methods to instance and optimize. I did not optimize the TryReadUntil that takes a Span delimiter yet.

For a single segment single delimiter I can get about 25% gain. The cost of comparing multiple delimiters eats a greater portion of the time pretty rapidly. I think were pretty close to optimal here (i.e. most of the time is in IndexOf/Any).

**Before (single segment)**
```
                            Method |       Mean |     Error |    StdDev |
---------------------------------- |-----------:|----------:|----------:|
      TryReadUntil_Span_OneSegment |   179.8 us |  3.220 us |  2.854 us |
 TryReadUntilAny_2_Span_OneSegment |   633.3 us |  6.364 us |  5.953 us |
 TryReadUntilAny_5_Span_OneSegment | 3,116.2 us | 16.157 us | 15.113 us |
```

**After (single segment)**
```
                            Method |       Mean |     Error |    StdDev |
---------------------------------- |-----------:|----------:|----------:|
      TryReadUntil_Span_OneSegment |   142.5 us |  2.651 us |  2.479 us |
 TryReadUntilAny_2_Span_OneSegment |   616.5 us |  6.070 us |  5.678 us |
 TryReadUntilAny_5_Span_OneSegment | 3,104.0 us | 51.189 us | 47.882 us |
```

For multiple segments I can get better improvements.

**Before (multiple segments)**
```
                     Method |     Mean |     Error |    StdDev |
--------------------------- |---------:|----------:|----------:|
      TryReadUntil_Sequence | 2.559 ms | 0.0390 ms | 0.0365 ms |
 TryReadUntilAny_2_Sequence | 5.848 ms | 0.0439 ms | 0.0390 ms |
 TryReadUntilAny_5_Sequence | 6.537 ms | 0.0312 ms | 0.0292 ms |
          TryReadUntil_Span | 3.278 ms | 0.0149 ms | 0.0133 ms |
     TryReadUntilAny_2_Span | 6.348 ms | 0.0305 ms | 0.0285 ms |
     TryReadUntilAny_5_Span | 8.161 ms | 0.0414 ms | 0.0367 ms |
```

**After (multiple segments)**
```
                     Method |     Mean |     Error |    StdDev |
--------------------------- |---------:|----------:|----------:|
      TryReadUntil_Sequence | 1.278 ms | 0.0051 ms | 0.0045 ms |
 TryReadUntilAny_2_Sequence | 2.185 ms | 0.0115 ms | 0.0089 ms |
 TryReadUntilAny_5_Sequence | 5.009 ms | 0.0486 ms | 0.0455 ms |
          TryReadUntil_Span | 1.817 ms | 0.0139 ms | 0.0130 ms |
     TryReadUntilAny_2_Span | 2.906 ms | 0.0104 ms | 0.0092 ms |
     TryReadUntilAny_5_Span | 5.548 ms | 0.0402 ms | 0.0376 ms |
```

cc: @benaadams, @mgravell, @Drawaes 
