### PR TITLE
Add json parsing performance tests and code clean up

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/JsonParseObject.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonParseObject.cs
@@ -3,7 +3,6 @@
 
 using System.Buffers;
 using System.Buffers.Text;
-using System.Collections.Generic;
 using System.Text.Utf8;
 
 using static System.Runtime.InteropServices.MemoryMarshal;

--- a/src/System.Text.JsonLab/System/Text/Json/JsonParseObject.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonParseObject.cs
@@ -12,16 +12,34 @@ namespace System.Text.JsonLab
 {
     public ref struct JsonObject
     {
-        private MemoryPool<byte> _pool;
-        private IMemoryOwner<byte> _dbMemory;
-        private ReadOnlySpan<byte> _db; 
+        private Span<byte> _db; 
         private ReadOnlySpan<byte> _values;
 
-        public static JsonObject Parse(ReadOnlySpan<byte> utf8Json)
+        public string PrintDatabase()
         {
-            var parser = new JsonParser();
-            var result = parser.Parse(utf8Json);
-            return result;
+            StringBuilder sb = new StringBuilder();
+            sb.Append(nameof(Record.Location) + "\t" + nameof(Record.Length) + "\t" + nameof(Record.Type) + "\r\n");
+            for (int i = 0; i < _db.Length; i += DbRow.Size)
+            {
+                DbRow record = Read<DbRow>(_db.Slice(i));
+                sb.Append(record.Location + "\t" + record.Length + "\t" + record.Type + "\r\n");
+            }
+            return sb.ToString();
+        }
+
+        public string PrintJson()
+        {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < _db.Length; i += DbRow.Size)
+            {
+                DbRow record = Read<DbRow>(_db.Slice(i));
+                if (record.IsSimpleValue)
+                {
+                    ReadOnlySpan<byte> value = _values.Slice(record.Location, record.Length);
+                    sb.Append(Encoding.UTF8.GetString(value.ToArray())).Append(", ");
+                }
+            }
+            return sb.ToString();
         }
 
         public static JsonObject Parse(ReadOnlySpan<byte> utf8Json, MemoryPool<byte> pool = null)
@@ -31,23 +49,90 @@ namespace System.Text.JsonLab
             return result;
         }
 
-        internal JsonObject(ReadOnlySpan<byte> values, ReadOnlySpan<byte> db, MemoryPool<byte> pool = null, IMemoryOwner<byte> dbMemory = null)
+        internal JsonObject(ReadOnlySpan<byte> values, Span<byte> db)
         {
             _db = db;
             _values = values;
-            _pool = pool;
-            _dbMemory = dbMemory;
+        }
+
+        public bool TryGetChild(out JsonObject value)
+        {
+            DbRow record = Record;
+
+            if (record.Length == 0)
+            {
+                value = default;
+                return false;
+            }
+            if (record.Type != JsonValueType.Object)
+            {
+                JsonThrowHelper.ThrowInvalidOperationException();
+            }
+
+            record = Read<DbRow>(_db.Slice(DbRow.Size));
+
+            int newStart = DbRow.Size + DbRow.Size;
+            int newEnd = newStart + DbRow.Size;
+
+            record = Read<DbRow>(_db.Slice(newStart));
+
+            if (!record.IsSimpleValue)
+            {
+                newEnd = newEnd + DbRow.Size * record.Length;
+            }
+
+            value = new JsonObject(_values, _db.Slice(newStart, newEnd - newStart));
+            return true;
+        }
+
+        public void Remove(JsonObject obj)
+        {
+            ReadOnlySpan<byte> values = obj._values;
+            Span<byte> db = obj._db;
+
+            DbRow objRecord = Read<DbRow>(db);
+            int reduce = objRecord.Length;
+
+            int idx = _db.IndexOf(db);
+
+            int sliceVal = idx + db.Length;
+
+            if (idx >= DbRow.Size)
+            {
+                reduce++;
+                reduce++;
+                idx -= DbRow.Size;
+            }
+
+            Span<byte> temp = _db.Slice(0, idx);
+
+            for (int i = 0; i < temp.Length; i += DbRow.Size)
+            {
+                DbRow record = Read<DbRow>(temp.Slice(i));
+                if (!record.IsSimpleValue)
+                {
+                    DbRow myObj = Read<DbRow>(_db.Slice(i + record.Length * DbRow.Size));
+                    if (myObj.Location > objRecord.Location)
+                    {
+                        DbRow fixup = new DbRow(record.Type, record.Location, record.Length - reduce);
+                        Write(temp.Slice(i), ref fixup);
+                    }
+                }
+            }
+
+            _db.Slice(sliceVal).CopyTo(_db.Slice(idx));
+            _db = _db.Slice(0, _db.Length - db.Length - DbRow.Size);
         }
 
         public bool TryGetValue(Utf8Span propertyName, out JsonObject value)
         {
-            var record = Record;
+            DbRow record = Record;
 
             if (record.Length == 0) {
-                throw new KeyNotFoundException();
+                JsonThrowHelper.ThrowKeyNotFoundException();
             }
             if (record.Type != JsonValueType.Object) {
-                throw new InvalidOperationException();
+                JsonThrowHelper.ThrowInvalidOperationException();
             }
 
             for (int i = DbRow.Size; i <= _db.Length; i += DbRow.Size) {
@@ -60,19 +145,16 @@ namespace System.Text.JsonLab
 
                 if (new Utf8Span(_values.Slice(record.Location, record.Length)) == propertyName) {
                     int newStart = i + DbRow.Size;
-                    int newEnd = newStart + DbRow.Size;
 
                     record = Read<DbRow>(_db.Slice(newStart));
 
-                    if (!record.IsSimpleValue) {
-                        newEnd = newEnd + DbRow.Size * record.Length;
-                    }
+                    int newEnd = record.IsSimpleValue ? i + 2 * DbRow.Size : i + (record.Length + 2) * DbRow.Size;
 
                     value = new JsonObject(_values, _db.Slice(newStart, newEnd - newStart));
                     return true;
                 }
 
-                var valueType = Read<JsonValueType>(_db.Slice(i + DbRow.Size + 8));
+                JsonValueType valueType = Read<JsonValueType>(_db.Slice(i + DbRow.Size + 8));
                 if (valueType != JsonValueType.Object && valueType != JsonValueType.Array) {
                     i += DbRow.Size;
                 }
@@ -87,14 +169,14 @@ namespace System.Text.JsonLab
             var record = Record;
             
             if (record.Length == 0) {
-                throw new KeyNotFoundException();
+                JsonThrowHelper.ThrowKeyNotFoundException();
             }
 
             if (record.Type != JsonValueType.Object) {
-                throw new InvalidOperationException();
+                JsonThrowHelper.ThrowInvalidOperationException();
             }
 
-            for (int i = DbRow.Size; i <= _db.Length; i += DbRow.Size) {
+            for (int i = DbRow.Size; i < _db.Length; i += DbRow.Size) {
                 record = Read<DbRow>(_db.Slice(i));
 
                 if (!record.IsSimpleValue) {
@@ -133,7 +215,8 @@ namespace System.Text.JsonLab
                 {
                     return value;
                 }
-                throw new KeyNotFoundException();
+                JsonThrowHelper.ThrowKeyNotFoundException();
+                return default;
             }
         }
 
@@ -143,20 +226,23 @@ namespace System.Text.JsonLab
                 {
                     return value;
                 }
-                throw new KeyNotFoundException();
+                JsonThrowHelper.ThrowKeyNotFoundException();
+                return default;
             }
         }
 
         public JsonObject this[int index] {
             get {
-                var record = Record;
+                DbRow record = Record;
 
-                if (index < 0 || index >= record.Length) {
-                    throw new IndexOutOfRangeException();
+                if ((uint)index >= (uint)record.Length) {
+                    JsonThrowHelper.ThrowIndexOutOfRangeException();
+                    return default;
                 }
 
                 if (record.Type != JsonValueType.Array) {
-                    throw new InvalidOperationException();
+                    JsonThrowHelper.ThrowInvalidOperationException();
+                    return default;
                 }
 
                 int counter = 0;
@@ -180,7 +266,8 @@ namespace System.Text.JsonLab
                     counter++;
                 }
 
-                throw new IndexOutOfRangeException();
+                JsonThrowHelper.ThrowIndexOutOfRangeException();
+                return default;
             }
         }
 
@@ -191,7 +278,7 @@ namespace System.Text.JsonLab
                 var record = Record;
                 if (record.Type != JsonValueType.Array)
                 {
-                    throw new InvalidOperationException();
+                    JsonThrowHelper.ThrowInvalidOperationException();
                 }
                 return record.Length; 
             }
@@ -199,15 +286,14 @@ namespace System.Text.JsonLab
 
         public static explicit operator string(JsonObject json)
         {
-            var utf8 = (Utf8Span)json;
-            return utf8.ToString();
+            return ((Utf8Span)json).ToString();
         }
 
         public static explicit operator Utf8Span(JsonObject json)
         {
-            var record = json.Record;
+            DbRow record = json.Record;
             if (!record.IsSimpleValue) {
-                throw new InvalidCastException();
+                JsonThrowHelper.ThrowInvalidCastException();
             }
 
             return new Utf8Span(json._values.Slice(record.Location, record.Length));
@@ -218,7 +304,7 @@ namespace System.Text.JsonLab
             DbRow record = json.Record;
             if (!record.IsSimpleValue)
             {
-                throw new InvalidCastException();
+                JsonThrowHelper.ThrowInvalidCastException();
             }
 
             return new Utf8String(json._values.Slice(record.Location, record.Length));
@@ -228,18 +314,18 @@ namespace System.Text.JsonLab
         {
             var record = json.Record;
             if (!record.IsSimpleValue) {
-                throw new InvalidCastException();
+                JsonThrowHelper.ThrowInvalidCastException();
             }
 
             if (record.Length < 4 || record.Length > 5) {
-                throw new InvalidCastException();
+                JsonThrowHelper.ThrowInvalidCastException();
             }
 
             var slice = json._values.Slice(record.Location);
 
             if (!Utf8Parser.TryParse(slice, out bool result, out _))
             {
-                throw new InvalidCastException();
+                JsonThrowHelper.ThrowInvalidCastException();
             }
             return result;
         }
@@ -248,14 +334,14 @@ namespace System.Text.JsonLab
         {
             var record = json.Record;
             if (!record.IsSimpleValue) {
-                throw new InvalidCastException();
+                JsonThrowHelper.ThrowInvalidCastException();
             }
 
             var slice = json._values.Slice(record.Location);
 
             if (!Utf8Parser.TryParse(slice, out int result, out _))
             {
-                throw new InvalidCastException();
+                JsonThrowHelper.ThrowInvalidCastException();
             }
             return result;
         }
@@ -264,7 +350,7 @@ namespace System.Text.JsonLab
         {
             var record = json.Record;
             if (!record.IsSimpleValue) {
-                throw new InvalidCastException();
+                JsonThrowHelper.ThrowInvalidCastException();
             }
 
             int count = record.Location;
@@ -277,7 +363,7 @@ namespace System.Text.JsonLab
             }
 
             if (nextByte < '0' || nextByte > '9' || count - record.Location >= record.Length) {
-                throw new InvalidCastException();
+                JsonThrowHelper.ThrowInvalidCastException();
             }
 
             int integerPart = 0;
@@ -329,22 +415,31 @@ namespace System.Text.JsonLab
             }
 
             if (count - record.Location > record.Length) {
-                throw new InvalidCastException();
+                JsonThrowHelper.ThrowInvalidCastException();
             }
 
             return isNegative ? result * -1 : result;
 
         }
 
-        internal DbRow Record => Read<DbRow>(_db);
-        public JsonValueType Type => Read<JsonValueType>(_db.Slice(8));
+        private DbRow Record => GetRecord(0);
+        private int Location => GetLocation(0);
+        private int Length => GetLength(0);
 
