### PR TITLE
Revert use of SkipPastAny in SkipWhiteSpace and optimize BufferReader.IsNext

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
@@ -101,7 +101,15 @@ namespace System.Text.JsonLab
 
         private void SkipWhiteSpace()
         {
-            _reader.SkipPastAny(JsonConstants.WhiteSpace);
+            while (true)
+            {
+                _reader.TryPeek(out byte val);
+                if (val != JsonConstants.Space && val != JsonConstants.CarriageReturn && val != JsonConstants.LineFeed && val != JsonConstants.Tab)
+                {
+                    break;
+                }
+                _reader.Advance(1);
+            }
         }
 
         private bool ReadMultiSegment()


### PR DESCRIPTION
- Split IsNext fast and slow paths.
- The general purpose SkipPastAny is too slow (mainly due to IndexOf) for the special case of JsonReader. We almost always only have to skip a single character, and that ends up being the space character (0x20). The loop based approach works best here (since the first check is almost always true the first time).

**Performance of the JsonReader is now back to baseline.**

**Performance of SkipWhiteSpace**

1) Use SkipPastAny: 15-50% regression

|               Method | NumberOfWhiteSpace |      Mean |     Error |    StdDev | Scaled | ScaledSD | Allocated |
|--------------------- |------------------- |----------:|----------:|----------:|-------:|---------:|----------:|
| **SkipWhiteSpaceBefore** |                  **0** |  **75.80 ns** | **0.3412 ns** | **0.2849 ns** |   **1.00** |     **0.00** |       **0 B** |
|  SkipWhiteSpaceAfter |                  0 |  80.29 ns | 1.5686 ns | 1.4673 ns |   1.06 |     0.02 |       0 B |
|                      |                    |           |           |           |        |          |           |
| **SkipWhiteSpaceBefore** |                  **1** |  **77.73 ns** | **1.4580 ns** | **1.2925 ns** |   **1.00** |     **0.00** |       **0 B** |
|  SkipWhiteSpaceAfter |                  1 |  90.09 ns | 1.7627 ns | 2.1648 ns |   1.16 |     0.03 |       0 B |
|                      |                    |           |           |           |        |          |           |
| **SkipWhiteSpaceBefore** |                  **2** |  **82.71 ns** | **1.6236 ns** | **2.1674 ns** |   **1.00** |     **0.00** |       **0 B** |
|  SkipWhiteSpaceAfter |                  2 |  88.13 ns | 0.8642 ns | 0.8084 ns |   1.07 |     0.03 |       0 B |
|                      |                    |           |           |           |        |          |           |
| **SkipWhiteSpaceBefore** |                  **3** |  **82.12 ns** | **0.8639 ns** | **0.8081 ns** |   **1.00** |     **0.00** |       **0 B** |
|  SkipWhiteSpaceAfter |                  3 | 100.95 ns | 2.0316 ns | 2.3396 ns |   1.23 |     0.03 |       0 B |
|                      |                    |           |           |           |        |          |           |
| **SkipWhiteSpaceBefore** |                 **10** |  **95.59 ns** | **0.8048 ns** | **0.6284 ns** |   **1.00** |     **0.00** |       **0 B** |
|  SkipWhiteSpaceAfter |                 10 | 129.27 ns | 2.5398 ns | 3.4765 ns |   1.35 |     0.04 |       0 B |

2) Use custom, but use IndexOf within the loop: 30-100% regression

