### PR TITLE
Ascii Casing Optimization

### DIFF
--- a/src/System.Text.Primitives/System/Text/Encoders/Ascii/Ascii_casing.cs
+++ b/src/System.Text.Primitives/System/Text/Encoders/Ascii/Ascii_casing.cs
@@ -27,50 +27,71 @@ namespace System.Buffers.Text
 
             public static OperationStatus ToLowerInPlace(Span<byte> ascii, out int bytesChanged)
             {
-                for (bytesChanged = 0; bytesChanged < ascii.Length; bytesChanged++)
+                int tempBytesChanged = 0;
+                for (tempBytesChanged = 0; tempBytesChanged < ascii.Length; tempBytesChanged++)
                 {
-                    byte next = ascii[bytesChanged];
+                    byte next = ascii[tempBytesChanged];
                     if (next > 127)
                     {
+                        bytesChanged = tempBytesChanged;
                         return OperationStatus.InvalidData;
                     }
-                    ascii[bytesChanged] = s_toLower[next];
+                    ascii[tempBytesChanged] = s_toLower[next];
                 }
+                bytesChanged = tempBytesChanged;
                 return OperationStatus.Done;
             }
 
             public static OperationStatus ToLower(ReadOnlySpan<byte> input, Span<byte> output, out int processedBytes)
             {
+                int tempProcessedBytes = 0;
                 int min = input.Length < output.Length ? input.Length : output.Length;
-                for (processedBytes = 0; processedBytes < min; processedBytes++)
+                for (tempProcessedBytes = 0; tempProcessedBytes < min; tempProcessedBytes++)
                 {
-                    byte next = input[processedBytes];
-                    if (next > 127) return OperationStatus.InvalidData;
-                    output[processedBytes] = s_toLower[next];
+                    byte next = input[tempProcessedBytes];
+                    if (next > 127)
+                    {
+                        processedBytes = tempProcessedBytes;
+                        return OperationStatus.InvalidData;
+                    }
+                    output[tempProcessedBytes] = s_toLower[next];
                 }
+                processedBytes = tempProcessedBytes;
                 return OperationStatus.Done;
             }
 
             public static OperationStatus ToUpperInPlace(Span<byte> ascii, out int bytesChanged)
             {
-                for (bytesChanged = 0; bytesChanged < ascii.Length; bytesChanged++)
+                int tempBytesChanged = 0;
+                for (tempBytesChanged = 0; tempBytesChanged < ascii.Length; tempBytesChanged++)
                 {
-                    byte next = ascii[bytesChanged];
-                    if (next > 127) return OperationStatus.InvalidData;
-                    ascii[bytesChanged] = s_toUpper[next];
+                    byte next = ascii[tempBytesChanged];
+                    if (next > 127)
+                    {
+                        bytesChanged = tempBytesChanged;
+                        return OperationStatus.InvalidData;
+                    }
+                    ascii[tempBytesChanged] = s_toUpper[next];
                 }
+                bytesChanged = tempBytesChanged;
                 return OperationStatus.Done;
             }
 
             public static OperationStatus ToUpper(ReadOnlySpan<byte> input, Span<byte> output, out int processedBytes)
             {
+                int tempProcessedBytes = 0;
                 int min = input.Length < output.Length ? input.Length : output.Length;
-                for (processedBytes = 0; processedBytes < min; processedBytes++)
+                for (tempProcessedBytes = 0; tempProcessedBytes < min; tempProcessedBytes++)
                 {
-                    byte next = input[processedBytes];
-                    if (next > 127) return OperationStatus.InvalidData;
-                    output[processedBytes] = s_toUpper[next];
+                    byte next = input[tempProcessedBytes];
+                    if (next > 127)
+                    {
+                        processedBytes = tempProcessedBytes;
+                        return OperationStatus.InvalidData;
+                    }
+                    output[tempProcessedBytes] = s_toUpper[next];
                 }
+                processedBytes = tempProcessedBytes;
                 return OperationStatus.Done;
             }
 

--- a/tests/Benchmarks/System.Text.Primitives/AsciiCasing.cs
+++ b/tests/Benchmarks/System.Text.Primitives/AsciiCasing.cs
@@ -1,34 +1,37 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
 using System.Buffers;
 
 namespace System.Text.Primitives.Benchmarks
 {
     public class AsciiCasing
     {
-        private byte[] bytes;
-        private byte[] output;
+        private byte[] _bytes;
+        private byte[] _output;
 
         [Params("/plaintext", "text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7")]
         public string Text;
 
-
         [GlobalSetup]
         public void Setup()
         {
-            bytes = Encoding.ASCII.GetBytes(Text);
-            output = new byte[bytes.Length];
+            _bytes = Encoding.ASCII.GetBytes(Text);
+            _output = new byte[_bytes.Length];
         }
 
         [Benchmark]
-        public OperationStatus AsciiToLowerInPlace() => Buffers.Text.Encodings.Ascii.ToLowerInPlace(bytes, out int bytesChanged);
+        public OperationStatus AsciiToLowerInPlace() => Buffers.Text.Encodings.Ascii.ToLowerInPlace(_bytes, out int bytesChanged);
 
         [Benchmark]
-        public OperationStatus AsciiToLower() => Buffers.Text.Encodings.Ascii.ToLower(bytes, output, out int bytesChanged);
+        public OperationStatus AsciiToLower() => Buffers.Text.Encodings.Ascii.ToLower(_bytes, _output, out int bytesChanged);
 
         [Benchmark]
-        public OperationStatus AsciiToUpperInPlace() => Buffers.Text.Encodings.Ascii.ToUpperInPlace(bytes, out int bytesChanged);
+        public OperationStatus AsciiToUpperInPlace() => Buffers.Text.Encodings.Ascii.ToUpperInPlace(_bytes, out int bytesChanged);
 
         [Benchmark]
-        public OperationStatus AsciiToUpper() => Buffers.Text.Encodings.Ascii.ToUpper(bytes, output, out int bytesChanged);
+        public OperationStatus AsciiToUpper() => Buffers.Text.Encodings.Ascii.ToUpper(_bytes, _output, out int bytesChanged);
     }
 }

