### PR TITLE
Remove TypeDelegator hack for netcoreapp2.2 build.

### DIFF
--- a/src/System.Reflection.TypeLoader/src/System/Reflection/TypeLoading/General/NetStandardBridge.cs
+++ b/src/System.Reflection.TypeLoader/src/System/Reflection/TypeLoading/General/NetStandardBridge.cs
@@ -54,10 +54,16 @@ namespace System.Reflection.TypeLoading
     // causes us to waste an extra pointer-sized field per Type instance. It is also fragile as TypeDelegator could break us in the future
     // by overriding more methods.
     //
-    internal abstract class LeveledTypeInfo : TypeDelegator
+    internal abstract class LeveledTypeInfo :
+#if netstandard
+        TypeDelegator
+#else
+        TypeInfo
+#endif
     {
         protected LeveledTypeInfo() : base() { }
 
+#if netstandard
         // This is an api that TypeDelegator overrides that it needn't have. Since RoType expects to fall through to System.Type's method, we have to reimplement
         // System.Type's behavior here to avoid getting TypeDelegator's method.
         //
@@ -65,7 +71,6 @@ namespace System.Reflection.TypeLoading
         // This could be policed by an analyzer that searches RoType's method bodies for non-virtual calls to apis declared on TypeDelegator.
         public override EventInfo[] GetEvents() => GetEvents(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public);
 
-#if netstandard
         public abstract bool IsGenericTypeParameter { get; }
         public abstract bool IsGenericMethodParameter { get; }
         public abstract bool IsSZArray { get; }

--- a/tests/System.Reflection.TypeLoader.Tests/System.Reflection.TypeLoader.Tests.csproj
+++ b/tests/System.Reflection.TypeLoader.Tests/System.Reflection.TypeLoader.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <AssemblyOriginatorKeyFile>../../tools/test_key.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/tests/System.Reflection.TypeLoader.Tests/src/Tests/CustomAttributes/DllImportTests.cs
+++ b/tests/System.Reflection.TypeLoader.Tests/src/Tests/CustomAttributes/DllImportTests.cs
@@ -244,13 +244,25 @@ namespace System.Reflection.Tests
             Assert.Equal(m1.ArraySubType, m2.ArraySubType);
             Assert.Equal(m1.IidParameterIndex, m2.IidParameterIndex);
             Assert.Equal(m1.MarshalCookie, m2.MarshalCookie);
-            Assert.Equal(m1.MarshalType, m2.MarshalType);
+            // The assembly identity of the serialized marshal type depends on which contracts the test assembly is built against.
+            Assert.Equal(m1.MarshalType.RemoveAssemblyQualification(), m2.MarshalType.RemoveAssemblyQualification());
             Assert.Equal(m1.MarshalTypeRef, m2.MarshalTypeRef);
             Assert.Equal(m1.SafeArraySubType, m2.SafeArraySubType);
             Assert.Equal(m1.SafeArrayUserDefinedSubType, m2.SafeArrayUserDefinedSubType);
             Assert.Equal(m1.SizeConst, m2.SizeConst);
             Assert.Equal(m1.SizeParamIndex, m2.SizeParamIndex);
             Assert.Equal(m1.Value, m2.Value);
+        }
+
+        private static string RemoveAssemblyQualification(this string s)
+        {
+            if (s == null)
+                return null;
+
+            int index = s.IndexOf(',');
+            if (index == -1)
+                return s;
+            return s.Substring(0, index);
         }
     }
 }


### PR DESCRIPTION
CoreFxLab is now consuming the netcoreapp contracts
that expose the TypeInfo constructor so remove the
"derive from TypeDelegator" hack for that version of
the build.

Also, fix a test that was broken on netstandard runs
(not currently built in corefxlab) in the last change.