+        private DbRow GetRecord(int index) => index == 0 ? Read<DbRow>(_db) : Read<DbRow>(_db.Slice(index));
+        private int GetLocation(int index) => index == 0 ? Read<int>(_db) : Read<int>(_db.Slice(index));
+        private int GetLength(int index) => index == 0 ? Read<int>(_db.Slice(4)) : Read<int>(_db.Slice(index + 4));
+        private JsonValueType GetType(int index) => index == 0 ? Read<JsonValueType>(_db.Slice(8)) : Read<JsonValueType>(_db.Slice(index + 8));
+
+        public JsonValueType Type => GetType(0);
+
+        // Do not change the order of the enum values, since IsSimpleValue relies on it.
         public enum JsonValueType : byte
         {
-            String = 0,
-            Number = 1,
-            Object = 2,
-            Array  = 3,
+            Object = 0,
+            Array = 1,
+            String = 2,
+            Number = 3,
             True   = 4,
             False  = 5,
             Null   = 6
@@ -352,11 +447,10 @@ namespace System.Text.JsonLab
 
         public bool HasValue()
         {
-            var record = Record;
+            DbRow record = Record;
 
             if (!record.IsSimpleValue) {
-                if (record.Length == 0) return false;
-                return true;
+                return record.Length != 0;
             } else {
                 if (_values[record.Location - 1] == '"' && _values[record.Location + 4] == '"') {
                     return true;
@@ -368,13 +462,8 @@ namespace System.Text.JsonLab
         public void Dispose()
         {
             //if (_pool == null) throw new InvalidOperationException("only root object can (and should) be disposed.");
-            _db = ReadOnlySpan<byte>.Empty;
+            _db = Span<byte>.Empty;
             _values = ReadOnlySpan<byte>.Empty;
-            if (_dbMemory != null)
-            {
-                _dbMemory.Dispose();
-                _dbMemory = null;
-            }
         }
     }
 }

--- a/src/System.Text.JsonLab/System/Text/Json/JsonParseObject.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonParseObject.cs
@@ -12,7 +12,7 @@ namespace System.Text.JsonLab
 {
     public ref struct JsonObject
     {
-        private Span<byte> _db; 
+        private Span<byte> _db;
         private ReadOnlySpan<byte> _values;
 
         public string PrintDatabase()
@@ -128,22 +128,27 @@ namespace System.Text.JsonLab
         {
             DbRow record = Record;
 
-            if (record.Length == 0) {
+            if (record.Length == 0)
+            {
                 JsonThrowHelper.ThrowKeyNotFoundException();
             }
-            if (record.Type != JsonValueType.Object) {
+            if (record.Type != JsonValueType.Object)
+            {
                 JsonThrowHelper.ThrowInvalidOperationException();
             }
 
-            for (int i = DbRow.Size; i <= _db.Length; i += DbRow.Size) {
+            for (int i = DbRow.Size; i <= _db.Length; i += DbRow.Size)
+            {
                 record = Read<DbRow>(_db.Slice(i));
 
-                if (!record.IsSimpleValue) {
+                if (!record.IsSimpleValue)
+                {
                     i += record.Length * DbRow.Size;
                     continue;
                 }
 
-                if (new Utf8Span(_values.Slice(record.Location, record.Length)) == propertyName) {
+                if (new Utf8Span(_values.Slice(record.Location, record.Length)) == propertyName)
+                {
                     int newStart = i + DbRow.Size;
 
                     record = Read<DbRow>(_db.Slice(newStart));
@@ -155,7 +160,8 @@ namespace System.Text.JsonLab
                 }
 
                 JsonValueType valueType = Read<JsonValueType>(_db.Slice(i + DbRow.Size + 8));
-                if (valueType != JsonValueType.Object && valueType != JsonValueType.Array) {
+                if (valueType != JsonValueType.Object && valueType != JsonValueType.Array)
+                {
                     i += DbRow.Size;
                 }
             }
@@ -167,30 +173,36 @@ namespace System.Text.JsonLab
         public bool TryGetValue(string propertyName, out JsonObject value)
         {
             var record = Record;
-            
-            if (record.Length == 0) {
+
+            if (record.Length == 0)
+            {
                 JsonThrowHelper.ThrowKeyNotFoundException();
             }
 
-            if (record.Type != JsonValueType.Object) {
+            if (record.Type != JsonValueType.Object)
+            {
                 JsonThrowHelper.ThrowInvalidOperationException();
             }
 
-            for (int i = DbRow.Size; i < _db.Length; i += DbRow.Size) {
+            for (int i = DbRow.Size; i < _db.Length; i += DbRow.Size)
+            {
                 record = Read<DbRow>(_db.Slice(i));
 
-                if (!record.IsSimpleValue) {
+                if (!record.IsSimpleValue)
+                {
                     i += record.Length * DbRow.Size;
                     continue;
                 }
 
-                if (new Utf8Span(_values.Slice(record.Location, record.Length)) == propertyName) {
+                if (new Utf8Span(_values.Slice(record.Location, record.Length)) == propertyName)
+                {
                     int newStart = i + DbRow.Size;
                     int newEnd = newStart + DbRow.Size;
 
                     record = Read<DbRow>(_db.Slice(newStart));
 
-                    if (!record.IsSimpleValue) {
+                    if (!record.IsSimpleValue)
+                    {
                         newEnd = newEnd + DbRow.Size * record.Length;
                     }
 
@@ -199,7 +211,8 @@ namespace System.Text.JsonLab
                 }
 
                 var valueType = Read<JsonValueType>(_db.Slice(i + DbRow.Size + 8));
-                if (valueType != JsonValueType.Object && valueType != JsonValueType.Array) {
+                if (valueType != JsonValueType.Object && valueType != JsonValueType.Array)
+                {
                     i += DbRow.Size;
                 }
             }
@@ -210,7 +223,8 @@ namespace System.Text.JsonLab
 
         public JsonObject this[Utf8Span name]
         {
-            get {
+            get
+            {
                 if (TryGetValue(name, out JsonObject value))
                 {
                     return value;
@@ -220,8 +234,10 @@ namespace System.Text.JsonLab
             }
         }
 
-        public JsonObject this[string name] {
-            get {
+        public JsonObject this[string name]
+        {
+            get
+            {
                 if (TryGetValue(name, out JsonObject value))
                 {
                     return value;
@@ -231,35 +247,43 @@ namespace System.Text.JsonLab
             }
         }
 
-        public JsonObject this[int index] {
-            get {
+        public JsonObject this[int index]
+        {
+            get
+            {
                 DbRow record = Record;
 
-                if ((uint)index >= (uint)record.Length) {
+                if ((uint)index >= (uint)record.Length)
+                {
                     JsonThrowHelper.ThrowIndexOutOfRangeException();
                     return default;
                 }
 
-                if (record.Type != JsonValueType.Array) {
+                if (record.Type != JsonValueType.Array)
+                {
                     JsonThrowHelper.ThrowInvalidOperationException();
                     return default;
                 }
 
                 int counter = 0;
-                for (int i = DbRow.Size; i <= _db.Length; i += DbRow.Size) {
+                for (int i = DbRow.Size; i <= _db.Length; i += DbRow.Size)
+                {
                     record = Read<DbRow>(_db.Slice(i));
 
-                    if (index == counter) {
+                    if (index == counter)
+                    {
                         int newStart = i;
                         int newEnd = i + DbRow.Size;
 
-                        if (!record.IsSimpleValue) {
+                        if (!record.IsSimpleValue)
+                        {
                             newEnd = newEnd + DbRow.Size * record.Length;
                         }
                         return new JsonObject(_values, _db.Slice(newStart, newEnd - newStart));
                     }
 
-                    if (!record.IsSimpleValue) {
+                    if (!record.IsSimpleValue)
+                    {
                         i += record.Length * DbRow.Size;
                     }
 
@@ -280,7 +304,7 @@ namespace System.Text.JsonLab
                 {
                     JsonThrowHelper.ThrowInvalidOperationException();
                 }
-                return record.Length; 
+                return record.Length;
             }
         }
 
@@ -292,7 +316,8 @@ namespace System.Text.JsonLab
         public static explicit operator Utf8Span(JsonObject json)
         {
             DbRow record = json.Record;
-            if (!record.IsSimpleValue) {
+            if (!record.IsSimpleValue)
+            {
                 JsonThrowHelper.ThrowInvalidCastException();
             }
 
@@ -313,11 +338,13 @@ namespace System.Text.JsonLab
         public static explicit operator bool(JsonObject json)
         {
             var record = json.Record;
-            if (!record.IsSimpleValue) {
+            if (!record.IsSimpleValue)
+            {
                 JsonThrowHelper.ThrowInvalidCastException();
             }
 
-            if (record.Length < 4 || record.Length > 5) {
+            if (record.Length < 4 || record.Length > 5)
+            {
                 JsonThrowHelper.ThrowInvalidCastException();
             }
 
@@ -333,7 +360,8 @@ namespace System.Text.JsonLab
         public static explicit operator int(JsonObject json)
         {
             var record = json.Record;
-            if (!record.IsSimpleValue) {
+            if (!record.IsSimpleValue)
+            {
                 JsonThrowHelper.ThrowInvalidCastException();
             }
 
@@ -349,25 +377,29 @@ namespace System.Text.JsonLab
         public static explicit operator double(JsonObject json)
         {
             var record = json.Record;
-            if (!record.IsSimpleValue) {
+            if (!record.IsSimpleValue)
+            {
                 JsonThrowHelper.ThrowInvalidCastException();
             }
 
             int count = record.Location;
             bool isNegative = false;
             var nextByte = json._values[count];
-            if (nextByte == '-') {
+            if (nextByte == '-')
+            {
                 isNegative = true;
                 count++;
                 nextByte = json._values[count];
             }
 
-            if (nextByte < '0' || nextByte > '9' || count - record.Location >= record.Length) {
+            if (nextByte < '0' || nextByte > '9' || count - record.Location >= record.Length)
+            {
                 JsonThrowHelper.ThrowInvalidCastException();
             }
 
             int integerPart = 0;
-            while (nextByte >= '0' && nextByte <= '9' && count - record.Location < record.Length) {
+            while (nextByte >= '0' && nextByte <= '9' && count - record.Location < record.Length)
+            {
                 int digit = nextByte - '0';
                 integerPart = integerPart * 10 + digit;
                 count++;
@@ -377,11 +409,13 @@ namespace System.Text.JsonLab
             double result = integerPart;
 
             int decimalPart = 0;
-            if (nextByte == '.') {
+            if (nextByte == '.')
+            {
                 count++;
                 int numberOfDigits = count;
                 nextByte = json._values[count];
-                while (nextByte >= '0' && nextByte <= '9' && count - record.Location < record.Length) {
+                while (nextByte >= '0' && nextByte <= '9' && count - record.Location < record.Length)
+                {
                     int digit = nextByte - '0';
                     decimalPart = decimalPart * 10 + digit;
                     count++;
@@ -394,17 +428,21 @@ namespace System.Text.JsonLab
 
             int exponentPart = 0;
             bool isExpNegative = false;
-            if (nextByte == 'e' || nextByte == 'E') {
+            if (nextByte == 'e' || nextByte == 'E')
+            {
                 count++;
                 nextByte = json._values[count];
-                if (nextByte == '-' || nextByte == '+') {
-                    if (nextByte == '-') {
+                if (nextByte == '-' || nextByte == '+')
+                {
+                    if (nextByte == '-')
+                    {
                         isExpNegative = true;
                     }
                     count++;
                 }
                 nextByte = json._values[count];
-                while (nextByte >= '0' && nextByte <= '9' && count - record.Location < record.Location) {
+                while (nextByte >= '0' && nextByte <= '9' && count - record.Location < record.Location)
+                {
                     int digit = nextByte - '0';
                     exponentPart = exponentPart * 10 + digit;
                     count++;
@@ -414,7 +452,8 @@ namespace System.Text.JsonLab
                 result *= (Math.Pow(10, isExpNegative ? exponentPart * -1 : exponentPart));
             }
 
-            if (count - record.Location > record.Length) {
+            if (count - record.Location > record.Length)
+            {
                 JsonThrowHelper.ThrowInvalidCastException();
             }
 
@@ -440,19 +479,23 @@ namespace System.Text.JsonLab
             Array = 1,
             String = 2,
             Number = 3,
-            True   = 4,
-            False  = 5,
-            Null   = 6
+            True = 4,
+            False = 5,
+            Null = 6
         }
 
         public bool HasValue()
         {
             DbRow record = Record;
 
-            if (!record.IsSimpleValue) {
+            if (!record.IsSimpleValue)
+            {
                 return record.Length != 0;
-            } else {
-                if (_values[record.Location - 1] == '"' && _values[record.Location + 4] == '"') {
+            }
+            else
+            {
+                if (_values[record.Location - 1] == '"' && _values[record.Location + 4] == '"')
+                {
                     return true;
                 }
                 return (_values[record.Location] != 'n' || _values[record.Location + 1] != 'u' || _values[record.Location + 2] != 'l' || _values[record.Location + 3] != 'l');

--- a/src/System.Text.JsonLab/System/Text/Json/JsonParser.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonParser.cs
@@ -53,8 +53,10 @@ namespace System.Text.JsonLab
 
         public int ArrayStackCount => arrayStackCount;
 
-        public bool IsFull {
-            get {
+        public bool IsFull
+        {
+            get
+            {
                 return objectStackCount >= capacity || arrayStackCount >= capacity;
             }
         }
@@ -66,12 +68,13 @@ namespace System.Text.JsonLab
             topOfStackArr = _span.Length;
             objectStackCount = 0;
             arrayStackCount = 0;
-            capacity = _span.Length/8;
+            capacity = _span.Length / 8;
         }
 
         public bool TryPushObject(int value)
         {
-            if (!IsFull) {
+            if (!IsFull)
+            {
                 Write(_span.Slice(topOfStackObj - 8), ref value);
                 topOfStackObj -= 8;
                 objectStackCount++;
@@ -82,7 +85,8 @@ namespace System.Text.JsonLab
 
         public bool TryPushArray(int value)
         {
-            if (!IsFull) {
+            if (!IsFull)
+            {
                 Write(_span.Slice(topOfStackArr - 4), ref value);
                 topOfStackArr -= 8;
                 arrayStackCount++;
@@ -172,12 +176,15 @@ namespace System.Text.JsonLab
             int arrayItemsCount = 0;
             int numberOfRowsForMembers = 0;
 
-            while (Read()) {
+            while (Read())
+            {
                 var tokenType = _tokenType;
-                switch (tokenType) {
+                switch (tokenType)
+                {
                     case JsonTokenType.ObjectStart:
                         AppendDbRow(JsonObject.JsonValueType.Object, _valuesIndex);
-                        while(!_stack.TryPushObject(numberOfRowsForMembers)) {
+                        while (!_stack.TryPushObject(numberOfRowsForMembers))
+                        {
                             ResizeDb();
                         }
                         numberOfRowsForMembers = 0;
@@ -188,7 +195,8 @@ namespace System.Text.JsonLab
                         break;
                     case JsonTokenType.ArrayStart:
                         AppendDbRow(JsonObject.JsonValueType.Array, _valuesIndex);
-                        while (!_stack.TryPushArray(arrayItemsCount)) {
+                        while (!_stack.TryPushArray(arrayItemsCount))
+                        {
                             ResizeDb();
                         }
                         arrayItemsCount = 0;
@@ -213,7 +221,7 @@ namespace System.Text.JsonLab
                 }
             }
 
-            var result =  new JsonObject(_values, _db.Slice(0, _dbIndex));
+            var result = new JsonObject(_values, _db.Slice(0, _dbIndex));
             _scratchManager.Dispose();
             _scratchManager = null;
             return result;
@@ -240,20 +248,26 @@ namespace System.Text.JsonLab
             int rowNumber = 0;
             int numFound = 0;
 
-            while (true) {
+            while (true)
+            {
                 int rowStartOffset = rowNumber * DbRow.Size;
                 DbRow row = Read<DbRow>(_db.Slice(rowStartOffset));
 
                 int lengthOffset = rowStartOffset + 4;
-                
-                if (row.Length == -1 && (lookingForObject ? row.Type == JsonObject.JsonValueType.Object : row.Type == JsonObject.JsonValueType.Array)) {
+
+                if (row.Length == -1 && (lookingForObject ? row.Type == JsonObject.JsonValueType.Object : row.Type == JsonObject.JsonValueType.Array))
+                {
                     numFound++;
                 }
 
-                if (index == numFound - 1) {
+                if (index == numFound - 1)
+                {
                     return lengthOffset;
-                } else {
-                    if (row.Length > 0 && (row.Type == JsonObject.JsonValueType.Object || row.Type == JsonObject.JsonValueType.Array)) {
+                }
+                else
+                {
+                    if (row.Length > 0 && (row.Type == JsonObject.JsonValueType.Object || row.Type == JsonObject.JsonValueType.Array))
+                    {
                         rowNumber += row.Length;
                     }
                     rowNumber++;
@@ -275,31 +289,38 @@ namespace System.Text.JsonLab
 
             var nextByte = _values[_valuesIndex];
 
-            if (nextByte == '"') {
+            if (nextByte == '"')
+            {
                 return JsonObject.JsonValueType.String;
             }
 
-            if (nextByte == '{') {
+            if (nextByte == '{')
+            {
                 return JsonObject.JsonValueType.Object;
             }
 
-            if (nextByte == '[') {
+            if (nextByte == '[')
+            {
                 return JsonObject.JsonValueType.Array;
             }
 
-            if (nextByte == 't') {
+            if (nextByte == 't')
+            {
                 return JsonObject.JsonValueType.True;
             }
 
-            if (nextByte == 'f') {
+            if (nextByte == 'f')
+            {
                 return JsonObject.JsonValueType.False;
             }
 
-            if (nextByte == 'n') {
+            if (nextByte == 'n')
+            {
                 return JsonObject.JsonValueType.Null;
             }
 
-            if (nextByte == '-' || (nextByte >= '0' && nextByte <= '9')) {
+            if (nextByte == '-' || (nextByte >= '0' && nextByte <= '9'))
+            {
                 return JsonObject.JsonValueType.Number;
             }
 
@@ -317,7 +338,8 @@ namespace System.Text.JsonLab
         private void ParseValue()
         {
             var type = PeekType();
-            switch (type) {
+            switch (type)
+            {
                 case JsonObject.JsonValueType.String:
                     ParseString();
                     break;
@@ -346,7 +368,8 @@ namespace System.Text.JsonLab
             _valuesIndex++; // eat quote
 
             var indexOfClosingQuote = _valuesIndex;
-            do {
+            do
+            {
                 indexOfClosingQuote = _values.Slice(indexOfClosingQuote).IndexOf((byte)'"');
             } while (AreNumOfBackSlashesAtEndOfStringOdd(_valuesIndex + indexOfClosingQuote - 2));
 
@@ -361,34 +384,41 @@ namespace System.Text.JsonLab
             var nextIndex = _valuesIndex;
 
             var nextByte = _values[nextIndex];
-            if (nextByte == '-') {
+            if (nextByte == '-')
+            {
                 nextIndex++;
             }
 
             nextByte = _values[nextIndex];
-            while (nextByte >= '0' && nextByte <= '9') {
+            while (nextByte >= '0' && nextByte <= '9')
+            {
                 nextIndex++;
                 nextByte = _values[nextIndex];
             }
 
-            if (nextByte == '.') {
+            if (nextByte == '.')
+            {
                 nextIndex++;
             }
 
             nextByte = _values[nextIndex];
-            while (nextByte >= '0' && nextByte <= '9') {
+            while (nextByte >= '0' && nextByte <= '9')
+            {
                 nextIndex++;
                 nextByte = _values[nextIndex];
             }
 
-            if (nextByte == 'e' || nextByte == 'E') {
+            if (nextByte == 'e' || nextByte == 'E')
+            {
                 nextIndex++;
                 nextByte = _values[nextIndex];
-                if (nextByte == '-' || nextByte == '+') {
+                if (nextByte == '-' || nextByte == '+')
+                {
                     nextIndex++;
                 }
                 nextByte = _values[nextIndex];
-                while (nextByte >= '0' && nextByte <= '9') {
+                while (nextByte >= '0' && nextByte <= '9')
+                {
                     nextIndex++;
                     nextByte = _values[nextIndex];
                 }
@@ -404,7 +434,8 @@ namespace System.Text.JsonLab
 
         private void ParseLiteral(JsonObject.JsonValueType literal, ReadOnlySpan<byte> expected)
         {
-            if (!_values.Slice(_valuesIndex).StartsWith(expected)) {
+            if (!_values.Slice(_valuesIndex).StartsWith(expected))
+            {
                 throw new FormatException("Invalid json, tried to read " + literal.ToString());
             }
             AppendDbRow(literal, _valuesIndex, expected.Length);
@@ -415,7 +446,8 @@ namespace System.Text.JsonLab
         private bool AppendDbRow(JsonObject.JsonValueType type, int valueIndex, int LengthOrNumberOfRows = DbRow.UnknownNumberOfRows)
         {
             var newIndex = _dbIndex + DbRow.Size;
-            if (newIndex >= _db.Length) {
+            if (newIndex >= _db.Length)
+            {
                 ResizeDb();
             }
 
@@ -428,7 +460,8 @@ namespace System.Text.JsonLab
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void SkipWhitespace()
         {
-            while (Unicode.IsWhitespace(_values[_valuesIndex])) {
+            while (Unicode.IsWhitespace(_values[_valuesIndex]))
+            {
                 _valuesIndex++;
             }
         }
@@ -439,17 +472,21 @@ namespace System.Text.JsonLab
 
             var nextByte = _values[_valuesIndex];
 
-            switch (_tokenType) {
+            switch (_tokenType)
+            {
                 case JsonTokenType.ObjectStart:
-                    if (nextByte != '}') {
+                    if (nextByte != '}')
+                    {
                         _tokenType = JsonTokenType.Property;
                         return;
                     }
                     break;
                 case JsonTokenType.ObjectEnd:
-                    if (nextByte == ',') {
+                    if (nextByte == ',')
+                    {
                         _valuesIndex++;
-                        if (_insideObject == _insideArray) {
+                        if (_insideObject == _insideArray)
+                        {
                             _tokenType = !_jsonStartIsObject ? JsonTokenType.Property : JsonTokenType.Value;
                             return;
                         }
@@ -458,15 +495,18 @@ namespace System.Text.JsonLab
                     }
                     break;
                 case JsonTokenType.ArrayStart:
-                    if (nextByte != ']') {
+                    if (nextByte != ']')
+                    {
                         _tokenType = JsonTokenType.Value;
                         return;
                     }
                     break;
                 case JsonTokenType.ArrayEnd:
-                    if (nextByte == ',') {
+                    if (nextByte == ',')
+                    {
                         _valuesIndex++;
-                        if (_insideObject == _insideArray) {
+                        if (_insideObject == _insideArray)
+                        {
                             _tokenType = !_jsonStartIsObject ? JsonTokenType.Property : JsonTokenType.Value;
                             return;
                         }
@@ -475,13 +515,15 @@ namespace System.Text.JsonLab
                     }
                     break;
                 case JsonTokenType.Property:
-                    if (nextByte == ',') {
+                    if (nextByte == ',')
+                    {
                         _valuesIndex++;
                         return;
                     }
                     break;
                 case JsonTokenType.Value:
-                    if (nextByte == ',') {
+                    if (nextByte == ',')
+                    {
                         _valuesIndex++;
                         return;
                     }
@@ -489,7 +531,8 @@ namespace System.Text.JsonLab
             }
 
             _valuesIndex++;
-            switch (nextByte) {
+            switch (nextByte)
+            {
                 case (byte)'{':
                     _insideObject++;
                     _tokenType = JsonTokenType.ObjectStart;
@@ -518,7 +561,8 @@ namespace System.Text.JsonLab
             var nextByte = _values[count];
             if (nextByte != '\\') return false;
             var numOfBackSlashes = 0;
-            while (nextByte == '\\') {
+            while (nextByte == '\\')
+            {
                 numOfBackSlashes++;
                 if ((length - numOfBackSlashes) < 0) return numOfBackSlashes % 2 != 0;
                 nextByte = _values[count - numOfBackSlashes];

--- a/src/System.Text.JsonLab/System/Text/Json/JsonParser.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonParser.cs
@@ -11,6 +11,9 @@ using static System.Runtime.InteropServices.MemoryMarshal;
 
 namespace System.Text.JsonLab
 {
+    // Location - offset - 0 - size - 4
+    // Length - offset - 4 - size - 4
+    // Type - offset - 8 - size - 1
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     internal struct DbRow
     {
@@ -29,11 +32,11 @@ namespace System.Text.JsonLab
             Type = type;
         }
 
-        public bool IsSimpleValue => Type != JsonObject.JsonValueType.Object && Type != JsonObject.JsonValueType.Array;
+        public bool IsSimpleValue => Type > JsonObject.JsonValueType.Array;
 
-        static DbRow()
+        unsafe static DbRow()
         {
-            unsafe { Size = sizeof(DbRow); }
+            Size = sizeof(DbRow);
         }
     }
 
@@ -210,7 +213,7 @@ namespace System.Text.JsonLab
                 }
             }
 
-            var result =  new JsonObject(_values, _db.Slice(0, _dbIndex), _pool, _scratchManager);
+            var result =  new JsonObject(_values, _db.Slice(0, _dbIndex));
             _scratchManager.Dispose();
             _scratchManager = null;
             return result;

--- a/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
@@ -3,7 +3,6 @@
 
 using System.Buffers;
 using System.Buffers.Reader;
-using System.Runtime.CompilerServices;
 
 namespace System.Text.JsonLab
 {

--- a/src/System.Text.JsonLab/System/Text/Json/JsonThrowHelper.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonThrowHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace System.Text.JsonLab
@@ -72,6 +73,50 @@ namespace System.Text.JsonLab
         private static JsonReaderException GetJsonReaderException()
         {
             return new JsonReaderException();
+        }
+
+        public static void ThrowInvalidCastException()
+        {
+            throw GetInvalidCastException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidCastException GetInvalidCastException()
+        {
+            return new InvalidCastException();
+        }
+
+        public static void ThrowKeyNotFoundException()
+        {
+            throw GetKeyNotFoundException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static KeyNotFoundException GetKeyNotFoundException()
+        {
+            return new KeyNotFoundException();
+        }
+
+        public static void ThrowInvalidOperationException()
+        {
+            throw GetInvalidOperationException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException GetInvalidOperationException()
+        {
+            return new InvalidOperationException();
+        }
+
+        public static void ThrowIndexOutOfRangeException()
+        {
+            throw GetIndexOutOfRangeException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static IndexOutOfRangeException GetIndexOutOfRangeException()
+        {
+            return new IndexOutOfRangeException();
         }
     }
 }

--- a/tests/Benchmarks/System.Buffers/Reader_Construction.cs
+++ b/tests/Benchmarks/System.Buffers/Reader_Construction.cs
@@ -5,7 +5,6 @@
 using BenchmarkDotNet.Attributes;
 using System.Buffers.Reader;
 using System.Buffers.Testing;
-using System.Buffers.Text;
 
 namespace System.Buffers.Benchmarks
 {

--- a/tests/Benchmarks/System.Buffers/Reader_Search.cs
+++ b/tests/Benchmarks/System.Buffers/Reader_Search.cs
@@ -5,7 +5,6 @@
 using BenchmarkDotNet.Attributes;
 using System.Buffers.Reader;
 using System.Buffers.Testing;
-using System.Buffers.Text;
 
 namespace System.Buffers.Benchmarks
 {

--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using Benchmarks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.IO;
+
+namespace System.Text.JsonLab.Benchmarks
+{
+    // Since there are 30 tests here (2 * 15), setting low values for the warmupCount and targetCount
+    [SimpleJob(-1, 3, 5)]
+    [MemoryDiagnoser]
+    public class JsonParserPerf
+    {
+        private byte[] _dataUtf8;
+        private MemoryStream _stream;
+        private StreamReader _reader;
+
+        [ParamsSource(nameof(TestCaseValues))]
+        public TestCaseType TestCase;
+
+        public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            string jsonString = JsonStrings.ResourceManager.GetString(TestCase.ToString());
+            _dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+
+            _stream = new MemoryStream(_dataUtf8);
+            _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
+        }
+
+        [Benchmark(Baseline = true)]
+        public void ParseNewtonsoft()
+        {
+            _stream.Seek(0, SeekOrigin.Begin);
+            using (JsonTextReader jsonReader = new JsonTextReader(_reader))
+            {
+                JToken.ReadFrom(jsonReader);
+            }
+        }
+
+        [Benchmark]
+        public void ReaderSystemTextJsonLab()
+        {
+            JsonObject.Parse(_dataUtf8);
+        }
+    }
+}

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -3,14 +3,9 @@
 
 using BenchmarkDotNet.Attributes;
 using Benchmarks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System.Buffers;
-using System.Buffers.Reader;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace System.Text.JsonLab.Benchmarks
 {
@@ -35,14 +30,12 @@ namespace System.Text.JsonLab.Benchmarks
     }
 
     // Since there are 90 tests here (6 * 15), setting low values for the warmupCount, targetCount, and invocationCount
-    [SimpleJob(-1, 5, 10)]
-    //[DisassemblyDiagnoser(printAsm: true, printSource: true)]
+    [SimpleJob(-1, 3, 5, 1024)]
     [MemoryDiagnoser]
     public class JsonReaderPerf
     {
         private string _jsonString;
         private byte[] _dataUtf8;
-        private byte[] _contentUtf8;
         private ReadOnlySequence<byte> _sequence;
         private ReadOnlySequence<byte> _sequenceSingle;
         private MemoryStream _stream;
@@ -52,9 +45,6 @@ namespace System.Text.JsonLab.Benchmarks
         public TestCaseType TestCase;
 
         public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));
-
-        [Params("Microsoft.AspNetCore.SignalR.Client.FunctionalTests.deps.json", /*"SocialWeather.deps.json", "WebSocketSample.deps.json",*/ "")]
-        public string Files { get; set; }
 
         [GlobalSetup]
         public void Setup()
@@ -71,17 +61,9 @@ namespace System.Text.JsonLab.Benchmarks
 
             _stream = new MemoryStream(_dataUtf8);
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
-
-            string helloWorld = "{ \"message\": \"Hello, World!\" }";
-            //string depsFile = @"E:\Other\trash\JsonDeps\Microsoft.AspNetCore.SignalR.Client.FunctionalTests.deps.json";
-            string content = Files == "" ? helloWorld : File.ReadAllText(@"E:\Other\trash\JsonDeps\" + Files);
-            _contentUtf8 = Encoding.UTF8.GetBytes(content);
-
-            _stream = new MemoryStream(_contentUtf8);
-            _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        //[Benchmark(Baseline = true)]
+        [Benchmark(Baseline = true)]
         public void ReaderNewtonsoftReaderEmptyLoop()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -90,7 +72,7 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public string ReaderNewtonsoftReaderReturnString()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -109,86 +91,28 @@ namespace System.Text.JsonLab.Benchmarks
             return sb.ToString();
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderSystemTextJsonLabSpanEmptyLoop()
         {
             var json = new Utf8JsonReader(_dataUtf8);
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequenceSingle);
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequence);
             while (json.Read()) ;
         }
 
-        //[Benchmark]
-        public void AdvanceOverheadComparison()
-        {
-            var test = new TypeA(_sequence);
-            for (int i = 0; i < 1_000_000; i++)
-            {
-                TypeA copy = test;
-                copy.Advance();
-            }
-        }
-
-        //[Benchmark(Baseline = true)]
-        public void ChangeEntryPointLibraryNameNewtonsoft()
-        {
-            _stream.Seek(0, SeekOrigin.Begin);
-            TextReader reader = _reader;
-            JToken deps;
-            using (JsonTextReader jsonReader = new JsonTextReader(reader))
-            {
-                deps = JObject.ReadFrom(jsonReader);
-            }
-
-            if (_contentUtf8.Length < 100) return;
-
-            foreach (JProperty target in deps["targets"])
-            {
-                JProperty targetLibrary = target.Value.Children<JProperty>().FirstOrDefault();
-                if (targetLibrary == null)
-                {
-                    continue;
-                }
-
-                targetLibrary.Remove();
-            }
-
-            JProperty library = deps["libraries"].Children<JProperty>().First();
-            library.Remove();
-        }
-
         [Benchmark]
-        public void ChangeEntryPointLibraryNameJsonLab()
-        {
-            JsonObject obj = JsonObject.Parse(_contentUtf8);
-
-            if (_contentUtf8.Length < 100) return;
-
-            JsonObject targets = obj["targets"];
-            if (targets.TryGetChild(out JsonObject child))
-            {
-                if (child.TryGetChild(out child))
-                obj.Remove(child);
-            }
-
-            JsonObject libraries = obj["libraries"];
-            if (libraries.TryGetChild(out child))
-            obj.Remove(child);
-        }
-
-        //[Benchmark]
         public byte[] ReaderSystemTextJsonLabReturnBytes()
         {
             byte[] outputArray = new byte[_dataUtf8.Length * 2];
@@ -250,7 +174,7 @@ namespace System.Text.JsonLab.Benchmarks
             return outputArray;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderUtf8JsonEmptyLoop()
         {
             Utf8Json.JsonReader json = new Utf8Json.JsonReader(_dataUtf8);
@@ -261,7 +185,7 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        //[Benchmark]
+        [Benchmark]
         public byte[] ReaderUtf8JsonReturnBytes()
         {
             Utf8Json.JsonReader json = new Utf8Json.JsonReader(_dataUtf8);
@@ -314,36 +238,4 @@ namespace System.Text.JsonLab.Benchmarks
             return segment;
         }
     }
-
-    public ref struct TypeA
-    {
-        private BufferReader _reader;
-        private ReadOnlySpan<byte> _buffer;
-
-        public TypeA(in ReadOnlySequence<byte> data)
-        {
-            _reader = new BufferReader(data);
-            _buffer = data.First.Span;
-        }
-
-        public bool Advance()
-        {
-            for (int i = 0; i < _buffer.Length; i++)
-            {
-                //_reader.Advance(1);
-                AdvanceInternal(1);
-            }
-            return false;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void AdvanceInternal(int byteCount)
-        {
-            if (byteCount < _buffer.Length)
-            {
-                _buffer = _buffer.Slice(byteCount);
-            }
-        }
-    }
-
 }

--- a/tests/System.Text.JsonLab.Tests/JsonObjectTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonObjectTests.cs
@@ -31,7 +31,7 @@ namespace System.Text.JsonLab.Tests
             obj.Remove(child);
 
             string actual = obj.PrintJson();
-            
+
             // Change casing to match what JSON.NET does.
             actual = actual.Replace("true", "True").Replace("false", "False");
 
@@ -45,7 +45,8 @@ namespace System.Text.JsonLab.Tests
             var buffer = StringToUtf8BufferWithEmptySpace(TestJson.SimpleArrayJson, 60);
 
             var parsedObject = JsonObject.Parse(buffer.AsSpan());
-            try { 
+            try
+            {
                 Assert.Equal(2, parsedObject.ArrayLength);
 
                 var phoneNumber = (string)parsedObject[0];
@@ -137,7 +138,7 @@ namespace System.Text.JsonLab.Tests
                     var _ = phoneNums[2];
                     throw new Exception("Never get here");
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     Assert.IsType<IndexOutOfRangeException>(ex);
                 }
@@ -185,7 +186,7 @@ namespace System.Text.JsonLab.Tests
             utf8Bytes.CopyTo(buffer);
             return new ArraySegment<byte>(buffer, 0, utf8Bytes.Length);
         }
-        
+
         private static string ChangeEntryPointLibraryNameExpected()
         {
             JToken deps = JObject.Parse(TestJson.DepsJson);

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -219,7 +219,7 @@ namespace System.Text.JsonLab.Tests
                         throw new InvalidDataException($"Unexpected token '{reader.TokenType}' when reading handshake response JSON.");
                 }
             };
-            
+
             return true;
         }
 

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -73,7 +73,7 @@ namespace System.Text.JsonLab.Tests
 
             Stream stream = new MemoryStream(dataUtf8);
             TextReader reader = new StreamReader(stream, Encoding.UTF8, false, 1024, true);
-            string expectedStr = NewtonsoftReturnStringHelper(reader);
+            string expectedStr = JsonTestHelper.NewtonsoftReturnStringHelper(reader);
 
             Assert.Equal(expectedStr, actualStr);
             Assert.Equal(expectedStr, actualStrSequence);
@@ -519,21 +519,6 @@ namespace System.Text.JsonLab.Tests
         private static byte[] JsonLabReturnBytesHelper(byte[] data, out int length)
         {
             return JsonLabReaderLoop(data, out length, new Utf8JsonReader(data));
-        }
-
-        private static string NewtonsoftReturnStringHelper(TextReader reader)
-        {
-            StringBuilder sb = new StringBuilder();
-            var json = new Newtonsoft.Json.JsonTextReader(reader);
-            while (json.Read())
-            {
-                if (json.Value != null)
-                {
-                    sb.Append(json.Value).Append(", ");
-                }
-            }
-
-            return sb.ToString();
         }
     }
 

--- a/tests/System.Text.JsonLab.Tests/JsonTestHelper.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonTestHelper.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+
+namespace System.Text.JsonLab.Tests
+{
+    public static class JsonTestHelper
+    {
+        public static string NewtonsoftReturnStringHelper(TextReader reader)
+        {
+            var sb = new StringBuilder();
+            var json = new Newtonsoft.Json.JsonTextReader(reader);
+            while (json.Read())
+            {
+                if (json.Value != null)
+                {
+                    sb.Append(json.Value).Append(", ");
+                }
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/tests/System.Text.JsonLab.Tests/Resources/TestJson.Designer.cs
+++ b/tests/System.Text.JsonLab.Tests/Resources/TestJson.Designer.cs
@@ -142,6 +142,27 @@ namespace System.Text.JsonLab.Tests.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {
+        ///  &quot;runtimeTarget&quot;: {
+        ///    &quot;name&quot;: &quot;.NETCoreApp,Version=v2.2&quot;,
+        ///    &quot;signature&quot;: &quot;96b3a7d355de094922eacd5950627ebb97271704&quot;
+        ///  },
+        ///  &quot;compilationOptions&quot;: {},
+        ///  &quot;targets&quot;: {
+        ///    &quot;.NETCoreApp,Version=v2.2&quot;: {
+        ///      &quot;Microsoft.AspNetCore.SignalR.Client.FunctionalTests/3.0.0-alpha1-t000&quot;: {
+        ///        &quot;dependencies&quot;: {
+        ///          &quot;Internal.AspNetCore.Sdk&quot;: &quot;3.0.0-alpha1-10015&quot;,
+        ///          &quot;Microsoft.AspNetCore.Authentication.JwtBearer&quot;: &quot;3.0.0-alpha1-10173&quot;,
+        ///          &quot;Microsoft.AspNetCore.Diagnostics&quot;: &quot;3 [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string DepsJson {
+            get {
+                return ResourceManager.GetString("DepsJson", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {&quot;age&quot;:30,&quot;first&quot;:&quot;John&quot;,&quot;last&quot;:&quot;Smith&quot;,&quot;phoneNumbers&quot;:[&quot;425-000-1212&quot;,&quot;425-000-1213&quot;],&quot;address&quot;:{&quot;street&quot;:&quot;1 Microsoft Way&quot;,&quot;city&quot;:&quot;Redmond&quot;,&quot;zip&quot;:98052}}.
         /// </summary>
         internal static string ExpectedBasicJson {

--- a/tests/System.Text.JsonLab.Tests/Resources/TestJson.resx
+++ b/tests/System.Text.JsonLab.Tests/Resources/TestJson.resx
@@ -617,7 +617,7 @@ tiline\"another\" String\\"],"str":"\"\""}</value>
 ]</value>
   </data>
   <data name="Json400KB" xml:space="preserve">
-            <value>[
+    <value>[
   {
     "_id": "5671eaf1eb61139592ea92ff",
     "index": 0,
@@ -15970,5 +15970,4303 @@ tiline\"another\" String\\"],"str":"\"\""}</value>
     "email": "7787 hooversexton@nitracyr.com 6664"
   }
 ]</value>
+  </data>
+  <data name="DepsJson" xml:space="preserve">
+    <value>{
+  "runtimeTarget": {
+    "name": ".NETCoreApp,Version=v2.2",
+    "signature": "96b3a7d355de094922eacd5950627ebb97271704"
+  },
+  "compilationOptions": {},
+  "targets": {
+    ".NETCoreApp,Version=v2.2": {
+      "Microsoft.AspNetCore.SignalR.Client.FunctionalTests/3.0.0-alpha1-t000": {
+        "dependencies": {
+          "Internal.AspNetCore.Sdk": "3.0.0-alpha1-10015",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Diagnostics": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Http": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.SignalR": "3.0.0-alpha1-t000",
+          "Microsoft.AspNetCore.SignalR.Client": "3.0.0-alpha1-t000",
+          "Microsoft.AspNetCore.SignalR.Tests.Utils": "3.0.0-alpha1-t000",
+          "Microsoft.AspNetCore.TestHost": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Testing": "3.0.0-alpha1-10173",
+          "Microsoft.NET.Test.Sdk": "15.6.1",
+          "Moq": "4.7.49",
+          "System.Reactive.Linq": "3.1.1",
+          "xunit": "2.3.1",
+          "xunit.runner.visualstudio": "2.4.0"
+        },
+        "runtime": {
+          "Microsoft.AspNetCore.SignalR.Client.FunctionalTests.dll": {}
+        }
+      },
+      "Castle.Core/4.1.0": {
+        "dependencies": {
+          "System.Collections.Specialized": "4.3.0",
+          "System.ComponentModel": "4.3.0",
+          "System.ComponentModel.TypeConverter": "4.3.0",
+          "System.Diagnostics.TraceSource": "4.3.0",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Xml.XmlDocument": "4.3.0"
+        },
+        "runtime": {
+          "lib/netstandard1.3/Castle.Core.dll": {
+            "assemblyVersion": "4.1.0.0",
+            "fileVersion": "4.1.0.0"
+          }
+        }
+      },
+      "Internal.AspNetCore.Sdk/3.0.0-alpha1-10015": {
+        "dependencies": {
+          "Microsoft.AspNetCore.BuildTools.ApiCheck": "3.0.0-alpha1-10015"
+        }
+      },
+      "MessagePack/1.7.3.4": {
+        "dependencies": {
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0",
+          "System.Threading.Tasks.Extensions": "4.6.0-preview1-26727-04",
+          "System.ValueTuple": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/MessagePack.dll": {
+            "assemblyVersion": "1.7.3.4",
+            "fileVersion": "1.7.3.4"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Authentication/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.Core": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.DataProtection": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Http": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Http.Extensions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.WebEncoders": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Authentication.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.Abstractions/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Authentication.Abstractions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.Core/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Http": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Http.Extensions": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Authentication.Core.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Authentication.JwtBearer/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication": "3.0.0-alpha1-10173",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "5.2.0"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Authentication.JwtBearer.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Authorization/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Authorization.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Authorization.Policy/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Authorization": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Authorization.Policy.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.BuildTools.ApiCheck/3.0.0-alpha1-10015": {},
+      "Microsoft.AspNetCore.Connections.Abstractions/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "3.0.0-alpha1-10173",
+          "System.IO.Pipelines": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Connections.Abstractions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Cryptography.Internal/3.0.0-alpha1-10173": {
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Cryptography.Internal.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.DataProtection/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Cryptography.Internal": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.DataProtection.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173",
+          "Microsoft.Win32.Registry": "4.6.0-preview1-26727-04",
+          "System.Security.Cryptography.Xml": "4.6.0-preview1-26727-04",
+          "System.Security.Principal.Windows": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.DataProtection.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.DataProtection.Abstractions/3.0.0-alpha1-10173": {
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.DataProtection.Abstractions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Diagnostics/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Diagnostics.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Http.Extensions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.WebUtilities": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.FileProviders.Physical": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173",
+          "System.Diagnostics.DiagnosticSource": "4.6.0-preview1-26727-04",
+          "System.Reflection.Metadata": "1.7.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Diagnostics.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Diagnostics.Abstractions/3.0.0-alpha1-10173": {
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Diagnostics.Abstractions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Hosting/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Hosting.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Http": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Http.Extensions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Configuration": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Configuration.FileExtensions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.DependencyInjection": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.FileProviders.Physical": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Hosting.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173",
+          "System.Diagnostics.DiagnosticSource": "4.6.0-preview1-26727-04",
+          "System.Reflection.Metadata": "1.7.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Hosting.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Hosting.Abstractions/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Http.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Hosting.Abstractions": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Hosting.Abstractions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Hosting.Server.Abstractions/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Configuration.Abstractions": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Hosting.Server.Abstractions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Http/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.WebUtilities": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.ObjectPool": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173",
+          "Microsoft.Net.Http.Headers": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Http.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Http.Abstractions/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "3.0.0-alpha1-10173",
+          "System.Text.Encodings.Web": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Http.Abstractions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Http.Extensions/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Net.Http.Headers": "3.0.0-alpha1-10173",
+          "System.Buffers": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Http.Extensions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Http.Features/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Http.Features.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Routing/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Extensions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Routing.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.ObjectPool": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Routing.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Routing.Abstractions/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Routing.Abstractions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Server.Kestrel/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Hosting": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Server.Kestrel.Core": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Server.Kestrel.Https": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Server.Kestrel.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Server.Kestrel.Core/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Hosting.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.WebUtilities": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Configuration.Binder": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173",
+          "Microsoft.Net.Http.Headers": "3.0.0-alpha1-10173",
+          "System.Memory": "4.6.0-preview1-26717-04",
+          "System.Numerics.Vectors": "4.6.0-preview1-26727-04",
+          "System.Runtime.CompilerServices.Unsafe": "4.6.0-preview1-26727-04",
+          "System.Security.Cryptography.Cng": "4.6.0-preview1-26727-04",
+          "System.Threading.Tasks.Extensions": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netcoreapp2.1/Microsoft.AspNetCore.Server.Kestrel.Core.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Server.Kestrel.Https/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Server.Kestrel.Core": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netcoreapp2.1/Microsoft.AspNetCore.Server.Kestrel.Https.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Connections.Abstractions": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Hosting.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netcoreapp2.1/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.TestHost/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Hosting": "3.0.0-alpha1-10173",
+          "System.IO.Pipelines": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.TestHost.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.Testing/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Win32.Registry": "4.6.0-preview1-26727-04",
+          "System.ValueTuple": "4.6.0-preview1-26727-04",
+          "xunit": "2.3.1"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.Testing.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.WebSockets/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Extensions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173",
+          "System.Net.WebSockets.WebSocketProtocol": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.WebSockets.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.AspNetCore.WebUtilities/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Net.Http.Headers": "3.0.0-alpha1-10173",
+          "System.Text.Encodings.Web": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.AspNetCore.WebUtilities.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.CodeCoverage/1.0.3": {
+        "runtime": {
+          "lib/netstandard1.0/Microsoft.VisualStudio.CodeCoverage.Shim.dll": {
+            "assemblyVersion": "15.0.0.0",
+            "fileVersion": "15.0.26228.0"
+          }
+        }
+      },
+      "Microsoft.CSharp/4.0.1": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "Microsoft.DotNet.PlatformAbstractions/1.0.3": {
+        "dependencies": {
+          "System.AppContext": "4.1.0",
+          "System.Collections": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0"
+        },
+        "runtime": {
+          "lib/netstandard1.3/Microsoft.DotNet.PlatformAbstractions.dll": {
+            "assemblyVersion": "1.0.1.0",
+            "fileVersion": "1.0.1.0"
+          }
+        }
+      },
+      "Microsoft.Extensions.Configuration/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Configuration.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Configuration.Abstractions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Configuration.Binder.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Configuration.EnvironmentVariables.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.FileProviders.Physical": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Configuration.FileExtensions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netcoreapp2.0/Microsoft.Extensions.DependencyInjection.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions/3.0.0-alpha1-10173": {
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.DependencyInjection.Abstractions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.DependencyModel/1.0.3": {
+        "dependencies": {
+          "Microsoft.DotNet.PlatformAbstractions": "1.0.3",
+          "Newtonsoft.Json": "11.0.2",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Linq": "4.3.0"
+        },
+        "runtime": {
+          "lib/netstandard1.6/Microsoft.Extensions.DependencyModel.dll": {
+            "assemblyVersion": "1.0.1.0",
+            "fileVersion": "1.0.1.0"
+          }
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.FileProviders.Abstractions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.FileSystemGlobbing": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.FileProviders.Physical.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing/3.0.0-alpha1-10173": {
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.FileSystemGlobbing.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.FileProviders.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Hosting.Abstractions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.Logging/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Logging.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions/3.0.0-alpha1-10173": {
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Logging.Abstractions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Logging.Configuration.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.Logging.Console/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging.Configuration": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Logging.Console.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.Logging.Testing/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Testing": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.DependencyInjection": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging.Console": "3.0.0-alpha1-10173",
+          "Serilog.Extensions.Logging": "1.4.0",
+          "Serilog.Sinks.File": "3.2.0",
+          "xunit.abstractions": "2.0.1",
+          "xunit.assert": "2.3.1",
+          "xunit.extensibility.execution": "2.3.1"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Logging.Testing.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.ObjectPool/3.0.0-alpha1-10173": {
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.ObjectPool.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.Options/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Primitives": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Options.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Configuration.Binder": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Options.ConfigurationExtensions.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.Primitives/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "System.Memory": "4.6.0-preview1-26717-04",
+          "System.Runtime.CompilerServices.Unsafe": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.Primitives.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.Extensions.WebEncoders/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173",
+          "System.Text.Encodings.Web": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Extensions.WebEncoders.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.IdentityModel.Logging/5.2.0": {
+        "dependencies": {
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0"
+        },
+        "runtime": {
+          "lib/netstandard1.4/Microsoft.IdentityModel.Logging.dll": {
+            "assemblyVersion": "5.2.0.0",
+            "fileVersion": "5.2.0.50129"
+          }
+        }
+      },
+      "Microsoft.IdentityModel.Protocols/5.2.0": {
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "5.2.0",
+          "Microsoft.IdentityModel.Tokens": "5.2.0",
+          "System.Collections.Specialized": "4.3.0",
+          "System.Diagnostics.Contracts": "4.3.0",
+          "System.Net.Http": "4.3.0"
+        },
+        "runtime": {
+          "lib/netstandard1.4/Microsoft.IdentityModel.Protocols.dll": {
+            "assemblyVersion": "5.2.0.0",
+            "fileVersion": "5.2.0.50129"
+          }
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect/5.2.0": {
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "5.2.0",
+          "Newtonsoft.Json": "11.0.2",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.IdentityModel.Tokens.Jwt": "5.2.0"
+        },
+        "runtime": {
+          "lib/netstandard1.4/Microsoft.IdentityModel.Protocols.OpenIdConnect.dll": {
+            "assemblyVersion": "5.2.0.0",
+            "fileVersion": "5.2.0.50129"
+          }
+        }
+      },
+      "Microsoft.IdentityModel.Tokens/5.2.0": {
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "5.2.0",
+          "Newtonsoft.Json": "11.0.2",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
+          "System.Runtime.Serialization.Xml": "4.3.0",
+          "System.Security.Claims": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.0",
+          "System.Threading": "4.3.0"
+        },
+        "runtime": {
+          "lib/netstandard1.4/Microsoft.IdentityModel.Tokens.dll": {
+            "assemblyVersion": "5.2.0.0",
+            "fileVersion": "5.2.0.50129"
+          }
+        }
+      },
+      "Microsoft.Net.Http.Headers/3.0.0-alpha1-10173": {
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "3.0.0-alpha1-10173",
+          "System.Buffers": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Net.Http.Headers.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.0.0.18210"
+          }
+        }
+      },
+      "Microsoft.NET.Test.Sdk/15.6.1": {
+        "dependencies": {
+          "Microsoft.CodeCoverage": "1.0.3",
+          "Microsoft.TestPlatform.TestHost": "15.6.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel/15.6.1": {
+        "dependencies": {
+          "System.ComponentModel.EventBasedAsync": "4.0.11",
+          "System.ComponentModel.TypeConverter": "4.3.0",
+          "System.Diagnostics.Process": "4.1.0",
+          "System.Diagnostics.TextWriterTraceListener": "4.0.0",
+          "System.Diagnostics.TraceSource": "4.3.0",
+          "System.Reflection.Metadata": "1.7.0-preview1-26727-04",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
+          "System.Runtime.Loader": "4.0.0",
+          "System.Runtime.Serialization.Json": "4.0.2",
+          "System.Runtime.Serialization.Primitives": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Xml.XPath.XmlDocument": "4.0.1"
+        },
+        "runtime": {
+          "lib/netstandard1.5/Microsoft.TestPlatform.CoreUtilities.dll": {
+            "assemblyVersion": "15.0.0.0",
+            "fileVersion": "15.0.0.0"
+          },
+          "lib/netstandard1.5/Microsoft.TestPlatform.PlatformAbstractions.dll": {
+            "assemblyVersion": "15.0.0.0",
+            "fileVersion": "15.0.0.0"
+          },
+          "lib/netstandard1.5/Microsoft.VisualStudio.TestPlatform.ObjectModel.dll": {
+            "assemblyVersion": "15.0.0.0",
+            "fileVersion": "15.0.0.0"
+          }
+        },
+        "resources": {
+          "lib/netstandard1.5/cs/Microsoft.TestPlatform.CoreUtilities.resources.dll": {
+            "locale": "cs"
+          },
+          "lib/netstandard1.5/cs/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll": {
+            "locale": "cs"
+          },
+          "lib/netstandard1.5/de/Microsoft.TestPlatform.CoreUtilities.resources.dll": {
+            "locale": "de"
+          },
+          "lib/netstandard1.5/de/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll": {
+            "locale": "de"
+          },
+          "lib/netstandard1.5/es/Microsoft.TestPlatform.CoreUtilities.resources.dll": {
+            "locale": "es"
+          },
+          "lib/netstandard1.5/es/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll": {
+            "locale": "es"
+          },
+          "lib/netstandard1.5/fr/Microsoft.TestPlatform.CoreUtilities.resources.dll": {
+            "locale": "fr"
+          },
+          "lib/netstandard1.5/fr/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll": {
+            "locale": "fr"
+          },
+          "lib/netstandard1.5/it/Microsoft.TestPlatform.CoreUtilities.resources.dll": {
+            "locale": "it"
+          },
+          "lib/netstandard1.5/it/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll": {
+            "locale": "it"
+          },
+          "lib/netstandard1.5/ja/Microsoft.TestPlatform.CoreUtilities.resources.dll": {
+            "locale": "ja"
+          },
+          "lib/netstandard1.5/ja/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll": {
+            "locale": "ja"
+          },
+          "lib/netstandard1.5/ko/Microsoft.TestPlatform.CoreUtilities.resources.dll": {
+            "locale": "ko"
+          },
+          "lib/netstandard1.5/ko/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll": {
+            "locale": "ko"
+          },
+          "lib/netstandard1.5/pl/Microsoft.TestPlatform.CoreUtilities.resources.dll": {
+            "locale": "pl"
+          },
+          "lib/netstandard1.5/pl/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll": {
+            "locale": "pl"
+          },
+          "lib/netstandard1.5/pt-BR/Microsoft.TestPlatform.CoreUtilities.resources.dll": {
+            "locale": "pt-BR"
+          },
+          "lib/netstandard1.5/pt-BR/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll": {
+            "locale": "pt-BR"
+          },
+          "lib/netstandard1.5/ru/Microsoft.TestPlatform.CoreUtilities.resources.dll": {
+            "locale": "ru"
+          },
+          "lib/netstandard1.5/ru/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll": {
+            "locale": "ru"
+          },
+          "lib/netstandard1.5/tr/Microsoft.TestPlatform.CoreUtilities.resources.dll": {
+            "locale": "tr"
+          },
+          "lib/netstandard1.5/tr/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll": {
+            "locale": "tr"
+          },
+          "lib/netstandard1.5/zh-Hans/Microsoft.TestPlatform.CoreUtilities.resources.dll": {
+            "locale": "zh-Hans"
+          },
+          "lib/netstandard1.5/zh-Hans/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll": {
+            "locale": "zh-Hans"
+          },
+          "lib/netstandard1.5/zh-Hant/Microsoft.TestPlatform.CoreUtilities.resources.dll": {
+            "locale": "zh-Hant"
+          },
+          "lib/netstandard1.5/zh-Hant/Microsoft.VisualStudio.TestPlatform.ObjectModel.resources.dll": {
+            "locale": "zh-Hant"
+          }
+        }
+      },
+      "Microsoft.TestPlatform.TestHost/15.6.1": {
+        "dependencies": {
+          "Microsoft.Extensions.DependencyModel": "1.0.3",
+          "Microsoft.TestPlatform.ObjectModel": "15.6.1",
+          "Newtonsoft.Json": "11.0.2"
+        },
+        "runtime": {
+          "lib/netstandard1.5/Microsoft.TestPlatform.CommunicationUtilities.dll": {
+            "assemblyVersion": "15.0.0.0",
+            "fileVersion": "15.0.0.0"
+          },
+          "lib/netstandard1.5/Microsoft.TestPlatform.CrossPlatEngine.dll": {
+            "assemblyVersion": "15.0.0.0",
+            "fileVersion": "15.0.0.0"
+          },
+          "lib/netstandard1.5/Microsoft.VisualStudio.TestPlatform.Common.dll": {
+            "assemblyVersion": "15.0.0.0",
+            "fileVersion": "15.0.0.0"
+          },
+          "lib/netstandard1.5/testhost.dll": {
+            "assemblyVersion": "15.0.0.0",
+            "fileVersion": "15.0.0.0"
+          }
+        },
+        "resources": {
+          "lib/netstandard1.5/cs/Microsoft.TestPlatform.CommunicationUtilities.resources.dll": {
+            "locale": "cs"
+          },
+          "lib/netstandard1.5/cs/Microsoft.TestPlatform.CrossPlatEngine.resources.dll": {
+            "locale": "cs"
+          },
+          "lib/netstandard1.5/cs/Microsoft.VisualStudio.TestPlatform.Common.resources.dll": {
+            "locale": "cs"
+          },
+          "lib/netstandard1.5/de/Microsoft.TestPlatform.CommunicationUtilities.resources.dll": {
+            "locale": "de"
+          },
+          "lib/netstandard1.5/de/Microsoft.TestPlatform.CrossPlatEngine.resources.dll": {
+            "locale": "de"
+          },
+          "lib/netstandard1.5/de/Microsoft.VisualStudio.TestPlatform.Common.resources.dll": {
+            "locale": "de"
+          },
+          "lib/netstandard1.5/es/Microsoft.TestPlatform.CommunicationUtilities.resources.dll": {
+            "locale": "es"
+          },
+          "lib/netstandard1.5/es/Microsoft.TestPlatform.CrossPlatEngine.resources.dll": {
+            "locale": "es"
+          },
+          "lib/netstandard1.5/es/Microsoft.VisualStudio.TestPlatform.Common.resources.dll": {
+            "locale": "es"
+          },
+          "lib/netstandard1.5/fr/Microsoft.TestPlatform.CommunicationUtilities.resources.dll": {
+            "locale": "fr"
+          },
+          "lib/netstandard1.5/fr/Microsoft.TestPlatform.CrossPlatEngine.resources.dll": {
+            "locale": "fr"
+          },
+          "lib/netstandard1.5/fr/Microsoft.VisualStudio.TestPlatform.Common.resources.dll": {
+            "locale": "fr"
+          },
+          "lib/netstandard1.5/it/Microsoft.TestPlatform.CommunicationUtilities.resources.dll": {
+            "locale": "it"
+          },
+          "lib/netstandard1.5/it/Microsoft.TestPlatform.CrossPlatEngine.resources.dll": {
+            "locale": "it"
+          },
+          "lib/netstandard1.5/it/Microsoft.VisualStudio.TestPlatform.Common.resources.dll": {
+            "locale": "it"
+          },
+          "lib/netstandard1.5/ja/Microsoft.TestPlatform.CommunicationUtilities.resources.dll": {
+            "locale": "ja"
+          },
+          "lib/netstandard1.5/ja/Microsoft.TestPlatform.CrossPlatEngine.resources.dll": {
+            "locale": "ja"
+          },
+          "lib/netstandard1.5/ja/Microsoft.VisualStudio.TestPlatform.Common.resources.dll": {
+            "locale": "ja"
+          },
+          "lib/netstandard1.5/ko/Microsoft.TestPlatform.CommunicationUtilities.resources.dll": {
+            "locale": "ko"
+          },
+          "lib/netstandard1.5/ko/Microsoft.TestPlatform.CrossPlatEngine.resources.dll": {
+            "locale": "ko"
+          },
+          "lib/netstandard1.5/ko/Microsoft.VisualStudio.TestPlatform.Common.resources.dll": {
+            "locale": "ko"
+          },
+          "lib/netstandard1.5/pl/Microsoft.TestPlatform.CommunicationUtilities.resources.dll": {
+            "locale": "pl"
+          },
+          "lib/netstandard1.5/pl/Microsoft.TestPlatform.CrossPlatEngine.resources.dll": {
+            "locale": "pl"
+          },
+          "lib/netstandard1.5/pl/Microsoft.VisualStudio.TestPlatform.Common.resources.dll": {
+            "locale": "pl"
+          },
+          "lib/netstandard1.5/pt-BR/Microsoft.TestPlatform.CommunicationUtilities.resources.dll": {
+            "locale": "pt-BR"
+          },
+          "lib/netstandard1.5/pt-BR/Microsoft.TestPlatform.CrossPlatEngine.resources.dll": {
+            "locale": "pt-BR"
+          },
+          "lib/netstandard1.5/pt-BR/Microsoft.VisualStudio.TestPlatform.Common.resources.dll": {
+            "locale": "pt-BR"
+          },
+          "lib/netstandard1.5/ru/Microsoft.TestPlatform.CommunicationUtilities.resources.dll": {
+            "locale": "ru"
+          },
+          "lib/netstandard1.5/ru/Microsoft.TestPlatform.CrossPlatEngine.resources.dll": {
+            "locale": "ru"
+          },
+          "lib/netstandard1.5/ru/Microsoft.VisualStudio.TestPlatform.Common.resources.dll": {
+            "locale": "ru"
+          },
+          "lib/netstandard1.5/tr/Microsoft.TestPlatform.CommunicationUtilities.resources.dll": {
+            "locale": "tr"
+          },
+          "lib/netstandard1.5/tr/Microsoft.TestPlatform.CrossPlatEngine.resources.dll": {
+            "locale": "tr"
+          },
+          "lib/netstandard1.5/tr/Microsoft.VisualStudio.TestPlatform.Common.resources.dll": {
+            "locale": "tr"
+          },
+          "lib/netstandard1.5/zh-Hans/Microsoft.TestPlatform.CommunicationUtilities.resources.dll": {
+            "locale": "zh-Hans"
+          },
+          "lib/netstandard1.5/zh-Hans/Microsoft.TestPlatform.CrossPlatEngine.resources.dll": {
+            "locale": "zh-Hans"
+          },
+          "lib/netstandard1.5/zh-Hans/Microsoft.VisualStudio.TestPlatform.Common.resources.dll": {
+            "locale": "zh-Hans"
+          },
+          "lib/netstandard1.5/zh-Hant/Microsoft.TestPlatform.CommunicationUtilities.resources.dll": {
+            "locale": "zh-Hant"
+          },
+          "lib/netstandard1.5/zh-Hant/Microsoft.TestPlatform.CrossPlatEngine.resources.dll": {
+            "locale": "zh-Hant"
+          },
+          "lib/netstandard1.5/zh-Hant/Microsoft.VisualStudio.TestPlatform.Common.resources.dll": {
+            "locale": "zh-Hant"
+          }
+        }
+      },
+      "Microsoft.Win32.Primitives/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "Microsoft.Win32.Registry/4.6.0-preview1-26727-04": {
+        "dependencies": {
+          "System.Security.AccessControl": "4.6.0-preview1-26727-04",
+          "System.Security.Principal.Windows": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/Microsoft.Win32.Registry.dll": {
+            "assemblyVersion": "4.1.2.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        },
+        "runtimeTargets": {
+          "runtimes/unix/lib/netstandard2.0/Microsoft.Win32.Registry.dll": {
+            "rid": "unix",
+            "assetType": "runtime",
+            "assemblyVersion": "4.1.2.0",
+            "fileVersion": "4.6.26727.4"
+          },
+          "runtimes/win/lib/netstandard2.0/Microsoft.Win32.Registry.dll": {
+            "rid": "win",
+            "assetType": "runtime",
+            "assemblyVersion": "4.1.2.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        }
+      },
+      "Moq/4.7.49": {
+        "dependencies": {
+          "Castle.Core": "4.1.0",
+          "System.Linq.Queryable": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0"
+        },
+        "runtime": {
+          "lib/netstandard1.3/Moq.dll": {
+            "assemblyVersion": "4.7.49.0",
+            "fileVersion": "4.7.49.0"
+          }
+        }
+      },
+      "Newtonsoft.Json/11.0.2": {
+        "runtime": {
+          "lib/netstandard2.0/Newtonsoft.Json.dll": {
+            "assemblyVersion": "11.0.0.0",
+            "fileVersion": "11.0.2.21924"
+          }
+        }
+      },
+      "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+        "runtimeTargets": {
+          "runtime/debian.8-x64/native/_._": {
+            "rid": "debian.8-x64",
+            "assetType": "native"
+          }
+        }
+      },
+      "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+        "runtimeTargets": {
+          "runtime/fedora.23-x64/native/_._": {
+            "rid": "fedora.23-x64",
+            "assetType": "native"
+          }
+        }
+      },
+      "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+        "runtimeTargets": {
+          "runtime/fedora.24-x64/native/_._": {
+            "rid": "fedora.24-x64",
+            "assetType": "native"
+          }
+        }
+      },
+      "runtime.native.System/4.3.0": {},
+      "runtime.native.System.IO.Compression/4.3.0": {},
+      "runtime.native.System.Net.Http/4.3.0": {},
+      "runtime.native.System.Net.Security/4.3.0": {},
+      "runtime.native.System.Security.Cryptography.Apple/4.3.0": {
+        "dependencies": {
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple": "4.3.0"
+        }
+      },
+      "runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+        "dependencies": {
+          "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0",
+          "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        }
+      },
+      "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+        "runtimeTargets": {
+          "runtime/opensuse.13.2-x64/native/_._": {
+            "rid": "opensuse.13.2-x64",
+            "assetType": "native"
+          }
+        }
+      },
+      "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+        "runtimeTargets": {
+          "runtime/opensuse.42.1-x64/native/_._": {
+            "rid": "opensuse.42.1-x64",
+            "assetType": "native"
+          }
+        }
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0": {
+        "runtimeTargets": {
+          "runtime/osx.10.10-x64/native/_._": {
+            "rid": "osx.10.10-x64",
+            "assetType": "native"
+          }
+        }
+      },
+      "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+        "runtimeTargets": {
+          "runtime/osx.10.10-x64/native/_._": {
+            "rid": "osx.10.10-x64",
+            "assetType": "native"
+          }
+        }
+      },
+      "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+        "runtimeTargets": {
+          "runtime/rhel.7-x64/native/_._": {
+            "rid": "rhel.7-x64",
+            "assetType": "native"
+          }
+        }
+      },
+      "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+        "runtimeTargets": {
+          "runtime/ubuntu.14.04-x64/native/_._": {
+            "rid": "ubuntu.14.04-x64",
+            "assetType": "native"
+          }
+        }
+      },
+      "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+        "runtimeTargets": {
+          "runtime/ubuntu.16.04-x64/native/_._": {
+            "rid": "ubuntu.16.04-x64",
+            "assetType": "native"
+          }
+        }
+      },
+      "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+        "runtimeTargets": {
+          "runtime/ubuntu.16.10-x64/native/_._": {
+            "rid": "ubuntu.16.10-x64",
+            "assetType": "native"
+          }
+        }
+      },
+      "Serilog/2.3.0": {
+        "dependencies": {
+          "Microsoft.CSharp": "4.0.1",
+          "System.Collections": "4.3.0",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.0",
+          "System.Threading": "4.3.0"
+        },
+        "runtime": {
+          "lib/netstandard1.3/Serilog.dll": {
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "2.3.0.0"
+          }
+        }
+      },
+      "Serilog.Extensions.Logging/1.4.0": {
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.0-alpha1-10173",
+          "Serilog": "2.3.0"
+        },
+        "runtime": {
+          "lib/netstandard1.3/Serilog.Extensions.Logging.dll": {
+            "assemblyVersion": "1.0.0.0",
+            "fileVersion": "1.4.0.0"
+          }
+        }
+      },
+      "Serilog.Sinks.File/3.2.0": {
+        "dependencies": {
+          "Serilog": "2.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Timer": "4.3.0"
+        },
+        "runtime": {
+          "lib/netstandard1.3/Serilog.Sinks.File.dll": {
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "3.2.0.0"
+          }
+        }
+      },
+      "StackExchange.Redis.StrongName/1.2.6": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Collections.NonGeneric": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.IO.Compression": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Net.NameResolution": "4.3.0",
+          "System.Net.Security": "4.3.0",
+          "System.Net.Sockets": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "System.Threading.Timer": "4.3.0"
+        },
+        "runtime": {
+          "lib/netstandard1.5/StackExchange.Redis.StrongName.dll": {
+            "assemblyVersion": "1.2.6.0",
+            "fileVersion": "1.2.6.0"
+          }
+        }
+      },
+      "System.AppContext/4.1.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Buffers/4.6.0-preview1-26727-04": {},
+      "System.Buffers.Experimental/0.1.0-preview2-180804-5": {
+        "dependencies": {
+          "System.Collections.Sequences": "0.1.0-preview2-180804-5",
+          "System.Text.Utf8String": "0.1.0-preview2-180804-5",
+          "System.ValueTuple": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Buffers.Experimental.dll": {
+            "assemblyVersion": "0.1.0.0",
+            "fileVersion": "0.1.0.0"
+          }
+        }
+      },
+      "System.Buffers.Primitives/0.1.0-preview2-180804-5": {
+        "dependencies": {
+          "System.Memory": "4.6.0-preview1-26717-04",
+          "System.Runtime.CompilerServices.Unsafe": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Buffers.Primitives.dll": {
+            "assemblyVersion": "0.1.0.0",
+            "fileVersion": "0.1.0.0"
+          }
+        }
+      },
+      "System.Buffers.ReaderWriter/0.1.0-preview2-180804-5": {
+        "dependencies": {
+          "System.Collections.Sequences": "0.1.0-preview2-180804-5",
+          "System.IO.Pipelines": "4.6.0-preview1-26727-04",
+          "System.Text.Primitives": "0.1.0-preview2-180804-5",
+          "System.Text.Utf8String": "0.1.0-preview2-180804-5"
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Buffers.ReaderWriter.dll": {
+            "assemblyVersion": "0.1.0.0",
+            "fileVersion": "0.1.0.0"
+          }
+        }
+      },
+      "System.Collections/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Collections.Concurrent/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Collections.Immutable/1.6.0-preview1-26727-04": {
+        "runtime": {
+          "lib/netstandard2.0/System.Collections.Immutable.dll": {
+            "assemblyVersion": "1.2.4.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        }
+      },
+      "System.Collections.NonGeneric/4.3.0": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Collections.Sequences/0.1.0-preview2-180804-5": {
+        "dependencies": {
+          "System.Buffers.Primitives": "0.1.0-preview2-180804-5"
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Collections.Sequences.dll": {
+            "assemblyVersion": "0.1.0.0",
+            "fileVersion": "0.1.0.0"
+          }
+        }
+      },
+      "System.Collections.Specialized/4.3.0": {
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Extensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.ComponentModel/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.ComponentModel.EventBasedAsync/4.0.11": {
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.ComponentModel.Primitives/4.3.0": {
+        "dependencies": {
+          "System.ComponentModel": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.ComponentModel.TypeConverter/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Collections.NonGeneric": "4.3.0",
+          "System.Collections.Specialized": "4.3.0",
+          "System.ComponentModel": "4.3.0",
+          "System.ComponentModel.Primitives": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Contracts/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Debug/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.DiagnosticSource/4.6.0-preview1-26727-04": {
+        "runtime": {
+          "lib/netstandard1.3/System.Diagnostics.DiagnosticSource.dll": {
+            "assemblyVersion": "4.0.4.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        }
+      },
+      "System.Diagnostics.Process/4.1.0": {
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "Microsoft.Win32.Registry": "4.6.0-preview1-26727-04",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        },
+        "runtimeTargets": {
+          "runtime/linux/lib/_._": {
+            "rid": "linux",
+            "assetType": "runtime"
+          },
+          "runtime/osx/lib/_._": {
+            "rid": "osx",
+            "assetType": "runtime"
+          },
+          "runtime/win/lib/_._": {
+            "rid": "win",
+            "assetType": "runtime"
+          }
+        }
+      },
+      "System.Diagnostics.TextWriterTraceListener/4.0.0": {
+        "dependencies": {
+          "System.Diagnostics.TraceSource": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Diagnostics.Tools/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Diagnostics.TraceSource/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        },
+        "runtimeTargets": {
+          "runtime/unix/lib/_._": {
+            "rid": "unix",
+            "assetType": "runtime"
+          },
+          "runtime/win/lib/_._": {
+            "rid": "win",
+            "assetType": "runtime"
+          }
+        }
+      },
+      "System.Diagnostics.Tracing/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Dynamic.Runtime/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Globalization/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Globalization.Calendars/4.3.0": {
+        "dependencies": {
+          "System.Globalization": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Globalization.Extensions/4.3.0": {
+        "dependencies": {
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0"
+        },
+        "runtimeTargets": {
+          "runtime/unix/lib/_._": {
+            "rid": "unix",
+            "assetType": "runtime"
+          },
+          "runtime/win/lib/_._": {
+            "rid": "win",
+            "assetType": "runtime"
+          }
+        }
+      },
+      "System.IdentityModel.Tokens.Jwt/5.2.0": {
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "5.2.0",
+          "Newtonsoft.Json": "11.0.2"
+        },
+        "runtime": {
+          "lib/netstandard1.4/System.IdentityModel.Tokens.Jwt.dll": {
+            "assemblyVersion": "5.2.0.0",
+            "fileVersion": "5.2.0.50129"
+          }
+        }
+      },
+      "System.IO/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.Compression/4.3.0": {
+        "dependencies": {
+          "System.Buffers": "4.6.0-preview1-26727-04",
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.IO.Compression": "4.3.0"
+        },
+        "runtimeTargets": {
+          "runtime/unix/lib/_._": {
+            "rid": "unix",
+            "assetType": "runtime"
+          },
+          "runtime/win/lib/_._": {
+            "rid": "win",
+            "assetType": "runtime"
+          }
+        }
+      },
+      "System.IO.FileSystem/4.3.0": {
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.IO.Pipelines/4.6.0-preview1-26727-04": {
+        "runtime": {
+          "lib/netcoreapp2.1/System.IO.Pipelines.dll": {
+            "assemblyVersion": "4.0.1.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        }
+      },
+      "System.Linq/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Linq.Expressions/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.ObjectModel": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Linq.Queryable/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Linq.Expressions": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Memory/4.6.0-preview1-26717-04": {},
+      "System.Net.Http/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.DiagnosticSource": "4.6.0-preview1-26727-04",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Extensions": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.Net.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.OpenSsl": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.Net.Http": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        },
+        "runtimeTargets": {
+          "runtime/unix/lib/_._": {
+            "rid": "unix",
+            "assetType": "runtime"
+          },
+          "runtime/win/lib/_._": {
+            "rid": "win",
+            "assetType": "runtime"
+          }
+        }
+      },
+      "System.Net.NameResolution/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Net.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Principal.Windows": "4.6.0-preview1-26727-04",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        },
+        "runtimeTargets": {
+          "runtime/unix/lib/_._": {
+            "rid": "unix",
+            "assetType": "runtime"
+          },
+          "runtime/win/lib/_._": {
+            "rid": "win",
+            "assetType": "runtime"
+          }
+        }
+      },
+      "System.Net.Primitives/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Net.Security/4.3.0": {
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.3.0",
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Diagnostics.Tracing": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Extensions": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Net.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Claims": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.OpenSsl": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Security.Cryptography.X509Certificates": "4.3.0",
+          "System.Security.Principal": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.Net.Security": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        },
+        "runtimeTargets": {
+          "runtime/unix/lib/_._": {
+            "rid": "unix",
+            "assetType": "runtime"
+          },
+          "runtime/win/lib/_._": {
+            "rid": "win",
+            "assetType": "runtime"
+          }
+        }
+      },
+      "System.Net.Sockets/4.3.0": {
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Net.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Net.WebSockets.WebSocketProtocol/4.6.0-preview1-26727-04": {
+        "runtime": {
+          "lib/netcoreapp2.1/System.Net.WebSockets.WebSocketProtocol.dll": {
+            "assemblyVersion": "4.0.1.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        }
+      },
+      "System.Numerics.Vectors/4.6.0-preview1-26727-04": {},
+      "System.ObjectModel/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0"
+        }
+      },
+      "System.Private.DataContractSerialization/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Emit.Lightweight": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0",
+          "System.Xml.XDocument": "4.3.0",
+          "System.Xml.XmlDocument": "4.3.0",
+          "System.Xml.XmlSerializer": "4.3.0"
+        }
+      },
+      "System.Reactive.Core/3.1.1": {
+        "dependencies": {
+          "System.ComponentModel": "4.3.0",
+          "System.Diagnostics.Contracts": "4.3.0",
+          "System.Dynamic.Runtime": "4.3.0",
+          "System.Reactive.Interfaces": "3.1.1",
+          "System.Threading.Thread": "4.3.0",
+          "System.Threading.ThreadPool": "4.3.0"
+        },
+        "runtime": {
+          "lib/netcoreapp1.0/System.Reactive.Core.dll": {
+            "assemblyVersion": "3.0.6000.0",
+            "fileVersion": "3.1.1.0"
+          }
+        }
+      },
+      "System.Reactive.Interfaces/3.1.1": {
+        "runtime": {
+          "lib/netstandard1.0/System.Reactive.Interfaces.dll": {
+            "assemblyVersion": "3.0.0.0",
+            "fileVersion": "3.1.1.0"
+          }
+        }
+      },
+      "System.Reactive.Linq/3.1.1": {
+        "dependencies": {
+          "System.Reactive.Core": "3.1.1",
+          "System.Runtime.InteropServices.WindowsRuntime": "4.0.1"
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Reactive.Linq.dll": {
+            "assemblyVersion": "3.0.3000.0",
+            "fileVersion": "3.1.1.0"
+          }
+        }
+      },
+      "System.Reflection/4.3.0": {
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit/4.3.0": {
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.3.0": {
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.3.0": {
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Extensions/4.3.0": {
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.Metadata/1.7.0-preview1-26727-04": {
+        "dependencies": {
+          "System.Collections.Immutable": "1.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/System.Reflection.Metadata.dll": {
+            "assemblyVersion": "1.4.4.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        }
+      },
+      "System.Reflection.Primitives/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Reflection.TypeExtensions/4.3.0": {
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Resources.ResourceManager/4.3.0": {
+        "dependencies": {
+          "System.Globalization": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime/4.3.0": {},
+      "System.Runtime.CompilerServices.Unsafe/4.6.0-preview1-26727-04": {
+        "runtime": {
+          "lib/netcoreapp2.0/System.Runtime.CompilerServices.Unsafe.dll": {
+            "assemblyVersion": "4.0.5.0",
+            "fileVersion": "0.0.0.0"
+          }
+        }
+      },
+      "System.Runtime.Extensions/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Handles/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices/4.3.0": {
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Runtime.InteropServices.RuntimeInformation/4.3.0": {
+        "dependencies": {
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Threading": "4.3.0",
+          "runtime.native.System": "4.3.0"
+        },
+        "runtimeTargets": {
+          "runtime/unix/lib/_._": {
+            "rid": "unix",
+            "assetType": "runtime"
+          },
+          "runtime/win/lib/_._": {
+            "rid": "win",
+            "assetType": "runtime"
+          }
+        }
+      },
+      "System.Runtime.InteropServices.WindowsRuntime/4.0.1": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Loader/4.0.0": {
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Numerics/4.3.0": {
+        "dependencies": {
+          "System.Globalization": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Json/4.0.2": {
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Private.DataContractSerialization": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Primitives/4.3.0": {
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Runtime.Serialization.Xml/4.3.0": {
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Private.DataContractSerialization": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Serialization.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0"
+        }
+      },
+      "System.Security.AccessControl/4.6.0-preview1-26727-04": {
+        "dependencies": {
+          "System.Security.Principal.Windows": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/System.Security.AccessControl.dll": {
+            "assemblyVersion": "4.1.2.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        },
+        "runtimeTargets": {
+          "runtimes/win/lib/netcoreapp2.0/System.Security.AccessControl.dll": {
+            "rid": "win",
+            "assetType": "runtime",
+            "assemblyVersion": "4.1.2.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        }
+      },
+      "System.Security.Claims/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Security.Principal": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.Algorithms/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.Apple": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        },
+        "runtimeTargets": {
+          "runtime/osx/lib/_._": {
+            "rid": "osx",
+            "assetType": "runtime"
+          },
+          "runtime/unix/lib/_._": {
+            "rid": "unix",
+            "assetType": "runtime"
+          },
+          "runtime/win/lib/_._": {
+            "rid": "win",
+            "assetType": "runtime"
+          }
+        }
+      },
+      "System.Security.Cryptography.Cng/4.6.0-preview1-26727-04": {
+        "runtime": {
+          "lib/netcoreapp2.1/System.Security.Cryptography.Cng.dll": {
+            "assemblyVersion": "4.3.2.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        },
+        "runtimeTargets": {
+          "runtimes/win/lib/netcoreapp2.1/System.Security.Cryptography.Cng.dll": {
+            "rid": "win",
+            "assetType": "runtime",
+            "assemblyVersion": "4.3.2.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        }
+      },
+      "System.Security.Cryptography.Csp/4.3.0": {
+        "dependencies": {
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0"
+        },
+        "runtimeTargets": {
+          "runtime/unix/lib/_._": {
+            "rid": "unix",
+            "assetType": "runtime"
+          },
+          "runtime/win/lib/_._": {
+            "rid": "win",
+            "assetType": "runtime"
+          }
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Collections.Concurrent": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        },
+        "runtimeTargets": {
+          "runtime/unix/lib/_._": {
+            "rid": "unix",
+            "assetType": "runtime"
+          },
+          "runtime/win/lib/_._": {
+            "rid": "win",
+            "assetType": "runtime"
+          }
+        }
+      },
+      "System.Security.Cryptography.OpenSsl/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        },
+        "runtimeTargets": {
+          "runtime/unix/lib/_._": {
+            "rid": "unix",
+            "assetType": "runtime"
+          }
+        }
+      },
+      "System.Security.Cryptography.Pkcs/4.6.0-preview1-26727-04": {
+        "dependencies": {
+          "System.Security.Cryptography.Cng": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netcoreapp2.1/System.Security.Cryptography.Pkcs.dll": {
+            "assemblyVersion": "4.0.4.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        },
+        "runtimeTargets": {
+          "runtimes/win/lib/netcoreapp2.1/System.Security.Cryptography.Pkcs.dll": {
+            "rid": "win",
+            "assetType": "runtime",
+            "assemblyVersion": "4.0.4.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.3.0": {
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.Globalization.Calendars": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.Handles": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Runtime.Numerics": "4.3.0",
+          "System.Security.Cryptography.Algorithms": "4.3.0",
+          "System.Security.Cryptography.Cng": "4.6.0-preview1-26727-04",
+          "System.Security.Cryptography.Csp": "4.3.0",
+          "System.Security.Cryptography.Encoding": "4.3.0",
+          "System.Security.Cryptography.OpenSsl": "4.3.0",
+          "System.Security.Cryptography.Primitives": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "runtime.native.System": "4.3.0",
+          "runtime.native.System.Net.Http": "4.3.0",
+          "runtime.native.System.Security.Cryptography.OpenSsl": "4.3.0"
+        },
+        "runtimeTargets": {
+          "runtime/unix/lib/_._": {
+            "rid": "unix",
+            "assetType": "runtime"
+          },
+          "runtime/win/lib/_._": {
+            "rid": "win",
+            "assetType": "runtime"
+          }
+        }
+      },
+      "System.Security.Cryptography.Xml/4.6.0-preview1-26727-04": {
+        "dependencies": {
+          "System.Security.Cryptography.Pkcs": "4.6.0-preview1-26727-04",
+          "System.Security.Permissions": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/System.Security.Cryptography.Xml.dll": {
+            "assemblyVersion": "4.0.2.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        }
+      },
+      "System.Security.Permissions/4.6.0-preview1-26727-04": {
+        "dependencies": {
+          "System.Security.AccessControl": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard2.0/System.Security.Permissions.dll": {
+            "assemblyVersion": "4.0.2.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        }
+      },
+      "System.Security.Principal/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Security.Principal.Windows/4.6.0-preview1-26727-04": {
+        "runtime": {
+          "lib/netstandard2.0/System.Security.Principal.Windows.dll": {
+            "assemblyVersion": "4.1.2.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        },
+        "runtimeTargets": {
+          "runtimes/unix/lib/netcoreapp2.0/System.Security.Principal.Windows.dll": {
+            "rid": "unix",
+            "assetType": "runtime",
+            "assemblyVersion": "4.1.2.0",
+            "fileVersion": "4.6.26727.4"
+          },
+          "runtimes/win/lib/netcoreapp2.0/System.Security.Principal.Windows.dll": {
+            "rid": "win",
+            "assetType": "runtime",
+            "assemblyVersion": "4.1.2.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        }
+      },
+      "System.Text.Encoding/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Encoding.Extensions/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Text.Encoding": "4.3.0"
+        }
+      },
+      "System.Text.Encodings.Web/4.6.0-preview1-26727-04": {
+        "runtime": {
+          "lib/netstandard2.0/System.Text.Encodings.Web.dll": {
+            "assemblyVersion": "4.0.4.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        }
+      },
+      "System.Text.Formatting/0.1.0-preview2-180804-5": {
+        "dependencies": {
+          "System.Buffers": "4.6.0-preview1-26727-04",
+          "System.Buffers.Experimental": "0.1.0-preview2-180804-5"
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.Formatting.dll": {
+            "assemblyVersion": "0.1.0.0",
+            "fileVersion": "0.1.0.0"
+          }
+        }
+      },
+      "System.Text.JsonLab/0.1.0-preview2-180804-5": {
+        "dependencies": {
+          "System.Buffers.ReaderWriter": "0.1.0-preview2-180804-5",
+          "System.Text.Formatting": "0.1.0-preview2-180804-5"
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Text.JsonLab.dll": {
+            "assemblyVersion": "0.1.0.0",
+            "fileVersion": "0.1.0.0"
+          }
+        }
+      },
+      "System.Text.Primitives/0.1.0-preview2-180804-5": {
+        "dependencies": {
+          "System.Buffers.Primitives": "0.1.0-preview2-180804-5",
+          "System.Numerics.Vectors": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Text.Primitives.dll": {
+            "assemblyVersion": "0.1.0.0",
+            "fileVersion": "0.1.0.0"
+          }
+        }
+      },
+      "System.Text.RegularExpressions/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Text.Utf8String/0.1.0-preview2-180804-5": {
+        "dependencies": {
+          "System.Text.Primitives": "0.1.0-preview2-180804-5"
+        },
+        "runtime": {
+          "lib/netstandard1.1/System.Text.Utf8String.dll": {
+            "assemblyVersion": "0.1.0.0",
+            "fileVersion": "0.1.0.0"
+          }
+        }
+      },
+      "System.Threading/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Threading.Channels/4.6.0-preview1-26727-04": {
+        "runtime": {
+          "lib/netcoreapp2.1/System.Threading.Channels.dll": {
+            "assemblyVersion": "4.0.1.0",
+            "fileVersion": "4.6.26727.4"
+          }
+        }
+      },
+      "System.Threading.Tasks/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions/4.6.0-preview1-26727-04": {},
+      "System.Threading.Thread/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Handles": "4.3.0"
+        }
+      },
+      "System.Threading.Timer/4.3.0": {
+        "dependencies": {
+          "System.Runtime": "4.3.0"
+        }
+      },
+      "System.ValueTuple/4.6.0-preview1-26727-04": {},
+      "System.Xml.ReaderWriter/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.IO.FileSystem": "4.3.0",
+          "System.IO.FileSystem.Primitives": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Runtime.InteropServices": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Text.Encoding.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.0",
+          "System.Threading.Tasks": "4.3.0",
+          "System.Threading.Tasks.Extensions": "4.6.0-preview1-26727-04"
+        }
+      },
+      "System.Xml.XDocument/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Diagnostics.Tools": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0"
+        }
+      },
+      "System.Xml.XmlDocument/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.Encoding": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0"
+        }
+      },
+      "System.Xml.XmlSerializer/4.3.0": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Linq": "4.3.0",
+          "System.Reflection": "4.3.0",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Reflection.Emit.ILGeneration": "4.3.0",
+          "System.Reflection.Extensions": "4.3.0",
+          "System.Reflection.Primitives": "4.3.0",
+          "System.Reflection.TypeExtensions": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Text.RegularExpressions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0",
+          "System.Xml.XmlDocument": "4.3.0"
+        }
+      },
+      "System.Xml.XPath/4.0.1": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Diagnostics.Debug": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0"
+        }
+      },
+      "System.Xml.XPath.XmlDocument/4.0.1": {
+        "dependencies": {
+          "System.Collections": "4.3.0",
+          "System.Globalization": "4.3.0",
+          "System.IO": "4.3.0",
+          "System.Resources.ResourceManager": "4.3.0",
+          "System.Runtime": "4.3.0",
+          "System.Runtime.Extensions": "4.3.0",
+          "System.Threading": "4.3.0",
+          "System.Xml.ReaderWriter": "4.3.0",
+          "System.Xml.XPath": "4.0.1",
+          "System.Xml.XmlDocument": "4.3.0"
+        },
+        "runtime": {
+          "lib/netstandard1.3/System.Xml.XPath.XmlDocument.dll": {
+            "assemblyVersion": "4.0.1.0",
+            "fileVersion": "1.0.24212.1"
+          }
+        }
+      },
+      "xunit/2.3.1": {
+        "dependencies": {
+          "xunit.analyzers": "0.7.0",
+          "xunit.assert": "2.3.1",
+          "xunit.core": "2.3.1"
+        }
+      },
+      "xunit.abstractions/2.0.1": {
+        "runtime": {
+          "lib/netstandard1.0/xunit.abstractions.dll": {
+            "assemblyVersion": "2.0.0.0",
+            "fileVersion": "2.0.0.0"
+          }
+        }
+      },
+      "xunit.analyzers/0.7.0": {},
+      "xunit.assert/2.3.1": {
+        "runtime": {
+          "lib/netstandard1.1/xunit.assert.dll": {
+            "assemblyVersion": "2.3.1.3858",
+            "fileVersion": "2.3.1.3858"
+          }
+        }
+      },
+      "xunit.core/2.3.1": {
+        "dependencies": {
+          "xunit.extensibility.core": "2.3.1",
+          "xunit.extensibility.execution": "2.3.1"
+        }
+      },
+      "xunit.extensibility.core/2.3.1": {
+        "dependencies": {
+          "xunit.abstractions": "2.0.1"
+        },
+        "runtime": {
+          "lib/netstandard1.1/xunit.core.dll": {
+            "assemblyVersion": "2.3.1.3858",
+            "fileVersion": "2.3.1.3858"
+          }
+        }
+      },
+      "xunit.extensibility.execution/2.3.1": {
+        "dependencies": {
+          "xunit.extensibility.core": "2.3.1"
+        },
+        "runtime": {
+          "lib/netstandard1.1/xunit.execution.dotnet.dll": {
+            "assemblyVersion": "2.3.1.3858",
+            "fileVersion": "2.3.1.3858"
+          }
+        }
+      },
+      "xunit.runner.visualstudio/2.4.0": {
+        "dependencies": {
+          "Microsoft.NET.Test.Sdk": "15.6.1"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Connections/3.0.0-alpha1-t000": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Authorization.Policy": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Hosting.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Http": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Http.Connections.Common": "3.0.0-alpha1-t000",
+          "Microsoft.AspNetCore.Routing": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.WebSockets": "3.0.0-alpha1-10173",
+          "Newtonsoft.Json": "11.0.2"
+        },
+        "runtime": {
+          "Microsoft.AspNetCore.Http.Connections.dll": {}
+        }
+      },
+      "Microsoft.AspNetCore.Http.Connections.Client/3.0.0-alpha1-t000": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Connections.Common": "3.0.0-alpha1-t000",
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.0-alpha1-10173"
+        },
+        "runtime": {
+          "Microsoft.AspNetCore.Http.Connections.Client.dll": {}
+        }
+      },
+      "Microsoft.AspNetCore.Http.Connections.Common/3.0.0-alpha1-t000": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Connections.Abstractions": "3.0.0-alpha1-10173",
+          "Newtonsoft.Json": "11.0.2",
+          "System.Buffers": "4.6.0-preview1-26727-04",
+          "System.Text.JsonLab": "0.1.0-preview2-180804-5"
+        },
+        "runtime": {
+          "Microsoft.AspNetCore.Http.Connections.Common.dll": {}
+        }
+      },
+      "Microsoft.AspNetCore.SignalR/3.0.0-alpha1-t000": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Connections": "3.0.0-alpha1-t000",
+          "Microsoft.AspNetCore.SignalR.Core": "3.0.0-alpha1-t000"
+        },
+        "runtime": {
+          "Microsoft.AspNetCore.SignalR.dll": {}
+        }
+      },
+      "Microsoft.AspNetCore.SignalR.Client/3.0.0-alpha1-t000": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Connections.Client": "3.0.0-alpha1-t000",
+          "Microsoft.AspNetCore.SignalR.Client.Core": "3.0.0-alpha1-t000"
+        },
+        "runtime": {
+          "Microsoft.AspNetCore.SignalR.Client.dll": {}
+        }
+      },
+      "Microsoft.AspNetCore.SignalR.Client.Core/3.0.0-alpha1-t000": {
+        "dependencies": {
+          "Microsoft.AspNetCore.SignalR.Common": "3.0.0-alpha1-t000",
+          "Microsoft.AspNetCore.SignalR.Protocols.Json": "3.0.0-alpha1-t000",
+          "Microsoft.Extensions.DependencyInjection": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging": "3.0.0-alpha1-10173",
+          "System.Threading.Channels": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "Microsoft.AspNetCore.SignalR.Client.Core.dll": {}
+        }
+      },
+      "Microsoft.AspNetCore.SignalR.Common/3.0.0-alpha1-t000": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Connections.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Options": "3.0.0-alpha1-10173",
+          "Newtonsoft.Json": "11.0.2",
+          "System.Buffers": "4.6.0-preview1-26727-04",
+          "System.Text.JsonLab": "0.1.0-preview2-180804-5"
+        },
+        "runtime": {
+          "Microsoft.AspNetCore.SignalR.Common.dll": {}
+        }
+      },
+      "Microsoft.AspNetCore.SignalR.Core/3.0.0-alpha1-t000": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Authorization": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.SignalR.Common": "3.0.0-alpha1-t000",
+          "Microsoft.AspNetCore.SignalR.Protocols.Json": "3.0.0-alpha1-t000",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging.Abstractions": "3.0.0-alpha1-10173",
+          "System.Reflection.Emit": "4.3.0",
+          "System.Threading.Channels": "4.6.0-preview1-26727-04"
+        },
+        "runtime": {
+          "Microsoft.AspNetCore.SignalR.Core.dll": {}
+        }
+      },
+      "Microsoft.AspNetCore.SignalR.Protocols.Json/3.0.0-alpha1-t000": {
+        "dependencies": {
+          "Microsoft.AspNetCore.SignalR.Common": "3.0.0-alpha1-t000",
+          "Newtonsoft.Json": "11.0.2"
+        },
+        "runtime": {
+          "Microsoft.AspNetCore.SignalR.Protocols.Json.dll": {}
+        }
+      },
+      "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/3.0.0-alpha1-t000": {
+        "dependencies": {
+          "MessagePack": "1.7.3.4",
+          "Microsoft.AspNetCore.SignalR.Common": "3.0.0-alpha1-t000"
+        },
+        "runtime": {
+          "Microsoft.AspNetCore.SignalR.Protocols.MessagePack.dll": {}
+        }
+      },
+      "Microsoft.AspNetCore.SignalR.Tests.Utils/3.0.0-alpha1-t000": {
+        "dependencies": {
+          "Microsoft.AspNetCore.Hosting": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.Server.Kestrel": "3.0.0-alpha1-10173",
+          "Microsoft.AspNetCore.SignalR.Client.Core": "3.0.0-alpha1-t000",
+          "Microsoft.AspNetCore.SignalR.Common": "3.0.0-alpha1-t000",
+          "Microsoft.AspNetCore.SignalR.Core": "3.0.0-alpha1-t000",
+          "Microsoft.AspNetCore.SignalR.Protocols.MessagePack": "3.0.0-alpha1-t000",
+          "Microsoft.AspNetCore.Testing": "3.0.0-alpha1-10173",
+          "Microsoft.Extensions.Logging.Testing": "3.0.0-alpha1-10173",
+          "Microsoft.NET.Test.Sdk": "15.6.1",
+          "Moq": "4.7.49",
+          "StackExchange.Redis.StrongName": "1.2.6",
+          "xunit": "2.3.1",
+          "xunit.runner.visualstudio": "2.4.0"
+        },
+        "runtime": {
+          "Microsoft.AspNetCore.SignalR.Tests.Utils.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Microsoft.AspNetCore.SignalR.Client.FunctionalTests/3.0.0-alpha1-t000": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "Castle.Core/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-1cUDbDJtCKE+JPkcz2H8obqkjYuReE1cuINx/ewZQ6nHPO8oEQUtlu2n8kNlBPp22Mm2oC+LOBfkc8rDEVhfQA==",
+      "path": "castle.core/4.1.0",
+      "hashPath": "castle.core.4.1.0.nupkg.sha512"
+    },
+    "Internal.AspNetCore.Sdk/3.0.0-alpha1-10015": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-C1YZGukn2ibSn5V4PZ5OU/6uyHrLHkflPveUVFLT2uB/YDWtccJzzFf3tTKU4tRGGWdreznAjjInHODDJRhzHw==",
+      "path": "internal.aspnetcore.sdk/3.0.0-alpha1-10015",
+      "hashPath": "internal.aspnetcore.sdk.3.0.0-alpha1-10015.nupkg.sha512"
+    },
+    "MessagePack/1.7.3.4": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-QSKZVq6BmNaz/B4n0bAM/moQnc4E6XZ7uXRbJcEXxUzZufJiDYDE6awYqDtNz6acupYoPt2QupGV4rpyPCRRtg==",
+      "path": "messagepack/1.7.3.4",
+      "hashPath": "messagepack.1.7.3.4.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Authentication/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-7+ckY0q7NAfOrOJzv+r5wTzblyF229pSn3eX6ztwel0hhXVteF5wic4WsB3bxu15XIrhydRcr6yc8PTZB+wVug==",
+      "path": "microsoft.aspnetcore.authentication/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.authentication.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Authentication.Abstractions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-qNvNI3T6L3AOWH2GqTTRgPmo3RbeC7zi1f9KCjAFESpN/B9wsNsz/UueINJncVhRlm9xVa8uhKeoR/73kpSYXg==",
+      "path": "microsoft.aspnetcore.authentication.abstractions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.authentication.abstractions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Authentication.Core/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-phJse3jPnAf32DX/JkeiUgHFU4BTMSz8ceix0qVV2V53xQdNc8f5nxzJKh/JprWLxKTCtmjuM6njKHE22groFA==",
+      "path": "microsoft.aspnetcore.authentication.core/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.authentication.core.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Authentication.JwtBearer/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-WzhDS3348L/bsmNHayXbZMz2Fp8O/8UCkuW1gTRnx7Ky7/yx3vee8HYGK7wkeuTig5EmQCCmapQmSEJLlyeuig==",
+      "path": "microsoft.aspnetcore.authentication.jwtbearer/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.authentication.jwtbearer.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Authorization/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-VJ0iEIYhbvpeHr4ykg5H7oIo+6fZYEgewQBSCHHLgauw35prxA9LRMUeVt7a3KHUEl5W97RDW8qR3HhDb/BF6g==",
+      "path": "microsoft.aspnetcore.authorization/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.authorization.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Authorization.Policy/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-gDd1HKdw6XbhdC4HqWaw/DhzSXIQh3ATdYUvQACt3Afg9Fy/n0p+7Oyvc2s7jy6V66NyJ07l11HEaQlOrd9qCQ==",
+      "path": "microsoft.aspnetcore.authorization.policy/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.authorization.policy.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.BuildTools.ApiCheck/3.0.0-alpha1-10015": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-0UIk/FJLN6lyTJrze4pTbhQrQbaqBdZJVAWdhRas73mGosysiGHxOc2z3fXkkUMDYBszyjslBX6CPq+PPpYZwg==",
+      "path": "microsoft.aspnetcore.buildtools.apicheck/3.0.0-alpha1-10015",
+      "hashPath": "microsoft.aspnetcore.buildtools.apicheck.3.0.0-alpha1-10015.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Connections.Abstractions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-gxjJQI25re2QbuvuGko1YC4RMidHD+Sxo52uqylo0G/vTTLjSpcHEtZD47zGQQEKehIou8RJJtaoJg+5dsar5A==",
+      "path": "microsoft.aspnetcore.connections.abstractions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.connections.abstractions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Cryptography.Internal/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-iGfBFA8bpuktXi61IR7fEAApBVmvpOOLseaKIVW77Yl9eThSeyrbShJz8YwIMBAsdUQC2LFGQyoXnPU3p40hgg==",
+      "path": "microsoft.aspnetcore.cryptography.internal/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.cryptography.internal.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.DataProtection/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-l/dV3oXxpuGRu2GBELoBUeZIP4wkzXAHUN4IiQiMWvmsEgv6C/pKEUmpvpPLBe9tcTurgQz0356d72p/4/JOUA==",
+      "path": "microsoft.aspnetcore.dataprotection/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.dataprotection.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.DataProtection.Abstractions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-/HoxLKiVJtgTCztnlc9AxanRJoO+mRG9ylQuVlMcKYwHvk6J+IqTCdIE42J1Uf4I1E9SFeM4I3p53PYZtBlfTA==",
+      "path": "microsoft.aspnetcore.dataprotection.abstractions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.dataprotection.abstractions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Diagnostics/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-gdIiInC+d1OAujUsjZdbShp9llF3nxoouAQMyLzuHfRHnVWZNO7SBZLNCa/EkdQKShe2MgFN/clX2iUc1fBntA==",
+      "path": "microsoft.aspnetcore.diagnostics/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.diagnostics.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Diagnostics.Abstractions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-rYuuHC53GTk78QMg9CQFzHmp5q30LGKgWG1Z3GGzpgsAxDjatAdt3yBFeok+Cs6rIDt1H7d0hslChE/oeTUN2Q==",
+      "path": "microsoft.aspnetcore.diagnostics.abstractions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.diagnostics.abstractions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Hosting/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-bNSmg/vlXuJu9j78ZAT6XS+7xjMWqpAQndM690PNCt4GhcGV+oa2gmOwTfOC44xySPL1YvOYUo9P0r+Hhmod0w==",
+      "path": "microsoft.aspnetcore.hosting/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.hosting.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Hosting.Abstractions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-OE7eM48IWS67Jsu8hFNCD6IftvD3yeMKZrmWifd14jDF+tFQsiO07CLrXL4F3cFnAd4HAzsB+Ab4F3vFwStHZQ==",
+      "path": "microsoft.aspnetcore.hosting.abstractions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.hosting.abstractions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Hosting.Server.Abstractions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-F8UwdOYKOiqWozzJNSnDVzxYiJKL3sRJf5nlVaGSaYPQckQ/uJ8jA6eCyZHYGLUSYQWkHTnOw18dPi27cXiWlg==",
+      "path": "microsoft.aspnetcore.hosting.server.abstractions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.hosting.server.abstractions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Http/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-00UtY0mlEegh172vmpzSKU4xZ9Aa1K0YeZQkZiGuWKpsbIY53I8GbD/jli1lURRAhaegCqsjfNY66qHjeyNdsQ==",
+      "path": "microsoft.aspnetcore.http/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.http.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Http.Abstractions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-DGPgMtljaZHBu8hg7Xc1EVp/Nnl5PwQuLzm9gEZisXDrfAWWETI8fRqZOOGkRufDv5eTZRcIhEWSkTSugBL9yg==",
+      "path": "microsoft.aspnetcore.http.abstractions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.http.abstractions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Http.Extensions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-EC175H6CedvLcem242D595bnehfeMbfj2ar8uM2L1Gh4V9dc9TsCXmSTZk+DfwzzT0gX4VRRgoONfiW9Pt8msQ==",
+      "path": "microsoft.aspnetcore.http.extensions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.http.extensions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Http.Features/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-w4T40Hrx87BdRXexaId16oXjaUybU/pawb2cCR4i9XlQBJ1rwGP7fTZCQfyPy41+YCVYVlZowz5jymxI6AnzwQ==",
+      "path": "microsoft.aspnetcore.http.features/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.http.features.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Routing/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-9rsmzBluR6OguqY6ybj/jmViWkJXB85uamh4YMAKKuFwuZhImhmtPAwTq0HbhiKfPAvzNm/7GOpMjhTkwGQfJw==",
+      "path": "microsoft.aspnetcore.routing/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.routing.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Routing.Abstractions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-nYSHBcRX73QmxISz5Xjjk0UhjtE1o6mMBCPyVmFURGYa/5L2+iqcW+D07aKy9jUkIoA6WIQWYFmaY4zlssJYew==",
+      "path": "microsoft.aspnetcore.routing.abstractions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.routing.abstractions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Server.Kestrel/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-gtvrEw7iYmzNBdAdPiLopJeUla264r0XnPVIFZtOYhGbQn4Gg3GnXKL/2nI2A40F+siuJQ9LDIc2uXl187NhbA==",
+      "path": "microsoft.aspnetcore.server.kestrel/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.server.kestrel.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Server.Kestrel.Core/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-V/uaiq3mjQeSrS0lM8eJthrL6ZcoWuRCpK52RnIwuQSiDvXWx5PjnB31mJrD0y2SFACb7F01xqlgMSRqzq0UQA==",
+      "path": "microsoft.aspnetcore.server.kestrel.core/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.server.kestrel.core.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Server.Kestrel.Https/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-KvTRJbbTsA21l3ohE7pFjk+jKD2wdmq2Gqq7Cknl4p3s2CubJadctYPafbqQqFm/ESj4b/q6Q7HjNFKBoSg0Mw==",
+      "path": "microsoft.aspnetcore.server.kestrel.https/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.server.kestrel.https.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Cedny41c4hqRpKqAXHZLj4B2/iayGRR88zYEXp+p5XmAmOShD0T5wFYoUBJs35SK/53Dm33YvIdcvg7rKXxeUw==",
+      "path": "microsoft.aspnetcore.server.kestrel.transport.abstractions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.server.kestrel.transport.abstractions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-FJpvNOOxxPWsvIrs2QH1y5bjDqt1OVg3fY+FswFvT3J8bfLaBSLtwwQ9qbboMXC9Tp2FDkfSnrKNcV9jGICQPQ==",
+      "path": "microsoft.aspnetcore.server.kestrel.transport.sockets/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.server.kestrel.transport.sockets.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.TestHost/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-a8/3WUASdMuWhzFUZZOc3CHNo/MjKeV8+PbxPHWZGtVvcxnIfUyHs9GHc4DFYJ3xmSTovFSB0UQ8aukqYiWYWA==",
+      "path": "microsoft.aspnetcore.testhost/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.testhost.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Testing/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Or6V7vEkOgjPN3SbZBAUBDnlo5cSadJGlcnJCNEB5bqndy16uA7ioZuDEMc6fx1wZyxY/uvC6R9zYgC6iq82/g==",
+      "path": "microsoft.aspnetcore.testing/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.testing.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.WebSockets/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-PVglnqw7KivZpsf4K0TCZDz4ThNYuIgVQJZeHRCCAd94BpvoTBUk87dog5MJzcGHxXzDyJ6T2TI1NNAMoj3Sug==",
+      "path": "microsoft.aspnetcore.websockets/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.websockets.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.WebUtilities/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-4tHmpEdEkkZOvTz0Dw9/Ll9Y4M48qW7S41MBRwAHMcnb5fhpTzuFrze4MNwnUcz0VfPwovnWOOnTgVMZvu8+HQ==",
+      "path": "microsoft.aspnetcore.webutilities/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.aspnetcore.webutilities.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.CodeCoverage/1.0.3": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-5KfX12XPfvBomjrZv9nCBfQ6lhZdroVxXvGnY6MqzG83bjqdq6SQ3xxJFdPgHv6oli83M9oNhZlynYehjmboUg==",
+      "path": "microsoft.codecoverage/1.0.3",
+      "hashPath": "microsoft.codecoverage.1.0.3.nupkg.sha512"
+    },
+    "Microsoft.CSharp/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-17h8b5mXa87XYKrrVqdgZ38JefSUqLChUQpXgSnpzsM0nDOhE40FTeNWOJ/YmySGV6tG6T8+hjz6vxbknHJr6A==",
+      "path": "microsoft.csharp/4.0.1",
+      "hashPath": "microsoft.csharp.4.0.1.nupkg.sha512"
+    },
+    "Microsoft.DotNet.PlatformAbstractions/1.0.3": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-rF92Gp5L2asYrFNf0cKNBxzzGLh1krHuj6TRDk9wdjN2qdvJLaNYOn1s9oYkMlptYX436KiEFqxhLB+I5veXvQ==",
+      "path": "microsoft.dotnet.platformabstractions/1.0.3",
+      "hashPath": "microsoft.dotnet.platformabstractions.1.0.3.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Configuration/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-dmNPKSYJ9/Uzi48AOYkjhSEJNqGqH6KzNdFG3kFa0Ai6VHWy9XIlvfnFjW8DQ3mGC8ffhmF77wUojwhsnClBag==",
+      "path": "microsoft.extensions.configuration/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.configuration.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Configuration.Abstractions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-MAOOHliiN53UVe8M4uu/SM9FQm3up8cybLBsDPVnHDVjfMa9L7ppUDucH41KTtGTmEt3BvmO0H3jCUExQTYXmQ==",
+      "path": "microsoft.extensions.configuration.abstractions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.configuration.abstractions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Configuration.Binder/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-WA7wwObIft1w2vXa6Nm0ErMB3yC3sEvb5HOMGvREZLTef3oXghbtSqAeyRsh+GJqiLTECajRchcMMPDADjvguQ==",
+      "path": "microsoft.extensions.configuration.binder/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.configuration.binder.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Configuration.EnvironmentVariables/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-eeb6437j6cErdt4+OKyul9EEsEhFjQlTOGNdha9mdjtJ7VSyrOyTulW8O4ad03M79C7FY73aON1ucsc2Q4L0/w==",
+      "path": "microsoft.extensions.configuration.environmentvariables/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.configuration.environmentvariables.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Configuration.FileExtensions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-lQ2G+LMnKYrWC3PAZ4Hwl8b8QvM46WB5h+3Bf3BI4riGWcysx7MPH3j3Y37/pc4LJwTJVtbimf2YqtyX0cCx2g==",
+      "path": "microsoft.extensions.configuration.fileextensions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.configuration.fileextensions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.DependencyInjection/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-zgSLvGtRQmx8+ZfMds4eyepfO7NdG7RcYkPsooaxKnOezxK6KizRHbkQLjc7qTjMrJwea9gWImMDwmhDpjlslg==",
+      "path": "microsoft.extensions.dependencyinjection/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.dependencyinjection.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.DependencyInjection.Abstractions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-a6ogO/wumx4U/0hGNxLpkkZ5TZkLQIMtqNP9jR1A4RbTMQurVy/np2tdlKRmG4OyNaIg9aVJBVZt5Z/pokf2mw==",
+      "path": "microsoft.extensions.dependencyinjection.abstractions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.dependencyinjection.abstractions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.DependencyModel/1.0.3": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Z3o19EnheuegmvgpCzwoSlnCWxYA6qIUhvKJ7ifKHHvU7U+oYR/gliLiL3LVYOOeGMEEzkpJ5W67sOcXizGtlw==",
+      "path": "microsoft.extensions.dependencymodel/1.0.3",
+      "hashPath": "microsoft.extensions.dependencymodel.1.0.3.nupkg.sha512"
+    },
+    "Microsoft.Extensions.FileProviders.Abstractions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-9XC0cIY2d5BqH63ZuXQ1O4/3HmLI1dAnORXr/mEtNXA6vQNWAGri2RTq/0Mg9zl33qb4Jdb4HQ8Z0HE7IzkDTQ==",
+      "path": "microsoft.extensions.fileproviders.abstractions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.fileproviders.abstractions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.FileProviders.Physical/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-gP78YZ+P7rsMaxO6uM2r/d4Ln8AEPHp5Ln49ci9H9QMFqLCyO7wjOZY5LlyhhXq87gr2zCFRj7/ffX3Rm/rmQw==",
+      "path": "microsoft.extensions.fileproviders.physical/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.fileproviders.physical.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.FileSystemGlobbing/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ok0ItgXVKyDaGzSIryb11uEoaIwpe9THWq2grPCwuGyUeWZbDhHpDBygHeZpvetCLAZhGPeHcsLRkZr9B0MNLQ==",
+      "path": "microsoft.extensions.filesystemglobbing/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.filesystemglobbing.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Hosting.Abstractions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-PhTwm+lfZaDRdfgqqQiB+D96Cg8YJfyTCg+yik08YFo/7waHL3nFHSN5G9yTQUeNkJxow0J+Xy/KrZIfmI1HTQ==",
+      "path": "microsoft.extensions.hosting.abstractions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.hosting.abstractions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Logging/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-PD2yxDdUAWGB6D8T8MyZ8m+1ei4eBaA/+idqFLgPqUyBlxlWC3U5wSUzXHKf/nGBKbHVGvpKq8Eqtn2HMGETIw==",
+      "path": "microsoft.extensions.logging/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.logging.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Logging.Abstractions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-6X1PZz7hZUlEC9S5cWbspYJvrPyvGuH5e40lekNco8pjmmbygt95UWNWER6SdlEGpORhcCMfrmimQ0vgZ10ivw==",
+      "path": "microsoft.extensions.logging.abstractions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.logging.abstractions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Logging.Configuration/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-SCCIPCfn8AFAWrzvWFquhVLuWxokUWuUBfemT85on4rEvbV+eSXByJnKobl5p4aLOkrtTPxFDjLdFyDE6LcX4g==",
+      "path": "microsoft.extensions.logging.configuration/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.logging.configuration.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Logging.Console/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-m7YIcELXk4voqK0d1z0qvJcQcIyXopVCwAOHeydDoJzKntLFlKKmMVG2tqbVrr4AxGpp1hr1nVhfHpsMA5gGlg==",
+      "path": "microsoft.extensions.logging.console/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.logging.console.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Logging.Testing/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-9zL3HwkrHbw9CK9urOKJ7JACDcvf7J6Uuh6SeRh7csS/PEAEwp19EAP1DuwOUayGQyrVa+Xn1BPCNb8iOidt0g==",
+      "path": "microsoft.extensions.logging.testing/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.logging.testing.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.ObjectPool/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-aRNhQ3YmPEYguyqMOOmMavupPM3HlabqPeVfpwIcK2DRQlEzChJXv7VBjBDMbOSOKgoXd9nugbAH76Fhk7cSUQ==",
+      "path": "microsoft.extensions.objectpool/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.objectpool.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Options/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-hJIzwiLiLJl1jU/8iPku8ZxynvijsBjAFTX03c3buhZ7HkTV0stWKDrSedsiIEEmBAF+Jbi4/Rd3fQ4FmyvALw==",
+      "path": "microsoft.extensions.options/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.options.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Options.ConfigurationExtensions/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-H+C2rGsXVs833QC0aB83yOopdd7kPMWOcSpsVMxVnXEscpMrvM3bkOB34cW1jkfZR7AZPu8hiqeCWD+uCCiTRA==",
+      "path": "microsoft.extensions.options.configurationextensions/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.options.configurationextensions.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.Primitives/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-HLR56m+sH11phSFECjOrlAvFlLBnerbN9/UVKZpixkFTIUeKxvb5Er0ZOvaZ6AgoWDC3Z6kTV3AK6tUmMzDibg==",
+      "path": "microsoft.extensions.primitives/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.primitives.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.Extensions.WebEncoders/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-N1KNiCH2KIP8n0dYKB+vpSaCnds0ubrbfqCal/8Ioqa6kdhsKZtuaMhhhcHEJEqCoH9Fo7tRR2cNU6e3FtUeHQ==",
+      "path": "microsoft.extensions.webencoders/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.extensions.webencoders.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.IdentityModel.Logging/5.2.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-OgiaeDGsuTpXrx77a4gyN6Flp4y7jro4La92UtVEEVxnRb+TnRxawVYY3Z5EVme5fSwvE31vo2iNAwI/jBKjPg==",
+      "path": "microsoft.identitymodel.logging/5.2.0",
+      "hashPath": "microsoft.identitymodel.logging.5.2.0.nupkg.sha512"
+    },
+    "Microsoft.IdentityModel.Protocols/5.2.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-pakGqbE3FRort3vb0qqWI0Qfy84IOXs8sG7ygANUpoRT+544svQ62JfvCX4UPnqf5bCUpSxVc3rDh8yCQBtc7w==",
+      "path": "microsoft.identitymodel.protocols/5.2.0",
+      "hashPath": "microsoft.identitymodel.protocols.5.2.0.nupkg.sha512"
+    },
+    "Microsoft.IdentityModel.Protocols.OpenIdConnect/5.2.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-hMjsfdvgI/Gk/HWPgyVnju6fy3iULralgn1XU6eL17KkkFN2rJ1fDzJX3RKrjr888Y5S+hTSQAUcGzb4Fe3aBA==",
+      "path": "microsoft.identitymodel.protocols.openidconnect/5.2.0",
+      "hashPath": "microsoft.identitymodel.protocols.openidconnect.5.2.0.nupkg.sha512"
+    },
+    "Microsoft.IdentityModel.Tokens/5.2.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Uz1Dk5Gw/jgIHEzac9cXhq7pH0Hf5P73vf23hR6QJn0IamLbPG4qoHnGyPMn9qQXc+jDb/j3fWOhvWGrteJXtA==",
+      "path": "microsoft.identitymodel.tokens/5.2.0",
+      "hashPath": "microsoft.identitymodel.tokens.5.2.0.nupkg.sha512"
+    },
+    "Microsoft.Net.Http.Headers/3.0.0-alpha1-10173": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-PiWb16yiNPh/h8+0uXuNpQpwmUGVm3NCUaBm1YIGqp9JVDVr6B1OIxlueROYN3BR8XpDNLJgZQdt2YvQ9tjkNA==",
+      "path": "microsoft.net.http.headers/3.0.0-alpha1-10173",
+      "hashPath": "microsoft.net.http.headers.3.0.0-alpha1-10173.nupkg.sha512"
+    },
+    "Microsoft.NET.Test.Sdk/15.6.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-K2AZ+uRGm8ttYzWm+fdA/jIiLp8bh/63D/KcDNdJ0MbKDmu0FUoit8OLTOmtoJRUMzP/+kRFwGg0qxqI/p8ugQ==",
+      "path": "microsoft.net.test.sdk/15.6.1",
+      "hashPath": "microsoft.net.test.sdk.15.6.1.nupkg.sha512"
+    },
+    "Microsoft.TestPlatform.ObjectModel/15.6.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-HJj5ZxGrr5o6f7fQQZNxqz1JH116W1TZTrzAEOSN5WWmu0gdBIhFC8RL4lw+R7FY9N6tUOf5KDlH7+bZtHwD/A==",
+      "path": "microsoft.testplatform.objectmodel/15.6.1",
+      "hashPath": "microsoft.testplatform.objectmodel.15.6.1.nupkg.sha512"
+    },
+    "Microsoft.TestPlatform.TestHost/15.6.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-DK3JygY+7uYKK0fPS4EPauC9v3Lvp9NvoYPIgG6qIrs1FfPHrnUM8WfKJw7BVnI86GHjCt7kOxcoauGTTQaM8g==",
+      "path": "microsoft.testplatform.testhost/15.6.1",
+      "hashPath": "microsoft.testplatform.testhost.15.6.1.nupkg.sha512"
+    },
+    "Microsoft.Win32.Primitives/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-9ZQKCWxH7Ijp9BfahvL2Zyf1cJIk8XYLF6Yjzr2yi0b2cOut/HQ31qf1ThHAgCc3WiZMdnWcfJCgN82/0UunxA==",
+      "path": "microsoft.win32.primitives/4.3.0",
+      "hashPath": "microsoft.win32.primitives.4.3.0.nupkg.sha512"
+    },
+    "Microsoft.Win32.Registry/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-JTB7O/g/S1DZocFGhzHgQ21V0sLHb0JjUKq2tPgsm4WbLMTko7ln/q0UHGmxmF1UFrHuai0YuUxV/G2eXBqFYg==",
+      "path": "microsoft.win32.registry/4.6.0-preview1-26727-04",
+      "hashPath": "microsoft.win32.registry.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "Moq/4.7.49": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-D23AaGaJrmoQvERnICuTmCPmLBCbKmKHCKVwq909M8kfqSg9W4sXoFSZVDYizoUd6sBBbBHbvuYKfiWU64eUvA==",
+      "path": "moq/4.7.49",
+      "hashPath": "moq.4.7.49.nupkg.sha512"
+    },
+    "Newtonsoft.Json/11.0.2": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-IvJe1pj7JHEsP8B8J8DwlMEx8UInrs/x+9oVY+oCD13jpLu4JbJU2WCIsMRn5C4yW9+DgkaO8uiVE5VHKjpmdQ==",
+      "path": "newtonsoft.json/11.0.2",
+      "hashPath": "newtonsoft.json.11.0.2.nupkg.sha512"
+    },
+    "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-HdSSp5MnJSsg08KMfZThpuLPJpPwE5hBXvHwoKWosyHHfe8Mh5WKT0ylEOf6yNzX6Ngjxe4Whkafh5q7Ymac4Q==",
+      "path": "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl/4.3.0",
+      "hashPath": "runtime.debian.8-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg.sha512"
+    },
+    "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-+yH1a49wJMy8Zt4yx5RhJrxO/DBDByAiCzNwiETI+1S4mPdCu0OY4djdciC7Vssk0l22wQaDLrXxXkp+3+7bVA==",
+      "path": "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl/4.3.0",
+      "hashPath": "runtime.fedora.23-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg.sha512"
+    },
+    "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-c3YNH1GQJbfIPJeCnr4avseugSqPrxwIqzthYyZDN6EuOyNOzq+y2KSUfRcXauya1sF4foESTgwM5e1A8arAKw==",
+      "path": "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl/4.3.0",
+      "hashPath": "runtime.fedora.24-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg.sha512"
+    },
+    "runtime.native.System/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-c/qWt2LieNZIj1jGnVNsE2Kl23Ya2aSTBuXMD6V7k9KWr6l16Tqdwq+hJScEpWER9753NWC8h96PaVNY5Ld7Jw==",
+      "path": "runtime.native.system/4.3.0",
+      "hashPath": "runtime.native.system.4.3.0.nupkg.sha512"
+    },
+    "runtime.native.System.IO.Compression/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-INBPonS5QPEgn7naufQFXJEp3zX6L4bwHgJ/ZH78aBTpeNfQMtf7C6VrAFhlq2xxWBveIOWyFzQjJ8XzHMhdOQ==",
+      "path": "runtime.native.system.io.compression/4.3.0",
+      "hashPath": "runtime.native.system.io.compression.4.3.0.nupkg.sha512"
+    },
+    "runtime.native.System.Net.Http/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ZVuZJqnnegJhd2k/PtAbbIcZ3aZeITq3sj06oKfMBSfphW3HDmk/t4ObvbOk/JA/swGR0LNqMksAh/f7gpTROg==",
+      "path": "runtime.native.system.net.http/4.3.0",
+      "hashPath": "runtime.native.system.net.http.4.3.0.nupkg.sha512"
+    },
+    "runtime.native.System.Net.Security/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-M2nN92ePS8BgQ2oi6Jj3PlTUzadYSIWLdZrHY1n1ZcW9o4wAQQ6W+aQ2lfq1ysZQfVCgDwY58alUdowrzezztg==",
+      "path": "runtime.native.system.net.security/4.3.0",
+      "hashPath": "runtime.native.system.net.security.4.3.0.nupkg.sha512"
+    },
+    "runtime.native.System.Security.Cryptography.Apple/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-DloMk88juo0OuOWr56QG7MNchmafTLYWvABy36izkrLI5VledI0rq28KGs1i9wbpeT9NPQrx/wTf8U2vazqQ3Q==",
+      "path": "runtime.native.system.security.cryptography.apple/4.3.0",
+      "hashPath": "runtime.native.system.security.cryptography.apple.4.3.0.nupkg.sha512"
+    },
+    "runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-NS1U+700m4KFRHR5o4vo9DSlTmlCKu/u7dtE5sUHVIPB+xpXxYQvgBgA6wEIeCz6Yfn0Z52/72WYsToCEPJnrw==",
+      "path": "runtime.native.system.security.cryptography.openssl/4.3.0",
+      "hashPath": "runtime.native.system.security.cryptography.openssl.4.3.0.nupkg.sha512"
+    },
+    "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-b3pthNgxxFcD+Pc0WSEoC0+md3MyhRS6aCEeenvNE3Fdw1HyJ18ZhRFVJJzIeR/O/jpxPboB805Ho0T3Ul7w8A==",
+      "path": "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl/4.3.0",
+      "hashPath": "runtime.opensuse.13.2-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg.sha512"
+    },
+    "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-KeLz4HClKf+nFS7p/6Fi/CqyLXh81FpiGzcmuS8DGi9lUqSnZ6Es23/gv2O+1XVGfrbNmviF7CckBpavkBoIFQ==",
+      "path": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl/4.3.0",
+      "hashPath": "runtime.opensuse.42.1-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg.sha512"
+    },
+    "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-kVXCuMTrTlxq4XOOMAysuNwsXWpYeboGddNGpIgNSZmv1b6r/s/DPk0fYMB7Q5Qo4bY68o48jt4T4y5BVecbCQ==",
+      "path": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple/4.3.0",
+      "hashPath": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.apple.4.3.0.nupkg.sha512"
+    },
+    "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-X7IdhILzr4ROXd8mI1BUCQMSHSQwelUlBjF1JyTKCjXaOGn2fB4EKBxQbCK2VjO3WaWIdlXZL3W6TiIVnrhX4g==",
+      "path": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl/4.3.0",
+      "hashPath": "runtime.osx.10.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg.sha512"
+    },
+    "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-nyFNiCk/r+VOiIqreLix8yN+q3Wga9+SE8BCgkf+2BwEKiNx6DyvFjCgkfV743/grxv8jHJ8gUK4XEQw7yzRYg==",
+      "path": "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl/4.3.0",
+      "hashPath": "runtime.rhel.7-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg.sha512"
+    },
+    "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ytoewC6wGorL7KoCAvRfsgoJPJbNq+64k2SqW6JcOAebWsFUvCCYgfzQMrnpvPiEl4OrblUlhF2ji+Q1+SVLrQ==",
+      "path": "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl/4.3.0",
+      "hashPath": "runtime.ubuntu.14.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg.sha512"
+    },
+    "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-I8bKw2I8k58Wx7fMKQJn2R8lamboCAiHfHeV/pS65ScKWMMI0+wJkLYlEKvgW1D/XvSl/221clBoR2q9QNNM7A==",
+      "path": "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl/4.3.0",
+      "hashPath": "runtime.ubuntu.16.04-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg.sha512"
+    },
+    "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-VB5cn/7OzUfzdnC8tqAIMQciVLiq2epm2NrAm1E9OjNRyG4lVhfR61SMcLizejzQP8R8Uf/0l5qOIbUEi+RdEg==",
+      "path": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl/4.3.0",
+      "hashPath": "runtime.ubuntu.16.10-x64.runtime.native.system.security.cryptography.openssl.4.3.0.nupkg.sha512"
+    },
+    "Serilog/2.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-JJMEqTUGe/bA4OEMefGd8W6si9oStSa3CF47dIHzkRKJHqFWFOW8D2aZTOW6VIgNLY2hzruQXhvp2tX0NVkgsw==",
+      "path": "serilog/2.3.0",
+      "hashPath": "serilog.2.3.0.nupkg.sha512"
+    },
+    "Serilog.Extensions.Logging/1.4.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-nsg2CFYIQsZcNXYajDBNL+Li0EnFibOSLaACcpy+XGyrbmIEhGdLYiMXxadUE10kFfLLLbruZtdbGJ7OOudXlA==",
+      "path": "serilog.extensions.logging/1.4.0",
+      "hashPath": "serilog.extensions.logging.1.4.0.nupkg.sha512"
+    },
+    "Serilog.Sinks.File/3.2.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-VHbo68pMg5hwSWrzLEdZv5b/rYmIgHIRhd4d5rl8GnC5/a8Fr+RShT5kWyeJOXax1el6mNJ+dmHDOVgnNUQxaw==",
+      "path": "serilog.sinks.file/3.2.0",
+      "hashPath": "serilog.sinks.file.3.2.0.nupkg.sha512"
+    },
+    "StackExchange.Redis.StrongName/1.2.6": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-UFmT1/JYu1PLiRwkyvEPVHk/tVTJa8Ka2rb9yzidzDoQARvhBVRpaWUeaP81373v54jupDBvAoGHGl0EY/HphQ==",
+      "path": "stackexchange.redis.strongname/1.2.6",
+      "hashPath": "stackexchange.redis.strongname.1.2.6.nupkg.sha512"
+    },
+    "System.AppContext/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-3QjO4jNV7PdKkmQAVp9atA+usVnKRwI3Kx1nMwJ93T0LcQfx7pKAYk0nKz5wn1oP5iqlhZuy6RXOFdhr7rDwow==",
+      "path": "system.appcontext/4.1.0",
+      "hashPath": "system.appcontext.4.1.0.nupkg.sha512"
+    },
+    "System.Buffers/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ExtSzvji3sYn2cOGTC1JZqDgbIxAdXBSqNlMYupnGImjMa+yprXSCHfjwvzvy6Y8PC31a/tXHT5Sffrx4qjMqA==",
+      "path": "system.buffers/4.6.0-preview1-26727-04",
+      "hashPath": "system.buffers.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Buffers.Experimental/0.1.0-preview2-180804-5": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-MuqdAfXWjBlluCd7g+rZ358iR7fckf4Pq3z45f3VLeY6YU1iCWkBUrchUb/vDcniJm+VoEXq8oUMoGIR6pX9dQ==",
+      "path": "system.buffers.experimental/0.1.0-preview2-180804-5",
+      "hashPath": "system.buffers.experimental.0.1.0-preview2-180804-5.nupkg.sha512"
+    },
+    "System.Buffers.Primitives/0.1.0-preview2-180804-5": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-/BAOKCeOLNV0kIAOBz7JTH3ObD6lbn6ORX/BVmfyPpaBSdiM5G58I8O8lsDKof5UQcqmsPm4P+hiPDoO+AkCnw==",
+      "path": "system.buffers.primitives/0.1.0-preview2-180804-5",
+      "hashPath": "system.buffers.primitives.0.1.0-preview2-180804-5.nupkg.sha512"
+    },
+    "System.Buffers.ReaderWriter/0.1.0-preview2-180804-5": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-nxrbRAsvXAQn4AjxcpzOOSR1vx7oldjNrbsMQ7z22gpy8vNJsWNYVayU4OWUon+vN3OYBjJrH2Ti9R2Q4abFRQ==",
+      "path": "system.buffers.readerwriter/0.1.0-preview2-180804-5",
+      "hashPath": "system.buffers.readerwriter.0.1.0-preview2-180804-5.nupkg.sha512"
+    },
+    "System.Collections/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-3Dcj85/TBdVpL5Zr+gEEBUuFe2icOnLalmEh9hfck1PTYbbyWuZgh4fmm2ysCLTrqLQw6t3TgTyJ+VLp+Qb+Lw==",
+      "path": "system.collections/4.3.0",
+      "hashPath": "system.collections.4.3.0.nupkg.sha512"
+    },
+    "System.Collections.Concurrent/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ztl69Xp0Y/UXCL+3v3tEU+lIy+bvjKNUmopn1wep/a291pVPK7dxBd6T7WnlQqRog+d1a/hSsgRsmFnIBKTPLQ==",
+      "path": "system.collections.concurrent/4.3.0",
+      "hashPath": "system.collections.concurrent.4.3.0.nupkg.sha512"
+    },
+    "System.Collections.Immutable/1.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-3iwaJ36QhFrtV9OUyyTMJaydklBi6u8eJZHCDXNv9Qj1cH/h7dz2l3KjfDS2M5HRqlkoP8PkclCypSbFcVoBJw==",
+      "path": "system.collections.immutable/1.6.0-preview1-26727-04",
+      "hashPath": "system.collections.immutable.1.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Collections.NonGeneric/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-prtjIEMhGUnQq6RnPEYLpFt8AtLbp9yq2zxOSrY7KJJZrw25Fi97IzBqY7iqssbM61Ek5b8f3MG/sG1N2sN5KA==",
+      "path": "system.collections.nongeneric/4.3.0",
+      "hashPath": "system.collections.nongeneric.4.3.0.nupkg.sha512"
+    },
+    "System.Collections.Sequences/0.1.0-preview2-180804-5": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-fBylD+CAX4UnW3a4DzppPl9kKUVNsUX7lWXVtXWHDtHuNgaGs61ye89Zxcsvne0APcEIYsfGYxnV8/wk9I7ARQ==",
+      "path": "system.collections.sequences/0.1.0-preview2-180804-5",
+      "hashPath": "system.collections.sequences.0.1.0-preview2-180804-5.nupkg.sha512"
+    },
+    "System.Collections.Specialized/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Epx8PoVZR0iuOnJJDzp7pWvdfMMOAvpUo95pC4ScH2mJuXkKA2Y4aR3cG9qt2klHgSons1WFh4kcGW7cSXvrxg==",
+      "path": "system.collections.specialized/4.3.0",
+      "hashPath": "system.collections.specialized.4.3.0.nupkg.sha512"
+    },
+    "System.ComponentModel/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-VyGn1jGRZVfxnh8EdvDCi71v3bMXrsu8aYJOwoV7SNDLVhiEqwP86pPMyRGsDsxhXAm2b3o9OIqeETfN5qfezw==",
+      "path": "system.componentmodel/4.3.0",
+      "hashPath": "system.componentmodel.4.3.0.nupkg.sha512"
+    },
+    "System.ComponentModel.EventBasedAsync/4.0.11": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Z7SO6vvQIR84daPE4uhaNdef9CjgjDMGYkas8epUhf0U3WGuaGgZ0Mm4QuNycMdbHUY8KEdZrtgxonkAiJaAlA==",
+      "path": "system.componentmodel.eventbasedasync/4.0.11",
+      "hashPath": "system.componentmodel.eventbasedasync.4.0.11.nupkg.sha512"
+    },
+    "System.ComponentModel.Primitives/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-j8GUkCpM8V4d4vhLIIoBLGey2Z5bCkMVNjEZseyAlm4n5arcsJOeI3zkUP+zvZgzsbLTYh4lYeP/ZD/gdIAPrw==",
+      "path": "system.componentmodel.primitives/4.3.0",
+      "hashPath": "system.componentmodel.primitives.4.3.0.nupkg.sha512"
+    },
+    "System.ComponentModel.TypeConverter/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-16pQ6P+EdhcXzPiEK4kbA953Fu0MNG2ovxTZU81/qsCd1zPRsKc3uif5NgvllCY598k6bI0KUyKW8fanlfaDQg==",
+      "path": "system.componentmodel.typeconverter/4.3.0",
+      "hashPath": "system.componentmodel.typeconverter.4.3.0.nupkg.sha512"
+    },
+    "System.Diagnostics.Contracts/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-eelRRbnm+OloiQvp9CXS0ixjNQldjjkHO4iIkR5XH2VIP8sUB/SIpa1TdUW6/+HDcQ+MlhP3pNa1u5SbzYuWGA==",
+      "path": "system.diagnostics.contracts/4.3.0",
+      "hashPath": "system.diagnostics.contracts.4.3.0.nupkg.sha512"
+    },
+    "System.Diagnostics.Debug/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ZUhUOdqmaG5Jk3Xdb8xi5kIyQYAA4PnTNlHx1mu9ZY3qv4ELIdKbnL/akbGaKi2RnNUWaZsAs31rvzFdewTj2g==",
+      "path": "system.diagnostics.debug/4.3.0",
+      "hashPath": "system.diagnostics.debug.4.3.0.nupkg.sha512"
+    },
+    "System.Diagnostics.DiagnosticSource/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-RpdAYd40Nese5UEt4mSZtK4c0o0BhbCAt8TUGEcS5agtD3JxyoiI5e0IcmkD+eBgZVWSg0tuXLKEmpXzVnDMCg==",
+      "path": "system.diagnostics.diagnosticsource/4.6.0-preview1-26727-04",
+      "hashPath": "system.diagnostics.diagnosticsource.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Diagnostics.Process/4.1.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-mpVZ5bnlSs3tTeJ6jYyDJEIa6tavhAd88lxq1zbYhkkCu0Pno2+gHXcvZcoygq2d8JxW3gojXqNJMTAshduqZA==",
+      "path": "system.diagnostics.process/4.1.0",
+      "hashPath": "system.diagnostics.process.4.1.0.nupkg.sha512"
+    },
+    "System.Diagnostics.TextWriterTraceListener/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-w36Dr8yKy8xP150qPANe7Td+/zOI3G62ImRcHDIEW+oUXUuTKZHd4DHmqRx5+x8RXd85v3tXd1uhNTfsr+yxjA==",
+      "path": "system.diagnostics.textwritertracelistener/4.0.0",
+      "hashPath": "system.diagnostics.textwritertracelistener.4.0.0.nupkg.sha512"
+    },
+    "System.Diagnostics.Tools/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-UUvkJfSYJMM6x527dJg2VyWPSRqIVB0Z7dbjHst1zmwTXz5CcXSYJFWRpuigfbO1Lf7yfZiIaEUesfnl/g5EyA==",
+      "path": "system.diagnostics.tools/4.3.0",
+      "hashPath": "system.diagnostics.tools.4.3.0.nupkg.sha512"
+    },
+    "System.Diagnostics.TraceSource/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-VnYp1NxGx8Ww731y2LJ1vpfb/DKVNKEZ8Jsh5SgQTZREL/YpWRArgh9pI8CDLmgHspZmLL697CaLvH85qQpRiw==",
+      "path": "system.diagnostics.tracesource/4.3.0",
+      "hashPath": "system.diagnostics.tracesource.4.3.0.nupkg.sha512"
+    },
+    "System.Diagnostics.Tracing/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-rswfv0f/Cqkh78rA5S8eN8Neocz234+emGCtTF3lxPY96F+mmmUen6tbn0glN6PMvlKQb9bPAY5e9u7fgPTkKw==",
+      "path": "system.diagnostics.tracing/4.3.0",
+      "hashPath": "system.diagnostics.tracing.4.3.0.nupkg.sha512"
+    },
+    "System.Dynamic.Runtime/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-SNVi1E/vfWUAs/WYKhE9+qlS6KqK0YVhnlT0HQtr8pMIA8YX3lwy3uPMownDwdYISBdmAF/2holEIldVp85Wag==",
+      "path": "system.dynamic.runtime/4.3.0",
+      "hashPath": "system.dynamic.runtime.4.3.0.nupkg.sha512"
+    },
+    "System.Globalization/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-kYdVd2f2PAdFGblzFswE4hkNANJBKRmsfa2X5LG2AcWE1c7/4t0pYae1L8vfZ5xvE2nK/R9JprtToA61OSHWIg==",
+      "path": "system.globalization/4.3.0",
+      "hashPath": "system.globalization.4.3.0.nupkg.sha512"
+    },
+    "System.Globalization.Calendars/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-GUlBtdOWT4LTV3I+9/PJW+56AnnChTaOqqTLFtdmype/L500M2LIyXgmtd9X2P2VOkmJd5c67H5SaC2QcL1bFA==",
+      "path": "system.globalization.calendars/4.3.0",
+      "hashPath": "system.globalization.calendars.4.3.0.nupkg.sha512"
+    },
+    "System.Globalization.Extensions/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-FhKmdR6MPG+pxow6wGtNAWdZh7noIOpdD5TwQ3CprzgIE1bBBoim0vbR1+AWsWjQmU7zXHgQo4TWSP6lCeiWcQ==",
+      "path": "system.globalization.extensions/4.3.0",
+      "hashPath": "system.globalization.extensions.4.3.0.nupkg.sha512"
+    },
+    "System.IdentityModel.Tokens.Jwt/5.2.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-E8tNMfMWPvlSF5fvmMIVZZHlGuIZzE5uktuR+GN2gFdngh0k6xoZquxfjKC02d0NqfsshNQVTCdSKXD5e9/lpA==",
+      "path": "system.identitymodel.tokens.jwt/5.2.0",
+      "hashPath": "system.identitymodel.tokens.jwt.5.2.0.nupkg.sha512"
+    },
+    "System.IO/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-3qjaHvxQPDpSOYICjUoTsmoq5u6QJAFRUITgeT/4gqkF1bajbSmb1kwSxEA8AHlofqgcKJcM8udgieRNhaJ5Cg==",
+      "path": "system.io/4.3.0",
+      "hashPath": "system.io.4.3.0.nupkg.sha512"
+    },
+    "System.IO.Compression/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-YHndyoiV90iu4iKG115ibkhrG+S3jBm8Ap9OwoUAzO5oPDAWcr0SFwQFm0HjM8WkEZWo0zvLTyLmbvTkW1bXgg==",
+      "path": "system.io.compression/4.3.0",
+      "hashPath": "system.io.compression.4.3.0.nupkg.sha512"
+    },
+    "System.IO.FileSystem/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-3wEMARTnuio+ulnvi+hkRNROYwa1kylvYahhcLk4HSoVdl+xxTFVeVlYOfLwrDPImGls0mDqbMhrza8qnWPTdA==",
+      "path": "system.io.filesystem/4.3.0",
+      "hashPath": "system.io.filesystem.4.3.0.nupkg.sha512"
+    },
+    "System.IO.FileSystem.Primitives/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-6QOb2XFLch7bEc4lIcJH49nJN2HV+OC3fHDgsLVsBVBk3Y4hFAnOBGzJ2lUu7CyDDFo9IBWkSsnbkT6IBwwiMw==",
+      "path": "system.io.filesystem.primitives/4.3.0",
+      "hashPath": "system.io.filesystem.primitives.4.3.0.nupkg.sha512"
+    },
+    "System.IO.Pipelines/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-g3VZ1n9csHJ0LrSZCcAbGb4pLhBMbqH5jXc4MYjKkExxt10SLxFe+MF7fE242Aj81qtmaImew8iuk4+TfCyzHw==",
+      "path": "system.io.pipelines/4.6.0-preview1-26727-04",
+      "hashPath": "system.io.pipelines.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Linq/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-5DbqIUpsDp0dFftytzuMmc0oeMdQwjcP/EWxsksIz/w1TcFRkZ3yKKz0PqiYFMmEwPSWw+qNVqD7PJ889JzHbw==",
+      "path": "system.linq/4.3.0",
+      "hashPath": "system.linq.4.3.0.nupkg.sha512"
+    },
+    "System.Linq.Expressions/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-PGKkrd2khG4CnlyJwxwwaWWiSiWFNBGlgXvJpeO0xCXrZ89ODrQ6tjEWS/kOqZ8GwEOUATtKtzp1eRgmYNfclg==",
+      "path": "system.linq.expressions/4.3.0",
+      "hashPath": "system.linq.expressions.4.3.0.nupkg.sha512"
+    },
+    "System.Linq.Queryable/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-In1Bmmvl/j52yPu3xgakQSI0YIckPUr870w4K5+Lak3JCCa8hl+my65lABOuKfYs4ugmZy25ScFerC4nz8+b6g==",
+      "path": "system.linq.queryable/4.3.0",
+      "hashPath": "system.linq.queryable.4.3.0.nupkg.sha512"
+    },
+    "System.Memory/4.6.0-preview1-26717-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Mox7RUbvXcCjVeAwnAq6zQKrj/BTJzVkJ6JZvGPjcnhwIPqKc1hES3Q9NtWsiFgVF+mfwaXDbE1gY466gvUMWQ==",
+      "path": "system.memory/4.6.0-preview1-26717-04",
+      "hashPath": "system.memory.4.6.0-preview1-26717-04.nupkg.sha512"
+    },
+    "System.Net.Http/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-sYg+FtILtRQuYWSIAuNOELwVuVsxVyJGWQyOnlAzhV4xvhyFnON1bAzYYC+jjRW8JREM45R0R5Dgi8MTC5sEwA==",
+      "path": "system.net.http/4.3.0",
+      "hashPath": "system.net.http.4.3.0.nupkg.sha512"
+    },
+    "System.Net.NameResolution/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-AFYl08R7MrsrEjqpQWTZWBadqXyTzNDaWpMqyxhb0d6sGhV6xMDKueuBXlLL30gz+DIRY6MpdgnHWlCh5wmq9w==",
+      "path": "system.net.nameresolution/4.3.0",
+      "hashPath": "system.net.nameresolution.4.3.0.nupkg.sha512"
+    },
+    "System.Net.Primitives/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-qOu+hDwFwoZPbzPvwut2qATe3ygjeQBDQj91xlsaqGFQUI5i4ZnZb8yyQuLGpDGivEPIt8EJkd1BVzVoP31FXA==",
+      "path": "system.net.primitives/4.3.0",
+      "hashPath": "system.net.primitives.4.3.0.nupkg.sha512"
+    },
+    "System.Net.Security/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-IgJKNfALqw7JRWp5LMQ5SWHNKvXVz094U6wNE3c1i8bOkMQvgBL+MMQuNt3xl9Qg9iWpj3lFxPZEY6XHmROjMQ==",
+      "path": "system.net.security/4.3.0",
+      "hashPath": "system.net.security.4.3.0.nupkg.sha512"
+    },
+    "System.Net.Sockets/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-m6icV6TqQOAdgt5N/9I5KNpjom/5NFtkmGseEH+AK/hny8XrytLH3+b5M8zL/Ycg3fhIocFpUMyl/wpFnVRvdw==",
+      "path": "system.net.sockets/4.3.0",
+      "hashPath": "system.net.sockets.4.3.0.nupkg.sha512"
+    },
+    "System.Net.WebSockets.WebSocketProtocol/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-rmHHAU5W81Ip6jMJSfhie7PWgZnxVedICthZFPQAVZgzdL2rUVFU7i3vRUbm1I7cURX0WTsBwjcTniV/vF4Ugw==",
+      "path": "system.net.websockets.websocketprotocol/4.6.0-preview1-26727-04",
+      "hashPath": "system.net.websockets.websocketprotocol.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Numerics.Vectors/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-P0FHGUrXoduN417GNIMC9fEjxiqUYK8uXxx56hcYFsJzefpA5VYRWMqT09ePQJGMlLN4l7WFWUZcJ2xD7WoSBA==",
+      "path": "system.numerics.vectors/4.6.0-preview1-26727-04",
+      "hashPath": "system.numerics.vectors.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.ObjectModel/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-bdX+80eKv9bN6K4N+d77OankKHGn6CH711a6fcOpMQu2Fckp/Ft4L/kW9WznHpyR0NRAvJutzOMHNNlBGvxQzQ==",
+      "path": "system.objectmodel/4.3.0",
+      "hashPath": "system.objectmodel.4.3.0.nupkg.sha512"
+    },
+    "System.Private.DataContractSerialization/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-FQ8EpQJ/nkhlWEZSJVQmDLNONiMufYRuLVL/X7YnsVUIFJuhWO6i1Yc5+s7j7ZUlJtuTvWs96aHr5TU/kFM31w==",
+      "path": "system.private.datacontractserialization/4.3.0",
+      "hashPath": "system.private.datacontractserialization.4.3.0.nupkg.sha512"
+    },
+    "System.Reactive.Core/3.1.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-CKWC+UP1aM75taNX+sTBn2P97uHIUjKxq+z45iy7P91QGFqNFleR2tsqIC76HMVvYl7o8oWyMiycdsc9rC1Z/g==",
+      "path": "system.reactive.core/3.1.1",
+      "hashPath": "system.reactive.core.3.1.1.nupkg.sha512"
+    },
+    "System.Reactive.Interfaces/3.1.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-aNVY3QoRznGFeQ+w+bMqhD8ElNWoyYq+7XTQIoxKKjBOyTOjUqIMEf1wvSdtwC4y92zg2W9q38b4Sr6cYNHVLg==",
+      "path": "system.reactive.interfaces/3.1.1",
+      "hashPath": "system.reactive.interfaces.3.1.1.nupkg.sha512"
+    },
+    "System.Reactive.Linq/3.1.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-HwsZsoYRg51cLGBOEa0uoZ5+d4CMcHEg/KrbqePhLxoz/SLA+ULISphBtn3woABPATOQ6j5YgGZWh4jxnJ3KYQ==",
+      "path": "system.reactive.linq/3.1.1",
+      "hashPath": "system.reactive.linq.3.1.1.nupkg.sha512"
+    },
+    "System.Reflection/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-KMiAFoW7MfJGa9nDFNcfu+FpEdiHpWgTcS2HdMpDvt9saK3y/G4GwprPyzqjFH9NTaGPQeWNHU+iDlDILj96aQ==",
+      "path": "system.reflection/4.3.0",
+      "hashPath": "system.reflection.4.3.0.nupkg.sha512"
+    },
+    "System.Reflection.Emit/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-228FG0jLcIwTVJyz8CLFKueVqQK36ANazUManGaJHkO0icjiIypKW7YLWLIWahyIkdh5M7mV2dJepllLyA1SKg==",
+      "path": "system.reflection.emit/4.3.0",
+      "hashPath": "system.reflection.emit.4.3.0.nupkg.sha512"
+    },
+    "System.Reflection.Emit.ILGeneration/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-59tBslAk9733NXLrUJrwNZEzbMAcu8k344OYo+wfSVygcgZ9lgBdGIzH/nrg3LYhXceynyvTc8t5/GD4Ri0/ng==",
+      "path": "system.reflection.emit.ilgeneration/4.3.0",
+      "hashPath": "system.reflection.emit.ilgeneration.4.3.0.nupkg.sha512"
+    },
+    "System.Reflection.Emit.Lightweight/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
+      "path": "system.reflection.emit.lightweight/4.3.0",
+      "hashPath": "system.reflection.emit.lightweight.4.3.0.nupkg.sha512"
+    },
+    "System.Reflection.Extensions/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-rJkrJD3kBI5B712aRu4DpSIiHRtr6QlfZSQsb0hYHrDCZORXCFjQfoipo2LaMUHoT9i1B7j7MnfaEKWDFmFQNQ==",
+      "path": "system.reflection.extensions/4.3.0",
+      "hashPath": "system.reflection.extensions.4.3.0.nupkg.sha512"
+    },
+    "System.Reflection.Metadata/1.7.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Eopfn4GUTnCTtAAqK3CrvSIuwna2BbUASNv9VmuqDEbA187yhOMu1TPUZUl56eXT1C8xWXjxgWDbYVZCK/k9/A==",
+      "path": "system.reflection.metadata/1.7.0-preview1-26727-04",
+      "hashPath": "system.reflection.metadata.1.7.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Reflection.Primitives/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-5RXItQz5As4xN2/YUDxdpsEkMhvw3e6aNveFXUn4Hl/udNTCNhnKp8lT9fnc3MhvGKh1baak5CovpuQUXHAlIA==",
+      "path": "system.reflection.primitives/4.3.0",
+      "hashPath": "system.reflection.primitives.4.3.0.nupkg.sha512"
+    },
+    "System.Reflection.TypeExtensions/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-7u6ulLcZbyxB5Gq0nMkQttcdBTx57ibzw+4IOXEfR+sXYQoHvjW5LTLyNr8O22UIMrqYbchJQJnos4eooYzYJA==",
+      "path": "system.reflection.typeextensions/4.3.0",
+      "hashPath": "system.reflection.typeextensions.4.3.0.nupkg.sha512"
+    },
+    "System.Resources.ResourceManager/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-/zrcPkkWdZmI4F92gL/TPumP98AVDu/Wxr3CSJGQQ+XN6wbRZcyfSKVoPo17ilb3iOr0cCRqJInGwNMolqhS8A==",
+      "path": "system.resources.resourcemanager/4.3.0",
+      "hashPath": "system.resources.resourcemanager.4.3.0.nupkg.sha512"
+    },
+    "System.Runtime/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-JufQi0vPQ0xGnAczR13AUFglDyVYt4Kqnz1AZaiKZ5+GICq0/1MH/mO/eAJHt/mHW1zjKBJd7kV26SrxddAhiw==",
+      "path": "system.runtime/4.3.0",
+      "hashPath": "system.runtime.4.3.0.nupkg.sha512"
+    },
+    "System.Runtime.CompilerServices.Unsafe/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-bUzrox43CZNrDCzQVOcucH2AAc2r58+Iitwxx5/LfCLhlg9fHuhKo/fBdZAOvg/vs+KaSlDlnoEh/pJnluGrpg==",
+      "path": "system.runtime.compilerservices.unsafe/4.6.0-preview1-26727-04",
+      "hashPath": "system.runtime.compilerservices.unsafe.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Runtime.Extensions/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-guW0uK0fn5fcJJ1tJVXYd7/1h5F+pea1r7FLSOz/f8vPEqbR2ZAknuRDvTQ8PzAilDveOxNjSfr0CHfIQfFk8g==",
+      "path": "system.runtime.extensions/4.3.0",
+      "hashPath": "system.runtime.extensions.4.3.0.nupkg.sha512"
+    },
+    "System.Runtime.Handles/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-OKiSUN7DmTWeYb3l51A7EYaeNMnvxwE249YtZz7yooT4gOZhmTjIn48KgSsw2k2lYdLgTKNJw/ZIfSElwDRVgg==",
+      "path": "system.runtime.handles/4.3.0",
+      "hashPath": "system.runtime.handles.4.3.0.nupkg.sha512"
+    },
+    "System.Runtime.InteropServices/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-uv1ynXqiMK8mp1GM3jDqPCFN66eJ5w5XNomaK2XD+TuCroNTLFGeZ+WCmBMcBDyTFKou3P6cR6J/QsaqDp7fGQ==",
+      "path": "system.runtime.interopservices/4.3.0",
+      "hashPath": "system.runtime.interopservices.4.3.0.nupkg.sha512"
+    },
+    "System.Runtime.InteropServices.RuntimeInformation/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-cbz4YJMqRDR7oLeMRbdYv7mYzc++17lNhScCX0goO2XpGWdvAt60CGN+FHdePUEHCe/Jy9jUlvNAiNdM+7jsOw==",
+      "path": "system.runtime.interopservices.runtimeinformation/4.3.0",
+      "hashPath": "system.runtime.interopservices.runtimeinformation.4.3.0.nupkg.sha512"
+    },
+    "System.Runtime.InteropServices.WindowsRuntime/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-oIIXM4w2y3MiEZEXA+RTtfPV+SZ1ymbFdWppHlUciNdNIL0/Uo3HW9q9iN2O7T7KUmRdvjA7C2Gv4exAyW4zEQ==",
+      "path": "system.runtime.interopservices.windowsruntime/4.0.1",
+      "hashPath": "system.runtime.interopservices.windowsruntime.4.0.1.nupkg.sha512"
+    },
+    "System.Runtime.Loader/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-4UN78GOVU/mbDFcXkEWtetJT/sJ0yic2gGk1HSlSpWI0TDf421xnrZTDZnwNBapk1GQeYN7U1lTj/aQB1by6ow==",
+      "path": "system.runtime.loader/4.0.0",
+      "hashPath": "system.runtime.loader.4.0.0.nupkg.sha512"
+    },
+    "System.Runtime.Numerics/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-yMH+MfdzHjy17l2KESnPiF2dwq7T+xLnSJar7slyimAkUh/gTrS9/UQOtv7xarskJ2/XDSNvfLGOBQPjL7PaHQ==",
+      "path": "system.runtime.numerics/4.3.0",
+      "hashPath": "system.runtime.numerics.4.3.0.nupkg.sha512"
+    },
+    "System.Runtime.Serialization.Json/4.0.2": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-+7DIJhnKYgCzUgcLbVTtRQb2l1M0FP549XFlFkQM5lmNiUBl44AfNbx4bz61xA8PzLtlYwfmif4JJJW7MPPnjg==",
+      "path": "system.runtime.serialization.json/4.0.2",
+      "hashPath": "system.runtime.serialization.json.4.0.2.nupkg.sha512"
+    },
+    "System.Runtime.Serialization.Primitives/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Wz+0KOukJGAlXjtKr+5Xpuxf8+c8739RI1C+A2BoQZT+wMCCoMDDdO8/4IRHfaVINqL78GO8dW8G2lW/e45Mcw==",
+      "path": "system.runtime.serialization.primitives/4.3.0",
+      "hashPath": "system.runtime.serialization.primitives.4.3.0.nupkg.sha512"
+    },
+    "System.Runtime.Serialization.Xml/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-TAmeIK/3CgzezE5Z1INAX2Vc5yMfSyyz+V/vyHEPf5p51liXoCmFgOJQUQxB6urmW7JllFWa/NX1Pd6THAb3FA==",
+      "path": "system.runtime.serialization.xml/4.3.0",
+      "hashPath": "system.runtime.serialization.xml.4.3.0.nupkg.sha512"
+    },
+    "System.Security.AccessControl/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-2d1+P1caMvcUyccsg1lHu9nNRuYskCFuoHbGQFsVB1l+V4IY1mG34XLNM5O3jWeokjWgFTFlMXxavjJ0eHZfDQ==",
+      "path": "system.security.accesscontrol/4.6.0-preview1-26727-04",
+      "hashPath": "system.security.accesscontrol.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Security.Claims/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-P/+BR/2lnc4PNDHt/TPBAWHVMLMRHsyYZbU1NphW4HIWzCggz8mJbTQQ3MKljFE7LS3WagmVFuBgoLcFzYXlkA==",
+      "path": "system.security.claims/4.3.0",
+      "hashPath": "system.security.claims.4.3.0.nupkg.sha512"
+    },
+    "System.Security.Cryptography.Algorithms/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-W1kd2Y8mYSCgc3ULTAZ0hOP2dSdG5YauTb1089T0/kRcN2MpSAW1izOFROrJgxSlMn3ArsgHXagigyi+ibhevg==",
+      "path": "system.security.cryptography.algorithms/4.3.0",
+      "hashPath": "system.security.cryptography.algorithms.4.3.0.nupkg.sha512"
+    },
+    "System.Security.Cryptography.Cng/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-PhVwFAVBRV47RxGDMYJAoykbSNzmKVNhJ0k4AIAJHHAzCL6IGZGsEZHuoHTtZMSXRFm6jUUeNhwruqC4fF1V/Q==",
+      "path": "system.security.cryptography.cng/4.6.0-preview1-26727-04",
+      "hashPath": "system.security.cryptography.cng.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Security.Cryptography.Csp/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-X4s/FCkEUnRGnwR3aSfVIkldBmtURMhmexALNTwpjklzxWU7yjMk7GHLKOZTNkgnWnE0q7+BCf9N2LVRWxewaA==",
+      "path": "system.security.cryptography.csp/4.3.0",
+      "hashPath": "system.security.cryptography.csp.4.3.0.nupkg.sha512"
+    },
+    "System.Security.Cryptography.Encoding/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-1DEWjZZly9ae9C79vFwqaO5kaOlI5q+3/55ohmq/7dpDyDfc8lYe7YVxJUZ5MF/NtbkRjwFRo14yM4OEo9EmDw==",
+      "path": "system.security.cryptography.encoding/4.3.0",
+      "hashPath": "system.security.cryptography.encoding.4.3.0.nupkg.sha512"
+    },
+    "System.Security.Cryptography.OpenSsl/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-h4CEgOgv5PKVF/HwaHzJRiVboL2THYCou97zpmhjghx5frc7fIvlkY1jL+lnIQyChrJDMNEXS6r7byGif8Cy4w==",
+      "path": "system.security.cryptography.openssl/4.3.0",
+      "hashPath": "system.security.cryptography.openssl.4.3.0.nupkg.sha512"
+    },
+    "System.Security.Cryptography.Pkcs/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-dy0k85M1u6XtIAqGt7MWNXKfxJGK5PFl9FfIhz7o90y2nZsjC0zhvyDTtjO7N2vdlegL7O/ATNsjvznD/jWGQw==",
+      "path": "system.security.cryptography.pkcs/4.6.0-preview1-26727-04",
+      "hashPath": "system.security.cryptography.pkcs.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Security.Cryptography.Primitives/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-7bDIyVFNL/xKeFHjhobUAQqSpJq9YTOpbEs6mR233Et01STBMXNAc/V+BM6dwYGc95gVh/Zf+iVXWzj3mE8DWg==",
+      "path": "system.security.cryptography.primitives/4.3.0",
+      "hashPath": "system.security.cryptography.primitives.4.3.0.nupkg.sha512"
+    },
+    "System.Security.Cryptography.X509Certificates/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-t2Tmu6Y2NtJ2um0RtcuhP7ZdNNxXEgUm2JeoA/0NvlMjAhKCnM1NX07TDl3244mVp3QU6LPEhT3HTtH1uF7IYw==",
+      "path": "system.security.cryptography.x509certificates/4.3.0",
+      "hashPath": "system.security.cryptography.x509certificates.4.3.0.nupkg.sha512"
+    },
+    "System.Security.Cryptography.Xml/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-oGksoaFoLzcX03X878FjpbFahr1KS8OQPoo/niM5usZuqRRN1gnqopMIvamH/A0lnpGRlmXjhl9tDxF3cO9HdQ==",
+      "path": "system.security.cryptography.xml/4.6.0-preview1-26727-04",
+      "hashPath": "system.security.cryptography.xml.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Security.Permissions/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-FdZZipFsi7iY2ck55GFbVxmpnbueukWcYIp4eWsKbqO/QPWsnq/L6+b4CZaoee7nnPcrXZPUJFa38WBTAy+UuQ==",
+      "path": "system.security.permissions/4.6.0-preview1-26727-04",
+      "hashPath": "system.security.permissions.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Security.Principal/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-I1tkfQlAoMM2URscUtpcRo/hX0jinXx6a/KUtEQoz3owaYwl3qwsO8cbzYVVnjxrzxjHo3nJC+62uolgeGIS9A==",
+      "path": "system.security.principal/4.3.0",
+      "hashPath": "system.security.principal.4.3.0.nupkg.sha512"
+    },
+    "System.Security.Principal.Windows/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-rHW1oIoIov5jLwIM14JTwSkXi1SxpUQr7Y2qKuIkcm+XmfTkHfWkLFERd2Yz/O+CE9hC8OkoK3uC2Xp2Hoj4Ng==",
+      "path": "system.security.principal.windows/4.6.0-preview1-26727-04",
+      "hashPath": "system.security.principal.windows.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Text.Encoding/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-BiIg+KWaSDOITze6jGQynxg64naAPtqGHBwDrLaCtixsa5bKiR8dpPOHA7ge3C0JJQizJE+sfkz1wV+BAKAYZw==",
+      "path": "system.text.encoding/4.3.0",
+      "hashPath": "system.text.encoding.4.3.0.nupkg.sha512"
+    },
+    "System.Text.Encoding.Extensions/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-YVMK0Bt/A43RmwizJoZ22ei2nmrhobgeiYwFzC4YAN+nue8RF6djXDMog0UCn+brerQoYVyaS+ghy9P/MUVcmw==",
+      "path": "system.text.encoding.extensions/4.3.0",
+      "hashPath": "system.text.encoding.extensions.4.3.0.nupkg.sha512"
+    },
+    "System.Text.Encodings.Web/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-yaiPUc6UX1z4o7AxSrMole7RxEGxfmRtg4Pcti8Sf2DoE0T+LcGPsF/A0gMlFiERfNdaRNTDPBpjX1aMd66/Dg==",
+      "path": "system.text.encodings.web/4.6.0-preview1-26727-04",
+      "hashPath": "system.text.encodings.web.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Text.Formatting/0.1.0-preview2-180804-5": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-A2+RKdMpFlT+G6xvwmDOIg6dGgVrNHwalOuftZLhorJjPp+Xc3bYglby4zPXu2Esoka2FMUrIp4RBOwZwa4y3A==",
+      "path": "system.text.formatting/0.1.0-preview2-180804-5",
+      "hashPath": "system.text.formatting.0.1.0-preview2-180804-5.nupkg.sha512"
+    },
+    "System.Text.JsonLab/0.1.0-preview2-180804-5": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-4WlTMKOK4hQZ0LAaUXmMx2PHw4YoEhTUcNnCD/tczokS80zpY3fcExt3lYjvpOaB1YGHBGTCUq0EZbMkAr2Cew==",
+      "path": "system.text.jsonlab/0.1.0-preview2-180804-5",
+      "hashPath": "system.text.jsonlab.0.1.0-preview2-180804-5.nupkg.sha512"
+    },
+    "System.Text.Primitives/0.1.0-preview2-180804-5": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-X32NLQVH3/4LziOhZsl9J5QVSt2SGeX149uQwWlVG57hQ+jWNudhVnV2pHglfvHWDfhMkc/r7Jzdpx6/+vBsMg==",
+      "path": "system.text.primitives/0.1.0-preview2-180804-5",
+      "hashPath": "system.text.primitives.0.1.0-preview2-180804-5.nupkg.sha512"
+    },
+    "System.Text.RegularExpressions/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-RpT2DA+L660cBt1FssIE9CAGpLFdFPuheB7pLpKpn6ZXNby7jDERe8Ua/Ne2xGiwLVG2JOqziiaVCGDon5sKFA==",
+      "path": "system.text.regularexpressions/4.3.0",
+      "hashPath": "system.text.regularexpressions.4.3.0.nupkg.sha512"
+    },
+    "System.Text.Utf8String/0.1.0-preview2-180804-5": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-gU/9YUgLLa+Be1ECPR67IwBJ+QSEG4UbrHn+7QIn9IfW0gDdWCM5k4yb5zUpZDd+Zy4H9BGdXbvxe/3xrxEtjQ==",
+      "path": "system.text.utf8string/0.1.0-preview2-180804-5",
+      "hashPath": "system.text.utf8string.0.1.0-preview2-180804-5.nupkg.sha512"
+    },
+    "System.Threading/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-VkUS0kOBcUf3Wwm0TSbrevDDZ6BlM+b/HRiapRFWjM5O0NS0LviG0glKmFK+hhPDd1XFeSdU1GmlLhb2CoVpIw==",
+      "path": "system.threading/4.3.0",
+      "hashPath": "system.threading.4.3.0.nupkg.sha512"
+    },
+    "System.Threading.Channels/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-AWgrKm6IxZSgmdl9PySQjrPwfbXJoLvCdSvRbzQ8Kv9IMkYgmn7zzLRMrG6t165gnQiPjWsL7wIV7nwU7fS1Dw==",
+      "path": "system.threading.channels/4.6.0-preview1-26727-04",
+      "hashPath": "system.threading.channels.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Threading.Tasks/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-LbSxKEdOUhVe8BezB/9uOGGppt+nZf6e1VFyw6v3DN6lqitm0OSn2uXMOdtP0M3W4iMcqcivm2J6UgqiwwnXiA==",
+      "path": "system.threading.tasks/4.3.0",
+      "hashPath": "system.threading.tasks.4.3.0.nupkg.sha512"
+    },
+    "System.Threading.Tasks.Extensions/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-ysuGD8pbzE9I3d6G0x7V8G/UTti8wthpFAvUCp6BwUlqn7DdLvzTot4n0vw3LRhxYkUXLYdTOVO4YTKdzUWB0A==",
+      "path": "system.threading.tasks.extensions/4.6.0-preview1-26727-04",
+      "hashPath": "system.threading.tasks.extensions.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Threading.Thread/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-OHmbT+Zz065NKII/ZHcH9XO1dEuLGI1L2k7uYss+9C1jLxTC9kTZZuzUOyXHayRk+dft9CiDf3I/QZ0t8JKyBQ==",
+      "path": "system.threading.thread/4.3.0",
+      "hashPath": "system.threading.thread.4.3.0.nupkg.sha512"
+    },
+    "System.Threading.ThreadPool/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-k/+g4b7vjdd4aix83sTgC9VG6oXYKAktSfNIJUNGxPEj7ryEOfzHHhfnmsZvjxawwcD9HyWXKCXmPjX8U4zeSw==",
+      "path": "system.threading.threadpool/4.3.0",
+      "hashPath": "system.threading.threadpool.4.3.0.nupkg.sha512"
+    },
+    "System.Threading.Timer/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Z6YfyYTCg7lOZjJzBjONJTFKGN9/NIYKSxhU5GRd+DTwHSZyvWp1xuI5aR+dLg+ayyC5Xv57KiY4oJ0tMO89fQ==",
+      "path": "system.threading.timer/4.3.0",
+      "hashPath": "system.threading.timer.4.3.0.nupkg.sha512"
+    },
+    "System.ValueTuple/4.6.0-preview1-26727-04": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-OkJ+oxE/fLsKoJ4TUB5kqRfxlQrKxltNMFvZeGb/0jIeC0I+jtcYiWLCzflsQwzp5SmjMikqxwiobf1E01iaOA==",
+      "path": "system.valuetuple/4.6.0-preview1-26727-04",
+      "hashPath": "system.valuetuple.4.6.0-preview1-26727-04.nupkg.sha512"
+    },
+    "System.Xml.ReaderWriter/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-GrprA+Z0RUXaR4N7/eW71j1rgMnEnEVlgii49GZyAjTH7uliMnrOU3HNFBr6fEDBCJCIdlVNq9hHbaDR621XBA==",
+      "path": "system.xml.readerwriter/4.3.0",
+      "hashPath": "system.xml.readerwriter.4.3.0.nupkg.sha512"
+    },
+    "System.Xml.XDocument/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-5zJ0XDxAIg8iy+t4aMnQAu0MqVbqyvfoUVl1yDV61xdo3Vth45oA2FoY4pPkxYAH5f8ixpmTqXeEIya95x0aCQ==",
+      "path": "system.xml.xdocument/4.3.0",
+      "hashPath": "system.xml.xdocument.4.3.0.nupkg.sha512"
+    },
+    "System.Xml.XmlDocument/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-lJ8AxvkX7GQxpC6GFCeBj8ThYVyQczx2+f/cWHJU8tjS7YfI6Cv6bon70jVEgs2CiFbmmM8b9j1oZVx0dSI2Ww==",
+      "path": "system.xml.xmldocument/4.3.0",
+      "hashPath": "system.xml.xmldocument.4.3.0.nupkg.sha512"
+    },
+    "System.Xml.XmlSerializer/4.3.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-MYoTCP7EZ98RrANESW05J5ZwskKDoN0AuZ06ZflnowE50LTpbR5yRg3tHckTVm5j/m47stuGgCrCHWePyHS70Q==",
+      "path": "system.xml.xmlserializer/4.3.0",
+      "hashPath": "system.xml.xmlserializer.4.3.0.nupkg.sha512"
+    },
+    "System.Xml.XPath/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-UWd1H+1IJ9Wlq5nognZ/XJdyj8qPE4XufBUkAW59ijsCPjZkZe0MUzKKJFBr+ZWBe5Wq1u1d5f2CYgE93uH7DA==",
+      "path": "system.xml.xpath/4.0.1",
+      "hashPath": "system.xml.xpath.4.0.1.nupkg.sha512"
+    },
+    "System.Xml.XPath.XmlDocument/4.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-Zm2BdeanuncYs3NhCj4c9e1x3EXFzFBVv2wPEc/Dj4ZbI9R8ecLSR5frAsx4zJCPBtKQreQ7Q/KxJEohJZbfzA==",
+      "path": "system.xml.xpath.xmldocument/4.0.1",
+      "hashPath": "system.xml.xpath.xmldocument.4.0.1.nupkg.sha512"
+    },
+    "xunit/2.3.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-IWux0xXfZ/bC7SgooK5rmW5KwCwFg9GFslmPxA7+pJsT+2SRyhOfOgNUXDd7B09UN4f6kogRT2TqNi6gbWEspA==",
+      "path": "xunit/2.3.1",
+      "hashPath": "xunit.2.3.1.nupkg.sha512"
+    },
+    "xunit.abstractions/2.0.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-bDm/zdG5rnRDsobKuKwrvL4HccBdC0uvT12be6fG12P3d1U7u9Wkvfoq/PM2GeyIeb0Dtcmm/7k2oaawiqQ2Dg==",
+      "path": "xunit.abstractions/2.0.1",
+      "hashPath": "xunit.abstractions.2.0.1.nupkg.sha512"
+    },
+    "xunit.analyzers/0.7.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-pEjPJ/pd+r9blGBJ9bXg961phkAiCl4k2DwxwWGEZyYC/7Tb1xJ1az0H18uGANX7zFIkvE5ZO1eZZ4vU7gny7w==",
+      "path": "xunit.analyzers/0.7.0",
+      "hashPath": "xunit.analyzers.0.7.0.nupkg.sha512"
+    },
+    "xunit.assert/2.3.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-+mUMp3aJOS0ag3qJ2tUhVa930KhwjyypxXT4Ab8lQozEQN8/xgkblQnYs0woIWpr2NbzEOxsZojytl9NBVRKxg==",
+      "path": "xunit.assert/2.3.1",
+      "hashPath": "xunit.assert.2.3.1.nupkg.sha512"
+    },
+    "xunit.core/2.3.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-LOG4qOFuVQcjYcIuZbKeo03Uvng3lSb2gZJU9ANljwCf+PTd//iAMZS5qcJQZrjhndc4aOUlJGQy5wa0+/iZ6w==",
+      "path": "xunit.core/2.3.1",
+      "hashPath": "xunit.core.2.3.1.nupkg.sha512"
+    },
+    "xunit.extensibility.core/2.3.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-1mgYqXeQfU+7zcSRW8/5Uf1jVZ5+5WELmi+BuRTh0xu/x0Q0gK0SuR3FLUF4BSd8sfZzvrRUrhWj3ltpyFxhrg==",
+      "path": "xunit.extensibility.core/2.3.1",
+      "hashPath": "xunit.extensibility.core.2.3.1.nupkg.sha512"
+    },
+    "xunit.extensibility.execution/2.3.1": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-i8xrHfKC5dyBWQ7I15FePzm0m8KNToBsTleCCQbOQuXRPZIvupd4nnfaCPeJuKHHe7yJ8JGtWxjIgw0ow/cMhg==",
+      "path": "xunit.extensibility.execution/2.3.1",
+      "hashPath": "xunit.extensibility.execution.2.3.1.nupkg.sha512"
+    },
+    "xunit.runner.visualstudio/2.4.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "sha512-spS399J48cRVHJL4BRPT3FXBlINlJ6hh9f/8VfgkPRVjsqTU+CuDxvqsFzdj6++k+HxfFJP0ZPnbnLVNeH8zhQ==",
+      "path": "xunit.runner.visualstudio/2.4.0",
+      "hashPath": "xunit.runner.visualstudio.2.4.0.nupkg.sha512"
+    },
+    "Microsoft.AspNetCore.Http.Connections/3.0.0-alpha1-t000": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "Microsoft.AspNetCore.Http.Connections.Client/3.0.0-alpha1-t000": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "Microsoft.AspNetCore.Http.Connections.Common/3.0.0-alpha1-t000": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "Microsoft.AspNetCore.SignalR/3.0.0-alpha1-t000": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "Microsoft.AspNetCore.SignalR.Client/3.0.0-alpha1-t000": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "Microsoft.AspNetCore.SignalR.Client.Core/3.0.0-alpha1-t000": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "Microsoft.AspNetCore.SignalR.Common/3.0.0-alpha1-t000": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "Microsoft.AspNetCore.SignalR.Core/3.0.0-alpha1-t000": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "Microsoft.AspNetCore.SignalR.Protocols.Json/3.0.0-alpha1-t000": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "Microsoft.AspNetCore.SignalR.Protocols.MessagePack/3.0.0-alpha1-t000": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    },
+    "Microsoft.AspNetCore.SignalR.Tests.Utils/3.0.0-alpha1-t000": {
+      "type": "project",
+      "serviceable": false,
+      "sha512": ""
+    }
+  }
+}</value>
   </data>
 </root>