--- a/tests/Benchmarks/System.Text.Primitives/AsciiCasing.cs
+++ b/tests/Benchmarks/System.Text.Primitives/AsciiCasing.cs
@@ -1,0 +1,34 @@
+﻿using BenchmarkDotNet.Attributes;
+using System.Buffers;
+
+namespace System.Text.Primitives.Benchmarks
+{
+    public class AsciiCasing
+    {
+        private byte[] bytes;
+        private byte[] output;
+
+        [Params("/plaintext", "text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7")]
+        public string Text;
+
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            bytes = Encoding.ASCII.GetBytes(Text);
+            output = new byte[bytes.Length];
+        }
+
+        [Benchmark]
+        public OperationStatus AsciiToLowerInPlace() => Buffers.Text.Encodings.Ascii.ToLowerInPlace(bytes, out int bytesChanged);
+
+        [Benchmark]
+        public OperationStatus AsciiToLower() => Buffers.Text.Encodings.Ascii.ToLower(bytes, output, out int bytesChanged);
+
+        [Benchmark]
+        public OperationStatus AsciiToUpperInPlace() => Buffers.Text.Encodings.Ascii.ToUpperInPlace(bytes, out int bytesChanged);
+
+        [Benchmark]
+        public OperationStatus AsciiToUpper() => Buffers.Text.Encodings.Ascii.ToUpper(bytes, output, out int bytesChanged);
+    }
+}


### PR DESCRIPTION
Below are results of the changes suggested in #1738. The first run has the change for Ascii.ToLowerInPlace() which is why you'll notice a discrepancy.
```
// * Summary *

BenchmarkDotNet=v0.10.14.683-nightly, OS=Windows 10.0.17134.191 (1803/April2018Update/Redstone4)
Intel Core i7-7820HQ CPU 2.90GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
Frequency=2835933 Hz, Resolution=352.6176 ns, Timer=TSC
.NET Core SDK=2.1.400
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT


              Method |                 Text |      Mean |     Error |    StdDev |
-------------------- |--------------------- |----------:|----------:|----------:|
 AsciiToLowerInPlace |           /plaintext |  21.76 ns | 0.3919 ns | 0.3474 ns |
        AsciiToLower |           /plaintext |  29.70 ns | 0.2521 ns | 0.2358 ns |
 AsciiToUpperInPlace |           /plaintext |  28.22 ns | 0.1585 ns | 0.1238 ns |
        AsciiToUpper |           /plaintext |  30.00 ns | 0.3067 ns | 0.2394 ns |
 AsciiToLowerInPlace | text/(...)q=0.7 [86] | 112.71 ns | 2.2612 ns | 2.7770 ns |
        AsciiToLower | text/(...)q=0.7 [86] | 179.32 ns | 3.0066 ns | 2.6653 ns |
 AsciiToUpperInPlace | text/(...)q=0.7 [86] | 184.81 ns | 3.7301 ns | 6.1287 ns |
        AsciiToUpper | text/(...)q=0.7 [86] | 184.16 ns | 3.8889 ns | 5.7002 ns |

// * Summary *

BenchmarkDotNet=v0.10.14.683-nightly, OS=Windows 10.0.17134.191 (1803/April2018Update/Redstone4)
Intel Core i7-7820HQ CPU 2.90GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
Frequency=2835933 Hz, Resolution=352.6176 ns, Timer=TSC
.NET Core SDK=2.1.400
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT


              Method |                 Text |      Mean |     Error |    StdDev |
-------------------- |--------------------- |----------:|----------:|----------:|
 AsciiToLowerInPlace |           /plaintext |  21.62 ns | 0.3449 ns | 0.3226 ns |
        AsciiToLower |           /plaintext |  20.93 ns | 0.2101 ns | 0.1965 ns |
 AsciiToUpperInPlace |           /plaintext |  21.48 ns | 0.3310 ns | 0.2934 ns |
        AsciiToUpper |           /plaintext |  21.28 ns | 0.2685 ns | 0.2380 ns |
 AsciiToLowerInPlace | text/(...)q=0.7 [86] | 110.34 ns | 1.8941 ns | 1.6790 ns |
        AsciiToLower | text/(...)q=0.7 [86] |  95.50 ns | 2.6976 ns | 2.5233 ns |
 AsciiToUpperInPlace | text/(...)q=0.7 [86] | 109.41 ns | 0.9965 ns | 0.8834 ns |
        AsciiToUpper | text/(...)q=0.7 [86] |  90.93 ns | 0.3209 ns | 0.3002 ns |

```