|               Method | NumberOfWhiteSpace |      Mean |     Error |     StdDev | Scaled | ScaledSD | Allocated |
|--------------------- |------------------- |----------:|----------:|-----------:|-------:|---------:|----------:|
| **SkipWhiteSpaceBefore** |                  **0** |  **79.76 ns** | **1.1925 ns** |  **1.1154 ns** |   **1.00** |     **0.00** |       **0 B** |
|  SkipWhiteSpaceAfter |                  0 |  80.41 ns | 1.6014 ns |  1.5728 ns |   1.01 |     0.02 |       0 B |
|                      |                    |           |           |            |        |          |           |
| **SkipWhiteSpaceBefore** |                  **1** |  **86.52 ns** | **1.7222 ns** |  **2.1150 ns** |   **1.00** |     **0.00** |       **0 B** |
|  SkipWhiteSpaceAfter |                  1 |  96.12 ns | 0.5369 ns |  0.4760 ns |   1.11 |     0.03 |       0 B |
|                      |                    |           |           |            |        |          |           |
| **SkipWhiteSpaceBefore** |                  **2** |  **92.79 ns** | **0.8253 ns** |  **0.6891 ns** |   **1.00** |     **0.00** |       **0 B** |
|  SkipWhiteSpaceAfter |                  2 |  88.32 ns | 1.7861 ns |  1.8342 ns |   0.95 |     0.02 |       0 B |
|                      |                    |           |           |            |        |          |           |
| **SkipWhiteSpaceBefore** |                  **3** |  **99.33 ns** | **2.7458 ns** |  **2.5684 ns** |   **1.00** |     **0.00** |       **0 B** |
|  SkipWhiteSpaceAfter |                  3 |  95.02 ns | 1.6061 ns |  1.5023 ns |   0.96 |     0.03 |       0 B |
|                      |                    |           |           |            |        |          |           |
| **SkipWhiteSpaceBefore** |                 **10** | **167.47 ns** | **3.6445 ns** | **10.3390 ns** |   **1.00** |     **0.00** |       **0 B** |
|  SkipWhiteSpaceAfter |                 10 | 138.30 ns | 2.7863 ns |  5.1645 ns |   0.83 |     0.06 |       0 B |

**Performance of IsNext**

**Before: (20% regression)**

|               Method | NumberOfWhiteSpace |      Mean |    Error |   StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
|--------------------- |------------------- |----------:|---------:|---------:|-------:|---------:|-------:|----------:|
| ConsumeFalseBefore |                  1 |  95.94 ns | 1.866 ns | 1.654 ns |   1.00 |     0.00 | 0.0094 |      40 B |
|  ConsumeFalseAfter |                  1 | 106.88 ns | 2.325 ns | 4.480 ns |   1.11 |     0.05 | 0.0094 |      40 B |

**After (back to baseline):**

|               Method | NumberOfWhiteSpace |     Mean |    Error |   StdDev |   Median | Scaled | ScaledSD |  Gen 0 | Allocated |
|--------------------- |------------------- |---------:|---------:|---------:|---------:|-------:|---------:|-------:|----------:|
| ConsumeFalseBefore |                  1 | 95.80 ns | 2.012 ns | 4.199 ns | 94.06 ns |   1.00 |     0.00 | 0.0094 |      40 B |
|  ConsumeFalseAfter |                  1 | 94.94 ns | 1.393 ns | 1.303 ns | 95.31 ns |   0.99 |     0.04 | 0.0094 |      40 B |

**JsonReader results from recent BufferReader changes (making it generic): https://github.com/dotnet/corefxlab/pull/2432**

**BEFORE: (baseline)**
                                            Method |   TestCase |            Mean |          Error |         StdDev |  Gen 0 | Allocated |
-------------------------------------------------- |----------- |----------------:|---------------:|---------------:|-------:|----------:|
              ReaderSystemTextJsonLabSpanEmptyLoop |  BasicJson |       578.13 ns |      7.4506 ns |      6.9693 ns |      - |       0 B |
 ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |  BasicJson |     1,079.27 ns |      4.3535 ns |      3.8593 ns | 0.0076 |      40 B |
              ReaderSystemTextJsonLabSpanEmptyLoop | HelloWorld |        70.70 ns |      0.6761 ns |      0.6324 ns |      - |       0 B |
 ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop | HelloWorld |       343.00 ns |      4.7307 ns |      4.4251 ns | 0.0091 |      40 B |
              ReaderSystemTextJsonLabSpanEmptyLoop |  Json400KB |   860,683.52 ns |  5,088.5071 ns |  4,759.7922 ns |      - |       0 B |
 ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |  Json400KB | 1,136,564.22 ns | 12,356.6923 ns | 11,558.4566 ns |      - |       0 B |