### PR DESCRIPTION
- Use ThrowHelper
- Fix use of var
- Add JsonTestHelper
- Add JsonObject TryGetChild and Remove APIs

``` ini

BenchmarkDotNet=v0.10.14.683-nightly, OS=Windows 10.0.17713
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-20180720-2
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  Job-JGLELY : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT

IterationCount=5  WarmupCount=3  

```
|                  Method |        TestCase |            Mean |           Error |        StdDev | Scaled | ScaledSD |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|------------------------ |---------------- |----------------:|----------------:|--------------:|-------:|---------:|---------:|---------:|---------:|----------:|
|         **ParseNewtonsoft** |       **BasicJson** |      **5,648.6 ns** |       **977.86 ns** |     **254.00 ns** |   **1.00** |     **0.00** |   **1.5564** |        **-** |        **-** |    **6536 B** |
|    ParseNewtonsoftUtf16 |       BasicJson |      5,187.2 ns |       180.93 ns |      46.99 ns |   0.92 |     0.04 |   1.5640 |        - |        - |    6568 B |
| ReaderSystemTextJsonLab |       BasicJson |      3,684.8 ns |        74.47 ns |      19.34 ns |   0.65 |     0.03 |   0.0038 |        - |        - |      24 B |
|                         |                 |                 |                 |               |        |          |          |          |          |           |
|         **ParseNewtonsoft** |   **BasicLargeNum** |      **6,418.3 ns** |       **424.03 ns** |     **110.14 ns** |   **1.00** |     **0.00** |   **1.7319** |        **-** |        **-** |    **7272 B** |
|    ParseNewtonsoftUtf16 |   BasicLargeNum |      6,614.6 ns |     1,394.21 ns |     362.14 ns |   1.03 |     0.05 |   1.7395 |        - |        - |    7304 B |
| ReaderSystemTextJsonLab |   BasicLargeNum |      2,317.7 ns |       171.33 ns |      44.50 ns |   0.36 |     0.01 |   0.0038 |        - |        - |      24 B |
|                         |                 |                 |                 |               |        |          |          |          |          |           |
|         **ParseNewtonsoft** |       **BroadTree** |     **81,450.9 ns** |     **5,306.21 ns** |   **1,378.27 ns** |   **1.00** |     **0.00** |  **17.0898** |   **0.1221** |        **-** |   **71960 B** |
|    ParseNewtonsoftUtf16 |       BroadTree |     81,380.5 ns |     9,543.23 ns |   2,478.82 ns |   1.00 |     0.03 |  17.0898 |   0.1221 |        - |   71992 B |
| ReaderSystemTextJsonLab |       BroadTree |     80,873.3 ns |     2,748.24 ns |     713.85 ns |   0.99 |     0.02 |        - |        - |        - |      24 B |
|                         |                 |                 |                 |               |        |          |          |          |          |           |
|         **ParseNewtonsoft** |        **DeepTree** |     **46,065.2 ns** |     **3,505.92 ns** |     **910.65 ns** |   **1.00** |     **0.00** |   **8.9111** |        **-** |        **-** |   **37536 B** |
|    ParseNewtonsoftUtf16 |        DeepTree |     45,659.6 ns |     7,928.30 ns |   2,059.35 ns |   0.99 |     0.04 |   8.9111 |        - |        - |   37568 B |
| ReaderSystemTextJsonLab |        DeepTree |     61,119.8 ns |     1,655.52 ns |     430.01 ns |   1.33 |     0.03 |        - |        - |        - |      24 B |
|                         |                 |                 |                 |               |        |          |          |          |          |           |
|         **ParseNewtonsoft** |     **FullSchema1** |     **19,101.8 ns** |     **3,024.46 ns** |     **785.59 ns** |   **1.00** |     **0.00** |   **3.9978** |        **-** |        **-** |   **16816 B** |
|    ParseNewtonsoftUtf16 |     FullSchema1 |     17,450.8 ns |       631.82 ns |     164.11 ns |   0.91 |     0.03 |   3.9978 |        - |        - |   16848 B |
| ReaderSystemTextJsonLab |     FullSchema1 |      6,695.4 ns |       478.87 ns |     124.38 ns |   0.35 |     0.01 |        - |        - |        - |      24 B |
|                         |                 |                 |                 |               |        |          |          |          |          |           |
|         **ParseNewtonsoft** |     **FullSchema2** |     **24,758.2 ns** |     **2,459.28 ns** |     **638.79 ns** |   **1.00** |     **0.00** |   **4.9744** |        **-** |        **-** |   **20952 B** |
|    ParseNewtonsoftUtf16 |     FullSchema2 |     26,410.7 ns |     4,068.53 ns |   1,056.79 ns |   1.07 |     0.05 |   4.9744 |        - |        - |   20984 B |
| ReaderSystemTextJsonLab |     FullSchema2 |     10,529.0 ns |     1,651.02 ns |     428.85 ns |   0.43 |     0.02 |        - |        - |        - |      24 B |
|                         |                 |                 |                 |               |        |          |          |          |          |           |
|         **ParseNewtonsoft** |      **HelloWorld** |        **983.8 ns** |       **167.49 ns** |      **43.50 ns** |   **1.00** |     **0.00** |   **0.7362** |        **-** |        **-** |    **3096 B** |
|    ParseNewtonsoftUtf16 |      HelloWorld |        926.4 ns |       214.65 ns |      55.75 ns |   0.94 |     0.06 |   0.7439 |        - |        - |    3128 B |
| ReaderSystemTextJsonLab |      HelloWorld |        457.2 ns |        42.90 ns |      11.14 ns |   0.47 |     0.02 |   0.0052 |        - |        - |      24 B |
|                         |                 |                 |                 |               |        |          |          |          |          |           |
|         **ParseNewtonsoft** |        **Json400B** |      **8,638.7 ns** |     **1,287.46 ns** |     **334.41 ns** |   **1.00** |     **0.00** |   **1.9684** |        **-** |        **-** |    **8304 B** |
|    ParseNewtonsoftUtf16 |        Json400B |      9,002.4 ns |     2,415.30 ns |     627.36 ns |   1.04 |     0.07 |   1.9836 |        - |        - |    8336 B |
| ReaderSystemTextJsonLab |        Json400B |      4,402.8 ns |       559.52 ns |     145.33 ns |   0.51 |     0.02 |        - |        - |        - |      24 B |
|                         |                 |                 |                 |               |        |          |          |          |          |           |
|         **ParseNewtonsoft** |       **Json400KB** | **10,065,638.1 ns** |   **687,598.56 ns** | **178,601.17 ns** |   **1.00** |     **0.00** | **750.0000** | **375.0000** |        **-** | **4721808 B** |
|    ParseNewtonsoftUtf16 |       Json400KB |  9,762,566.3 ns | 1,704,063.59 ns | 442,624.18 ns |   0.97 |     0.04 | 750.0000 | 375.0000 |        - | 4721840 B |
| ReaderSystemTextJsonLab |       Json400KB |  5,533,148.7 ns |   241,622.68 ns |  62,760.59 ns |   0.55 |     0.01 | 328.1250 | 328.1250 | 328.1250 | 1711944 B |
|                         |                 |                 |                 |               |        |          |          |          |          |           |
|         **ParseNewtonsoft** |        **Json40KB** |    **665,240.4 ns** |    **65,487.13 ns** |  **17,010.04 ns** |   **1.00** |     **0.00** |  **85.9375** |  **35.1563** |        **-** |  **482368 B** |
|    ParseNewtonsoftUtf16 |        Json40KB |    674,611.5 ns |    49,729.94 ns |  12,917.17 ns |   1.01 |     0.03 |  87.8906 |  36.1328 |        - |  482400 B |
| ReaderSystemTextJsonLab |        Json40KB |    454,512.1 ns |    83,537.52 ns |  21,698.56 ns |   0.68 |     0.03 |        - |        - |        - |      24 B |
|                         |                 |                 |                 |               |        |          |          |          |          |           |
|         **ParseNewtonsoft** |         **Json4KB** |     **65,033.6 ns** |    **11,822.73 ns** |   **3,070.91 ns** |   **1.00** |     **0.00** |  **11.8408** |        **-** |        **-** |   **49744 B** |
|    ParseNewtonsoftUtf16 |         Json4KB |     63,758.1 ns |     3,913.43 ns |   1,016.50 ns |   0.98 |     0.04 |  11.8408 |        - |        - |   49776 B |
| ReaderSystemTextJsonLab |         Json4KB |     43,706.7 ns |     9,388.00 ns |   2,438.50 ns |   0.67 |     0.04 |        - |        - |        - |      24 B |
|                         |                 |                 |                 |               |        |          |          |          |          |           |
|         **ParseNewtonsoft** |   **LotsOfNumbers** |     **24,908.5 ns** |     **7,735.46 ns** |   **2,009.26 ns** |   **1.00** |     **0.00** |   **4.9438** |        **-** |        **-** |   **20760 B** |
|    ParseNewtonsoftUtf16 |   LotsOfNumbers |     26,720.1 ns |     5,088.57 ns |   1,321.74 ns |   1.08 |     0.09 |   4.9438 |        - |        - |   20792 B |
| ReaderSystemTextJsonLab |   LotsOfNumbers |     12,557.7 ns |     1,328.99 ns |     345.20 ns |   0.51 |     0.04 |        - |        - |        - |      24 B |
|                         |                 |                 |                 |               |        |          |          |          |          |           |
|         **ParseNewtonsoft** |   **LotsOfStrings** |     **12,019.8 ns** |       **903.95 ns** |     **234.80 ns** |   **1.00** |     **0.00** |   **2.5787** |        **-** |        **-** |   **10832 B** |
|    ParseNewtonsoftUtf16 |   LotsOfStrings |     13,427.3 ns |     6,097.10 ns |   1,583.70 ns |   1.12 |     0.12 |   2.5787 |        - |        - |   10864 B |
| ReaderSystemTextJsonLab |   LotsOfStrings |     11,340.3 ns |       933.54 ns |     242.48 ns |   0.94 |     0.02 |        - |        - |        - |      24 B |
|                         |                 |                 |                 |               |        |          |          |          |          |           |
|         **ParseNewtonsoft** | **ProjectLockJson** |  **3,324,947.0 ns** |   **442,119.98 ns** | **114,839.02 ns** |   **1.00** |     **0.00** | **312.5000** | **156.2500** |        **-** | **1874584 B** |
|    ParseNewtonsoftUtf16 | ProjectLockJson |  3,186,968.8 ns |   462,143.23 ns | 120,039.99 ns |   0.96 |     0.04 | 312.5000 | 156.2500 |        - | 1874616 B |
| ReaderSystemTextJsonLab | ProjectLockJson |  1,890,295.9 ns |   183,876.16 ns |  47,761.15 ns |   0.57 |     0.02 |        - |        - |        - |      24 B |
|                         |                 |                 |                 |               |        |          |          |          |          |           |
|         **ParseNewtonsoft** |  **SpecialNumForm** |     **13,446.7 ns** |       **394.42 ns** |     **102.45 ns** |   **1.00** |     **0.00** |   **2.3346** |        **-** |        **-** |    **9856 B** |
|    ParseNewtonsoftUtf16 |  SpecialNumForm |     14,391.0 ns |     5,567.54 ns |   1,446.15 ns |   1.07 |     0.10 |   2.3499 |        - |        - |    9888 B |
| ReaderSystemTextJsonLab |  SpecialNumForm |      3,540.3 ns |       195.17 ns |      50.69 ns |   0.26 |     0.00 |   0.0038 |        - |        - |      24 B |
