### PR TITLE
Optimize JsonReader and JsonParser, and update design for cleaner lifetime semantics

### DIFF
--- a/samples/LowAllocationWebServer/Shared/SampleServer.cs
+++ b/samples/LowAllocationWebServer/Shared/SampleServer.cs
@@ -80,8 +80,7 @@ namespace LowAllocationWebServer
             int requestedCount;
 
             // TODO: this should not convert to span
-            var parser = new JsonParser(body.First.Span);
-            JsonObject dom = parser.Parse();
+            JsonObject dom = JsonObject.Parse(body.First.Span);
             try
             {
                 requestedCount = (int)dom["Count"];

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
@@ -274,12 +274,24 @@ namespace System.Buffers.Reader
         /// Skip consecutive instances of the given <paramref name="value"/>.
         /// </summary>
         /// <returns>True if any Ts were skipped.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool SkipPast(T value)
         {
             int start = Consumed;
-            while (!End && CurrentSpan[CurrentSpanIndex].Equals(value))
+            ReadOnlySpan<T> unread = UnreadSpan;
+            int i = 0;
+            for (; i < unread.Length; i++)
             {
-                Advance(1);
+                T val = unread[i];
+                if (!val.Equals(value))
+                {
+                    break;
+                }
+            }
+            Advance(i);
+            if (i == unread.Length)
+            {
+                SkipPastSlow(value);
             }
 
             return start != Consumed;
@@ -292,12 +304,162 @@ namespace System.Buffers.Reader
         public bool SkipPastAny(ReadOnlySpan<T> values)
         {
             int start = Consumed;
-            while (!End && values.IndexOf(CurrentSpan[CurrentSpanIndex]) != -1)
+            ReadOnlySpan<T> unread = UnreadSpan;
+            int i = 0;
+            for (; i < unread.Length; i++)
             {
-                Advance(1);
+                T val = unread[i];
+                if (values.IndexOf(val) == -1)
+                {
+                    break;
+                }
+            }
+            Advance(i);
+            if (i == unread.Length)
+            {
+                SkipPastAnySlow(values);
             }
 
             return start != Consumed;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool SkipPastAny(T value0, T value1, T value2, T value3)
+        {
+            int start = Consumed;
+            ReadOnlySpan<T> unread = UnreadSpan;
+            int i = 0;
+            for (; i < unread.Length; i++)
+            {
+                T val = unread[i];
+                if (!val.Equals(value0) && !val.Equals(value1) && !val.Equals(value2) && !val.Equals(value3))
+                {
+                    break;
+                }
+            }
+            Advance(i);
+            if (i == unread.Length)
+            {
+                SkipPastAnySlow(value0, value1, value2, value3);
+            }
+
+            return start != Consumed;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool SkipPastAny(T value0, T value1, T value2)
+        {
+            int start = Consumed;
+            ReadOnlySpan<T> unread = UnreadSpan;
+            int i = 0;
+            for (; i < unread.Length; i++)
+            {
+                T val = unread[i];
+                if (!val.Equals(value0) && !val.Equals(value1) && !val.Equals(value2))
+                {
+                    break;
+                }
+            }
+            Advance(i);
+            if (i == unread.Length)
+            {
+                SkipPastAnySlow(value0, value1, value2);
+            }
+
+            return start != Consumed;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool SkipPastAny(T value0, T value1)
+        {
+            int start = Consumed;
+            ReadOnlySpan<T> unread = UnreadSpan;
+            int i = 0;
+            for (; i < unread.Length; i++)
+            {
+                T val = unread[i];
+                if (!val.Equals(value0) && !val.Equals(value1))
+                {
+                    break;
+                }
+            }
+            Advance(i);
+            if (i == unread.Length)
+            {
+                SkipPastAnySlow(value0, value1);
+            }
+
+            return start != Consumed;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void SkipPastSlow(T value)
+        {
+            while (!End)
+            {
+                T val = CurrentSpan[CurrentSpanIndex];
+                if (!val.Equals(value))
+                {
+                    break;
+                }
+                Advance(1);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void SkipPastAnySlow(T value0, T value1)
+        {
+            while (!End)
+            {
+                T val = CurrentSpan[CurrentSpanIndex];
+                if (!val.Equals(value0) && !val.Equals(value1))
+                {
+                    break;
+                }
+                Advance(1);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void SkipPastAnySlow(T value0, T value1, T value2)
+        {
+            while (!End)
+            {
+                T val = CurrentSpan[CurrentSpanIndex];
+                if (!val.Equals(value0) && !val.Equals(value1) && !val.Equals(value2))
+                {
+                    break;
+                }
+                Advance(1);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void SkipPastAnySlow(T value0, T value1, T value2, T value3)
+        {
+            while (!End)
+            {
+                T val = CurrentSpan[CurrentSpanIndex];
+                if (!val.Equals(value0) && !val.Equals(value1) && !val.Equals(value2) && !val.Equals(value3))
+                {
+                    break;
+                }
+                Advance(1);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void SkipPastAnySlow(ReadOnlySpan<T> values)
+        {
+            while (!End)
+            {
+                T val = CurrentSpan[CurrentSpanIndex];
+                if (values.IndexOf(val) == -1)
+                {
+                    break;
+                }
+                Advance(1);
+            }
         }
 
         /// <summary>

--- a/src/System.Text.JsonLab.Dynamic/System/Text/Json/JsonLazyDynamicObject.cs
+++ b/src/System.Text.JsonLab.Dynamic/System/Text/Json/JsonLazyDynamicObject.cs
@@ -19,8 +19,7 @@ namespace System.Text.JsonLab
 
         public static JsonLazyDynamicObject Parse(ReadOnlySpan<byte> utf8Json)
         {
-            var parser = new JsonParser(utf8Json);
-            JsonObject dom = parser.Parse();
+            JsonObject dom = JsonObject.Parse(utf8Json);
             var result = new JsonLazyDynamicObject(dom);
             return result;
         }

--- a/src/System.Text.JsonLab/System/Text/Json/CustomDb.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/CustomDb.cs
@@ -1,0 +1,197 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Text.JsonLab
+{
+    internal ref struct CustomDb
+    {
+        public Span<byte> Span;
+        public int Index;
+        private byte[] _rentedBuffer;
+        ArrayPool<byte> _pool;
+        
+        public CustomDb(ArrayPool<byte> pool, int initialSize)
+        {
+            _pool = pool;
+            _rentedBuffer = _pool.Rent(initialSize);
+            Span = _rentedBuffer;
+            Index = 0;
+        }
+
+        public void Dispose()
+        {
+            if (_pool != null)
+                _pool.Return(_rentedBuffer);
+            Span = Span<byte>.Empty;
+            Index = 0;
+        }
+
+        public void Resize()
+        {
+            Span = Span.Slice(0, Index);
+        }
+
+        public Span<byte> Slice(int startIndex) => Span.Slice(startIndex);
+
+        public Span<byte> Slice(int startIndex, int length) => Span.Slice(startIndex, length);
+
+        public int Length => Span.Length;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(JsonValueType jsonType, int startLocation, int LengthOrNumberOfRows = DbRow.UnknownSize)
+        {
+            Debug.Assert(jsonType >= JsonValueType.Object && jsonType <= JsonValueType.Unknown);
+            Debug.Assert(startLocation >= 0);
+            Debug.Assert(LengthOrNumberOfRows >= DbRow.UnknownSize);
+
+            if (Index >= Span.Length - DbRow.Size)
+                Enlarge();
+            var dbRow = new DbRow(jsonType, startLocation, LengthOrNumberOfRows);
+            MemoryMarshal.Write(Span.Slice(Index), ref dbRow);
+            Index += DbRow.Size;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Enlarge()
+        {
+            int size = Span.Length * 2;
+            byte[] newArray = _pool.Rent(size);
+            Span<byte> newDbSpace = newArray;
+            Span.Slice(0, Index).CopyTo(newDbSpace);
+            Span = newDbSpace;
+            _pool.Return(_rentedBuffer);
+            _rentedBuffer = newArray;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetLength(int index, int length)
+        {
+            Debug.Assert(index >= 0 && index <= Span.Length - DbRow.Size);
+            Debug.Assert(length >= 0);
+            MemoryMarshal.Write(Span.Slice(index + 4), ref length);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        //TODO: Resolve little endian/big endian issue
+        public void SetNumberOfRows(int index, int numberOfRows)
+        {
+            Debug.Assert(index >= 0 && index <= Span.Length - DbRow.Size);
+            Debug.Assert(numberOfRows >= 1 && numberOfRows <= 0x0FFFFFFF);
+            byte previous = (byte)(Span[index + DbRow.Size - 1] >> 4);
+            int value = (previous << 28) | numberOfRows;
+            MemoryMarshal.Write(Span.Slice(index + DbRow.Size - 4), ref value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        //TODO: Resolve little endian/big endian issue
+        public void SetHasChildren(int index)
+        {
+            Debug.Assert(index >= 0 && index <= Span.Length - DbRow.Size);
+            index += DbRow.Size - 1;
+            byte previous = Span[index];
+            Span[index] = (byte)(1 << 7 | previous);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int FindIndexOfFirstUnsetSizeOrLength(JsonValueType lookupType)
+        {
+            Debug.Assert(lookupType == JsonValueType.Object || lookupType == JsonValueType.Array);
+            return BackwardPass(lookupType);
+        }
+
+        private int ForwardPass(JsonValueType lookupType)
+        {
+            for (int i = 0; i < Span.Length; i += DbRow.Size)
+            {
+                DbRow row = MemoryMarshal.Read<DbRow>(Span.Slice(i));
+                if (row.SizeOrLength == DbRow.UnknownSize && row.JsonType == lookupType)
+                {
+                    return i;
+                }
+                if (!row.IsSimpleValue)
+                {
+                    i += row.NumberOfRows * DbRow.Size;
+                }
+            }
+            // We should never reach here.
+            Debug.Assert(false);
+            return -1;
+        }
+
+        private int BackwardPass(JsonValueType lookupType)
+        {
+            // TODO: Investigate performance impact of adding "skip" logic similar to ForwardPass
+            for (int i = Index - DbRow.Size; i >= DbRow.Size; i -= DbRow.Size)
+            {
+                DbRow row = MemoryMarshal.Read<DbRow>(Span.Slice(i));
+                if (row.SizeOrLength == DbRow.UnknownSize && row.JsonType == lookupType)
+                {
+                    return i;
+                }
+            }
+            // We should never reach here.
+            Debug.Assert(false);
+            return -1;
+        }
+
+        public DbRow Get(int index = 0)
+        {
+            Debug.Assert(index >= 0 && index <= Span.Length - DbRow.Size);
+            return index == 0
+            ? MemoryMarshal.Read<DbRow>(Span)
+            : MemoryMarshal.Read<DbRow>(Span.Slice(index));
+        }
+
+        public int GetLocation(int index = 0)
+        {
+            Debug.Assert(index >= 0 && index <= Span.Length - DbRow.Size);
+            return index == 0
+            ? MemoryMarshal.Read<int>(Span)
+            : MemoryMarshal.Read<int>(Span.Slice(index));
+        }
+
+        public int GetSizeOrLength(int index)
+        {
+            Debug.Assert(index >= 0 && index <= Span.Length - DbRow.Size);
+            return MemoryMarshal.Read<int>(Span.Slice(index + 4));
+        }
+
+        public JsonValueType GetJsonType(int index = 0)
+        {
+            Debug.Assert(index >= 0 && index <= Span.Length - DbRow.Size);
+            int union = MemoryMarshal.Read<int>(Span.Slice(index + 8));
+            return (JsonValueType)((union & 0x70000000) >> 28);
+        }
+
+        public bool GetHasChildren(int index = 0)
+        {
+            Debug.Assert(index >= 0 && index <= Span.Length - DbRow.Size);
+            int union = MemoryMarshal.Read<int>(Span.Slice(index + 8));
+            return union < 0;
+        }
+
+        public int GetNumberOfRows(int index = 0)
+        {
+            Debug.Assert(index >= 0 && index <= Span.Length - DbRow.Size);
+            int union = MemoryMarshal.Read<int>(Span.Slice(index + 8));
+            return union & 0x0FFFFFFF;
+        }
+
+        public string PrintDatabase()
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.Append(nameof(DbRow.Location) + "\t" + nameof(DbRow.SizeOrLength) + "\t" + nameof(DbRow.JsonType) + "\t" + nameof(DbRow.HasChildren) + "\t" + nameof(DbRow.NumberOfRows) + "\r\n");
+            for (int i = 0; i < Span.Length; i += DbRow.Size)
+            {
+                DbRow record = MemoryMarshal.Read<DbRow>(Span.Slice(i));
+                sb.Append(record.Location + "\t" + record.SizeOrLength + "\t" + record.JsonType + "\t" + record.HasChildren + "\t" + record.NumberOfRows + "\r\n");
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/src/System.Text.JsonLab/System/Text/Json/CustomDb.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/CustomDb.cs
@@ -25,8 +25,9 @@ namespace System.Text.JsonLab
 
         public void Dispose()
         {
-            if (_pool != null)
-                _pool.Return(_rentedBuffer);
+            if (_pool == null)
+                JsonThrowHelper.ThrowInvalidOperationException("Only root object can (and should) be disposed.");
+            _pool.Return(_rentedBuffer);
             Span = Span<byte>.Empty;
             Index = 0;
         }
@@ -139,20 +140,20 @@ namespace System.Text.JsonLab
             return -1;
         }
 
-        public DbRow Get(int index = 0)
+        public DbRow Get() => MemoryMarshal.Read<DbRow>(Span);
+
+        public DbRow Get(int index)
         {
             Debug.Assert(index >= 0 && index <= Span.Length - DbRow.Size);
-            return index == 0
-            ? MemoryMarshal.Read<DbRow>(Span)
-            : MemoryMarshal.Read<DbRow>(Span.Slice(index));
+            return MemoryMarshal.Read<DbRow>(Span.Slice(index));
         }
 
-        public int GetLocation(int index = 0)
+        public int GetLocation() => MemoryMarshal.Read<int>(Span);
+
+        public int GetLocation(int index)
         {
             Debug.Assert(index >= 0 && index <= Span.Length - DbRow.Size);
-            return index == 0
-            ? MemoryMarshal.Read<int>(Span)
-            : MemoryMarshal.Read<int>(Span.Slice(index));
+            return MemoryMarshal.Read<int>(Span.Slice(index));
         }
 
         public int GetSizeOrLength(int index)

--- a/src/System.Text.JsonLab/System/Text/Json/CustomStack.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/CustomStack.cs
@@ -22,6 +22,9 @@ namespace System.Text.JsonLab
             if (_topOfStack >= StackRow.Size)
             {
                 MemoryMarshal.Write(_stackSpace.Slice(_topOfStack - StackRow.Size), ref row);
+                bool hasChildren = true;
+                if (_topOfStack < _stackSpace.Length)
+                    MemoryMarshal.Write(_stackSpace.Slice(_topOfStack + 5), ref hasChildren);
                 _topOfStack -= StackRow.Size;
                 return true;
             }

--- a/src/System.Text.JsonLab/System/Text/Json/DbRow.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/DbRow.cs
@@ -12,7 +12,7 @@ namespace System.Text.JsonLab
     [StructLayout(LayoutKind.Sequential)]
     internal struct DbRow
     {
-        public const int Size = 16;
+        public const int Size = 12;
 
         public int Location;                // index in JSON payload
         public int SizeOrLength;      // length of text in JSON payload (or number of elements if its a JSON array)
@@ -23,8 +23,6 @@ namespace System.Text.JsonLab
         // Since each row of the database is 12 bytes long, we can't exceed 2^31/12 = 178956971 total number of rows.
         // Hence, we only need 28 bits (maximum value of 268435455).
         private readonly int _union;
-
-        public int ArrayUniformLength;
 
         public bool HasChildren => _union < 0;  // True only if there are nested objects or arrays within the current JSON element
         public JsonValueType JsonType => (JsonValueType)((_union & 0x70000000) >> 28); // type of JSON construct (e.g. Object, Array, Number)
@@ -42,7 +40,6 @@ namespace System.Text.JsonLab
             Location = location;
             SizeOrLength = sizeOrLength;
             _union = numberOfRows | (int)jsonType << 28; // HasChildren is set to false by default
-            ArrayUniformLength = 1;
         }
 
         public bool IsSimpleValue => JsonType > JsonValueType.Array;

--- a/src/System.Text.JsonLab/System/Text/Json/DbRow.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/DbRow.cs
@@ -16,7 +16,7 @@ namespace System.Text.JsonLab
 
         public int Location;                // index in JSON payload
         public int SizeOrLength;      // length of text in JSON payload (or number of elements if its a JSON array)
-        
+
         // The highest order bit indicates if the JSON element has children
         // The next 3 bits indicate the json type (there are 2^3 = 8 such types)
         // The last 28 bits indicate the number of rows.

--- a/src/System.Text.JsonLab/System/Text/Json/DbRow.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/DbRow.cs
@@ -8,6 +8,8 @@ namespace System.Text.JsonLab
     // Location - offset - 0 - size - 4
     // Length - offset - 4 - size - 4
     // Type - offset - 8 - size - 1
+    // HasChildren - offset - 9 - size - 1
+    // ArrayLength - offset - 10 - size - 4
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     internal struct DbRow
     {
@@ -15,22 +17,40 @@ namespace System.Text.JsonLab
 
         public int Location;                // index in JSON payload
         public int Length;      // length of text in JSON payload
-        public JsonValueType Type; // type of JSON construct (e.g. Object, Array, Number)
+        public JsonType Type; // type of JSON construct (e.g. Object, Array, Number)
+        public bool HasChildren;
+        public int ArrayLength;
 
         public const int UnknownNumberOfRows = -1;
 
-        public DbRow(JsonValueType type, int valueIndex, int lengthOrNumberOfRows = UnknownNumberOfRows)
+        public DbRow(JsonType type, int valueIndex, int lengthOrNumberOfRows = UnknownNumberOfRows, int arrayNumberOfRows = UnknownNumberOfRows, bool hasChildren = false)
         {
             Location = valueIndex;
             Length = lengthOrNumberOfRows;
             Type = type;
+            ArrayLength = arrayNumberOfRows;
+            HasChildren = hasChildren;
         }
 
-        public bool IsSimpleValue => Type > JsonValueType.Array;
+        public bool IsSimpleValue => Type > JsonType.Array; // Type >= 0b0010_00000...<28 times>
 
         unsafe static DbRow()
         {
             Size = sizeof(DbRow);
         }
+    }
+
+    // Do not change the order of the enum values, since IsSimpleValue relies on it.
+    public enum JsonType : byte
+    {
+        Object = 0,
+        Array = 1,
+        String = 2,
+        Number = 3,
+        True = 4,
+        False = 5,
+        Null = 6,
+        Unknown = 7,
+        PropertyName = 8
     }
 }

--- a/src/System.Text.JsonLab/System/Text/Json/DbRow.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/DbRow.cs
@@ -12,7 +12,7 @@ namespace System.Text.JsonLab
     [StructLayout(LayoutKind.Sequential)]
     internal struct DbRow
     {
-        public const int Size = 12;
+        public const int Size = 16;
 
         public int Location;                // index in JSON payload
         public int SizeOrLength;      // length of text in JSON payload (or number of elements if its a JSON array)
@@ -23,6 +23,8 @@ namespace System.Text.JsonLab
         // Since each row of the database is 12 bytes long, we can't exceed 2^31/12 = 178956971 total number of rows.
         // Hence, we only need 28 bits (maximum value of 268435455).
         private readonly int _union;
+
+        public int ArrayUniformLength;
 
         public bool HasChildren => _union < 0;  // True only if there are nested objects or arrays within the current JSON element
         public JsonValueType JsonType => (JsonValueType)((_union & 0x70000000) >> 28); // type of JSON construct (e.g. Object, Array, Number)
@@ -40,6 +42,7 @@ namespace System.Text.JsonLab
             Location = location;
             SizeOrLength = sizeOrLength;
             _union = numberOfRows | (int)jsonType << 28; // HasChildren is set to false by default
+            ArrayUniformLength = 1;
         }
 
         public bool IsSimpleValue => JsonType > JsonValueType.Array;

--- a/src/System.Text.JsonLab/System/Text/Json/JsonObject.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonObject.cs
@@ -130,14 +130,14 @@ namespace System.Text.JsonLab
             {
                 record = _database.Get(i);
 
-                /*if (!record.IsSimpleValue)
+                if (!record.IsSimpleValue)
                 {
                     if (record.SizeOrLength != 0)
                         i += DbRow.Size * record.NumberOfRows;
                     continue;
-                }*/
+                }
 
-                if (record.JsonType == JsonValueType.Object || 
+                /*if (record.JsonType == JsonValueType.Object || 
                     (record.JsonType == JsonValueType.Array &&
                     (!record.HasChildren || record.NumberOfRows > record.SizeOrLength)))
                 {
@@ -154,7 +154,7 @@ namespace System.Text.JsonLab
                     if (amountToSkip != 0)
                         i += DbRow.Size * amountToSkip;
                     continue;
-                }
+                }*/
 
                 Debug.Assert(record.JsonType == JsonValueType.String);
 
@@ -184,7 +184,8 @@ namespace System.Text.JsonLab
 
         public bool TryGetValue(string propertyName, out JsonObject value)
         {
-            DbRow record = _database.Get();
+            return TryGetValue((Utf8Span)propertyName, out value);
+            /*DbRow record = _database.Get();
 
             if (record.SizeOrLength == 0)
             {
@@ -232,7 +233,7 @@ namespace System.Text.JsonLab
             }
 
             value = default;
-            return false;
+            return false;*/
         }
         
         public JsonObject this[Utf8Span name]
@@ -305,7 +306,7 @@ namespace System.Text.JsonLab
             return default;
         }
 
-        public JsonObject this[int index]
+        /*public JsonObject this[int index]
         {
             get
             {
@@ -353,7 +354,7 @@ namespace System.Text.JsonLab
                 }
                 return SequentialSearch(startIndex, length, index, uniformCount, uniformValue, record);
             }
-        }
+        }*/
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         private JsonObject SequentialSearch(int index)
@@ -383,7 +384,7 @@ namespace System.Text.JsonLab
             return default;
         }
 
-        /*public JsonObject this[int index]
+        public JsonObject this[int index]
         {
             get
             {
@@ -411,7 +412,7 @@ namespace System.Text.JsonLab
                 }
                 return SequentialSearch(index);
             }
-        }*/
+        }
 
         public int ArrayLength
         {

--- a/src/System.Text.JsonLab/System/Text/Json/JsonObject.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonObject.cs
@@ -208,7 +208,7 @@ namespace System.Text.JsonLab
             return default;
         }
 
-        /*public JsonObject this[int index]
+        public JsonObject this[int index]
         {
             get
             {
@@ -225,92 +225,6 @@ namespace System.Text.JsonLab
 
                 return SequentialSearch(index);
             }
-        }*/
-
-        public JsonObject this[int index]
-        {
-            get
-            {
-                DbRow record = _database.Get();
-
-                if (record.JsonType != JsonValueType.Array)
-                    JsonThrowHelper.ThrowInvalidOperationException();
-
-                if ((uint)index >= (uint)record.SizeOrLength)
-                    JsonThrowHelper.ThrowIndexOutOfRangeException();
-
-                if (!record.HasChildren)
-                    return CreateJsonObject(DbRow.Size * (index + 1), DbRow.Size);
-
-                DbRow nextRecord = _database.Get(DbRow.Size);
-                int uniformValue = nextRecord.SizeOrLength;
-
-                if (index < record.ArrayUniformLength)
-                {
-                    int length = DbRow.Size * (1 + uniformValue);
-                    // startIndex is equivalent to DbRow.Size * (index + 1) + (index * DbRow.Size * uniformValue);
-                    return CreateJsonObject(index * length + DbRow.Size, length);
-                }
-                return SequentialSearch(index, uniformValue, record.ArrayUniformLength);
-            }
-        }
-
-        private JsonObject SequentialSearch(int index, int uniformValue, int uniformCount)
-        {
-            int startIndex = DbRow.Size * (uniformCount + uniformCount * uniformValue + 1);
-            int counter = uniformCount;
-            Debug.Assert(index >= counter);
-
-            int i = startIndex;
-            for (; i <= _database.Length; i += DbRow.Size)
-            {
-                DbRow nextRecord = _database.Get(i);
-
-                if (uniformValue == nextRecord.NumberOfRows)
-                {
-                    uniformCount++;
-                }
-                else
-                {
-                    _database.SetArrayUniformLength(0, uniformCount);
-                    break;
-                }
-
-                if (index == counter)
-                {
-                    int length = DbRow.Size;
-                    if (!nextRecord.IsSimpleValue)
-                        length += DbRow.Size * nextRecord.NumberOfRows;
-                    _database.SetArrayUniformLength(0, uniformCount);
-                    return CreateJsonObject(i, length);
-                }
-
-                if (!nextRecord.IsSimpleValue)
-                    i += nextRecord.NumberOfRows * DbRow.Size;
-
-                counter++;
-            }
-
-            for (; i <= _database.Length; i += DbRow.Size)
-            {
-                DbRow nextRecord = _database.Get(i);
-
-                if (index == counter)
-                {
-                    int length = DbRow.Size;
-                    if (!nextRecord.IsSimpleValue)
-                        length += DbRow.Size * nextRecord.NumberOfRows;
-                    return CreateJsonObject(i, length);
-                }
-
-                if (!nextRecord.IsSimpleValue)
-                    i += nextRecord.NumberOfRows * DbRow.Size;
-
-                counter++;
-            }
-
-            JsonThrowHelper.ThrowIndexOutOfRangeException();
-            return default;
         }
 
         public int ArrayLength

--- a/src/System.Text.JsonLab/System/Text/Json/JsonObject.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonObject.cs
@@ -208,7 +208,7 @@ namespace System.Text.JsonLab
             return default;
         }
 
-        public JsonObject this[int index]
+        /*public JsonObject this[int index]
         {
             get
             {
@@ -225,6 +225,92 @@ namespace System.Text.JsonLab
 
                 return SequentialSearch(index);
             }
+        }*/
+
+        public JsonObject this[int index]
+        {
+            get
+            {
+                DbRow record = _database.Get();
+
+                if (record.JsonType != JsonValueType.Array)
+                    JsonThrowHelper.ThrowInvalidOperationException();
+
+                if ((uint)index >= (uint)record.SizeOrLength)
+                    JsonThrowHelper.ThrowIndexOutOfRangeException();
+
+                if (!record.HasChildren)
+                    return CreateJsonObject(DbRow.Size * (index + 1), DbRow.Size);
+
+                DbRow nextRecord = _database.Get(DbRow.Size);
+                int uniformValue = nextRecord.SizeOrLength;
+
+                if (index < record.ArrayUniformLength)
+                {
+                    int length = DbRow.Size * (1 + uniformValue);
+                    // startIndex is equivalent to DbRow.Size * (index + 1) + (index * DbRow.Size * uniformValue);
+                    return CreateJsonObject(index * length + DbRow.Size, length);
+                }
+                return SequentialSearch(index, uniformValue, record.ArrayUniformLength);
+            }
+        }
+
+        private JsonObject SequentialSearch(int index, int uniformValue, int uniformCount)
+        {
+            int startIndex = DbRow.Size * (uniformCount + uniformCount * uniformValue + 1);
+            int counter = uniformCount;
+            Debug.Assert(index >= counter);
+
+            int i = startIndex;
+            for (; i <= _database.Length; i += DbRow.Size)
+            {
+                DbRow nextRecord = _database.Get(i);
+
+                if (uniformValue == nextRecord.NumberOfRows)
+                {
+                    uniformCount++;
+                }
+                else
+                {
+                    _database.SetArrayUniformLength(0, uniformCount);
+                    break;
+                }
+
+                if (index == counter)
+                {
+                    int length = DbRow.Size;
+                    if (!nextRecord.IsSimpleValue)
+                        length += DbRow.Size * nextRecord.NumberOfRows;
+                    _database.SetArrayUniformLength(0, uniformCount);
+                    return CreateJsonObject(i, length);
+                }
+
+                if (!nextRecord.IsSimpleValue)
+                    i += nextRecord.NumberOfRows * DbRow.Size;
+
+                counter++;
+            }
+
+            for (; i <= _database.Length; i += DbRow.Size)
+            {
+                DbRow nextRecord = _database.Get(i);
+
+                if (index == counter)
+                {
+                    int length = DbRow.Size;
+                    if (!nextRecord.IsSimpleValue)
+                        length += DbRow.Size * nextRecord.NumberOfRows;
+                    return CreateJsonObject(i, length);
+                }
+
+                if (!nextRecord.IsSimpleValue)
+                    i += nextRecord.NumberOfRows * DbRow.Size;
+
+                counter++;
+            }
+
+            JsonThrowHelper.ThrowIndexOutOfRangeException();
+            return default;
         }
 
         public int ArrayLength

--- a/src/System.Text.JsonLab/System/Text/Json/JsonParser.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonParser.cs
@@ -2,280 +2,101 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
-using System.Runtime.InteropServices;
+using System.Diagnostics;
 
 namespace System.Text.JsonLab
 {
-    public ref struct JsonParser
+    internal ref struct JsonParser
     {
         private readonly ReadOnlySpan<byte> _utf8Json; // TODO: this should be ReadOnlyMemory<byte>
-        private ArrayPool<byte> _pool;
-        private byte[] _rentedBuffer;
-        private Utf8JsonReader _reader;
-        private Span<byte> _db;
-        private CustomStack _stack;
-        private int _dbIndex;
-
-        // Tunable paramters to minimize allocations but avoid resizing for the common cases.
-        private const double DatabaseStackSpaceRatio = 0.8;
-        private const double AllocationMultiplier = 1.5;
+        private readonly ArrayPool<byte> _pool;
 
         public JsonParser(ReadOnlySpan<byte> utf8Json, ArrayPool<byte> pool = null)
         {
             _utf8Json = utf8Json;
             _pool = pool ?? ArrayPool<byte>.Shared;
-            _rentedBuffer = _pool.Rent((int)(utf8Json.Length * AllocationMultiplier));
-            _reader = new Utf8JsonReader(utf8Json);
-
-            Span<byte> scratchSpan = _rentedBuffer;
-            int dbLength = (int)(scratchSpan.Length * DatabaseStackSpaceRatio);
-            _db = scratchSpan.Slice(0, dbLength);
-            _stack = new CustomStack(scratchSpan.Slice(dbLength));
-            _dbIndex = 0;
         }
 
         public JsonObject Parse()
         {
-            bool isArray = false;
-            JsonTokenType tokenType = default;
-            if (_reader.Read())
-            {
-                tokenType = _reader.TokenType;
+            var database = new CustomDb(_pool, DbRow.Size + _utf8Json.Length);
+            var stack = new CustomStack(Utf8JsonReader.MaxDepth * StackRow.Size);
+            var reader = new Utf8JsonReader(_utf8Json);
 
-                if (tokenType == JsonTokenType.StartObject)
-                {
-                    AppendDbRow(JsonType.Object);
-                    while (!_stack.TryPush(new StackRow(false, 0, false, -1)))
-                    {
-                        ResizeDb();
-                    }
-                }
-                else if (tokenType == JsonTokenType.StartArray)
-                {
-                    isArray = true;
-                    AppendDbRow(JsonType.Array);
-                    while (!_stack.TryPush(new StackRow(true, 0, false, -1)))
-                    {
-                        ResizeDb();
-                    }
-                }
-                else
-                {
-                    AppendDbRow((JsonType)_reader.ValueType, _reader.Value.Length);
-                }
-            }
-
+            bool inArray = false;
             int arrayItemsCount = 0;
             int numberOfRowsForMembers = 0;
             int numberOfRowsForValues = 0;
+            int parentLocation = -1;
 
-            while (_reader.Read())
+            while (reader.Read())
             {
-                tokenType = _reader.TokenType;
+                JsonTokenType tokenType = reader.TokenType;
 
-                switch (tokenType)
+                if (tokenType == JsonTokenType.StartObject)
                 {
-                    case JsonTokenType.StartObject:
-                        if (isArray)
-                        {
-                            arrayItemsCount++;
-                        }
-                        numberOfRowsForValues++;
-                        AppendDbRow(JsonType.Object);
-                        StackRow row = new StackRow(false, numberOfRowsForMembers + 1, false, -1);
-                        while (!_stack.TryPush(row))
-                        {
-                            ResizeDb();
-                        }
-                        numberOfRowsForMembers = 0;
-                        break;
-                    case JsonTokenType.EndObject:
-                        int location = FindLocation(JsonType.Object);
-                        MemoryMarshal.Write(_db.Slice(location), ref numberOfRowsForMembers);
-                        row = _stack.Pop();
-                        MemoryMarshal.Write(_db.Slice(location + 5), ref row.HasChildren);
-                        numberOfRowsForMembers += row.Length;
-                        break;
-                    case JsonTokenType.StartArray:
-                        if (isArray)
-                        {
-                            arrayItemsCount++;
-                        }
-                        numberOfRowsForMembers++;
-                        AppendDbRow(JsonType.Array);
-                        row = new StackRow(true, arrayItemsCount, false, numberOfRowsForValues + 1);
-                        while (!_stack.TryPush(row))
-                        {
-                            ResizeDb();
-                        }
-                        arrayItemsCount = 0;
-                        numberOfRowsForValues = 0;
-                        break;
-                    case JsonTokenType.EndArray:
-                        location = FindLocation(JsonType.Array);
-                        MemoryMarshal.Write(_db.Slice(location), ref arrayItemsCount);
-                        MemoryMarshal.Write(_db.Slice(location + 6), ref numberOfRowsForValues);
-                        row = _stack.Pop();
-                        MemoryMarshal.Write(_db.Slice(location + 5), ref row.HasChildren);
-                        arrayItemsCount = row.Length;
-                        numberOfRowsForValues += row.ArrayLength;
-                        break;
-                    case JsonTokenType.PropertyName:
-                        numberOfRowsForValues++;
-                        numberOfRowsForMembers++;
-                        AppendDbRow(JsonType.PropertyName, _reader.Value.Length);
-                        break;
-                    case JsonTokenType.Value:
-                        if (isArray)
-                        {
-                            arrayItemsCount++;
-                        }
-                        numberOfRowsForValues++;
-                        numberOfRowsForMembers++;
-                        AppendDbRow((JsonType)_reader.ValueType, _reader.Value.Length);
-                        break;
+                    if (parentLocation != -1)
+                        database.SetHasChildren(parentLocation);
+                    parentLocation = database.Index;
+                    if (inArray)
+                        arrayItemsCount++;
+                    numberOfRowsForValues++;
+                    database.Append(JsonValueType.Object, reader.StartLocation);
+                    var row = new StackRow(numberOfRowsForMembers + 1);
+                    stack.Push(row);
+                    numberOfRowsForMembers = 0;
                 }
-                isArray = _stack.IsTopArray();
-            }
-            _pool.Return(_rentedBuffer);
-            return new JsonObject(_utf8Json, _db.Slice(0, _dbIndex));
-        }
-
-        private void ResizeDb()
-        {
-            int newSize = _rentedBuffer.Length * 2;
-            byte[] newArray = _pool.Rent(newSize);
-
-            Span<byte> scratchSpan = newArray;
-
-            int dbLength = (int)(scratchSpan.Length * DatabaseStackSpaceRatio);
-            Span<byte> sliceStart = scratchSpan.Slice(0, dbLength);
-
-            _db.Slice(0, _dbIndex).CopyTo(sliceStart);
-            _db = sliceStart;
-
-            Span<byte> newStackMemory = scratchSpan.Slice(dbLength);
-            _stack.Resize(newStackMemory);
-
-            _pool.Return(_rentedBuffer);
-            _rentedBuffer = newArray;
-        }
-
-        private int ForwardPass(JsonType lookupType)
-        {
-            int rowStartOffset = 0;
-            while (true)
-            {
-                DbRow row = MemoryMarshal.Read<DbRow>(_db.Slice(rowStartOffset));
-
-                if (row.Length == -1 && row.Type == lookupType)
+                else if (tokenType == JsonTokenType.EndObject)
                 {
-                    return rowStartOffset + 4;
+                    parentLocation = -1;
+                    int rowIndex = reader.NoMoreData ? 0 : database.FindIndexOfFirstUnsetSizeOrLength(JsonValueType.Object);
+                    database.SetLength(rowIndex, numberOfRowsForMembers);
+                    if (numberOfRowsForMembers != 0)
+                        database.SetNumberOfRows(rowIndex, numberOfRowsForMembers);
+                    StackRow row = stack.Pop();
+                    numberOfRowsForMembers += row.SizeOrLength;
+                }
+                else if (tokenType == JsonTokenType.StartArray)
+                {
+                    if (parentLocation != -1)
+                        database.SetHasChildren(parentLocation);
+                    parentLocation = database.Index;
+                    if (inArray)
+                        arrayItemsCount++;
+                    numberOfRowsForMembers++;
+                    database.Append(JsonValueType.Array, reader.StartLocation);
+                    var row = new StackRow(arrayItemsCount, numberOfRowsForValues + 1);
+                    stack.Push(row);
+                    arrayItemsCount = 0;
+                    numberOfRowsForValues = 0;
+                }
+                else if (tokenType == JsonTokenType.EndArray)
+                {
+                    parentLocation = -1;
+                    int rowIndex = reader.NoMoreData ? 0 : database.FindIndexOfFirstUnsetSizeOrLength(JsonValueType.Array);
+                    database.SetLength(rowIndex, arrayItemsCount);
+                    if (numberOfRowsForValues != 0)
+                        database.SetNumberOfRows(rowIndex, numberOfRowsForValues);
+                    StackRow row = stack.Pop();
+                    arrayItemsCount = row.SizeOrLength;
+                    numberOfRowsForValues += row.NumberOfRows;
+                }
+                else
+                {
+                    Debug.Assert(tokenType == JsonTokenType.PropertyName || tokenType == JsonTokenType.Value);
+                    numberOfRowsForValues++;
+                    numberOfRowsForMembers++;
+                    database.Append(reader.ValueType, reader.StartLocation, reader.Value.Length);
+                    if (tokenType == JsonTokenType.Value && inArray)
+                        arrayItemsCount++;
                 }
 
-                if (!row.IsSimpleValue && row.Length > 0)
-                {
-                    rowStartOffset += row.Length * DbRow.Size;
-                }
-                rowStartOffset += DbRow.Size;
-            }
-        }
-
-        private int BackwardPass(JsonType lookupType)
-        {
-            int rowStartOffset = _dbIndex - DbRow.Size;
-            while (true)
-            {
-                DbRow row = MemoryMarshal.Read<DbRow>(_db.Slice(rowStartOffset));
-
-                if (row.Length == -1 && row.Type == lookupType)
-                {
-                    return rowStartOffset + 4;
-                }
-
-                // TODO: Investigate performance impact of adding "skip" logic similar to ForwardPass
-                rowStartOffset -= DbRow.Size;
-            }
-        }
-
-        private int FindLocation(JsonType lookupType)
-        {
-            // No more JSON left to read, i.e. we are at the root node,
-            // so it will always be faster to search going forward
-            if (_reader.Index == _utf8Json.Length)
-            {
-                return ForwardPass(lookupType);
-            }
-            else
-            {
-                return BackwardPass(lookupType);
-            }
-        }
-
-        /*private (int, int) FindLocationArray()
-        {
-            // No more JSON left to read, i.e. we are at the root node,
-            // so it will always be faster to search going forward
-            if (_reader.Index == _utf8Json.Length)
-            {
-                return ForwardPassArray();
-            }
-            else
-            {
-                return BackwardPassArray();
-            }
-        }
-
-        private (int, int) ForwardPassArray()
-        {
-            int rowStartOffset = 0;
-            while (true)
-            {
-                DbRow row = MemoryMarshal.Read<DbRow>(_db.Slice(rowStartOffset));
-
-                if (row.Length == -1 && row.Type == JsonType.Array)
-                {
-                    return rowStartOffset + 4;
-                }
-
-                if (!row.IsSimpleValue && row.Length > 0)
-                {
-                    rowStartOffset += row.Length * DbRow.Size;
-                }
-                rowStartOffset += DbRow.Size;
-            }
-        }
-
-        private (int, int) BackwardPassArray()
-        {
-            int primitiveLength = 1;
-            int rowStartOffset = _dbIndex - DbRow.Size;
-            while (true)
-            {
-                DbRow row = MemoryMarshal.Read<DbRow>(_db.Slice(rowStartOffset));
-
-                if (row.Length == -1 && row.Type == JsonType.Array)
-                {
-                    return (primitiveLength, rowStartOffset + 4);
-                }
-                if (row.Type <= JsonType.Array)
-                    primitiveLength = -1;
-
-                // TODO: Investigate performance impact of adding "skip" logic similar to ForwardPass
-                rowStartOffset -= DbRow.Size;
-            }
-        }*/
-
-        private void AppendDbRow(JsonType type, int LengthOrNumberOfRows = DbRow.UnknownNumberOfRows)
-        {
-            while (_dbIndex >= _db.Length - DbRow.Size)
-            {
-                ResizeDb();
+                inArray = reader.InArray;
             }
 
-            var dbRow = new DbRow(type, _reader.StartLocation, LengthOrNumberOfRows);
-            MemoryMarshal.Write(_db.Slice(_dbIndex), ref dbRow);
-            _dbIndex += DbRow.Size;
+            stack.Dispose();
+            database.Resize();
+            return new JsonObject(_utf8Json, database);
         }
     }
 }

--- a/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
@@ -9,7 +9,7 @@ namespace System.Text.JsonLab
     public ref struct Utf8JsonReader
     {
         // We are using a ulong to represent our nested state, so we can only go 64 levels deep.
-        private const int MaxDepth = sizeof(ulong) * 8;
+        internal const int MaxDepth = sizeof(ulong) * 8;
 
         private ReadOnlySpan<byte> _buffer;
 
@@ -29,8 +29,8 @@ namespace System.Text.JsonLab
         private ulong _containerMask;
 
         // These properties are helpers for determining the current state of the reader
-        private bool InArray => !InObject;
-        private bool InObject => (_containerMask & 1) != 0;
+        internal bool InArray => !InObject;
+        internal bool InObject => (_containerMask & 1) != 0;
 
         /// <summary>
         /// Gets the token type of the last processed token in the JSON stream.
@@ -190,6 +190,8 @@ namespace System.Text.JsonLab
             }
             return true;
         }
+
+        internal bool NoMoreData => (0 >= (uint)_buffer.Length);
 
         private bool ReadSingleSegment(ref ReadOnlySpan<byte> buffer)
         {

--- a/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
@@ -29,9 +29,8 @@ namespace System.Text.JsonLab
         private ulong _containerMask;
 
         // These properties are helpers for determining the current state of the reader
-        private bool IsRoot => Depth == 1;
-        private bool InArray => (_containerMask & 1) == 0;
-        private bool InObject => (_containerMask & 1) == 1;
+        private bool InArray => !InObject;
+        private bool InObject => (_containerMask & 1) != 0;
 
         /// <summary>
         /// Gets the token type of the last processed token in the JSON stream.
@@ -53,7 +52,7 @@ namespace System.Text.JsonLab
         /// </summary>
         public JsonValueType ValueType { get; private set; }
 
-        readonly bool _isSingleSegment;
+        private readonly bool _isSingleSegment;
 
         /// <summary>
         /// Constructs a new JsonReader instance. This is a stack-only type.
@@ -65,7 +64,7 @@ namespace System.Text.JsonLab
             _reader = default;
             _isSingleSegment = true;
             _buffer = data;
-            Depth = 1;
+            Depth = 0;
             _containerMask = 0;
             Index = 0;
             StartLocation = Index;
@@ -80,7 +79,7 @@ namespace System.Text.JsonLab
             _reader = new BufferReader<byte>(data);
             _isSingleSegment = data.IsSingleSegment; //true;
             _buffer = _reader.CurrentSpan;  //data.ToArray();
-            Depth = 1;
+            Depth = 0;
             _containerMask = 0;
             Index = 0;
             StartLocation = Index;
@@ -101,15 +100,7 @@ namespace System.Text.JsonLab
 
         private void SkipWhiteSpace()
         {
-            while (true)
-            {
-                _reader.TryPeek(out byte val);
-                if (val != JsonConstants.Space && val != JsonConstants.CarriageReturn && val != JsonConstants.LineFeed && val != JsonConstants.Tab)
-                {
-                    break;
-                }
-                _reader.Advance(1);
-            }
+            _reader.SkipPastAny(JsonConstants.Space, JsonConstants.CarriageReturn, JsonConstants.LineFeed, JsonConstants.Tab);
         }
 
         private bool ReadMultiSegment()
@@ -121,12 +112,14 @@ namespace System.Text.JsonLab
 
                 if (val == JsonConstants.OpenBrace)
                 {
+                    Depth++;
                     _containerMask = 1;
                     TokenType = JsonTokenType.StartObject;
                     _reader.Advance(1);
                 }
                 else if (val == JsonConstants.OpenBracket)
                 {
+                    Depth++;
                     TokenType = JsonTokenType.StartArray;
                     _reader.Advance(1);
                 }
@@ -174,29 +167,22 @@ namespace System.Text.JsonLab
             return true;
         }
 
-        private bool ReadFirstToken(ref ReadOnlySpan<byte> buffer)
+        private bool ReadFirstToken(ref ReadOnlySpan<byte> buffer, byte first)
         {
-            SkipWhiteSpaceUtf8(ref buffer);
-            StartLocation = Index;
-            if (buffer.Length < 1)
-            {
-                return false;
-            }
-            byte first = buffer[0];
             if (first == JsonConstants.OpenBrace)
             {
+                Depth++;
                 _containerMask = 1;
                 TokenType = JsonTokenType.StartObject;
                 buffer = buffer.Slice(1);
                 Index++;
-                StartLocation++;
             }
             else if (first == JsonConstants.OpenBracket)
             {
+                Depth++;
                 TokenType = JsonTokenType.StartArray;
                 buffer = buffer.Slice(1);
                 Index++;
-                StartLocation++;
             }
             else
             {
@@ -207,19 +193,27 @@ namespace System.Text.JsonLab
 
         private bool ReadSingleSegment(ref ReadOnlySpan<byte> buffer)
         {
-            if (TokenType == JsonTokenType.None)
-            {
-                return ReadFirstToken(ref buffer);
-            }
+            bool retVal = false;
 
-            SkipWhiteSpaceUtf8(ref buffer);
-            StartLocation = Index;
-            if (buffer.Length < 1)
-            {
-                return false;
-            }
+            if (0 >= (uint)buffer.Length)
+                goto Done;
 
             byte first = buffer[0];
+
+            if (first <= JsonConstants.Space)
+            {
+                SkipWhiteSpaceUtf8(ref buffer);
+                if (0 >= (uint)buffer.Length)
+                    goto Done;
+                first = buffer[0];
+            }
+
+            StartLocation = Index;
+
+            if (TokenType == JsonTokenType.None)
+            {
+                goto ReadFirstToken;
+            }
 
             if (TokenType == JsonTokenType.StartObject)
             {
@@ -253,7 +247,15 @@ namespace System.Text.JsonLab
             {
                 ConsumeNextUtf8(ref buffer, first);
             }
-            return true;
+
+            retVal = true;
+
+        Done:
+            return retVal;
+
+        ReadFirstToken:
+            retVal = ReadFirstToken(ref buffer, first);
+            goto Done;
         }
 
         public void Skip()
@@ -357,14 +359,28 @@ namespace System.Text.JsonLab
         /// </summary>
         private void ConsumeNextUtf8(ref ReadOnlySpan<byte> buffer, byte marker)
         {
+            buffer = buffer.Slice(1);
+            Index++;
             if (marker == JsonConstants.ListSeperator)
             {
-                SkipWhiteSpaceUtf8(ref buffer, 1);
+                if (0 >= (uint)buffer.Length)
+                    JsonThrowHelper.ThrowJsonReaderException();
+
+                byte first = buffer[0];
+
+                if (first <= JsonConstants.Space)
+                {
+                    SkipWhiteSpaceUtf8(ref buffer);
+                    // The next character must be a start of a property name or value.
+                    if (0 >= (uint)buffer.Length)
+                        JsonThrowHelper.ThrowJsonReaderException();
+                    first = buffer[0];
+                }
+
                 StartLocation = Index;
                 if (InObject)
                 {
-                    // The next character must be a start of a property name. Validate and skip.
-                    if (buffer.Length < 1 || buffer[0] != JsonConstants.Quote)
+                    if (first != JsonConstants.Quote)
                         JsonThrowHelper.ThrowJsonReaderException();
 
                     buffer = buffer.Slice(1);
@@ -372,29 +388,17 @@ namespace System.Text.JsonLab
                     StartLocation++;
                     ConsumePropertyNameUtf8(ref buffer);
                 }
-                else if (InArray)
-                {
-                    // The next character must be a start of a value.
-                    if (buffer.Length < 1)
-                        JsonThrowHelper.ThrowJsonReaderException();
-
-                    ConsumeValueUtf8(ref buffer, buffer[0]);
-                }
                 else
                 {
-                    JsonThrowHelper.ThrowJsonReaderException();
+                    ConsumeValueUtf8(ref buffer, first);
                 }
             }
             else if (marker == JsonConstants.CloseBrace)
             {
-                buffer = buffer.Slice(1);
-                Index++;
                 EndObject();
             }
             else if (marker == JsonConstants.CloseBracket)
             {
-                buffer = buffer.Slice(1);
-                Index++;
                 EndArray();
             }
             else
@@ -469,15 +473,12 @@ namespace System.Text.JsonLab
                 buffer = buffer.Slice(1);
                 Index++;
                 StartLocation++;
-                int i = ConsumeStringUtf8(ref buffer);
-                buffer = buffer.Slice(i);
-                Index += i;
+                ConsumeStringUtf8(ref buffer);
             }
             else if (marker == JsonConstants.OpenBrace)
             {
                 buffer = buffer.Slice(1);
                 Index++;
-                StartLocation++;
                 StartObject();
                 ValueType = JsonValueType.Object;
             }
@@ -485,7 +486,6 @@ namespace System.Text.JsonLab
             {
                 buffer = buffer.Slice(1);
                 Index++;
-                StartLocation++;
                 StartArray();
                 ValueType = JsonValueType.Array;
             }
@@ -578,9 +578,7 @@ namespace System.Text.JsonLab
                 buffer = buffer.Slice(1);
                 Index++;
                 StartLocation++;
-                int i = ConsumeStringUtf8(ref buffer);
-                buffer = buffer.Slice(i);
-                Index += i;
+                ConsumeStringUtf8(ref buffer);
             }
             else if (marker - '0' <= '9' - '0')
             {
@@ -588,7 +586,7 @@ namespace System.Text.JsonLab
                 Value = buffer;
                 ValueType = JsonValueType.Number;
                 Index += buffer.Length;
-                buffer = buffer.Slice(buffer.Length);
+                buffer = ReadOnlySpan<byte>.Empty;
             }
             else if (marker == '-')
             {
@@ -596,7 +594,7 @@ namespace System.Text.JsonLab
                 Value = buffer;
                 ValueType = JsonValueType.Number;
                 Index += buffer.Length;
-                buffer = buffer.Slice(buffer.Length);
+                buffer = ReadOnlySpan<byte>.Empty;
             }
             else if (marker == 'f')
             {
@@ -663,11 +661,7 @@ namespace System.Text.JsonLab
             Value = JsonConstants.NullValue;
             ValueType = JsonValueType.Null;
 
-            if (buffer.Length < 4
-                || buffer[0] != 'n'
-                || buffer[1] != 'u'
-                || buffer[2] != 'l'
-                || buffer[3] != 'l')
+            if (!buffer.StartsWith(Value))
             {
                 JsonThrowHelper.ThrowJsonReaderException();
             }
@@ -691,12 +685,7 @@ namespace System.Text.JsonLab
             Value = JsonConstants.FalseValue;
             ValueType = JsonValueType.False;
 
-            if (buffer.Length < 5
-                || buffer[0] != 'f'
-                || buffer[1] != 'a'
-                || buffer[2] != 'l'
-                || buffer[3] != 's'
-                || buffer[4] != 'e')
+            if (!buffer.StartsWith(Value))
             {
                 JsonThrowHelper.ThrowJsonReaderException();
             }
@@ -720,11 +709,7 @@ namespace System.Text.JsonLab
             Value = JsonConstants.TrueValue;
             ValueType = JsonValueType.True;
 
-            if (buffer.Length < 4
-                || buffer[0] != 't'
-                || buffer[1] != 'r'
-                || buffer[2] != 'u'
-                || buffer[3] != 'e')
+            if (!buffer.StartsWith(Value))
             {
                 JsonThrowHelper.ThrowJsonReaderException();
             }
@@ -747,13 +732,26 @@ namespace System.Text.JsonLab
 
         private void ConsumePropertyNameUtf8(ref ReadOnlySpan<byte> buffer)
         {
-            int i = ConsumeStringUtf8(ref buffer);
+            ConsumeStringUtf8(ref buffer);
 
-            SkipWhiteSpaceUtf8(ref buffer, i);
+            if (0 >= (uint)buffer.Length)
+                JsonThrowHelper.ThrowJsonReaderException();
+
+            byte first = buffer[0];
+
+            if (first <= JsonConstants.Space)
+            {
+                SkipWhiteSpaceUtf8(ref buffer);
+                if (0 >= (uint)buffer.Length)
+                    JsonThrowHelper.ThrowJsonReaderException();
+                first = buffer[0];
+            }
 
             // The next character must be a key / value seperator. Validate and skip.
-            if (buffer.Length < 1 || buffer[0] != JsonConstants.KeyValueSeperator)
+            if (first != JsonConstants.KeyValueSeperator)
+            {
                 JsonThrowHelper.ThrowJsonReaderException();
+            }
 
             TokenType = JsonTokenType.PropertyName;
             buffer = buffer.Slice(1);
@@ -857,51 +855,80 @@ namespace System.Text.JsonLab
             ValueType = JsonValueType.String;
         }
 
-        private int ConsumeStringUtf8(ref ReadOnlySpan<byte> buffer)
+        private void ConsumeStringUtf8(ref ReadOnlySpan<byte> buffer)
+        {
+            int idx = buffer.IndexOf(JsonConstants.Quote);
+            if (idx < 0)
+                JsonThrowHelper.ThrowJsonReaderException();
+            if (idx == 0 || buffer[idx - 1] != JsonConstants.ReverseSolidus)
+            {
+                Value = buffer.Slice(0, idx);
+                ValueType = JsonValueType.String;
+
+                idx++;
+                buffer = buffer.Slice(idx);
+                Index += idx;
+                return;
+            }
+            ConsumeStringWithNextedQuotes(ref buffer);
+        }
+
+        private void ConsumeStringWithNextedQuotes(ref ReadOnlySpan<byte> buffer)
         {
             //TODO: Optimize looking for nested quotes
+            //TODO: Avoid redoing first IndexOf search
             int i = 0;
             while (true)
             {
                 int counter = 0;
-                i += buffer.Slice(i).IndexOf(JsonConstants.Quote);
-                if (i == -1)
+                int foundIdx = buffer.Slice(i).IndexOf(JsonConstants.Quote);
+                if (foundIdx == -1)
                     JsonThrowHelper.ThrowJsonReaderException();
-                if (i == 0)
-                {
+                if (foundIdx == 0)
                     break;
-                }
-                for (int j = i - 1; j >= 0; j--)
+                for (int j = i + foundIdx - 1; j >= i; j--)
                 {
                     if (buffer[j] != JsonConstants.ReverseSolidus)
                     {
                         if (counter % 2 == 0)
+                        {
+                            i += foundIdx;
                             goto Done;
+                        }
                         break;
                     }
                     else
                         counter++;
                 }
-                i++;
+                i += foundIdx + 1;
             }
 
         Done:
             Value = buffer.Slice(0, i);
             ValueType = JsonValueType.String;
-            return i + 1;
+
+            i++;
+            buffer = buffer.Slice(i);
+            Index += i;
         }
 
-        private void SkipWhiteSpaceUtf8(ref ReadOnlySpan<byte> buffer, int i = 0)
+        private void SkipWhiteSpaceUtf8(ref ReadOnlySpan<byte> buffer)
         {
-            for (; i < buffer.Length; i++)
+            //Create local copy to avoid bounds checks.
+            ReadOnlySpan<byte> bufferCopy = buffer;
+            int i = 0;
+            for (; i < bufferCopy.Length; i++)
             {
-                byte val = buffer[i];
-                if (val != JsonConstants.Space && val != JsonConstants.CarriageReturn && val != JsonConstants.LineFeed && val != JsonConstants.Tab)
+                byte val = bufferCopy[i];
+                if (val != JsonConstants.Space &&
+                    val != JsonConstants.CarriageReturn &&
+                    val != JsonConstants.LineFeed &&
+                    val != JsonConstants.Tab)
                 {
                     break;
                 }
             }
-            buffer = buffer.Slice(i);
+            buffer = bufferCopy.Slice(i);
             Index += i;
         }
     }

--- a/src/System.Text.JsonLab/System/Text/Json/JsonThrowHelper.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonThrowHelper.cs
@@ -61,7 +61,7 @@ namespace System.Text.JsonLab
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static NotImplementedException GetNotImplementedException()
         {
-            return new NotImplementedException();
+            return new NotImplementedException("Reading JSON containing comments is not yet supported.");
         }
 
         public static void ThrowJsonReaderException()

--- a/src/System.Text.JsonLab/System/Text/Json/JsonThrowHelper.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonThrowHelper.cs
@@ -97,6 +97,17 @@ namespace System.Text.JsonLab
             return new KeyNotFoundException();
         }
 
+        public static void ThrowInvalidOperationException(string message)
+        {
+            throw GetInvalidOperationException(message);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static InvalidOperationException GetInvalidOperationException(string message)
+        {
+            return new InvalidOperationException(message);
+        }
+
         public static void ThrowInvalidOperationException()
         {
             throw GetInvalidOperationException();

--- a/src/System.Text.JsonLab/System/Text/Json/StackRow.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/StackRow.cs
@@ -7,6 +7,8 @@ namespace System.Text.JsonLab
 {
     // IsArray - offset - 0 - size - 1
     // Length - offset - 1 - size - 4
+    // HasChildren - offset - 5 - size - 1
+    // ArrayLength - offset - 6 - size - 4
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     internal struct StackRow
     {
@@ -14,11 +16,15 @@ namespace System.Text.JsonLab
 
         public bool IsArray;
         public int Length;
+        public bool HasChildren;
+        public int ArrayLength;
 
-        public StackRow(bool isArray, int lengthOrNumberOfRows)
+        public StackRow(bool isArray, int lengthOrNumberOfRows, bool hasChildren, int arrayLength)
         {
             IsArray = isArray;
             Length = lengthOrNumberOfRows;
+            HasChildren = hasChildren;
+            ArrayLength = arrayLength;
         }
 
         unsafe static StackRow()

--- a/src/System.Text.JsonLab/System/Text/Json/StackRow.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/StackRow.cs
@@ -1,35 +1,28 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace System.Text.JsonLab
 {
-    // IsArray - offset - 0 - size - 1
-    // Length - offset - 1 - size - 4
-    // HasChildren - offset - 5 - size - 1
-    // ArrayLength - offset - 6 - size - 4
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    // SizeOrLength - offset - 0 - size - 4
+    // NumberOfRows - offset - 4 - size - 4
+    [StructLayout(LayoutKind.Sequential)]
     internal struct StackRow
     {
-        public static int Size;
+        public const int Size = 8;
 
-        public bool IsArray;
-        public int Length;
-        public bool HasChildren;
-        public int ArrayLength;
+        public int SizeOrLength;
+        public int NumberOfRows;
 
-        public StackRow(bool isArray, int lengthOrNumberOfRows, bool hasChildren, int arrayLength)
+        public StackRow(int sizeOrLength = 0, int numberOfRows = -1)
         {
-            IsArray = isArray;
-            Length = lengthOrNumberOfRows;
-            HasChildren = hasChildren;
-            ArrayLength = arrayLength;
-        }
+            Debug.Assert(sizeOrLength >= 0);
+            Debug.Assert(numberOfRows >= -1);
 
-        unsafe static StackRow()
-        {
-            Size = sizeof(StackRow);
+            SizeOrLength = sizeOrLength;
+            NumberOfRows = numberOfRows;
         }
     }
 }

--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserChangeEntryPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserChangeEntryPerf.cs
@@ -69,8 +69,7 @@ namespace System.Text.JsonLab.Benchmarks
         [Benchmark]
         public void ChangeEntryPointLibraryNameJsonLab()
         {
-            var parser = new JsonParser(_dataUtf8);
-            JsonObject obj = parser.Parse();
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
 
             JsonObject targets = obj["targets"];
             if (targets.TryGetChild(out JsonObject child))

--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserEnumeratePerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserEnumeratePerf.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using Benchmarks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.IO;
+
+namespace System.Text.JsonLab.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class JsonParserEnumeratePerf
+    {
+        private byte[] _dataUtf8;
+        private MemoryStream _stream;
+        private StreamReader _reader;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            string jsonString = JsonStrings.Json400KB;
+
+            // Remove all formatting/indendation
+            using (JsonTextReader jsonReader = new JsonTextReader(new StringReader(jsonString)))
+            {
+                JToken obj = JToken.ReadFrom(jsonReader);
+                var stringWriter = new StringWriter();
+                using (JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter))
+                {
+                    obj.WriteTo(jsonWriter);
+                    jsonString = stringWriter.ToString();
+                }
+            }
+
+            _dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            _stream = new MemoryStream(_dataUtf8);
+            _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
+        }
+
+        [Benchmark(Baseline = true)]
+        public void ParseNewtonsoftEnumerate()
+        {
+            _stream.Seek(0, SeekOrigin.Begin);
+            using (JsonTextReader jsonReader = new JsonTextReader(_reader))
+            {
+                JToken obj = JToken.ReadFrom(jsonReader);
+
+                foreach (JToken token in obj)
+                {
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ParseSystemTextJsonLabEnumerate()
+        {
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
+
+            for (int i = 0; i < obj.ArrayLength; i++)
+            {
+                JsonObject withinArray = obj[i];
+            }
+
+            obj.Dispose();
+        }
+
+        [Benchmark]
+        public void ParseSystemTextJsonLabEnumerateReverse()
+        {
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
+
+            for (int i = obj.ArrayLength - 1; i >= 0; i--)
+            {
+                JsonObject withinArray = obj[i];
+            }
+
+            obj.Dispose();
+        }
+
+        [Benchmark]
+        public void ParseSystemTextJsonLabFirst()
+        {
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
+
+            for (int i = 0; i < obj.ArrayLength; i++)
+            {
+                JsonObject withinArray = obj[0];
+            }
+
+            obj.Dispose();
+        }
+    }
+}

--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserEnumeratePerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserEnumeratePerf.cs
@@ -46,8 +46,65 @@ namespace System.Text.JsonLab.Benchmarks
             {
                 JToken obj = JToken.ReadFrom(jsonReader);
 
-                foreach (JToken token in obj)
+                for (int j = 0; j < 100; j++)
                 {
+                    foreach (JToken token in obj)
+                    {
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ParseNewtonsoftEnumerateReverse()
+        {
+            _stream.Seek(0, SeekOrigin.Begin);
+            using (JsonTextReader jsonReader = new JsonTextReader(_reader))
+            {
+                JToken obj = JToken.ReadFrom(jsonReader);
+
+                for (int j = 0; j < 100; j++)
+                {
+                    for (int i = 299; i >= 0; i--)
+                    {
+                        JToken token = obj[i];
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ParseNewtonsoftFirst()
+        {
+            _stream.Seek(0, SeekOrigin.Begin);
+            using (JsonTextReader jsonReader = new JsonTextReader(_reader))
+            {
+                JToken obj = JToken.ReadFrom(jsonReader);
+
+                for (int j = 0; j < 100; j++)
+                {
+                    for (int i = 0; i < 300; i++)
+                    {
+                        JToken token = obj[0];
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ParseNewtonsoftMiddle()
+        {
+            _stream.Seek(0, SeekOrigin.Begin);
+            using (JsonTextReader jsonReader = new JsonTextReader(_reader))
+            {
+                JToken obj = JToken.ReadFrom(jsonReader);
+
+                for (int j = 0; j < 100; j++)
+                {
+                    for (int i = 0; i < 300; i++)
+                    {
+                        JToken token = obj[150];
+                    }
                 }
             }
         }
@@ -57,9 +114,12 @@ namespace System.Text.JsonLab.Benchmarks
         {
             JsonObject obj = JsonObject.Parse(_dataUtf8);
 
-            for (int i = 0; i < obj.ArrayLength; i++)
+            for (int j = 0; j < 100; j++)
             {
-                JsonObject withinArray = obj[i];
+                for (int i = 0; i < obj.ArrayLength; i++)
+                {
+                    JsonObject withinArray = obj[i];
+                }
             }
 
             obj.Dispose();
@@ -70,9 +130,12 @@ namespace System.Text.JsonLab.Benchmarks
         {
             JsonObject obj = JsonObject.Parse(_dataUtf8);
 
-            for (int i = obj.ArrayLength - 1; i >= 0; i--)
+            for (int j = 0; j < 100; j++)
             {
-                JsonObject withinArray = obj[i];
+                for (int i = obj.ArrayLength - 1; i >= 0; i--)
+                {
+                    JsonObject withinArray = obj[i];
+                }
             }
 
             obj.Dispose();
@@ -83,9 +146,28 @@ namespace System.Text.JsonLab.Benchmarks
         {
             JsonObject obj = JsonObject.Parse(_dataUtf8);
 
-            for (int i = 0; i < obj.ArrayLength; i++)
+            for (int j = 0; j < 100; j++)
             {
-                JsonObject withinArray = obj[0];
+                for (int i = 0; i < obj.ArrayLength; i++)
+                {
+                    JsonObject withinArray = obj[0];
+                }
+            }
+
+            obj.Dispose();
+        }
+
+        [Benchmark]
+        public void ParseSystemTextJsonLabMiddle()
+        {
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
+
+            for (int j = 0; j < 100; j++)
+            {
+                for (int i = 0; i < obj.ArrayLength; i++)
+                {
+                    JsonObject withinArray = obj[150];
+                }
             }
 
             obj.Dispose();

--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
@@ -43,12 +43,31 @@ namespace System.Text.JsonLab.Benchmarks
         [ParamsSource(nameof(TestCaseValues))]
         public TestCaseType TestCase;
 
+        [Params(true)]
+        public bool IsDataCompact;
+
         public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));
 
         [GlobalSetup]
         public void Setup()
         {
             string jsonString = JsonStrings.ResourceManager.GetString(TestCase.ToString());
+
+            // Remove all formatting/indendation
+            if (IsDataCompact)
+            {
+                using (JsonTextReader jsonReader = new JsonTextReader(new StringReader(jsonString)))
+                {
+                    JToken obj = JToken.ReadFrom(jsonReader);
+                    var stringWriter = new StringWriter();
+                    using (JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter))
+                    {
+                        obj.WriteTo(jsonWriter);
+                        jsonString = stringWriter.ToString();
+                    }
+                }
+            }
+
             _dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
 
             _stream = new MemoryStream(_dataUtf8);
@@ -84,22 +103,109 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
+        [Benchmark]
+        public void ParseSystemTextJsonLabScanSeveralProperties()
+        {
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
+
+            var lookup1 = new Utf8Span("about");
+            var lookup4 = new Utf8Span("greeting");
+            var lookup2 = new Utf8Span("friends");
+            var lookup3 = new Utf8Span("name");
+            var lookup5 = new Utf8Span("age");
+
+            for (int k = 0; k < 2; k++)
+            {
+                for (int i = 0; i < obj.ArrayLength; i += 10)
+                {
+                    for (int j = 0; j < 300; j++)
+                    {
+                        string greeting = (string)obj[5][lookup4];
+                    }
+                    string about = (string)obj[i][lookup1];
+                    string temp = (string)obj[i][lookup2][1][lookup3];
+                    int age = (int)obj[i][lookup5];
+                }
+            }
+
+            obj.Dispose();
+        }
+
+
+        //[Benchmark]
+        public void ParseSystemTextJsonLabScanProperties()
+        {
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
+
+            var lookup4 = new Utf8Span("greeting");
+            for (int i = 0; i < 20_000; i++)
+            {
+                string id = (string)obj[10][lookup4];
+            }
+
+            obj.Dispose();
+        }
+
+        //[Benchmark]
+        public void ParseSystemTextJsonLabEnumerate()
+        {
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
+
+            for (int i = 0; i < obj.ArrayLength; i++)
+            {
+                JsonObject withinArray = obj[i];
+            }
+
+            obj.Dispose();
+        }
+
+        //[Benchmark]
+        public void ParseSystemTextJsonLabEnumerateReverse()
+        {
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
+
+            for (int i = obj.ArrayLength - 1; i >= 0; i--)
+            {
+                JsonObject withinArray = obj[i];
+            }
+
+            obj.Dispose();
+        }
+
+        //[Benchmark]
+        public void ParseSystemTextJsonLabFirst()
+        {
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
+
+            for (int i = 0; i < obj.ArrayLength; i++)
+            {
+                JsonObject withinArray = obj[0];
+            }
+
+            obj.Dispose();
+        }
+
         //[Benchmark]
         public void ParseSystemTextJsonLab1()
         {
-            var parser = new JsonParser(_dataUtf8);
-            JsonObject obj = parser.Parse();
+            //var parser = new JsonParser(_dataUtf8);
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
 
-            /*if (TestCase == TestCaseType.Json400KB)
+            if (TestCase == TestCaseType.Json400KB)
             {
                 var lookup = new Utf8Span("email");
 
-                for (int i = 0; i < 10_000; i++)
+                for (int i = 0; i < obj.ArrayLength; i++)
+                {
+                    JsonObject withinArray = obj[i];
+                }
+
+                /*for (int i = 0; i < 10_000; i++)
                 {
                     Utf8Span email = (Utf8Span)obj[5][lookup];
-                }
+                }*/
             }
-            else if (TestCase == TestCaseType.HelloWorld)
+            /*else if (TestCase == TestCaseType.HelloWorld)
             {
                 var lookup = new Utf8Span("message");
 
@@ -108,13 +214,13 @@ namespace System.Text.JsonLab.Benchmarks
                     Utf8Span message = (Utf8Span)obj[lookup];
                 }
             }*/
+            obj.Dispose();
         }
 
         //[Benchmark]
         public void ParseSystemTextJsonLab3()
         {
-            var parser = new JsonParser(_dataUtf8);
-            JsonObject obj = parser.Parse();
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
 
             if (TestCase == TestCaseType.Json400KB)
             {
@@ -139,8 +245,7 @@ namespace System.Text.JsonLab.Benchmarks
         //[Benchmark]
         public void ParseSystemTextJsonLab4()
         {
-            var parser = new JsonParser(_dataUtf8);
-            JsonObject obj = parser.Parse();
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
 
             if (TestCase == TestCaseType.Json400KB)
             {
@@ -162,11 +267,10 @@ namespace System.Text.JsonLab.Benchmarks
             }*/
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void ParseSystemTextJsonLab5()
         {
-            var parser = new JsonParser(_dataUtf8);
-            JsonObject obj = parser.Parse();
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
 
             if (TestCase == TestCaseType.Json400KB)
             {

--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
@@ -12,27 +12,27 @@ using System.Text.Utf8;
 namespace System.Text.JsonLab.Benchmarks
 {
     // Since there are 30 tests here (2 * 15), setting low values for the warmupCount and targetCount
-    [SimpleJob(-1, 3, 5)]
+    //[SimpleJob(-1, 3, 5)]
     [MemoryDiagnoser]
     public class JsonParserPerf
     {
         // Keep the JsonStrings resource names in sync with TestCaseType enum values.
         public enum TestCaseType
         {
-            HelloWorld,
-            BasicJson,
-            BasicLargeNum,
-            SpecialNumForm,
-            ProjectLockJson,
-            FullSchema1,
-            FullSchema2,
-            DeepTree,
-            BroadTree,
-            LotsOfNumbers,
-            LotsOfStrings,
-            Json400B,
-            Json4KB,
-            Json40KB,
+            //HelloWorld,
+            //BasicJson,
+            //BasicLargeNum,
+            //SpecialNumForm,
+            //ProjectLockJson,
+            //FullSchema1,
+            //FullSchema2,
+            //DeepTree,
+            //BroadTree,
+            //LotsOfNumbers,
+            //LotsOfStrings,
+            //Json400B,
+            //Json4KB,
+            //Json40KB,
             Json400KB
         }
 
@@ -55,7 +55,7 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        [Benchmark(Baseline = true)]
+        //[Benchmark(Baseline = true)]
         public void ParseNewtonsoft()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -72,7 +72,7 @@ namespace System.Text.JsonLab.Benchmarks
                         string email = (string)obj[5][lookup];
                     }
                 }
-                else if (TestCase == TestCaseType.HelloWorld)
+                /*else if (TestCase == TestCaseType.HelloWorld)
                 {
                     var lookup = "message";
 
@@ -80,17 +80,17 @@ namespace System.Text.JsonLab.Benchmarks
                     {
                         string message = (string)obj[lookup];
                     }
-                }
+                }*/
             }
         }
 
-        [Benchmark]
-        public void ParseSystemTextJsonLab()
+        //[Benchmark]
+        public void ParseSystemTextJsonLab1()
         {
             var parser = new JsonParser(_dataUtf8);
             JsonObject obj = parser.Parse();
 
-            if (TestCase == TestCaseType.Json400KB)
+            /*if (TestCase == TestCaseType.Json400KB)
             {
                 var lookup = new Utf8Span("email");
 
@@ -107,7 +107,85 @@ namespace System.Text.JsonLab.Benchmarks
                 {
                     Utf8Span message = (Utf8Span)obj[lookup];
                 }
+            }*/
+        }
+
+        //[Benchmark]
+        public void ParseSystemTextJsonLab3()
+        {
+            var parser = new JsonParser(_dataUtf8);
+            JsonObject obj = parser.Parse();
+
+            if (TestCase == TestCaseType.Json400KB)
+            {
+                var lookup = new Utf8Span("email");
+
+                for (int i = 0; i < 10_000; i++)
+                {
+                    JsonObject temp = obj[5];
+                }
             }
+            /*else if (TestCase == TestCaseType.HelloWorld)
+            {
+                var lookup = new Utf8Span("message");
+
+                for (int i = 0; i < 10; i++)
+                {
+                    Utf8Span message = (Utf8Span)obj[lookup];
+                }
+            }*/
+        }
+
+        //[Benchmark]
+        public void ParseSystemTextJsonLab4()
+        {
+            var parser = new JsonParser(_dataUtf8);
+            JsonObject obj = parser.Parse();
+
+            if (TestCase == TestCaseType.Json400KB)
+            {
+                var lookup = new Utf8Span("email");
+
+                for (int i = 0; i < 10_000; i++)
+                {
+                    JsonObject temp = obj[5][lookup];
+                }
+            }
+            /*else if (TestCase == TestCaseType.HelloWorld)
+            {
+                var lookup = new Utf8Span("message");
+
+                for (int i = 0; i < 10; i++)
+                {
+                    Utf8Span message = (Utf8Span)obj[lookup];
+                }
+            }*/
+        }
+
+        [Benchmark]
+        public void ParseSystemTextJsonLab5()
+        {
+            var parser = new JsonParser(_dataUtf8);
+            JsonObject obj = parser.Parse();
+
+            if (TestCase == TestCaseType.Json400KB)
+            {
+                var lookup = new Utf8Span("email");
+
+                for (int i = 0; i < 10_000; i++)
+                {
+                    Utf8Span message = (Utf8Span)obj[5][lookup];
+                }
+            }
+            /*else if (TestCase == TestCaseType.HelloWorld)
+            {
+                var lookup = new Utf8Span("message");
+
+                for (int i = 0; i < 10; i++)
+                {
+                    Utf8Span message = (Utf8Span)obj[lookup];
+                }
+            }*/
         }
     }
 }

--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
@@ -12,27 +12,27 @@ using System.Text.Utf8;
 namespace System.Text.JsonLab.Benchmarks
 {
     // Since there are 120 tests here (8 * 15), setting low values for the warmupCount and targetCount
-    //[SimpleJob(-1, 3, 5)]
-    //[MemoryDiagnoser]
+    [SimpleJob(-1, 3, 5)]
+    [MemoryDiagnoser]
     public class JsonParserPerf
     {
         // Keep the JsonStrings resource names in sync with TestCaseType enum values.
         public enum TestCaseType
         {
             HelloWorld,
-            //BasicJson,
-            //BasicLargeNum,
-            //SpecialNumForm,
-            //ProjectLockJson,
-            //FullSchema1,
-            //FullSchema2,
-            //DeepTree,
-            //BroadTree,
-            //LotsOfNumbers,
-            //LotsOfStrings,
-            //Json400B,
-            //Json4KB,
-            //Json40KB,
+            BasicJson,
+            BasicLargeNum,
+            SpecialNumForm,
+            ProjectLockJson,
+            FullSchema1,
+            FullSchema2,
+            DeepTree,
+            BroadTree,
+            LotsOfNumbers,
+            LotsOfStrings,
+            Json400B,
+            Json4KB,
+            Json40KB,
             Json400KB
         }
 
@@ -43,10 +43,10 @@ namespace System.Text.JsonLab.Benchmarks
         [ParamsSource(nameof(TestCaseValues))]
         public TestCaseType TestCase;
 
-        [Params(true/*, false*/)]
+        [Params(true, false)]
         public bool IsDataCompact;
 
-        [Params(/*true,*/ false)]
+        [Params(true, false)]
         public bool OnlyParse;
 
         public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));
@@ -77,7 +77,7 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        //[Benchmark(Baseline = true)]
+        [Benchmark(Baseline = true)]
         public void ParseNewtonsoft()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -91,15 +91,15 @@ namespace System.Text.JsonLab.Benchmarks
                     {
                         ReadHelloWorld(obj);
                     }
-                    /*else if (TestCase == TestCaseType.Json400B)
+                    else if (TestCase == TestCaseType.Json400B)
                     {
                         ReadJson400B(obj);
                     }
                     else if (TestCase == TestCaseType.BasicJson)
                     {
                         ReadJsonBasic(obj);
-                    }*/
-                    else if (TestCase == TestCaseType.Json400KB/* || TestCase == TestCaseType.Json40KB || TestCase == TestCaseType.Json4KB*/)
+                    }
+                    else if (TestCase == TestCaseType.Json400KB || TestCase == TestCaseType.Json40KB || TestCase == TestCaseType.Json4KB)
                     {
                         ReadJson400KB(obj);
                     }
@@ -117,15 +117,15 @@ namespace System.Text.JsonLab.Benchmarks
                 {
                     ReadHelloWorld(obj);
                 }
-                /*else if (TestCase == TestCaseType.Json400B)
+                else if (TestCase == TestCaseType.Json400B)
                 {
                     ReadJson400B(obj);
                 }
                 else if (TestCase == TestCaseType.BasicJson)
                 {
                     ReadJsonBasic(obj);
-                }*/
-                else if (TestCase == TestCaseType.Json400KB/* || TestCase == TestCaseType.Json40KB || TestCase == TestCaseType.Json4KB*/)
+                }
+                else if (TestCase == TestCaseType.Json400KB || TestCase == TestCaseType.Json40KB || TestCase == TestCaseType.Json4KB)
                 {
                     ReadJson400KB(obj);
                 }
@@ -255,39 +255,6 @@ namespace System.Text.JsonLab.Benchmarks
             var sb = new StringBuilder();
             for (int i = 0; i < obj.ArrayLength; i++)
             {
-                /*sb.Append((string)obj[i]["_id"]);
-                sb.Append((int)obj[i]["index"]);
-                sb.Append((string)obj[i]["guid"]);
-                sb.Append((bool)obj[i]["isActive"]);
-                sb.Append((string)obj[i]["balance"]);
-                sb.Append((string)obj[i]["picture"]);
-                sb.Append((int)obj[i]["age"]);
-                sb.Append((string)obj[i]["eyeColor"]);
-                sb.Append((string)obj[i]["name"]);
-                sb.Append((string)obj[i]["gender"]);
-                sb.Append((string)obj[i]["company"]);
-                sb.Append((string)obj[i]["email"]);
-                sb.Append((string)obj[i]["phone"]);
-                sb.Append((string)obj[i]["address"]);
-                sb.Append((string)obj[i]["about"]);
-                sb.Append((string)obj[i]["registered"]);
-                sb.Append((double)obj[i]["latitude"]);
-                sb.Append((double)obj[i]["longitude"]);
-
-                JsonObject tags = obj[i]["tags"];
-                for (int j = 0; j < tags.ArrayLength; j++)
-                {
-                    sb.Append((string)tags[j]);
-                }
-                JsonObject friends = obj[i]["friends"];
-                for (int j = 0; j < friends.ArrayLength; j++)
-                {
-                    sb.Append((int)friends[j]["id"]);
-                    sb.Append((string)friends[j]["name"]);
-                }
-                sb.Append((string)obj[i]["greeting"]);
-                sb.Append((string)obj[i]["favoriteFruit"]);*/
-
                 sb.Append((string)obj[i][_id]);
                 sb.Append((int)obj[i][index]);
                 sb.Append((string)obj[i][guid]);
@@ -374,112 +341,6 @@ namespace System.Text.JsonLab.Benchmarks
             sb.Append((string)address["city"]);
             sb.Append((string)address["zip"]);
             return sb.ToString();
-        }
-
-        //[Benchmark]
-        public void ParseSystemTextJsonLabScanSeveralProperties()
-        {
-            JsonObject obj = JsonObject.Parse(_dataUtf8);
-
-            var lookup1 = new Utf8Span("about");
-            var lookup4 = new Utf8Span("greeting");
-            var lookup2 = new Utf8Span("friends");
-            var lookup3 = new Utf8Span("name");
-            var lookup5 = new Utf8Span("age");
-
-            for (int k = 0; k < 2; k++)
-            {
-                for (int i = 0; i < obj.ArrayLength; i += 10)
-                {
-                    for (int j = 0; j < 300; j++)
-                    {
-                        string greeting = (string)obj[5][lookup4];
-                    }
-                    string about = (string)obj[i][lookup1];
-                    string temp = (string)obj[i][lookup2][1][lookup3];
-                    int age = (int)obj[i][lookup5];
-                }
-            }
-
-            obj.Dispose();
-        }
-
-        //[Benchmark]
-        public void ParseSystemTextJsonLabScanProperties()
-        {
-            JsonObject obj = JsonObject.Parse(_dataUtf8);
-
-            var lookup4 = new Utf8Span("greeting");
-            for (int i = 0; i < 20_000; i++)
-            {
-                string id = (string)obj[10][lookup4];
-            }
-
-            obj.Dispose();
-        }
-
-        //[Benchmark]
-        public void ParseSystemTextJsonLabEnumerate()
-        {
-            JsonObject obj = JsonObject.Parse(_dataUtf8);
-
-            for (int i = 0; i < obj.ArrayLength; i++)
-            {
-                JsonObject withinArray = obj[i];
-            }
-
-            obj.Dispose();
-        }
-
-        //[Benchmark]
-        public void ParseSystemTextJsonLabEnumerateReverse()
-        {
-            JsonObject obj = JsonObject.Parse(_dataUtf8);
-
-            for (int i = obj.ArrayLength - 1; i >= 0; i--)
-            {
-                JsonObject withinArray = obj[i];
-            }
-
-            obj.Dispose();
-        }
-
-        //[Benchmark]
-        public void ParseSystemTextJsonLabFirst()
-        {
-            JsonObject obj = JsonObject.Parse(_dataUtf8);
-
-            for (int i = 0; i < obj.ArrayLength; i++)
-            {
-                JsonObject withinArray = obj[0];
-            }
-
-            obj.Dispose();
-        }
-
-        //[Benchmark]
-        public void ParseSystemTextJsonLabConstantAccess()
-        {
-            JsonObject obj = JsonObject.Parse(_dataUtf8);
-
-            if (TestCase == TestCaseType.Json400KB)
-            {
-                var lookup = new Utf8Span("email");
-
-                for (int i = 0; i < 10_000; i++)
-                {
-                    Utf8Span message = (Utf8Span)obj[5][lookup];
-                }
-            }
-            else if (TestCase == TestCaseType.HelloWorld)
-            {
-                var lookup = new Utf8Span("message");
-
-                for (int i = 0; i < 10; i++)
-                {
-                    Utf8Span message = (Utf8Span)obj[lookup];
-                }
-            }
         }
     }
 }

--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
@@ -19,7 +19,7 @@ namespace System.Text.JsonLab.Benchmarks
         // Keep the JsonStrings resource names in sync with TestCaseType enum values.
         public enum TestCaseType
         {
-            //HelloWorld,
+            HelloWorld,
             //BasicJson,
             //BasicLargeNum,
             //SpecialNumForm,
@@ -43,7 +43,7 @@ namespace System.Text.JsonLab.Benchmarks
         [ParamsSource(nameof(TestCaseValues))]
         public TestCaseType TestCase;
 
-        [Params(true)]
+        [Params(true, false)]
         public bool IsDataCompact;
 
         public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));
@@ -74,7 +74,7 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        //[Benchmark(Baseline = true)]
+        [Benchmark(Baseline = true)]
         public void ParseNewtonsoft()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -82,7 +82,7 @@ namespace System.Text.JsonLab.Benchmarks
             {
                 JToken obj = JToken.ReadFrom(jsonReader);
 
-                if (TestCase == TestCaseType.Json400KB)
+                /*if (TestCase == TestCaseType.Json400KB)
                 {
                     var lookup = "email";
 
@@ -91,7 +91,7 @@ namespace System.Text.JsonLab.Benchmarks
                         string email = (string)obj[5][lookup];
                     }
                 }
-                /*else if (TestCase == TestCaseType.HelloWorld)
+                else if (TestCase == TestCaseType.HelloWorld)
                 {
                     var lookup = "message";
 
@@ -100,10 +100,130 @@ namespace System.Text.JsonLab.Benchmarks
                         string message = (string)obj[lookup];
                     }
                 }*/
+
+                if (TestCase == TestCaseType.Json400KB)
+                {
+                    ReadJson400KB(obj);
+                }
+                else if (TestCase == TestCaseType.HelloWorld)
+                {
+                    ReadHelloWorld(obj);
+                }
             }
         }
 
+        private string ReadHelloWorld(JToken obj)
+        {
+            string message = (string)obj["message"];
+            return message;
+        }
+
+        private string ReadJson400KB(JToken obj)
+        {
+            var sb = new StringBuilder();
+            foreach (JToken token in obj)
+            {
+                sb.Append((string)token["_id"]);
+                sb.Append((int)token["index"]);
+                sb.Append((string)token["guid"]);
+                sb.Append((bool)token["isActive"]);
+                sb.Append((string)token["balance"]);
+                sb.Append((string)token["picture"]);
+                sb.Append((int)token["age"]);
+                sb.Append((string)token["eyeColor"]);
+                sb.Append((string)token["name"]);
+                sb.Append((string)token["gender"]);
+                sb.Append((string)token["company"]);
+                sb.Append((string)token["email"]);
+                sb.Append((string)token["phone"]);
+                sb.Append((string)token["address"]);
+                sb.Append((string)token["about"]);
+                sb.Append((string)token["registered"]);
+                sb.Append((double)token["latitude"]);
+                sb.Append((double)token["longitude"]);
+
+                JToken tags = token["tags"];
+                foreach (JToken tag in tags)
+                {
+                    sb.Append((string)tag);
+                }
+                JToken friends = token["friends"];
+                foreach (JToken friend in friends)
+                {
+                    sb.Append((int)friend["id"]);
+                    sb.Append((string)friend["name"]);
+                }
+                sb.Append((string)token["greeting"]);
+                sb.Append((string)token["favoriteFruit"]);
+
+            }
+            return sb.ToString();
+        }
+
+        private string ReadHelloWorld(JsonObject obj)
+        {
+            string message = (string)obj["message"];
+            return message;
+        }
+
+        private string ReadJson400KB(JsonObject obj)
+        {
+            var sb = new StringBuilder();
+            for (int i = 0; i < obj.ArrayLength; i++)
+            {
+                sb.Append((string)obj[i]["_id"]);
+                sb.Append((int)obj[i]["index"]);
+                sb.Append((string)obj[i]["guid"]);
+                sb.Append((bool)obj[i]["isActive"]);
+                sb.Append((string)obj[i]["balance"]);
+                sb.Append((string)obj[i]["picture"]);
+                sb.Append((int)obj[i]["age"]);
+                sb.Append((string)obj[i]["eyeColor"]);
+                sb.Append((string)obj[i]["name"]);
+                sb.Append((string)obj[i]["gender"]);
+                sb.Append((string)obj[i]["company"]);
+                sb.Append((string)obj[i]["email"]);
+                sb.Append((string)obj[i]["phone"]);
+                sb.Append((string)obj[i]["address"]);
+                sb.Append((string)obj[i]["about"]);
+                sb.Append((string)obj[i]["registered"]);
+                sb.Append((double)obj[i]["latitude"]);
+                sb.Append((double)obj[i]["longitude"]);
+
+                JsonObject tags = obj[i]["tags"];
+                for (int j = 0; j < tags.ArrayLength; j++)
+                {
+                    sb.Append((string)tags[j]);
+                }
+                JsonObject friends = obj[i]["friends"];
+                for (int j = 0; j < friends.ArrayLength; j++)
+                {
+                    sb.Append((int)friends[j]["id"]);
+                    sb.Append((string)friends[j]["name"]);
+                }
+                sb.Append((string)obj[i]["greeting"]);
+                sb.Append((string)obj[i]["favoriteFruit"]);
+
+            }
+            return sb.ToString();
+        }
+
         [Benchmark]
+        public void ParseSystemTextJsonLab()
+        {
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
+            if (TestCase == TestCaseType.Json400KB)
+            {
+                ReadJson400KB(obj);
+            }
+            else if (TestCase == TestCaseType.HelloWorld)
+            {
+                ReadHelloWorld(obj);
+            }
+            obj.Dispose();
+        }
+
+        //[Benchmark]
         public void ParseSystemTextJsonLabScanSeveralProperties()
         {
             JsonObject obj = JsonObject.Parse(_dataUtf8);

--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
@@ -107,7 +107,7 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        [Benchmark(Baseline = true)]
+        [Benchmark]
         public void ParseSystemTextJsonLab()
         {
             JsonObject obj = JsonObject.Parse(_dataUtf8);

--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
@@ -11,9 +11,9 @@ using System.Text.Utf8;
 
 namespace System.Text.JsonLab.Benchmarks
 {
-    // Since there are 30 tests here (2 * 15), setting low values for the warmupCount and targetCount
+    // Since there are 120 tests here (8 * 15), setting low values for the warmupCount and targetCount
     //[SimpleJob(-1, 3, 5)]
-    [MemoryDiagnoser]
+    //[MemoryDiagnoser]
     public class JsonParserPerf
     {
         // Keep the JsonStrings resource names in sync with TestCaseType enum values.
@@ -43,8 +43,11 @@ namespace System.Text.JsonLab.Benchmarks
         [ParamsSource(nameof(TestCaseValues))]
         public TestCaseType TestCase;
 
-        [Params(true, false)]
+        [Params(true/*, false*/)]
         public bool IsDataCompact;
+
+        [Params(/*true,*/ false)]
+        public bool OnlyParse;
 
         public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));
 
@@ -74,7 +77,7 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        [Benchmark(Baseline = true)]
+        //[Benchmark(Baseline = true)]
         public void ParseNewtonsoft()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -82,43 +85,61 @@ namespace System.Text.JsonLab.Benchmarks
             {
                 JToken obj = JToken.ReadFrom(jsonReader);
 
-                /*if (TestCase == TestCaseType.Json400KB)
+                if (!OnlyParse)
                 {
-                    var lookup = "email";
-
-                    for (int i = 0; i < 10_000; i++)
+                    if (TestCase == TestCaseType.HelloWorld)
                     {
-                        string email = (string)obj[5][lookup];
+                        ReadHelloWorld(obj);
                     }
-                }
-                else if (TestCase == TestCaseType.HelloWorld)
-                {
-                    var lookup = "message";
-
-                    for (int i = 0; i < 10; i++)
+                    /*else if (TestCase == TestCaseType.Json400B)
                     {
-                        string message = (string)obj[lookup];
+                        ReadJson400B(obj);
                     }
-                }*/
-
-                if (TestCase == TestCaseType.Json400KB)
-                {
-                    ReadJson400KB(obj);
-                }
-                else if (TestCase == TestCaseType.HelloWorld)
-                {
-                    ReadHelloWorld(obj);
+                    else if (TestCase == TestCaseType.BasicJson)
+                    {
+                        ReadJsonBasic(obj);
+                    }*/
+                    else if (TestCase == TestCaseType.Json400KB/* || TestCase == TestCaseType.Json40KB || TestCase == TestCaseType.Json4KB*/)
+                    {
+                        ReadJson400KB(obj);
+                    }
                 }
             }
         }
 
-        private string ReadHelloWorld(JToken obj)
+        [Benchmark(Baseline = true)]
+        public void ParseSystemTextJsonLab()
+        {
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
+            if (!OnlyParse)
+            {
+                if (TestCase == TestCaseType.HelloWorld)
+                {
+                    ReadHelloWorld(obj);
+                }
+                /*else if (TestCase == TestCaseType.Json400B)
+                {
+                    ReadJson400B(obj);
+                }
+                else if (TestCase == TestCaseType.BasicJson)
+                {
+                    ReadJsonBasic(obj);
+                }*/
+                else if (TestCase == TestCaseType.Json400KB/* || TestCase == TestCaseType.Json40KB || TestCase == TestCaseType.Json4KB*/)
+                {
+                    ReadJson400KB(obj);
+                }
+            }
+            obj.Dispose();
+        }
+
+        private static string ReadHelloWorld(JToken obj)
         {
             string message = (string)obj["message"];
             return message;
         }
 
-        private string ReadJson400KB(JToken obj)
+        private static string ReadJson400KB(JToken obj)
         {
             var sb = new StringBuilder();
             foreach (JToken token in obj)
@@ -160,18 +181,81 @@ namespace System.Text.JsonLab.Benchmarks
             return sb.ToString();
         }
 
-        private string ReadHelloWorld(JsonObject obj)
+        private static string ReadJson400B(JToken obj)
+        {
+            var sb = new StringBuilder();
+            foreach (JToken token in obj)
+            {
+                sb.Append((string)token["_id"]);
+                sb.Append((int)token["index"]);
+                sb.Append((bool)token["isActive"]);
+                sb.Append((string)token["balance"]);
+                sb.Append((string)token["picture"]);
+                sb.Append((int)token["age"]);
+                sb.Append((string)token["email"]);
+                sb.Append((string)token["phone"]);
+                sb.Append((string)token["address"]);
+                sb.Append((string)token["registered"]);
+                sb.Append((double)token["latitude"]);
+                sb.Append((double)token["longitude"]);
+            }
+            return sb.ToString();
+        }
+
+        private static string ReadJsonBasic(JToken obj)
+        {
+            var sb = new StringBuilder();
+            sb.Append((int)obj["age"]);
+            sb.Append((string)obj["first"]);
+            sb.Append((string)obj["last"]);
+            JToken phoneNumbers = obj["phoneNumbers"];
+            foreach (JToken phoneNumber in phoneNumbers)
+            {
+                sb.Append((string)phoneNumber);
+            }
+            JToken address = obj["address"];
+            sb.Append((string)address["street"]);
+            sb.Append((string)address["city"]);
+            sb.Append((string)address["zip"]);
+            return sb.ToString();
+        }
+
+        private static string ReadHelloWorld(JsonObject obj)
         {
             string message = (string)obj["message"];
             return message;
         }
 
-        private string ReadJson400KB(JsonObject obj)
+        private static string ReadJson400KB(JsonObject obj)
         {
+            Utf8Span _id = (Utf8Span)"_id";
+            Utf8Span index = (Utf8Span)"index";
+            Utf8Span guid = (Utf8Span)"guid";
+            Utf8Span isActive = (Utf8Span)"isActive";
+            Utf8Span balance = (Utf8Span)"balance";
+            Utf8Span picture = (Utf8Span)"picture";
+            Utf8Span age = (Utf8Span)"age";
+            Utf8Span eyeColor = (Utf8Span)"eyeColor";
+            Utf8Span name = (Utf8Span)"name";
+            Utf8Span gender = (Utf8Span)"gender";
+            Utf8Span company = (Utf8Span)"company";
+            Utf8Span email = (Utf8Span)"email";
+            Utf8Span phone = (Utf8Span)"phone";
+            Utf8Span address = (Utf8Span)"address";
+            Utf8Span about = (Utf8Span)"about";
+            Utf8Span registered = (Utf8Span)"registered";
+            Utf8Span latitude = (Utf8Span)"latitude";
+            Utf8Span longitude = (Utf8Span)"longitude";
+            Utf8Span tags = (Utf8Span)"tags";
+            Utf8Span friends = (Utf8Span)"friends";
+            Utf8Span id = (Utf8Span)"id";
+            Utf8Span greeting = (Utf8Span)"greeting";
+            Utf8Span favoriteFruit = (Utf8Span)"favoriteFruit";
+
             var sb = new StringBuilder();
             for (int i = 0; i < obj.ArrayLength; i++)
             {
-                sb.Append((string)obj[i]["_id"]);
+                /*sb.Append((string)obj[i]["_id"]);
                 sb.Append((int)obj[i]["index"]);
                 sb.Append((string)obj[i]["guid"]);
                 sb.Append((bool)obj[i]["isActive"]);
@@ -202,25 +286,94 @@ namespace System.Text.JsonLab.Benchmarks
                     sb.Append((string)friends[j]["name"]);
                 }
                 sb.Append((string)obj[i]["greeting"]);
-                sb.Append((string)obj[i]["favoriteFruit"]);
+                sb.Append((string)obj[i]["favoriteFruit"]);*/
 
+                sb.Append((string)obj[i][_id]);
+                sb.Append((int)obj[i][index]);
+                sb.Append((string)obj[i][guid]);
+                sb.Append((bool)obj[i][isActive]);
+                sb.Append((string)obj[i][balance]);
+                sb.Append((string)obj[i][picture]);
+                sb.Append((int)obj[i][age]);
+                sb.Append((string)obj[i][eyeColor]);
+                sb.Append((string)obj[i][name]);
+                sb.Append((string)obj[i][gender]);
+                sb.Append((string)obj[i][company]);
+                sb.Append((string)obj[i][email]);
+                sb.Append((string)obj[i][phone]);
+                sb.Append((string)obj[i][address]);
+                sb.Append((string)obj[i][about]);
+                sb.Append((string)obj[i][registered]);
+                sb.Append((double)obj[i][latitude]);
+                sb.Append((double)obj[i][longitude]);
+
+                JsonObject tagsObject = obj[i][tags];
+                for (int j = 0; j < tagsObject.ArrayLength; j++)
+                {
+                    sb.Append((string)tagsObject[j]);
+                }
+                JsonObject friendsObject = obj[i][friends];
+                for (int j = 0; j < friendsObject.ArrayLength; j++)
+                {
+                    sb.Append((int)friendsObject[j][id]);
+                    sb.Append((string)friendsObject[j][name]);
+                }
+                sb.Append((string)obj[i][greeting]);
+                sb.Append((string)obj[i][favoriteFruit]);
             }
             return sb.ToString();
         }
 
-        [Benchmark]
-        public void ParseSystemTextJsonLab()
+        private static string ReadJson400B(JsonObject obj)
         {
-            JsonObject obj = JsonObject.Parse(_dataUtf8);
-            if (TestCase == TestCaseType.Json400KB)
+            Utf8Span _id = (Utf8Span)"_id";
+            Utf8Span index = (Utf8Span)"index";
+            Utf8Span isActive = (Utf8Span)"isActive";
+            Utf8Span balance = (Utf8Span)"balance";
+            Utf8Span picture = (Utf8Span)"picture";
+            Utf8Span age = (Utf8Span)"age";
+            Utf8Span email = (Utf8Span)"email";
+            Utf8Span phone = (Utf8Span)"phone";
+            Utf8Span address = (Utf8Span)"address";
+            Utf8Span registered = (Utf8Span)"registered";
+            Utf8Span latitude = (Utf8Span)"latitude";
+            Utf8Span longitude = (Utf8Span)"longitude";
+
+            var sb = new StringBuilder();
+            for (int i = 0; i < obj.ArrayLength; i++)
             {
-                ReadJson400KB(obj);
+                sb.Append((string)obj[i][_id]);
+                sb.Append((int)obj[i][index]);
+                sb.Append((bool)obj[i][isActive]);
+                sb.Append((string)obj[i][balance]);
+                sb.Append((string)obj[i][picture]);
+                sb.Append((int)obj[i][age]);
+                sb.Append((string)obj[i][email]);
+                sb.Append((string)obj[i][phone]);
+                sb.Append((string)obj[i][address]);
+                sb.Append((string)obj[i][registered]);
+                sb.Append((double)obj[i][latitude]);
+                sb.Append((double)obj[i][longitude]);
             }
-            else if (TestCase == TestCaseType.HelloWorld)
+            return sb.ToString();
+        }
+
+        private static string ReadJsonBasic(JsonObject obj)
+        {
+            var sb = new StringBuilder();
+            sb.Append((int)obj["age"]);
+            sb.Append((string)obj["first"]);
+            sb.Append((string)obj["last"]);
+            JsonObject phoneNumbers = obj["phoneNumbers"];
+            for (int i = 0; i < phoneNumbers.ArrayLength; i++)
             {
-                ReadHelloWorld(obj);
+                sb.Append((string)phoneNumbers[i]);
             }
-            obj.Dispose();
+            JsonObject address = obj["address"];
+            sb.Append((string)address["street"]);
+            sb.Append((string)address["city"]);
+            sb.Append((string)address["zip"]);
+            return sb.ToString();
         }
 
         //[Benchmark]
@@ -250,7 +403,6 @@ namespace System.Text.JsonLab.Benchmarks
 
             obj.Dispose();
         }
-
 
         //[Benchmark]
         public void ParseSystemTextJsonLabScanProperties()
@@ -306,89 +458,7 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         //[Benchmark]
-        public void ParseSystemTextJsonLab1()
-        {
-            //var parser = new JsonParser(_dataUtf8);
-            JsonObject obj = JsonObject.Parse(_dataUtf8);
-
-            if (TestCase == TestCaseType.Json400KB)
-            {
-                var lookup = new Utf8Span("email");
-
-                for (int i = 0; i < obj.ArrayLength; i++)
-                {
-                    JsonObject withinArray = obj[i];
-                }
-
-                /*for (int i = 0; i < 10_000; i++)
-                {
-                    Utf8Span email = (Utf8Span)obj[5][lookup];
-                }*/
-            }
-            /*else if (TestCase == TestCaseType.HelloWorld)
-            {
-                var lookup = new Utf8Span("message");
-
-                for (int i = 0; i < 10; i++)
-                {
-                    Utf8Span message = (Utf8Span)obj[lookup];
-                }
-            }*/
-            obj.Dispose();
-        }
-
-        //[Benchmark]
-        public void ParseSystemTextJsonLab3()
-        {
-            JsonObject obj = JsonObject.Parse(_dataUtf8);
-
-            if (TestCase == TestCaseType.Json400KB)
-            {
-                var lookup = new Utf8Span("email");
-
-                for (int i = 0; i < 10_000; i++)
-                {
-                    JsonObject temp = obj[5];
-                }
-            }
-            /*else if (TestCase == TestCaseType.HelloWorld)
-            {
-                var lookup = new Utf8Span("message");
-
-                for (int i = 0; i < 10; i++)
-                {
-                    Utf8Span message = (Utf8Span)obj[lookup];
-                }
-            }*/
-        }
-
-        //[Benchmark]
-        public void ParseSystemTextJsonLab4()
-        {
-            JsonObject obj = JsonObject.Parse(_dataUtf8);
-
-            if (TestCase == TestCaseType.Json400KB)
-            {
-                var lookup = new Utf8Span("email");
-
-                for (int i = 0; i < 10_000; i++)
-                {
-                    JsonObject temp = obj[5][lookup];
-                }
-            }
-            /*else if (TestCase == TestCaseType.HelloWorld)
-            {
-                var lookup = new Utf8Span("message");
-
-                for (int i = 0; i < 10; i++)
-                {
-                    Utf8Span message = (Utf8Span)obj[lookup];
-                }
-            }*/
-        }
-
-        //[Benchmark]
-        public void ParseSystemTextJsonLab5()
+        public void ParseSystemTextJsonLabConstantAccess()
         {
             JsonObject obj = JsonObject.Parse(_dataUtf8);
 
@@ -401,7 +471,7 @@ namespace System.Text.JsonLab.Benchmarks
                     Utf8Span message = (Utf8Span)obj[5][lookup];
                 }
             }
-            /*else if (TestCase == TestCaseType.HelloWorld)
+            else if (TestCase == TestCaseType.HelloWorld)
             {
                 var lookup = new Utf8Span("message");
 
@@ -409,7 +479,7 @@ namespace System.Text.JsonLab.Benchmarks
                 {
                     Utf8Span message = (Utf8Span)obj[lookup];
                 }
-            }*/
+            }
         }
     }
 }

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -20,7 +20,7 @@ namespace System.Text.JsonLab.Benchmarks
         public enum TestCaseType
         {
             HelloWorld,
-            BasicJson,
+            //BasicJson,
             //BasicLargeNum,
             //SpecialNumForm,
             //ProjectLockJson,
@@ -46,7 +46,7 @@ namespace System.Text.JsonLab.Benchmarks
         [ParamsSource(nameof(TestCaseValues))]
         public TestCaseType TestCase;
 
-        [Params(true)]
+        [Params(true, false)]
         public bool IsDataCompact;
 
         public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -12,7 +12,7 @@ using System.IO;
 namespace System.Text.JsonLab.Benchmarks
 {
     // Since there are 90 tests here (6 * 15), setting low values for the warmupCount, targetCount, and invocationCount
-    //[SimpleJob(-1, 3, 5, 1024)]
+    [SimpleJob(-1, 3, 5, 1024)]
     [MemoryDiagnoser]
     public class JsonReaderPerf
     {
@@ -20,19 +20,19 @@ namespace System.Text.JsonLab.Benchmarks
         public enum TestCaseType
         {
             HelloWorld,
-            //BasicJson,
-            //BasicLargeNum,
-            //SpecialNumForm,
-            //ProjectLockJson,
-            //FullSchema1,
-            //FullSchema2,
-            //DeepTree,
-            //BroadTree,
-            //LotsOfNumbers,
-            //LotsOfStrings,
-            //Json400B,
-            //Json4KB,
-            //Json40KB,
+            BasicJson,
+            BasicLargeNum,
+            SpecialNumForm,
+            ProjectLockJson,
+            FullSchema1,
+            FullSchema2,
+            DeepTree,
+            BroadTree,
+            LotsOfNumbers,
+            LotsOfStrings,
+            Json400B,
+            Json4KB,
+            Json40KB,
             Json400KB
         }
 
@@ -84,7 +84,7 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        //[Benchmark(Baseline = true)]
+        [Benchmark(Baseline = true)]
         public void ReaderNewtonsoftReaderEmptyLoop()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -93,7 +93,7 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public string ReaderNewtonsoftReaderReturnString()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -119,21 +119,21 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequenceSingle);
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequence);
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public byte[] ReaderSystemTextJsonLabReturnBytes()
         {
             byte[] outputArray = new byte[_dataUtf8.Length * 2];
@@ -195,7 +195,7 @@ namespace System.Text.JsonLab.Benchmarks
             return outputArray;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderUtf8JsonEmptyLoop()
         {
             Utf8Json.JsonReader json = new Utf8Json.JsonReader(_dataUtf8);
@@ -206,7 +206,7 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        //[Benchmark]
+        [Benchmark]
         public byte[] ReaderUtf8JsonReturnBytes()
         {
             Utf8Json.JsonReader json = new Utf8Json.JsonReader(_dataUtf8);

--- a/tests/System.Text.JsonLab.Tests/JsonObjectTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonObjectTests.cs
@@ -184,6 +184,7 @@ namespace System.Text.JsonLab.Tests
             {
                 using (JsonTextReader jsonReader = new JsonTextReader(new StringReader(jsonString)))
                 {
+                    jsonReader.FloatParseHandling = FloatParseHandling.Decimal;
                     JToken jtoken = JToken.ReadFrom(jsonReader);
                     var stringWriter = new StringWriter();
                     using (JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter))

--- a/tests/System.Text.JsonLab.Tests/JsonObjectTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonObjectTests.cs
@@ -71,6 +71,7 @@ namespace System.Text.JsonLab.Tests
             JsonObject obj = parser.Parse();
 
             string actual = obj.PrintJson();
+            string database1 = obj.PrintDatabase();
 
             // Change casing to match what JSON.NET does.
             actual = actual.Replace("true", "True").Replace("false", "False");
@@ -79,6 +80,18 @@ namespace System.Text.JsonLab.Tests
             string expected = JsonTestHelper.NewtonsoftReturnStringHelper(reader);
 
             Assert.Equal(expected, actual);
+
+            if (type == TestCaseType.Json400KB)
+            {
+                string database = obj.PrintDatabase();
+                var lookup = new Utf8Span("email");
+                JsonObject withinArray = obj[5];
+                database = withinArray.PrintDatabase();
+                JsonObject withinObject = withinArray[lookup];
+                database = withinObject.PrintDatabase();
+                Utf8Span email = (Utf8Span)withinObject;
+                Assert.Equal("kentlester@solgan.com", email.ToString());
+            }
         }
 
         [Theory]

--- a/tests/System.Text.JsonLab.Tests/JsonObjectTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonObjectTests.cs
@@ -62,6 +62,104 @@ namespace System.Text.JsonLab.Tests
             Json400KB,
         }
 
+        private string ReadHelloWorld(JToken obj)
+        {
+            string message = (string)obj["message"];
+            return message;
+        }
+
+        private string ReadJson400KB(JToken obj)
+        {
+            var sb = new StringBuilder();
+            foreach (JToken token in obj)
+            {
+                sb.Append((string)token["_id"]);
+                sb.Append((int)token["index"]);
+                sb.Append((string)token["guid"]);
+                sb.Append((bool)token["isActive"]);
+                sb.Append((string)token["balance"]);
+                sb.Append((string)token["picture"]);
+                sb.Append((int)token["age"]);
+                sb.Append((string)token["eyeColor"]);
+                sb.Append((string)token["name"]);
+                sb.Append((string)token["gender"]);
+                sb.Append((string)token["company"]);
+                sb.Append((string)token["email"]);
+                sb.Append((string)token["phone"]);
+                sb.Append((string)token["address"]);
+                sb.Append((string)token["about"]);
+                sb.Append((string)token["registered"]);
+                sb.Append((double)token["latitude"]);
+                sb.Append((double)token["longitude"]);
+
+                JToken tags = token["tags"];
+                foreach (JToken tag in tags)
+                {
+                    sb.Append((string)tag);
+                }
+                JToken friends = token["friends"];
+                foreach (JToken friend in friends)
+                {
+                    sb.Append((int)friend["id"]);
+                    sb.Append((string)friend["name"]);
+                }
+                sb.Append((string)token["greeting"]);
+                sb.Append((string)token["favoriteFruit"]);
+
+            }
+            return sb.ToString();
+        }
+
+        private string ReadHelloWorld(JsonObject obj)
+        {
+            string message = (string)obj["message"];
+            return message;
+        }
+
+        private string ReadJson400KB(JsonObject obj)
+        {
+            string db = obj.PrintDatabase();
+            var sb = new StringBuilder();
+            for (int i = 0; i < obj.ArrayLength; i++)
+            {
+                sb.Append((string)obj[i]["_id"]);
+                sb.Append((int)obj[i]["index"]);
+                sb.Append((string)obj[i]["guid"]);
+                sb.Append((bool)obj[i]["isActive"]);
+                sb.Append((string)obj[i]["balance"]);
+                sb.Append((string)obj[i]["picture"]);
+                sb.Append((int)obj[i]["age"]);
+                sb.Append((string)obj[i]["eyeColor"]);
+                sb.Append((string)obj[i]["name"]);
+                sb.Append((string)obj[i]["gender"]);
+                sb.Append((string)obj[i]["company"]);
+                sb.Append((string)obj[i]["email"]);
+                sb.Append((string)obj[i]["phone"]);
+                sb.Append((string)obj[i]["address"]);
+                sb.Append((string)obj[i]["about"]);
+                sb.Append((string)obj[i]["registered"]);
+                sb.Append((double)obj[i]["latitude"]);
+                sb.Append((double)obj[i]["longitude"]);
+
+                JsonObject tags = obj[i]["tags"];
+                for (int j = 0; j < tags.ArrayLength; j++)
+                {
+                    sb.Append((string)tags[j]);
+                }
+                JsonObject friends = obj[i]["friends"];
+                for (int j = 0; j < friends.ArrayLength; j++)
+                {
+                    sb.Append((int)friends[j]["id"]);
+                    sb.Append((string)friends[j]["name"]);
+                }
+                sb.Append((string)obj[i]["greeting"]);
+                sb.Append((string)obj[i]["favoriteFruit"]);
+
+            }
+            return sb.ToString();
+        }
+
+
         // TestCaseType is only used to give the json strings a descriptive name.
         [Theory]
         [MemberData(nameof(TestCases))]
@@ -83,7 +181,32 @@ namespace System.Text.JsonLab.Tests
             }*/
 
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+
             JsonObject obj = JsonObject.Parse(dataUtf8);
+
+            var _stream = new MemoryStream(dataUtf8);
+            var _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
+
+            _stream.Seek(0, SeekOrigin.Begin);
+            using (JsonTextReader jsonReader = new JsonTextReader(_reader))
+            {
+                JToken jtoken = JToken.ReadFrom(jsonReader);
+
+                string expectedString = "";
+                string actualString = "";
+
+                if (type == TestCaseType.Json400KB)
+                {
+                    expectedString = ReadJson400KB(jtoken);
+                    actualString = ReadJson400KB(obj);
+                }
+                else if (type == TestCaseType.HelloWorld)
+                {
+                    expectedString = ReadHelloWorld(jtoken);
+                    actualString = ReadHelloWorld(obj);
+                }
+                Assert.Equal(expectedString, actualString);
+            }
 
             string actual = obj.PrintJson();
             string database1 = obj.PrintDatabase();
@@ -136,7 +259,7 @@ namespace System.Text.JsonLab.Tests
                     Assert.Equal(31, age);
                     Assert.Equal("Lawrence Hewitt", name);
                     Assert.Equal("Nulla qui enim dolor nisi enim occaecat sit ullamco commodo eiusmod proident ipsum eiusmod. Ad incididunt nulla proident ea aute commodo consequat sit esse voluptate nulla laborum ea in. Ipsum laborum dolor consectetur exercitation adipisicing occaecat consectetur excepteur.", about);
-                    Assert.Equal("Hello, Paul Cruz! You have 1 unread messages.", greeting);
+                    //Assert.Equal("Hello, Paul Cruz! You have 1 unread messages.", greeting);
                 }
 
 

--- a/tests/System.Text.JsonLab.Tests/JsonObjectTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonObjectTests.cs
@@ -118,11 +118,35 @@ namespace System.Text.JsonLab.Tests
 
         private string ReadJson400KB(JsonObject obj)
         {
-            string db = obj.PrintDatabase();
+            Utf8Span _id = (Utf8Span)"_id";
+            Utf8Span index = (Utf8Span)"index";
+            Utf8Span guid = (Utf8Span)"guid";
+            Utf8Span isActive = (Utf8Span)"isActive";
+            Utf8Span balance = (Utf8Span)"balance";
+            Utf8Span picture = (Utf8Span)"picture";
+            Utf8Span age = (Utf8Span)"age";
+            Utf8Span eyeColor = (Utf8Span)"eyeColor";
+            Utf8Span name = (Utf8Span)"name";
+            Utf8Span gender = (Utf8Span)"gender";
+            Utf8Span company = (Utf8Span)"company";
+            Utf8Span email = (Utf8Span)"email";
+            Utf8Span phone = (Utf8Span)"phone";
+            Utf8Span address = (Utf8Span)"address";
+            Utf8Span about = (Utf8Span)"about";
+            Utf8Span registered = (Utf8Span)"registered";
+            Utf8Span latitude = (Utf8Span)"latitude";
+            Utf8Span longitude = (Utf8Span)"longitude";
+            Utf8Span tags = (Utf8Span)"tags";
+            Utf8Span friends = (Utf8Span)"friends";
+            Utf8Span id = (Utf8Span)"id";
+            Utf8Span greeting = (Utf8Span)"greeting";
+            Utf8Span favoriteFruit = (Utf8Span)"favoriteFruit";
+
+
             var sb = new StringBuilder();
             for (int i = 0; i < obj.ArrayLength; i++)
             {
-                sb.Append((string)obj[i]["_id"]);
+                /*sb.Append((string)obj[i]["_id"]);
                 sb.Append((int)obj[i]["index"]);
                 sb.Append((string)obj[i]["guid"]);
                 sb.Append((bool)obj[i]["isActive"]);
@@ -153,12 +177,44 @@ namespace System.Text.JsonLab.Tests
                     sb.Append((string)friends[j]["name"]);
                 }
                 sb.Append((string)obj[i]["greeting"]);
-                sb.Append((string)obj[i]["favoriteFruit"]);
+                sb.Append((string)obj[i]["favoriteFruit"]);*/
+
+                sb.Append((string)obj[i][_id]);
+                sb.Append((int)obj[i][index]);
+                sb.Append((string)obj[i][guid]);
+                sb.Append((bool)obj[i][isActive]);
+                sb.Append((string)obj[i][balance]);
+                sb.Append((string)obj[i][picture]);
+                sb.Append((int)obj[i][age]);
+                sb.Append((string)obj[i][eyeColor]);
+                sb.Append((string)obj[i][name]);
+                sb.Append((string)obj[i][gender]);
+                sb.Append((string)obj[i][company]);
+                sb.Append((string)obj[i][email]);
+                sb.Append((string)obj[i][phone]);
+                sb.Append((string)obj[i][address]);
+                sb.Append((string)obj[i][about]);
+                sb.Append((string)obj[i][registered]);
+                sb.Append((double)obj[i][latitude]);
+                sb.Append((double)obj[i][longitude]);
+
+                JsonObject tagsObject = obj[i][tags];
+                for (int j = 0; j < tagsObject.ArrayLength; j++)
+                {
+                    sb.Append((string)tagsObject[j]);
+                }
+                JsonObject friendsObject = obj[i][friends];
+                for (int j = 0; j < friendsObject.ArrayLength; j++)
+                {
+                    sb.Append((int)friendsObject[j][id]);
+                    sb.Append((string)friendsObject[j][name]);
+                }
+                sb.Append((string)obj[i][greeting]);
+                sb.Append((string)obj[i][favoriteFruit]);
 
             }
             return sb.ToString();
         }
-
 
         // TestCaseType is only used to give the json strings a descriptive name.
         [Theory]

--- a/tests/System.Text.JsonLab.Tests/JsonObjectTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonObjectTests.cs
@@ -21,22 +21,39 @@ namespace System.Text.JsonLab.Tests
             {
                 return new List<object[]>
                 {
-                    new object[] { TestCaseType.Basic, TestJson.BasicJson},
-                    new object[] { TestCaseType.BasicLargeNum, TestJson.BasicJsonWithLargeNum}, // Json.NET treats numbers starting with 0 as octal (0425 becomes 277)
-                    new object[] { TestCaseType.BroadTree, TestJson.BroadTree}, // \r\n behavior is different between Json.NET and JsonLab
-                    new object[] { TestCaseType.DeepTree, TestJson.DeepTree},
-                    new object[] { TestCaseType.FullSchema1, TestJson.FullJsonSchema1},
-                    //new object[] { TestCaseType.FullSchema2, TestJson.FullJsonSchema2},   // Behavior of E-notation is different between Json.NET and JsonLab
-                    new object[] { TestCaseType.HelloWorld, TestJson.HelloWorld},
-                    new object[] { TestCaseType.LotsOfNumbers, TestJson.LotsOfNumbers},
-                    new object[] { TestCaseType.LotsOfStrings, TestJson.LotsOfStrings},
-                    new object[] { TestCaseType.ProjectLockJson, TestJson.ProjectLockJson},
-                    //new object[] { TestCaseType.SpecialStrings, TestJson.JsonWithSpecialStrings},    // Behavior of escaping is different between Json.NET and JsonLab
-                    //new object[] { TestCaseType.SpecialNumForm, TestJson.JsonWithSpecialNumFormat},    // Behavior of E-notation is different between Json.NET and JsonLab
-                    new object[] { TestCaseType.Json400B, TestJson.Json400B},
-                    new object[] { TestCaseType.Json4KB, TestJson.Json4KB},
-                    new object[] { TestCaseType.Json40KB, TestJson.Json40KB},
-                    new object[] { TestCaseType.Json400KB, TestJson.Json400KB}
+                    new object[] { true, TestCaseType.Basic, TestJson.BasicJson},
+                    new object[] { true, TestCaseType.BasicLargeNum, TestJson.BasicJsonWithLargeNum}, // Json.NET treats numbers starting with 0 as octal (0425 becomes 277)
+                    new object[] { true, TestCaseType.BroadTree, TestJson.BroadTree}, // \r\n behavior is different between Json.NET and JsonLab
+                    new object[] { true, TestCaseType.DeepTree, TestJson.DeepTree},
+                    new object[] { true, TestCaseType.FullSchema1, TestJson.FullJsonSchema1},
+                    //new object[] { true, TestCaseType.FullSchema2, TestJson.FullJsonSchema2},   // Behavior of E-notation is different between Json.NET and JsonLab
+                    new object[] { true, TestCaseType.HelloWorld, TestJson.HelloWorld},
+                    new object[] { true, TestCaseType.LotsOfNumbers, TestJson.LotsOfNumbers},
+                    new object[] { true, TestCaseType.LotsOfStrings, TestJson.LotsOfStrings},
+                    new object[] { true, TestCaseType.ProjectLockJson, TestJson.ProjectLockJson},
+                    //new object[] { true, TestCaseType.SpecialStrings, TestJson.JsonWithSpecialStrings},    // Behavior of escaping is different between Json.NET and JsonLab
+                    //new object[] { true, TestCaseType.SpecialNumForm, TestJson.JsonWithSpecialNumFormat},    // Behavior of E-notation is different between Json.NET and JsonLab
+                    new object[] { true, TestCaseType.Json400B, TestJson.Json400B},
+                    new object[] { true, TestCaseType.Json4KB, TestJson.Json4KB},
+                    new object[] { true, TestCaseType.Json40KB, TestJson.Json40KB},
+                    new object[] { true, TestCaseType.Json400KB, TestJson.Json400KB},
+
+                    new object[] { false, TestCaseType.Basic, TestJson.BasicJson},
+                    new object[] { false, TestCaseType.BasicLargeNum, TestJson.BasicJsonWithLargeNum}, // Json.NET treats numbers starting with 0 as octal (0425 becomes 277)
+                    new object[] { false, TestCaseType.BroadTree, TestJson.BroadTree}, // \r\n behavior is different between Json.NET and JsonLab
+                    new object[] { false, TestCaseType.DeepTree, TestJson.DeepTree},
+                    new object[] { false, TestCaseType.FullSchema1, TestJson.FullJsonSchema1},
+                    //new object[] { false, TestCaseType.FullSchema2, TestJson.FullJsonSchema2},   // Behavior of E-notation is different between Json.NET and JsonLab
+                    new object[] { false, TestCaseType.HelloWorld, TestJson.HelloWorld},
+                    new object[] { false, TestCaseType.LotsOfNumbers, TestJson.LotsOfNumbers},
+                    new object[] { false, TestCaseType.LotsOfStrings, TestJson.LotsOfStrings},
+                    new object[] { false, TestCaseType.ProjectLockJson, TestJson.ProjectLockJson},
+                    //new object[] { false, TestCaseType.SpecialStrings, TestJson.JsonWithSpecialStrings},    // Behavior of escaping is different between Json.NET and JsonLab
+                    //new object[] { false, TestCaseType.SpecialNumForm, TestJson.JsonWithSpecialNumFormat},    // Behavior of E-notation is different between Json.NET and JsonLab
+                    new object[] { false, TestCaseType.Json400B, TestJson.Json400B},
+                    new object[] { false, TestCaseType.Json4KB, TestJson.Json4KB},
+                    new object[] { false, TestCaseType.Json40KB, TestJson.Json40KB},
+                    new object[] { false, TestCaseType.Json400KB, TestJson.Json400KB}
                 };
             }
         }
@@ -118,35 +135,10 @@ namespace System.Text.JsonLab.Tests
 
         private string ReadJson400KB(JsonObject obj)
         {
-            Utf8Span _id = (Utf8Span)"_id";
-            Utf8Span index = (Utf8Span)"index";
-            Utf8Span guid = (Utf8Span)"guid";
-            Utf8Span isActive = (Utf8Span)"isActive";
-            Utf8Span balance = (Utf8Span)"balance";
-            Utf8Span picture = (Utf8Span)"picture";
-            Utf8Span age = (Utf8Span)"age";
-            Utf8Span eyeColor = (Utf8Span)"eyeColor";
-            Utf8Span name = (Utf8Span)"name";
-            Utf8Span gender = (Utf8Span)"gender";
-            Utf8Span company = (Utf8Span)"company";
-            Utf8Span email = (Utf8Span)"email";
-            Utf8Span phone = (Utf8Span)"phone";
-            Utf8Span address = (Utf8Span)"address";
-            Utf8Span about = (Utf8Span)"about";
-            Utf8Span registered = (Utf8Span)"registered";
-            Utf8Span latitude = (Utf8Span)"latitude";
-            Utf8Span longitude = (Utf8Span)"longitude";
-            Utf8Span tags = (Utf8Span)"tags";
-            Utf8Span friends = (Utf8Span)"friends";
-            Utf8Span id = (Utf8Span)"id";
-            Utf8Span greeting = (Utf8Span)"greeting";
-            Utf8Span favoriteFruit = (Utf8Span)"favoriteFruit";
-
-
             var sb = new StringBuilder();
             for (int i = 0; i < obj.ArrayLength; i++)
             {
-                /*sb.Append((string)obj[i]["_id"]);
+                sb.Append((string)obj[i]["_id"]);
                 sb.Append((int)obj[i]["index"]);
                 sb.Append((string)obj[i]["guid"]);
                 sb.Append((bool)obj[i]["isActive"]);
@@ -177,41 +169,7 @@ namespace System.Text.JsonLab.Tests
                     sb.Append((string)friends[j]["name"]);
                 }
                 sb.Append((string)obj[i]["greeting"]);
-                sb.Append((string)obj[i]["favoriteFruit"]);*/
-
-                sb.Append((string)obj[i][_id]);
-                sb.Append((int)obj[i][index]);
-                sb.Append((string)obj[i][guid]);
-                sb.Append((bool)obj[i][isActive]);
-                sb.Append((string)obj[i][balance]);
-                sb.Append((string)obj[i][picture]);
-                sb.Append((int)obj[i][age]);
-                sb.Append((string)obj[i][eyeColor]);
-                sb.Append((string)obj[i][name]);
-                sb.Append((string)obj[i][gender]);
-                sb.Append((string)obj[i][company]);
-                sb.Append((string)obj[i][email]);
-                sb.Append((string)obj[i][phone]);
-                sb.Append((string)obj[i][address]);
-                sb.Append((string)obj[i][about]);
-                sb.Append((string)obj[i][registered]);
-                sb.Append((double)obj[i][latitude]);
-                sb.Append((double)obj[i][longitude]);
-
-                JsonObject tagsObject = obj[i][tags];
-                for (int j = 0; j < tagsObject.ArrayLength; j++)
-                {
-                    sb.Append((string)tagsObject[j]);
-                }
-                JsonObject friendsObject = obj[i][friends];
-                for (int j = 0; j < friendsObject.ArrayLength; j++)
-                {
-                    sb.Append((int)friendsObject[j][id]);
-                    sb.Append((string)friendsObject[j][name]);
-                }
-                sb.Append((string)obj[i][greeting]);
-                sb.Append((string)obj[i][favoriteFruit]);
-
+                sb.Append((string)obj[i]["favoriteFruit"]);
             }
             return sb.ToString();
         }
@@ -219,10 +177,10 @@ namespace System.Text.JsonLab.Tests
         // TestCaseType is only used to give the json strings a descriptive name.
         [Theory]
         [MemberData(nameof(TestCases))]
-        public void ParseJson(TestCaseType type, string jsonString)
+        public void ParseJson(bool compactData, TestCaseType type, string jsonString)
         {
             // Remove all formatting/indendation
-            /*if (true)
+            if (compactData)
             {
                 using (JsonTextReader jsonReader = new JsonTextReader(new StringReader(jsonString)))
                 {
@@ -234,17 +192,15 @@ namespace System.Text.JsonLab.Tests
                         jsonString = stringWriter.ToString();
                     }
                 }
-            }*/
+            }
 
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
 
             JsonObject obj = JsonObject.Parse(dataUtf8);
 
-            var _stream = new MemoryStream(dataUtf8);
-            var _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
-
-            _stream.Seek(0, SeekOrigin.Begin);
-            using (JsonTextReader jsonReader = new JsonTextReader(_reader))
+            var stream = new MemoryStream(dataUtf8);
+            var streamReader = new StreamReader(stream, Encoding.UTF8, false, 1024, true);
+            using (JsonTextReader jsonReader = new JsonTextReader(streamReader))
             {
                 JToken jtoken = JToken.ReadFrom(jsonReader);
 
@@ -265,7 +221,6 @@ namespace System.Text.JsonLab.Tests
             }
 
             string actual = obj.PrintJson();
-            string database1 = obj.PrintDatabase();
 
             // Change casing to match what JSON.NET does.
             actual = actual.Replace("true", "True").Replace("false", "False");
@@ -274,95 +229,6 @@ namespace System.Text.JsonLab.Tests
             string expected = JsonTestHelper.NewtonsoftReturnStringHelper(reader);
 
             Assert.Equal(expected, actual);
-
-            if (type == TestCaseType.Json400KB)
-            {
-
-                {
-                    var lookup1a = new Utf8Span("about");
-                    var lookup4a = new Utf8Span("greeting");
-                    var lookup2a = new Utf8Span("friends");
-                    var lookup3a = new Utf8Span("name");
-                    var lookup5a = new Utf8Span("age");
-
-                    string greeting = "";
-                    string about = "";
-                    string name = "";
-                    int age = 0;
-
-                    for (int i = 0; i < obj.ArrayLength; i += 10)
-                    {
-                        greeting = (string)obj[i][lookup4a];
-                        about = (string)obj[i][lookup1a];
-                        name = (string)obj[i][lookup2a][1][lookup3a];
-                        age = (int)obj[i][lookup5a];
-                    }
-
-                    for (int k = 0; k < 2; k++)
-                    {
-                        for (int i = 0; i < obj.ArrayLength; i += 10)
-                        {
-                            for (int j = 0; j < 300; j++)
-                            {
-                                greeting = (string)obj[5][lookup4a];
-                            }
-                            about = (string)obj[i][lookup1a];
-                            name = (string)obj[i][lookup2a][1][lookup3a];
-                            age = (int)obj[i][lookup5a];
-                        }
-                    }
-
-                    Assert.Equal(31, age);
-                    Assert.Equal("Lawrence Hewitt", name);
-                    Assert.Equal("Nulla qui enim dolor nisi enim occaecat sit ullamco commodo eiusmod proident ipsum eiusmod. Ad incididunt nulla proident ea aute commodo consequat sit esse voluptate nulla laborum ea in. Ipsum laborum dolor consectetur exercitation adipisicing occaecat consectetur excepteur.", about);
-                    //Assert.Equal("Hello, Paul Cruz! You have 1 unread messages.", greeting);
-                }
-
-
-                var lookup1 = new Utf8Span("tags");
-                var lookup2 = new Utf8Span("friends");
-                var lookup3 = new Utf8Span("name");
-                var lookup4 = new Utf8Span("name1");
-                var lookup5 = new Utf8Span("greeting");
-
-                string t1 = (string)obj[1][lookup1][6];
-                string t2 = (string)obj[1][lookup2][2][lookup3];
-                
-                Assert.Equal("consequat", t1);
-                Assert.Equal("Burns Giles", t2);
-                string database3 = obj.PrintDatabase();
-                try
-                {
-                    int id = (int)obj[1][lookup4];
-                    Assert.True(false);
-                }
-                catch (KeyNotFoundException)
-                {
-
-                }
-
-                string t3 = (string)obj[1][lookup5];
-                Assert.Equal("Hello, Faith Cantrell! You have 8 unread messages.", t3);
-
-                /*string t1 = (string)obj[0]["tags"][6];
-                string t2 = (string)obj[0]["friends"][2]["name"];
-                int id = (int)obj[0]["id"];*/
-
-                for (int i = 0; i < obj.ArrayLength; i++)
-                {
-                    JsonObject temp = obj[i];
-                }
-
-                string database = obj.PrintDatabase();
-                var lookup = new Utf8Span("email");
-                JsonObject withinArray = obj[5];
-                database = withinArray.PrintDatabase();
-                database = obj.PrintDatabase();
-                JsonObject withinObject = withinArray[lookup];
-                database = withinObject.PrintDatabase();
-                Utf8Span email = (Utf8Span)withinObject;
-                Assert.Equal("kentlester@solgan.com", email.ToString());
-            }
         }
 
         [Theory]
@@ -378,7 +244,6 @@ namespace System.Text.JsonLab.Tests
             JsonObject obj = JsonObject.Parse(dataUtf8);
 
             string actual = obj.PrintJson();
-            string database1 = obj.PrintDatabase();
 
             // Change casing to match what JSON.NET does.
             actual = actual.Replace("true", "True").Replace("false", "False");
@@ -395,8 +260,6 @@ namespace System.Text.JsonLab.Tests
             string depsJson = TestJson.DepsJsonSignalR;
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(depsJson);
             JsonObject obj = JsonObject.Parse(dataUtf8);
-
-            string temp = obj.PrintDatabase();
 
             var targetsString = new Utf8Span("targets");
             var librariesString = new Utf8Span("libraries");
@@ -547,7 +410,6 @@ namespace System.Text.JsonLab.Tests
         {
             var buffer = StringToUtf8BufferWithEmptySpace("[true,false]", 60);
             JsonObject parsedObject = JsonObject.Parse(buffer);
-            string temp = parsedObject.PrintDatabase();
             try
             {
                 var first = (bool)parsedObject[0];

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System.Buffers;
 using System.Buffers.Text;
 using System.Collections.Generic;
@@ -20,22 +22,39 @@ namespace System.Text.JsonLab.Tests
             {
                 return new List<object[]>
                 {
-                    new object[] { TestCaseType.Basic, TestJson.BasicJson},
-                    new object[] { TestCaseType.BasicLargeNum, TestJson.BasicJsonWithLargeNum}, // Json.NET treats numbers starting with 0 as octal (0425 becomes 277)
-                    new object[] { TestCaseType.BroadTree, TestJson.BroadTree}, // \r\n behavior is different between Json.NET and JsonLab
-                    new object[] { TestCaseType.DeepTree, TestJson.DeepTree},
-                    new object[] { TestCaseType.FullSchema1, TestJson.FullJsonSchema1},
-                    //new object[] { TestCaseType.FullSchema2, TestJson.FullJsonSchema2},   // Behavior of E-notation is different between Json.NET and JsonLab
-                    new object[] { TestCaseType.HelloWorld, TestJson.HelloWorld},
-                    new object[] { TestCaseType.LotsOfNumbers, TestJson.LotsOfNumbers},
-                    new object[] { TestCaseType.LotsOfStrings, TestJson.LotsOfStrings},
-                    new object[] { TestCaseType.ProjectLockJson, TestJson.ProjectLockJson},
-                    //new object[] { TestCaseType.SpecialStrings, TestJson.JsonWithSpecialStrings},    // Behavior of escaping is different between Json.NET and JsonLab
-                    //new object[] { TestCaseType.SpecialNumForm, TestJson.JsonWithSpecialNumFormat},    // Behavior of E-notation is different between Json.NET and JsonLab
-                    new object[] { TestCaseType.Json400B, TestJson.Json400B},
-                    new object[] { TestCaseType.Json4KB, TestJson.Json4KB},
-                    new object[] { TestCaseType.Json40KB, TestJson.Json40KB},
-                    new object[] { TestCaseType.Json400KB, TestJson.Json400KB}
+                    new object[] { true, TestCaseType.Basic, TestJson.BasicJson},
+                    new object[] { true, TestCaseType.BasicLargeNum, TestJson.BasicJsonWithLargeNum}, // Json.NET treats numbers starting with 0 as octal (0425 becomes 277)
+                    new object[] { true, TestCaseType.BroadTree, TestJson.BroadTree}, // \r\n behavior is different between Json.NET and JsonLab
+                    new object[] { true, TestCaseType.DeepTree, TestJson.DeepTree},
+                    new object[] { true, TestCaseType.FullSchema1, TestJson.FullJsonSchema1},
+                    //new object[] { true, TestCaseType.FullSchema2, TestJson.FullJsonSchema2},   // Behavior of E-notation is different between Json.NET and JsonLab
+                    new object[] { true, TestCaseType.HelloWorld, TestJson.HelloWorld},
+                    new object[] { true, TestCaseType.LotsOfNumbers, TestJson.LotsOfNumbers},
+                    new object[] { true, TestCaseType.LotsOfStrings, TestJson.LotsOfStrings},
+                    new object[] { true, TestCaseType.ProjectLockJson, TestJson.ProjectLockJson},
+                    //new object[] { true, TestCaseType.SpecialStrings, TestJson.JsonWithSpecialStrings},    // Behavior of escaping is different between Json.NET and JsonLab
+                    //new object[] { true, TestCaseType.SpecialNumForm, TestJson.JsonWithSpecialNumFormat},    // Behavior of E-notation is different between Json.NET and JsonLab
+                    new object[] { true, TestCaseType.Json400B, TestJson.Json400B},
+                    new object[] { true, TestCaseType.Json4KB, TestJson.Json4KB},
+                    new object[] { true, TestCaseType.Json40KB, TestJson.Json40KB},
+                    new object[] { true, TestCaseType.Json400KB, TestJson.Json400KB},
+
+                    new object[] { false, TestCaseType.Basic, TestJson.BasicJson},
+                    new object[] { false, TestCaseType.BasicLargeNum, TestJson.BasicJsonWithLargeNum}, // Json.NET treats numbers starting with 0 as octal (0425 becomes 277)
+                    new object[] { false, TestCaseType.BroadTree, TestJson.BroadTree}, // \r\n behavior is different between Json.NET and JsonLab
+                    new object[] { false, TestCaseType.DeepTree, TestJson.DeepTree},
+                    new object[] { false, TestCaseType.FullSchema1, TestJson.FullJsonSchema1},
+                    //new object[] { false, TestCaseType.FullSchema2, TestJson.FullJsonSchema2},   // Behavior of E-notation is different between Json.NET and JsonLab
+                    new object[] { false, TestCaseType.HelloWorld, TestJson.HelloWorld},
+                    new object[] { false, TestCaseType.LotsOfNumbers, TestJson.LotsOfNumbers},
+                    new object[] { false, TestCaseType.LotsOfStrings, TestJson.LotsOfStrings},
+                    new object[] { false, TestCaseType.ProjectLockJson, TestJson.ProjectLockJson},
+                    //new object[] { false, TestCaseType.SpecialStrings, TestJson.JsonWithSpecialStrings},    // Behavior of escaping is different between Json.NET and JsonLab
+                    //new object[] { false, TestCaseType.SpecialNumForm, TestJson.JsonWithSpecialNumFormat},    // Behavior of E-notation is different between Json.NET and JsonLab
+                    new object[] { false, TestCaseType.Json400B, TestJson.Json400B},
+                    new object[] { false, TestCaseType.Json4KB, TestJson.Json4KB},
+                    new object[] { false, TestCaseType.Json40KB, TestJson.Json40KB},
+                    new object[] { false, TestCaseType.Json400KB, TestJson.Json400KB}
                 };
             }
         }
@@ -63,8 +82,23 @@ namespace System.Text.JsonLab.Tests
         // TestCaseType is only used to give the json strings a descriptive name.
         [Theory]
         [MemberData(nameof(TestCases))]
-        public static void TestJsonReaderUtf8(TestCaseType type, string jsonString)
+        public static void TestJsonReaderUtf8(bool compactData, TestCaseType type, string jsonString)
         {
+            // Remove all formatting/indendation
+            if (compactData)
+            {
+                using (JsonTextReader jsonReader = new JsonTextReader(new StringReader(jsonString)))
+                {
+                    JToken jtoken = JToken.ReadFrom(jsonReader);
+                    var stringWriter = new StringWriter();
+                    using (JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter))
+                    {
+                        jtoken.WriteTo(jsonWriter);
+                        jsonString = stringWriter.ToString();
+                    }
+                }
+            }
+
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
             byte[] result = JsonLabReturnBytesHelper(dataUtf8, out int length);
             string actualStr = Encoding.UTF8.GetString(result.AsSpan(0, length));

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -89,6 +89,7 @@ namespace System.Text.JsonLab.Tests
             {
                 using (JsonTextReader jsonReader = new JsonTextReader(new StringReader(jsonString)))
                 {
+                    jsonReader.FloatParseHandling = FloatParseHandling.Decimal;
                     JToken jtoken = JToken.ReadFrom(jsonReader);
                     var stringWriter = new StringWriter();
                     using (JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter))

--- a/tests/System.Text.JsonLab.Tests/Resources/TestJson.resx
+++ b/tests/System.Text.JsonLab.Tests/Resources/TestJson.resx
@@ -694,7 +694,7 @@ tiline\"another\" String\\"],"str":"\"\""}</value>
     "friends": [
       {
         "id": 0,
-        "name1": "Weeks Abbott"
+        "name": "Weeks Abbott"
       },
       {
         "id": 1,

--- a/tests/System.Text.JsonLab.Tests/Resources/TestJson.resx
+++ b/tests/System.Text.JsonLab.Tests/Resources/TestJson.resx
@@ -694,7 +694,7 @@ tiline\"another\" String\\"],"str":"\"\""}</value>
     "friends": [
       {
         "id": 0,
-        "name": "Weeks Abbott"
+        "name1": "Weeks Abbott"
       },
       {
         "id": 1,


### PR DESCRIPTION
- Add SkipPastAny overloads.
- Add SkipPastSlow which advances 1 at a time.
- Add back static JsonObject.Parse method.
- Break out the db functionality from JsonParser into a new CustomDb type.
- Add a union column in DbRow that stores more info during parsing.
- Use a static byte array for the initial stack space.
- Add JsonParserEnumeratePerf benchmark. Experiments with attempting amortized O(n) enumeration of arrays was only beneficial for large json objects. We should revisit this change.
- Add compact (no whitespace/formatting) json payloads to benchmarks.
- Add parser benchmark mode where we rebuild the json string from the parsing loop.
- Change JsonReader implementation to optimize the zero-space cases.

``` ini
BenchmarkDotNet=v0.10.14.683-nightly, OS=Windows 10.0.17713
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-20180720-2
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
```

**Before:**

|                 Method | IsDataCompact | OnlyParse |   TestCase |           Mean |         Error |        StdDev |  Gen 0 | Allocated |
|----------------------- |-------------- |---------- |----------- |---------------:|--------------:|--------------:|-------:|----------:|
| **ParseSystemTextJsonLab** |          **True** |     **False** |  **BasicJson** |     **4,349.4 ns** |     **48.266 ns** |     **42.786 ns** | **0.2594** |    **1088 B** |
| **ParseSystemTextJsonLab** |          **True** |     **False** | **HelloWorld** |       **688.9 ns** |     **12.978 ns** |     **12.746 ns** | **0.0191** |      **88 B** |
| **ParseSystemTextJsonLab** |          **True** |     **False** |   **Json400B** |     **7,522.4 ns** |    **146.124 ns** |    **129.535 ns** | **0.5341** |    **2296 B** |
| **ParseSystemTextJsonLab** |          **True** |     **False** |  **Json400KB** |             **NA** |            **NA** |            **NA** |    **N/A** |       **N/A** |
| **ParseSystemTextJsonLab** |          **True** |     **False** |   **Json40KB** |             **NA** |            **NA** |            **NA** |    **N/A** |       **N/A** |
| **ParseSystemTextJsonLab** |          **True** |     **False** |    **Json4KB** |             **NA** |            **NA** |            **NA** |    **N/A** |       **N/A** |
| **ParseSystemTextJsonLab** |          **True** |      **True** |  **BasicJson** |     **1,758.5 ns** |     **13.974 ns** |     **13.071 ns** |      **-** |       **0 B** |
| **ParseSystemTextJsonLab** |          **True** |      **True** | **HelloWorld** |       **424.7 ns** |      **2.690 ns** |      **2.516 ns** |      **-** |       **0 B** |
| **ParseSystemTextJsonLab** |          **True** |      **True** |   **Json400B** |     **2,351.3 ns** |     **32.048 ns** |     **26.761 ns** |      **-** |       **0 B** |
| **ParseSystemTextJsonLab** |          **True** |      **True** |  **Json400KB** | **1,875,418.0 ns** | **13,582.975 ns** | **12,705.522 ns** |      **-** |       **0 B** |
| **ParseSystemTextJsonLab** |          **True** |      **True** |   **Json40KB** |   **181,970.2 ns** |  **2,600.134 ns** |  **2,304.951 ns** |      **-** |       **0 B** |
| **ParseSystemTextJsonLab** |          **True** |      **True** |    **Json4KB** |    **17,087.7 ns** |    **255.761 ns** |    **239.239 ns** |      **-** |       **0 B** |

**After:**

|                 Method | IsDataCompact | OnlyParse |   TestCase |           Mean |          Error |         StdDev | Scaled |    Gen 0 |    Gen 1 |   Gen 2 | Allocated |
|----------------------- |-------------- |---------- |----------- |---------------:|---------------:|---------------:|-------:|---------:|---------:|--------:|----------:|
| **ParseSystemTextJsonLab** |          **True** |     **False** |  **BasicJson** |     **3,814.5 ns** |      **76.070 ns** |     **170.141 ns** |   **1.00** |   **0.2594** |        **-** |       **-** |    **1088 B** |
|                        |               |           |            |                |                |                |        |          |          |         |           |
| **ParseSystemTextJsonLab** |          **True** |     **False** | **HelloWorld** |       **575.0 ns** |      **11.254 ns** |      **17.186 ns** |   **1.00** |   **0.0200** |        **-** |       **-** |      **88 B** |
|                        |               |           |            |                |                |                |        |          |          |         |           |
| **ParseSystemTextJsonLab** |          **True** |     **False** |   **Json400B** |     **7,259.4 ns** |     **192.590 ns** |     **523.955 ns** |   **1.00** |   **0.5417** |        **-** |       **-** |    **2296 B** |
|                        |               |           |            |                |                |                |        |          |          |         |           |
| **ParseSystemTextJsonLab** |          **True** |     **False** |  **Json400KB** | **9,682,912.5 ns** | **252,709.150 ns** | **733,155.066 ns** |   **1.00** | **296.8750** | **203.1250** | **93.7500** | **1545428 B** |
|                        |               |           |            |                |                |                |        |          |          |         |           |
| **ParseSystemTextJsonLab** |          **True** |     **False** |   **Json40KB** |   **469,846.8 ns** |   **9,346.559 ns** |  **14,273.183 ns** |   **1.00** |  **36.6211** |        **-** |       **-** |  **156656 B** |
|                        |               |           |            |                |                |                |        |          |          |         |           |
| **ParseSystemTextJsonLab** |          **True** |     **False** |    **Json4KB** |    **45,779.1 ns** |     **910.711 ns** |     **807.322 ns** |   **1.00** |   **4.3945** |        **-** |       **-** |   **18440 B** |
|                        |               |           |            |                |                |                |        |          |          |         |           |
| **ParseSystemTextJsonLab** |          **True** |      **True** |  **BasicJson** |     **1,041.7 ns** |      **18.954 ns** |      **15.827 ns** |   **1.00** |        **-** |        **-** |       **-** |       **0 B** |
|                        |               |           |            |                |                |                |        |          |          |         |           |
| **ParseSystemTextJsonLab** |          **True** |      **True** | **HelloWorld** |       **281.0 ns** |       **5.549 ns** |       **5.937 ns** |   **1.00** |        **-** |        **-** |       **-** |       **0 B** |
|                        |               |           |            |                |                |                |        |          |          |         |           |
| **ParseSystemTextJsonLab** |          **True** |      **True** |   **Json400B** |     **1,501.3 ns** |      **41.962 ns** |      **35.040 ns** |   **1.00** |        **-** |        **-** |       **-** |       **0 B** |
|                        |               |           |            |                |                |                |        |          |          |         |           |
| **ParseSystemTextJsonLab** |          **True** |      **True** |  **Json400KB** | **1,267,946.4 ns** |  **25,046.191 ns** |  **29,815.708 ns** |   **1.00** |        **-** |        **-** |       **-** |       **0 B** |
|                        |               |           |            |                |                |                |        |          |          |         |           |
| **ParseSystemTextJsonLab** |          **True** |      **True** |   **Json40KB** |   **121,033.9 ns** |   **2,396.071 ns** |   **3,279.769 ns** |   **1.00** |        **-** |        **-** |       **-** |       **0 B** |
|                        |               |           |            |                |                |                |        |          |          |         |           |
| **ParseSystemTextJsonLab** |          **True** |      **True** |    **Json4KB** |    **10,486.9 ns** |     **200.862 ns** |     **268.145 ns** |   **1.00** |        **-** |        **-** |       **-** |       **0 B** |

**Before:**

|                                            Method | IsDataCompact |   TestCase |           Mean |         Error |        StdDev |         Median |  Gen 0 | Allocated |
|-------------------------------------------------- |-------------- |----------- |---------------:|--------------:|--------------:|---------------:|-------:|----------:|
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **BasicJson** |     **3,544.9 ns** |    **425.366 ns** |  **1,240.811 ns** |     **3,200.0 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |  BasicJson |     1,434.9 ns |     10.236 ns |      9.575 ns |     1,436.2 ns | 0.0076 |      40 B |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** | **HelloWorld** |       **125.8 ns** |      **4.125 ns** |      **3.657 ns** |       **124.8 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True | HelloWorld |       498.2 ns |      4.788 ns |      4.479 ns |       499.0 ns | 0.0086 |      40 B |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json400B** |     **1,226.3 ns** |     **11.142 ns** |     **10.422 ns** |     **1,226.0 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |   Json400B |     1,715.0 ns |     25.443 ns |     23.800 ns |     1,712.6 ns |      - |       0 B |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **Json400KB** | **1,127,673.7 ns** |  **8,321.665 ns** |  **7,376.938 ns** | **1,127,924.8 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |  Json400KB | 1,410,088.7 ns | 14,474.088 ns | 11,300.415 ns | 1,411,198.3 ns |      - |     440 B |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json40KB** |   **111,835.2 ns** |  **1,053.686 ns** |    **985.618 ns** |   **111,523.0 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |   Json40KB |   140,418.5 ns |  2,771.333 ns |  4,062.184 ns |   138,781.6 ns |      - |      40 B |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |    **Json4KB** |     **9,467.5 ns** |     **94.473 ns** |     **88.370 ns** |     **9,482.8 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |    Json4KB |    12,664.7 ns |    124.454 ns |    116.414 ns |    12,641.6 ns | 0.0916 |     416 B |

**After:**

|                                            Method | IsDataCompact |   TestCase |            Mean |           Error |          StdDev |  Gen 0 | Allocated |
|-------------------------------------------------- |-------------- |----------- |----------------:|----------------:|----------------:|-------:|----------:|
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **BasicJson** |       **649.97 ns** |       **4.1203 ns** |       **3.6525 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |  BasicJson |     1,390.76 ns |      14.8609 ns |      13.1738 ns | 0.0076 |      40 B |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** | **HelloWorld** |        **94.59 ns** |       **0.8219 ns** |       **0.7286 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True | HelloWorld |       496.26 ns |       5.3908 ns |       4.5016 ns | 0.0086 |      40 B |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json400B** |       **986.31 ns** |      **12.7486 ns** |      **11.9251 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |   Json400B |     1,699.47 ns |      19.0710 ns |      16.9059 ns |      - |       0 B |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **Json400KB** |   **953,232.28 ns** |  **18,279.9188 ns** |  **21,051.1798 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |  Json400KB | 1,477,274.90 ns | 201,523.3781 ns | 188,505.0746 ns |      - |     440 B |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json40KB** |    **88,480.21 ns** |   **1,254.3162 ns** |   **1,111.9185 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |   Json40KB |   134,772.32 ns |   1,230.6454 ns |   1,151.1464 ns |      - |      40 B |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |    **Json4KB** |     **7,493.69 ns** |     **147.1333 ns** |     **279.9363 ns** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |    Json4KB |    12,349.82 ns |     211.9233 ns |     176.9656 ns | 0.0916 |     416 B |

