### PR TITLE
Constructor work & perf tweaks

### DIFF
--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_binary.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_binary.cs
@@ -20,7 +20,7 @@ namespace System.Buffers.Reader
         /// </returns>
         public unsafe bool TryRead<T>(out T value) where T : unmanaged
         {
-            ReadOnlySpan<byte> span = UnreadSegment;
+            ReadOnlySpan<byte> span = UnreadSpan;
             if (span.Length < sizeof(T))
                 return TryReadSlow(out value);
 
@@ -31,7 +31,7 @@ namespace System.Buffers.Reader
 
         private unsafe bool TryReadSlow<T>(out T value) where T : unmanaged
         {
-            Debug.Assert(UnreadSegment.Length < sizeof(T));
+            Debug.Assert(UnreadSpan.Length < sizeof(T));
 
             // Not enough data in the current segment, try to peek for the data we need.
             byte* buffer = stackalloc byte[sizeof(T)];

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
@@ -14,7 +14,7 @@ namespace System.Buffers.Reader
         /// <returns>True if the data was found.</returns>
         public bool TryReadUntil(out ReadOnlySpan<byte> span, byte delimiter, bool movePastDelimiter = true)
         {
-            ReadOnlySpan<byte> remaining = CurrentSegmentIndex == 0 ? CurrentSegment : UnreadSegment;
+            ReadOnlySpan<byte> remaining = UnreadSpan;
             int index = remaining.IndexOf(delimiter);
             if (index != -1)
             {
@@ -55,7 +55,7 @@ namespace System.Buffers.Reader
             BufferReader copy = this;
             if (skip > 0)
                 Advance(skip);
-            ReadOnlySpan<byte> remaining = CurrentSegmentIndex == 0 ? CurrentSegment : UnreadSegment;
+            ReadOnlySpan<byte> remaining = UnreadSpan;
 
             while (!End)
             {
@@ -77,7 +77,7 @@ namespace System.Buffers.Reader
                 }
 
                 Advance(remaining.Length);
-                remaining = CurrentSegment;
+                remaining = CurrentSpan;
             }
 
             // Didn't find anything, reset our original state.
@@ -95,7 +95,7 @@ namespace System.Buffers.Reader
         /// <returns>True if the data was found.</returns>
         public bool TryReadUntilAny(out ReadOnlySpan<byte> span, ReadOnlySpan<byte> delimiters, bool movePastDelimiter = true)
         {
-            ReadOnlySpan<byte> remaining = UnreadSegment;
+            ReadOnlySpan<byte> remaining = UnreadSpan;
             int index = remaining.IndexOfAny(delimiters);
             if (index != -1)
             {
@@ -136,7 +136,7 @@ namespace System.Buffers.Reader
             BufferReader copy = this;
             if (skip > 0)
                 Advance(skip);
-            ReadOnlySpan<byte> remaining = CurrentSegmentIndex == 0 ? CurrentSegment : UnreadSegment;
+            ReadOnlySpan<byte> remaining = CurrentSpanIndex == 0 ? CurrentSpan : UnreadSpan;
 
             while (!End)
             {
@@ -158,7 +158,7 @@ namespace System.Buffers.Reader
                 }
 
                 Advance(remaining.Length);
-                remaining = CurrentSegment;
+                remaining = CurrentSpan;
             }
 
             // Didn't find anything, reset our original state.

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_text.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_text.cs
@@ -11,7 +11,7 @@ namespace System.Buffers.Reader
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe bool TryParse(out bool value)
         {
-            ReadOnlySpan<byte> unread = UnreadSegment;
+            ReadOnlySpan<byte> unread = UnreadSpan;
 
             // For other types (int, etc) we won't know if we've consumed all of the type
             // ("235612" can be split over segments, for example). For bool, Utf8Parser
@@ -28,7 +28,7 @@ namespace System.Buffers.Reader
         private unsafe bool TryParseSlow(out bool value)
         {
             const int MaxLength = 5;
-            ReadOnlySpan<byte> unread = UnreadSegment;
+            ReadOnlySpan<byte> unread = UnreadSpan;
 
             if (unread.Length > MaxLength)
             {
@@ -51,7 +51,7 @@ namespace System.Buffers.Reader
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe bool TryParse(out int value)
         {
-            ReadOnlySpan<byte> unread = UnreadSegment;
+            ReadOnlySpan<byte> unread = UnreadSpan;
             if (Utf8Parser.TryParse(unread, out value, out int consumed) && consumed < unread.Length)
             {
                 Advance(consumed);
@@ -64,7 +64,8 @@ namespace System.Buffers.Reader
         private unsafe bool TryParseSlow(out int value)
         {
             const int MaxLength = 15;
-            ReadOnlySpan<byte> unread = UnreadSegment;
+
+            ReadOnlySpan<byte> unread = UnreadSpan;
 
             if (unread.Length > MaxLength)
             {
@@ -87,7 +88,7 @@ namespace System.Buffers.Reader
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe bool TryParse(out ulong value)
         {
-            ReadOnlySpan<byte> unread = UnreadSegment;
+            ReadOnlySpan<byte> unread = UnreadSpan;
             if (Utf8Parser.TryParse(unread, out value, out int consumed) && consumed < unread.Length)
             {
                 Advance(consumed);
@@ -100,7 +101,7 @@ namespace System.Buffers.Reader
         private unsafe bool TryParseSlow(out ulong value)
         {
             const int MaxLength = 30;
-            ReadOnlySpan<byte> unread = UnreadSegment;
+            ReadOnlySpan<byte> unread = UnreadSpan;
 
             if (unread.Length > MaxLength)
             {

--- a/src/System.Text.Http/System/Text/Http/Parser/HttpParser.cs
+++ b/src/System.Text.Http/System/Text/Http/Parser/HttpParser.cs
@@ -242,7 +242,7 @@ namespace System.Text.Http.Parser
 
             var bufferEnd = buffer.End;
 
-            var reader = BufferReader.Create(buffer);
+            var reader = new BufferReader(buffer);
             var start = default(BufferReader);
             var done = false;
 
@@ -250,14 +250,14 @@ namespace System.Text.Http.Parser
             {
                 while (!reader.End)
                 {
-                    var span = reader.CurrentSegment;
-                    var remaining = span.Length - reader.CurrentSegmentIndex;
+                    var span = reader.CurrentSpan;
+                    var remaining = span.Length - reader.CurrentSpanIndex;
 
                     fixed (byte* pBuffer = &MemoryMarshal.GetReference(span))
                     {
                         while (remaining > 0)
                         {
-                            var index = reader.CurrentSegmentIndex;
+                            var index = reader.CurrentSpanIndex;
                             int ch1;
                             int ch2;
 
@@ -291,7 +291,7 @@ namespace System.Text.Http.Parser
                                 {
                                     // If we got 2 bytes from the span directly so skip ahead 2 so that
                                     // the reader's state matches what we expect
-                                    if (index == reader.CurrentSegmentIndex)
+                                    if (index == reader.CurrentSpanIndex)
                                     {
                                         reader.Advance(2);
                                     }
@@ -306,10 +306,10 @@ namespace System.Text.Http.Parser
 
                             // We moved the reader so look ahead 2 bytes so reset both the reader
                             // and the index
-                            if (index != reader.CurrentSegmentIndex)
+                            if (index != reader.CurrentSpanIndex)
                             {
                                 reader = start;
-                                index = reader.CurrentSegmentIndex;
+                                index = reader.CurrentSpanIndex;
                             }
 
                             var endIndex = new ReadOnlySpan<byte>(pBuffer + index, remaining).IndexOf(ByteLF);

--- a/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
@@ -72,7 +72,7 @@ namespace System.Text.JsonLab
 
         public Utf8JsonReader(in ReadOnlySequence<byte> data)
         {
-            _reader = BufferReader.Create(data);
+            _reader = new BufferReader(data);
             _isSingleSegment = data.IsSingleSegment; //true;
             _buffer = data.First.Span;  //data.ToArray();
             Depth = 1;

--- a/tests/Benchmarks/System.Buffers/Reader.cs
+++ b/tests/Benchmarks/System.Buffers/Reader.cs
@@ -43,7 +43,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void ParseInt32BufferReader()
         {
-            BufferReader reader = BufferReader.Create(s_ros);
+            BufferReader reader = new BufferReader(s_ros);
 
             while (reader.TryParse(out int value))
             {
@@ -54,9 +54,9 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void ParseInt32BufferReaderRaw()
         {
-            BufferReader reader = BufferReader.Create(s_ros);
+            BufferReader reader = new BufferReader(s_ros);
 
-            while (Utf8Parser.TryParse(reader.CurrentSegment.Slice(reader.ConsumedBytes), out int value, out int consumed))
+            while (Utf8Parser.TryParse(reader.CurrentSpan.Slice(reader.ConsumedBytes), out int value, out int consumed))
             {
                 reader.Advance(consumed + 1);
             }

--- a/tests/Benchmarks/System.Buffers/Reader_Binary.cs
+++ b/tests/Benchmarks/System.Buffers/Reader_Binary.cs
@@ -26,7 +26,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void ReadInt32()
         {
-            BufferReader reader = BufferReader.Create(s_ros);
+            BufferReader reader = new BufferReader(s_ros);
 
             while (reader.TryRead(out int value))
             {
@@ -36,7 +36,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void ReadInt32_BigEndian()
         {
-            BufferReader reader = BufferReader.Create(s_ros);
+            BufferReader reader = new BufferReader(s_ros);
 
             while (reader.TryReadInt32BigEndian(out int value))
             {
@@ -46,7 +46,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void ReadInt32_LittleEndian()
         {
-            BufferReader reader = BufferReader.Create(s_ros);
+            BufferReader reader = new BufferReader(s_ros);
 
             while (reader.TryReadInt32LittleEndian(out int value))
             {
@@ -60,7 +60,7 @@ namespace System.Buffers.Benchmarks
             const int Iterations = 100_000;
             Span<byte> span = new Span<byte>(s_buffer, 0, Count);
 
-            BufferReader reader = BufferReader.Create(s_ros);
+            BufferReader reader = new BufferReader(s_ros);
             for (int i = 0; i < Iterations; i++)
                 reader.Peek(span);
         }

--- a/tests/Benchmarks/System.Buffers/Reader_Construction.cs
+++ b/tests/Benchmarks/System.Buffers/Reader_Construction.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using System.Buffers.Reader;
+using System.Buffers.Testing;
+using System.Buffers.Text;
+
+namespace System.Buffers.Benchmarks
+{
+    public class Reader_Construction
+    {
+        private static byte[] s_array;
+        private static ReadOnlySequence<byte> s_ros;
+        private static ReadOnlySequence<byte> s_rosSplit;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            s_array = new byte[1000];
+            Random r = new Random(1776);
+            r.NextBytes(s_array);
+            s_ros = new ReadOnlySequence<byte>(s_array);
+            s_rosSplit = BufferUtilities.CreateSplitBuffer(s_array, 10, 100);
+        }
+
+        [Benchmark]
+        public void ConstructSingleSegment()
+        {
+            new BufferReader(s_ros);
+        }
+
+
+        [Benchmark]
+        public void ConstructMultiSegment()
+        {
+            new BufferReader(s_rosSplit);
+        }
+    }
+}

--- a/tests/Benchmarks/System.Buffers/Reader_ParseInt.cs
+++ b/tests/Benchmarks/System.Buffers/Reader_ParseInt.cs
@@ -41,7 +41,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void ParseInt32()
         {
-            BufferReader reader = BufferReader.Create(s_ros);
+            BufferReader reader = new BufferReader(s_ros);
 
             while (reader.TryParse(out int value))
             {
@@ -53,7 +53,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void ParseInt32_Split()
         {
-            BufferReader reader = BufferReader.Create(s_rosSplit);
+            BufferReader reader = new BufferReader(s_rosSplit);
 
             while (reader.TryParse(out int value))
             {

--- a/tests/Benchmarks/System.Buffers/Reader_Search.cs
+++ b/tests/Benchmarks/System.Buffers/Reader_Search.cs
@@ -28,7 +28,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void TryReadUntil_Sequence()
         {
-            BufferReader reader = BufferReader.Create(s_rosSplit);
+            BufferReader reader = new BufferReader(s_rosSplit);
             while (reader.TryReadUntil(out ReadOnlySequence<byte> bytes, 42))
             {
             }
@@ -37,7 +37,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void TryReadUntilAny_2_Sequence()
         {
-            BufferReader reader = BufferReader.Create(s_rosSplit);
+            BufferReader reader = new BufferReader(s_rosSplit);
             byte[] delimiters = { 0, 255 };
             while (reader.TryReadUntilAny(out ReadOnlySequence<byte> bytes, delimiters))
             {
@@ -47,7 +47,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void TryReadUntilAny_5_Sequence()
         {
-            BufferReader reader = BufferReader.Create(s_rosSplit);
+            BufferReader reader = new BufferReader(s_rosSplit);
             byte[] delimiters = { 2, 3, 5, 7, 11 };
             while (reader.TryReadUntilAny(out ReadOnlySequence<byte> bytes, delimiters))
             {
@@ -57,7 +57,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void TryReadUntil_Span()
         {
-            BufferReader reader = BufferReader.Create(s_rosSplit);
+            BufferReader reader = new BufferReader(s_rosSplit);
             while (reader.TryReadUntil(out ReadOnlySpan<byte> bytes, 42))
             {
             }
@@ -66,7 +66,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void TryReadUntil_Span_OneSegment()
         {
-            BufferReader reader = BufferReader.Create(s_ros);
+            BufferReader reader = new BufferReader(s_ros);
             while (reader.TryReadUntil(out ReadOnlySpan<byte> bytes, 42))
             {
             }
@@ -75,7 +75,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void TryReadUntilAny_2_Span()
         {
-            BufferReader reader = BufferReader.Create(s_rosSplit);
+            BufferReader reader = new BufferReader(s_rosSplit);
             byte[] delimiters = { 0, 255 };
             while (reader.TryReadUntilAny(out ReadOnlySpan<byte> bytes, delimiters))
             {
@@ -85,7 +85,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void TryReadUntilAny_2_Span_OneSegment()
         {
-            BufferReader reader = BufferReader.Create(s_ros);
+            BufferReader reader = new BufferReader(s_ros);
             byte[] delimiters = { 0, 255 };
             while (reader.TryReadUntilAny(out ReadOnlySpan<byte> bytes, delimiters))
             {
@@ -95,7 +95,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void TryReadUntilAny_5_Span()
         {
-            BufferReader reader = BufferReader.Create(s_rosSplit);
+            BufferReader reader = new BufferReader(s_rosSplit);
             byte[] delimiters = { 2, 3, 5, 7, 11 };
             while (reader.TryReadUntilAny(out ReadOnlySpan<byte> bytes, delimiters))
             {
@@ -105,7 +105,7 @@ namespace System.Buffers.Benchmarks
         [Benchmark]
         public void TryReadUntilAny_5_Span_OneSegment()
         {
-            BufferReader reader = BufferReader.Create(s_ros);
+            BufferReader reader = new BufferReader(s_ros);
             byte[] delimiters = { 2, 3, 5, 7, 11 };
             while (reader.TryReadUntilAny(out ReadOnlySpan<byte> bytes, delimiters))
             {

--- a/tests/System.Buffers.ReaderWriter.Tests/BufferReaderTests.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/BufferReaderTests.cs
@@ -28,7 +28,7 @@ namespace System.Buffers.Tests
         [Fact]
         public void TryParseRos()
         {
-            var reader = BufferReader.Create(s_ros);
+            var reader = new BufferReader(s_ros);
 
             while (reader.TryParse(out int value))
             {

--- a/tests/System.Buffers.ReaderWriter.Tests/BytesReaderTests.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/BytesReaderTests.cs
@@ -13,7 +13,7 @@ namespace System.Buffers.Tests
         public void SingleSegmentBytesReader()
         {
             var bytes = new ReadOnlySequence<byte>(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 });
-            var reader = BufferReader.Create(bytes);
+            var reader = new BufferReader(bytes);
 
             Assert.True(reader.TryReadUntil(out ReadOnlySequence<byte> ab, 3));
             Assert.True(ab.First.SequenceEqual(new byte[] { 1, 2 }));
@@ -46,7 +46,7 @@ namespace System.Buffers.Tests
                 new byte[] { 4          },
             });
 
-            var reader = BufferReader.Create(bytes);
+            var reader = new BufferReader(bytes);
 
             Assert.True(reader.TryReadUntil(out ReadOnlySequence<byte> bytesValue, 2));
             var span = bytesValue.ToSpan();
@@ -86,7 +86,7 @@ namespace System.Buffers.Tests
         public void EmptyBytesReader()
         {
             var bytes = ReadOnlySequence<byte>.Empty;
-            var reader = BufferReader.Create(bytes);
+            var reader = new BufferReader(bytes);
             Assert.False(reader.TryReadUntil(out ReadOnlySequence<byte> range, (byte)' '));
         }
 
@@ -94,7 +94,7 @@ namespace System.Buffers.Tests
         public void BytesReaderParse()
         {
             ReadOnlySequence<byte> bytes = BufferFactory.Parse("12|3Tr|ue|456Tr|ue7|89False|");
-            var reader = BufferReader.Create(bytes);
+            var reader = new BufferReader(bytes);
 
             Assert.True(reader.TryParse(out ulong u64));
             Assert.Equal(123ul, u64);
@@ -131,7 +131,7 @@ namespace System.Buffers.Tests
             var readOnlyBytes = new ReadOnlySequence<byte>(data);
             var bytesRange = new ReadOnlySequence<byte>(data);
 
-            var robReader = BufferReader.Create(readOnlyBytes);
+            var robReader = new BufferReader(readOnlyBytes);
 
             long robSum = 0;
             while (robReader.TryParse(out int value))
@@ -140,7 +140,7 @@ namespace System.Buffers.Tests
                 robReader.Advance(1);
             }
 
-            var brReader = BufferReader.Create(bytesRange);
+            var brReader = new BufferReader(bytesRange);
             long brSum = 0;
             while (brReader.TryParse(out int value))
             {

--- a/tests/System.Buffers.ReaderWriter.Tests/ReadableBufferReaderFacts.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/ReadableBufferReaderFacts.cs
@@ -30,26 +30,26 @@ namespace System.IO.Pipelines.Tests
             [Fact]
             public void AdvanceSingleBufferSkipsBytes()
             {
-                var reader = BufferReader.Create(BufferUtilities.CreateBuffer(new byte[] { 1, 2, 3, 4, 5 }));
+                var reader = new BufferReader(BufferUtilities.CreateBuffer(new byte[] { 1, 2, 3, 4, 5 }));
                 reader.Advance(2);
-                Assert.Equal(2, reader.CurrentSegmentIndex);
-                Assert.Equal(3, reader.CurrentSegment[reader.CurrentSegmentIndex]);
+                Assert.Equal(2, reader.CurrentSpanIndex);
+                Assert.Equal(3, reader.CurrentSpan[reader.CurrentSpanIndex]);
                 Assert.Equal(3, reader.Peek());
                 reader.Advance(2);
                 Assert.Equal(5, reader.Peek());
-                Assert.Equal(4, reader.CurrentSegmentIndex);
-                Assert.Equal(5, reader.CurrentSegment[reader.CurrentSegmentIndex]);
+                Assert.Equal(4, reader.CurrentSpanIndex);
+                Assert.Equal(5, reader.CurrentSpan[reader.CurrentSpanIndex]);
             }
 
             [Fact]
             public void TakeReturnsByteAndMoves()
             {
-                var reader = BufferReader.Create(Factory.CreateWithContent(new byte[] { 1, 2 }));
-                Assert.Equal(0, reader.CurrentSegmentIndex);
-                Assert.Equal(1, reader.CurrentSegment[reader.CurrentSegmentIndex]);
+                var reader = new BufferReader(Factory.CreateWithContent(new byte[] { 1, 2 }));
+                Assert.Equal(0, reader.CurrentSpanIndex);
+                Assert.Equal(1, reader.CurrentSpan[reader.CurrentSpanIndex]);
                 Assert.Equal(1, reader.Read());
-                Assert.Equal(1, reader.CurrentSegmentIndex);
-                Assert.Equal(2, reader.CurrentSegment[reader.CurrentSegmentIndex]);
+                Assert.Equal(1, reader.CurrentSpanIndex);
+                Assert.Equal(2, reader.CurrentSpan[reader.CurrentSpanIndex]);
                 Assert.Equal(2, reader.Read());
                 Assert.Equal(-1, reader.Read());
             }
@@ -71,7 +71,7 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public void PeekReturnsByteWithoutMoving()
         {
-            var reader = BufferReader.Create(Factory.CreateWithContent(new byte[] { 1, 2 }));
+            var reader = new BufferReader(Factory.CreateWithContent(new byte[] { 1, 2 }));
             Assert.Equal(1, reader.Peek());
             Assert.Equal(1, reader.Peek());
         }
@@ -79,7 +79,7 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public void CursorIsCorrectAtEnd()
         {
-            var reader = BufferReader.Create(Factory.CreateWithContent(new byte[] { 1, 2 }));
+            var reader = new BufferReader(Factory.CreateWithContent(new byte[] { 1, 2 }));
             reader.Read();
             reader.Read();
             Assert.True(reader.End);
@@ -95,7 +95,7 @@ namespace System.IO.Pipelines.Tests
             first.SetMemory(new OwnedArray<byte>(new byte[] { 1, 2 }), 0, 2);
             first.SetNext(last);
 
-            var reader = BufferReader.Create(new ReadOnlySequence<byte>(first, first.Start, last, last.Start));
+            var reader = new BufferReader(new ReadOnlySequence<byte>(first, first.Start, last, last.Start));
             reader.Read();
             reader.Read();
             reader.Read();
@@ -107,7 +107,7 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public void PeekReturnsMinusOneByteInTheEnd()
         {
-            var reader = BufferReader.Create(Factory.CreateWithContent(new byte[] { 1, 2 }));
+            var reader = new BufferReader(Factory.CreateWithContent(new byte[] { 1, 2 }));
             Assert.Equal(1, reader.Read());
             Assert.Equal(2, reader.Read());
             Assert.Equal(-1, reader.Peek());
@@ -116,7 +116,7 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public void AdvanceToEndThenPeekReturnsMinusOne()
         {
-            var reader = BufferReader.Create(Factory.CreateWithContent(new byte[] { 1, 2, 3, 4, 5 }));
+            var reader = new BufferReader(Factory.CreateWithContent(new byte[] { 1, 2, 3, 4, 5 }));
             reader.Advance(5);
             Assert.True(reader.End);
             Assert.Equal(-1, reader.Peek());
@@ -125,7 +125,7 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public void AdvancingPastLengthThrows()
         {
-            var reader = BufferReader.Create(Factory.CreateWithContent(new byte[] { 1, 2, 3, 4, 5 }));
+            var reader = new BufferReader(Factory.CreateWithContent(new byte[] { 1, 2, 3, 4, 5 }));
             try
             {
                 reader.Advance(6);
@@ -141,7 +141,7 @@ namespace System.IO.Pipelines.Tests
         public void CtorFindsFirstNonEmptySegment()
         {
             var buffer = Factory.CreateWithContent(new byte[] { 1 });
-            var reader = BufferReader.Create(buffer);
+            var reader = new BufferReader(buffer);
 
             Assert.Equal(1, reader.Peek());
         }
@@ -150,7 +150,7 @@ namespace System.IO.Pipelines.Tests
         public void EmptySegmentsAreSkippedOnMoveNext()
         {
             var buffer = Factory.CreateWithContent(new byte[] { 1, 2 });
-            var reader = BufferReader.Create(buffer);
+            var reader = new BufferReader(buffer);
 
             Assert.Equal(1, reader.Peek());
             reader.Advance(1);
@@ -161,7 +161,7 @@ namespace System.IO.Pipelines.Tests
         public void PeekGoesToEndIfAllEmptySegments()
         {
             var buffer = BufferUtilities.CreateBuffer(new[] { new byte[] { }, new byte[] { }, new byte[] { }, new byte[] { } });
-            var reader = BufferReader.Create(buffer);
+            var reader = new BufferReader(buffer);
 
             Assert.Equal(-1, reader.Peek());
             Assert.True(reader.End);
@@ -171,10 +171,10 @@ namespace System.IO.Pipelines.Tests
         public void AdvanceTraversesSegments()
         {
             var buffer = Factory.CreateWithContent(new byte[] { 1, 2, 3 });
-            var reader = BufferReader.Create(buffer);
+            var reader = new BufferReader(buffer);
 
             reader.Advance(2);
-            Assert.Equal(3, reader.CurrentSegment[reader.CurrentSegmentIndex]);
+            Assert.Equal(3, reader.CurrentSpan[reader.CurrentSpanIndex]);
             Assert.Equal(3, reader.Read());
         }
 
@@ -182,7 +182,7 @@ namespace System.IO.Pipelines.Tests
         public void AdvanceThrowsPastLengthMultipleSegments()
         {
             var buffer = Factory.CreateWithContent(new byte[] { 1, 2, 3 });
-            var reader = BufferReader.Create(buffer);
+            var reader = new BufferReader(buffer);
 
             try
             {
@@ -199,7 +199,7 @@ namespace System.IO.Pipelines.Tests
         public void TakeTraversesSegments()
         {
             var buffer = Factory.CreateWithContent(new byte[] { 1, 2, 3 });
-            var reader = BufferReader.Create(buffer);
+            var reader = new BufferReader(buffer);
 
             Assert.Equal(1, reader.Read());
             Assert.Equal(2, reader.Read());
@@ -211,12 +211,12 @@ namespace System.IO.Pipelines.Tests
         public void PeekTraversesSegments()
         {
             var buffer = Factory.CreateWithContent(new byte[] { 1, 2 });
-            var reader = BufferReader.Create(buffer);
+            var reader = new BufferReader(buffer);
 
-            Assert.Equal(1, reader.CurrentSegment[reader.CurrentSegmentIndex]);
+            Assert.Equal(1, reader.CurrentSpan[reader.CurrentSpanIndex]);
             Assert.Equal(1, reader.Read());
 
-            Assert.Equal(2, reader.CurrentSegment[reader.CurrentSegmentIndex]);
+            Assert.Equal(2, reader.CurrentSpan[reader.CurrentSpanIndex]);
             Assert.Equal(2, reader.Peek());
             Assert.Equal(2, reader.Read());
             Assert.Equal(-1, reader.Peek());
@@ -227,10 +227,10 @@ namespace System.IO.Pipelines.Tests
         public void PeekWorkesWithEmptySegments()
         {
             var buffer = Factory.CreateWithContent(new byte[] { 1 });
-            var reader = BufferReader.Create(buffer);
+            var reader = new BufferReader(buffer);
 
-            Assert.Equal(0, reader.CurrentSegmentIndex);
-            Assert.Equal(1, reader.CurrentSegment.Length);
+            Assert.Equal(0, reader.CurrentSpanIndex);
+            Assert.Equal(1, reader.CurrentSpan.Length);
             Assert.Equal(1, reader.Peek());
             Assert.Equal(1, reader.Read());
             Assert.Equal(-1, reader.Peek());
@@ -240,10 +240,10 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public void WorkesWithEmptyBuffer()
         {
-            var reader = BufferReader.Create(Factory.CreateWithContent(new byte[] { }));
+            var reader = new BufferReader(Factory.CreateWithContent(new byte[] { }));
 
-            Assert.Equal(0, reader.CurrentSegmentIndex);
-            Assert.Equal(0, reader.CurrentSegment.Length);
+            Assert.Equal(0, reader.CurrentSpanIndex);
+            Assert.Equal(0, reader.CurrentSpan.Length);
             Assert.Equal(-1, reader.Peek());
             Assert.Equal(-1, reader.Read());
         }
@@ -258,7 +258,7 @@ namespace System.IO.Pipelines.Tests
         public void ReturnsCorrectCursor(int takes, bool end)
         {
             var readableBuffer = Factory.CreateWithContent(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
-            var reader = BufferReader.Create(readableBuffer);
+            var reader = new BufferReader(readableBuffer);
             for (int i = 0; i < takes; i++)
             {
                 reader.Read();
@@ -274,25 +274,25 @@ namespace System.IO.Pipelines.Tests
             var buffer = Factory.CreateWithContent(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 });
             var sliced = buffer.Slice(2L);
 
-            var reader = BufferReader.Create(sliced);
+            var reader = new BufferReader(sliced);
             Assert.Equal(sliced.ToArray(), buffer.Slice(reader.Position).ToArray());
             Assert.Equal(2, reader.Peek());
-            Assert.Equal(0, reader.CurrentSegmentIndex);
+            Assert.Equal(0, reader.CurrentSpanIndex);
         }
 
         [Fact]
         public void ReaderIndexIsCorrect()
         {
             var buffer = Factory.CreateWithContent(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
-            var reader = BufferReader.Create(buffer);
+            var reader = new BufferReader(buffer);
 
             var counter = 1;
             while (!reader.End)
             {
-                var span = reader.CurrentSegment;
-                for (int i = reader.CurrentSegmentIndex; i < span.Length; i++)
+                var span = reader.CurrentSpan;
+                for (int i = reader.CurrentSpanIndex; i < span.Length; i++)
                 {
-                    Assert.Equal(counter++, reader.CurrentSegment[i]);
+                    Assert.Equal(counter++, reader.CurrentSpan[i]);
                 }
                 reader.Advance(span.Length);
             }
@@ -305,7 +305,7 @@ namespace System.IO.Pipelines.Tests
             var content = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
             Span<byte> buffer = new byte[content.Length + 1];
-            var reader = BufferReader.Create(Factory.CreateWithContent(content));
+            var reader = new BufferReader(Factory.CreateWithContent(content));
 
             // this loop skips more and more items in the reader
             for (int i = 0; i < content.Length; i++)
@@ -332,7 +332,7 @@ namespace System.IO.Pipelines.Tests
             var content = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
             Span<byte> buffer = new byte[content.Length];
-            var reader = BufferReader.Create(Factory.CreateWithContent(content));
+            var reader = new BufferReader(Factory.CreateWithContent(content));
 
             // this loop skips more and more items in the reader
             for (int i = 0; i < content.Length; i++)


### PR DESCRIPTION
Making the constructor public cuts the construction time by about a third.

Tweak UnreadSpan to inline and give back the current span if at the start.

Skip out on getting the next memory from the sequence if we're single segment.

Cuts 5-10% off of some of the perf tests.

Also change terms to Span from Segment. It was mentally taxing to juggle Span/Segment/Sequence/SequencePosition.



cc: @benaadams, @mgravell, @Drawaes, @davidfowl 