**ONLY change BufferReader to generic (don't use new APIs): (no regression)**
                                            Method |   TestCase |            Mean |         Error |        StdDev |  Gen 0 | Allocated |
-------------------------------------------------- |----------- |----------------:|--------------:|--------------:|-------:|----------:|
              ReaderSystemTextJsonLabSpanEmptyLoop |  BasicJson |       570.60 ns |      3.915 ns |      3.662 ns |      - |       0 B |
 ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |  BasicJson |     1,063.36 ns |      7.001 ns |      6.207 ns | 0.0076 |      40 B |
              ReaderSystemTextJsonLabSpanEmptyLoop | HelloWorld |        72.83 ns |      1.260 ns |      1.179 ns |      - |       0 B |
 ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop | HelloWorld |       339.86 ns |      1.661 ns |      1.387 ns | 0.0091 |      40 B |
              ReaderSystemTextJsonLabSpanEmptyLoop |  Json400KB |   851,212.17 ns |  8,762.192 ns |  7,316.826 ns |      - |       0 B |
 ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |  Json400KB | 1,150,907.72 ns | 13,001.690 ns | 11,525.658 ns |      - |       0 B |

**MASTER: (significant regression, roughly 10-50%)**
                                            Method |   TestCase |            Mean |         Error |        StdDev |  Gen 0 | Allocated |
-------------------------------------------------- |----------- |----------------:|--------------:|--------------:|-------:|----------:|
              ReaderSystemTextJsonLabSpanEmptyLoop |  BasicJson |       592.41 ns |     10.156 ns |     14.237 ns |      - |       0 B |
 ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |  BasicJson |     1,574.72 ns |     31.223 ns |     29.206 ns | 0.0076 |      40 B |
              ReaderSystemTextJsonLabSpanEmptyLoop | HelloWorld |        75.51 ns |      1.506 ns |      1.905 ns |      - |       0 B |
 ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop | HelloWorld |       377.45 ns |      7.145 ns |      6.334 ns | 0.0091 |      40 B |
              ReaderSystemTextJsonLabSpanEmptyLoop |  Json400KB |   894,063.95 ns | 17,770.550 ns | 37,870.491 ns |      - |       0 B |
 ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |  Json400KB | 1,750,685.84 ns | 34,103.193 ns | 51,044.054 ns |      - |       0 B |


**This PR: (back to baseline)**
``` ini

BenchmarkDotNet=v0.10.14.683-nightly, OS=Windows 10.0.17713
Intel Core i7-6700 CPU 3.40GHz (Max: 1.60GHz) (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-20180720-2
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT


```
|                                            Method |   TestCase |            Mean |          Error |         StdDev |  Gen 0 | Allocated |
|-------------------------------------------------- |----------- |----------------:|---------------:|---------------:|-------:|----------:|
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |  **BasicJson** |       **573.12 ns** |     **14.9985 ns** |     **12.5244 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |  BasicJson |     1,115.69 ns |     26.0203 ns |     74.2374 ns | 0.0076 |      40 B |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** | **HelloWorld** |        **72.05 ns** |      **0.8316 ns** |      **0.6493 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop | HelloWorld |       335.61 ns |      6.9771 ns |      6.5264 ns | 0.0091 |      40 B |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |  **Json400KB** |   **857,269.46 ns** |  **2,701.4416 ns** |  **2,394.7573 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |  Json400KB | 1,127,767.34 ns | 12,737.6925 ns | 10,636.5491 ns |      - |       0 B |
