### PR TITLE
Add support for writing a JsonObject and array-based overload

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/DbRow.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/DbRow.cs
@@ -42,6 +42,20 @@ namespace System.Text.JsonLab
             _union = numberOfRows | (int)jsonType << 28; // HasChildren is set to false by default
         }
 
+        internal DbRow(JsonValueType jsonType, int location, bool hasChildren, int sizeOrLength, int numberOfRows)
+        {
+            Debug.Assert(jsonType >= JsonValueType.Object && jsonType <= JsonValueType.Unknown);
+            Debug.Assert(location >= 0);
+            Debug.Assert(sizeOrLength >= UnknownSize);
+            Debug.Assert(numberOfRows >= 1 && numberOfRows <= 0x0FFFFFFF);
+
+            Location = location;
+            SizeOrLength = sizeOrLength;
+            _union = numberOfRows | (int)jsonType << 28;
+            if (hasChildren)
+                _union = _union | 1 << 31;
+        }
+
         public bool IsSimpleValue => JsonType > JsonValueType.Array;
     }
 }

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -2,20 +2,21 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Diagnostics.Windows.Configs;
 using System.Buffers.Text;
 using System.IO;
 using System.Text.Formatting;
 
 namespace System.Text.JsonLab.Benchmarks
 {
-    [SimpleJob(-1, 5, 10, 32768)]
-    [DisassemblyDiagnoser(printAsm: true, printSource: true)]
-    [InliningDiagnoser()]
+    [SimpleJob(-1, 3, 5)]
     [MemoryDiagnoser]
     public class JsonWriterPerf
     {
-        private const int ExtraArraySize = 1000;
+        private static readonly byte[] Message = Encoding.UTF8.GetBytes("message");
+        private static readonly byte[] HelloWorld = Encoding.UTF8.GetBytes("Hello, World!");
+        private static readonly byte[] ExtraArray = Encoding.UTF8.GetBytes("ExtraArray");
+
+        private const int ExtraArraySize = 10000000;
         private const int BufferSize = 1024 + (ExtraArraySize * 64);
 
         private ArrayFormatterWrapper _arrayFormatterWrapper;
@@ -94,6 +95,10 @@ namespace System.Text.JsonLab.Benchmarks
         [Arguments(10)]
         [Arguments(100)]
         [Arguments(1000)]
+        [Arguments(10000)]
+        [Arguments(100000)]
+        [Arguments(1000000)]
+        [Arguments(10000000)]
         public void WriterSystemTextJsonArrayOnly(int size)
         {
             _arrayFormatterWrapper.Clear();
@@ -107,6 +112,10 @@ namespace System.Text.JsonLab.Benchmarks
         [Arguments(10)]
         [Arguments(100)]
         [Arguments(1000)]
+        [Arguments(10000)]
+        [Arguments(100000)]
+        [Arguments(1000000)]
+        [Arguments(10000000)]
         public void WriterUtf8JsonArrayOnly(int size)
         {
             WriterUtf8JsonArrayOnly(_data.AsSpan(0, size), _output);
@@ -135,14 +144,7 @@ namespace System.Text.JsonLab.Benchmarks
             json.WriteAttribute("city", "Redmond");
             json.WriteAttribute("zip", 98052);
             json.WriteObjectEnd();
-
-            json.WriteArrayStart("ExtraArray");
-            for (var i = 0; i < data.Length; i++)
-            {
-                json.WriteValue(data[i]);
-            }
-            json.WriteArrayEnd();
-
+            json.WriteArrayUtf8(ExtraArray, data);
             json.WriteObjectEnd();
             json.Flush();
         }
@@ -240,7 +242,7 @@ namespace System.Text.JsonLab.Benchmarks
             Utf8JsonWriter<ArrayFormatterWrapper> json = Utf8JsonWriter.Create(output, formatted);
 
             json.WriteObjectStart();
-            json.WriteAttribute("message", "Hello, World!");
+            json.WriteAttributeUtf8(Message, HelloWorld);
             json.WriteObjectEnd();
             json.Flush();
         }
@@ -272,12 +274,7 @@ namespace System.Text.JsonLab.Benchmarks
         {
             Utf8JsonWriter<ArrayFormatterWrapper> json = Utf8JsonWriter.Create(output, formatted);
 
-            json.WriteArrayStart("ExtraArray");
-            for (var i = 0; i < data.Length; i++)
-            {
-                json.WriteValue(data[i]);
-            }
-            json.WriteArrayEnd();
+            json.WriteArrayUtf8(ExtraArray, data);
             json.Flush();
         }
 

--- a/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonWriterTests.cs
@@ -37,6 +37,8 @@ namespace System.Text.JsonLab.Tests
 
         static void Write(ref Utf8JsonWriter<ArrayFormatterWrapper> json)
         {
+            int[] values = { 425121, -425122, 425123 };
+            byte[] valueString = Encoding.UTF8.GetBytes("values");
             json.WriteObjectStart();
             json.WriteAttribute("age", 30);
             json.WriteAttribute("first", "John");
@@ -51,11 +53,7 @@ namespace System.Text.JsonLab.Tests
             json.WriteAttribute("city", "Redmond");
             json.WriteAttribute("zip", 98052);
             json.WriteObjectEnd();
-            json.WriteArrayStart("values");
-            json.WriteValue(425121);
-            json.WriteValue(-425122);
-            json.WriteValue(425123);
-            json.WriteArrayEnd();
+            json.WriteArrayUtf8(valueString, values);
             json.WriteObjectEnd();
             json.Flush();
         }
@@ -87,7 +85,7 @@ namespace System.Text.JsonLab.Tests
         public void WriteBasicJsonUtf8(bool prettyPrint)
         {
             int[] data = GetData(ExtraArraySize, 42, -10000, 10000);
-
+            byte[] ExtraArray = Encoding.UTF8.GetBytes("ExtraArray");
             string expectedStr = GetExpectedString(prettyPrint, isUtf8: true, data);
 
             var output = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
@@ -108,12 +106,7 @@ namespace System.Text.JsonLab.Tests
             jsonUtf8.WriteObjectEnd();
 
             // Add a large array of values
-            jsonUtf8.WriteArrayStart("ExtraArray");
-            for (var i = 0; i < ExtraArraySize; i++)
-            {
-                jsonUtf8.WriteValue(data[i]);
-            }
-            jsonUtf8.WriteArrayEnd();
+            jsonUtf8.WriteArrayUtf8(ExtraArray, data);
 
             jsonUtf8.WriteObjectEnd();
             jsonUtf8.Flush();


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.10.14.683-nightly, OS=Windows 10.0.17738
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-20180720-2
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  Job-UKSANP : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT

IterationCount=5  WarmupCount=3  

```

**BEFORE:**

|                         Method | Formatted |     size |              Mean |            Error |          StdDev | Allocated |
|------------------------------- |---------- |--------- |------------------:|-----------------:|----------------:|----------:|
|  **WriterSystemTextJsonArrayOnly** |     **False** |        **1** |          **82.38 ns** |         **1.170 ns** |       **0.3039 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** |        **2** |          **95.62 ns** |        **31.021 ns** |       **8.0575 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** |        **5** |         **119.77 ns** |         **6.126 ns** |       **1.5913 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** |       **10** |         **164.55 ns** |         **3.491 ns** |       **0.9068 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** |      **100** |         **994.11 ns** |        **32.006 ns** |       **8.3134 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** |     **1000** |      **12,436.67 ns** |       **171.867 ns** |      **44.6418 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** |    **10000** |     **142,924.65 ns** |     **6,927.978 ns** |   **1,799.5166 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** |   **100000** |   **1,424,913.54 ns** |   **250,920.267 ns** |  **65,175.6057 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** |  **1000000** |  **13,985,240.00 ns** |   **193,256.477 ns** |  **50,197.6510 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |     **False** | **10000000** | **140,551,895.00 ns** | **2,033,978.752 ns** | **528,318.4135 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |     **False** |        **?** |         **701.36 ns** |        **89.420 ns** |      **23.2266 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |     False |        ? |          89.82 ns |         5.585 ns |       1.4507 ns |       0 B |
|  **WriterSystemTextJsonArrayOnly** |      **True** |        **1** |         **101.65 ns** |         **2.053 ns** |       **0.5332 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** |        **2** |         **116.96 ns** |         **2.590 ns** |       **0.6728 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** |        **5** |         **161.02 ns** |         **1.314 ns** |       **0.3413 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** |       **10** |         **232.16 ns** |         **4.692 ns** |       **1.2187 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** |      **100** |       **1,618.34 ns** |        **56.628 ns** |      **14.7088 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** |     **1000** |      **17,740.87 ns** |     **1,217.724 ns** |     **316.2993 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** |    **10000** |     **187,386.93 ns** |    **34,644.726 ns** |   **8,998.8388 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** |   **100000** |   **1,843,282.88 ns** |    **31,104.060 ns** |   **8,079.1638 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** |  **1000000** |  **18,693,626.25 ns** |   **285,331.113 ns** |  **74,113.6950 ns** |       **0 B** |
|  **WriterSystemTextJsonArrayOnly** |      **True** | **10000000** | **187,322,440.00 ns** | **3,308,084.929 ns** | **859,262.7529 ns** |       **0 B** |
|      **WriterSystemTextJsonBasic** |      **True** |        **?** |       **1,001.84 ns** |        **20.565 ns** |       **5.3418 ns** |       **0 B** |
| WriterSystemTextJsonHelloWorld |      True |        ? |         133.45 ns |         4.176 ns |       1.0847 ns |       0 B |

**AFTER:**

|                         Method | Formatted |     size |              Mean |              Error |            StdDev |   Gen 0 |   Allocated |
|------------------------------- |---------- |--------- |------------------:|-------------------:|------------------:|--------:|------------:|
|  **WriterSystemTextJsonArrayOnly** |     **False** |        **1** |          **59.09 ns** |          **0.8759 ns** |         **0.2275 ns** |       **-** |         **0 B** |
|        WriterUtf8JsonArrayOnly |     False |        1 |         112.43 ns |          7.2046 ns |         1.8714 ns |  0.0741 |       312 B |
|  **WriterSystemTextJsonArrayOnly** |     **False** |        **2** |          **65.24 ns** |          **1.3899 ns** |         **0.3610 ns** |       **-** |         **0 B** |
|        WriterUtf8JsonArrayOnly |     False |        2 |         132.06 ns |         14.4629 ns |         3.7567 ns |  0.0741 |       312 B |
|  **WriterSystemTextJsonArrayOnly** |     **False** |        **5** |          **85.29 ns** |          **1.1558 ns** |         **0.3002 ns** |       **-** |         **0 B** |
|        WriterUtf8JsonArrayOnly |     False |        5 |         173.33 ns |         10.4133 ns |         2.7048 ns |  0.0741 |       312 B |
|  **WriterSystemTextJsonArrayOnly** |     **False** |       **10** |         **119.62 ns** |          **3.5281 ns** |         **0.9164 ns** |       **-** |         **0 B** |
|        WriterUtf8JsonArrayOnly |     False |       10 |         264.40 ns |         98.0968 ns |        25.4803 ns |  0.0739 |       312 B |
|  **WriterSystemTextJsonArrayOnly** |     **False** |      **100** |         **750.80 ns** |         **16.8153 ns** |         **4.3677 ns** |       **-** |         **0 B** |
|        WriterUtf8JsonArrayOnly |     False |      100 |       1,988.90 ns |         86.1610 ns |        22.3800 ns |  0.4501 |      1896 B |
|  **WriterSystemTextJsonArrayOnly** |     **False** |     **1000** |       **9,615.06 ns** |        **347.9064 ns** |        **90.3674 ns** |       **-** |         **0 B** |
|        WriterUtf8JsonArrayOnly |     False |     1000 |      20,865.60 ns |      3,015.7498 ns |       783.3298 ns |  3.8757 |     16304 B |
|  **WriterSystemTextJsonArrayOnly** |     **False** |    **10000** |     **118,026.14 ns** |      **2,755.2745 ns** |       **715.6723 ns** |       **-** |         **0 B** |
|        WriterUtf8JsonArrayOnly |     False |    10000 |     207,320.42 ns |      2,578.8788 ns |       669.8542 ns | 31.0059 |    131064 B |
|  **WriterSystemTextJsonArrayOnly** |     **False** |   **100000** |   **1,190,018.88 ns** |     **30,678.5259 ns** |     **7,968.6330 ns** |       **-** |         **0 B** |
|        WriterUtf8JsonArrayOnly |     False |   100000 |   2,768,089.82 ns |     99,403.0612 ns |    25,819.5753 ns | 27.3438 |   2097240 B |
|  **WriterSystemTextJsonArrayOnly** |     **False** |  **1000000** |  **12,432,389.38 ns** |  **1,540,118.4978 ns** |   **400,040.0499 ns** |       **-** |         **0 B** |
|        WriterUtf8JsonArrayOnly |     False |  1000000 |  27,543,725.00 ns | 10,097,389.1849 ns | 2,622,759.2743 ns |       - |  16777376 B |
|  **WriterSystemTextJsonArrayOnly** |     **False** | **10000000** | **121,304,410.00 ns** |  **7,236,407.6767 ns** | **1,879,629.9716 ns** |       **-** |         **0 B** |
|        WriterUtf8JsonArrayOnly |     False | 10000000 | 260,646,520.00 ns | 23,742,465.1473 ns | 6,167,016.9903 ns |       - | 134217960 B |
|      **WriterSystemTextJsonBasic** |     **False** |        **?** |         **659.40 ns** |         **49.0251 ns** |        **12.7341 ns** |       **-** |         **0 B** |
|          WriterNewtonsoftBasic |     False |        ? |       1,498.39 ns |         74.9395 ns |        19.4652 ns |  0.0973 |       416 B |
|            WriterUtf8JsonBasic |     False |        ? |         839.64 ns |          6.6206 ns |         1.7197 ns |  0.0734 |       312 B |
| WriterSystemTextJsonHelloWorld |     False |        ? |          55.88 ns |          0.8816 ns |         0.2290 ns |       - |         0 B |
|     WriterNewtonsoftHelloWorld |     False |        ? |         282.29 ns |         74.8672 ns |        19.4465 ns |  0.0606 |       256 B |
|       WriterUtf8JsonHelloWorld |     False |        ? |         122.38 ns |          2.1770 ns |         0.5655 ns |  0.0741 |       312 B |


|                                Method |           TestCase |         Mean |      Error |     StdDev | Scaled |    Gen 0 |    Gen 1 | Allocated |
|-------------------------------------- |------------------- |-------------:|-----------:|-----------:|-------:|---------:|---------:|----------:|
| **ChangeEntryPointLibraryNameNewtonsoft** |    **DepsJsonSignalR** | **3,501.417 us** | **68.1043 us** | **69.9381 us** |   **1.00** | **292.9688** | **144.5313** | **1789776 B** |
|    ChangeEntryPointLibraryNameJsonLab |    DepsJsonSignalR |   858.901 us | 15.2435 us | 13.5130 us |   0.25 |        - |        - |      72 B |
|                                       |                    |              |            |            |        |          |          |           |
| **ChangeEntryPointLibraryNameNewtonsoft** |    **DepsJsonWeather** | **1,678.468 us** | **16.0675 us** | **14.2434 us** |   **1.00** | **156.2500** |  **78.1250** |  **934720 B** |
|    ChangeEntryPointLibraryNameJsonLab |    DepsJsonWeather |   450.922 us |  9.2343 us | 19.2755 us |   0.27 |        - |        - |      72 B |
|                                       |                    |              |            |            |        |          |          |           |
| **ChangeEntryPointLibraryNameNewtonsoft** | **DepsJsonWebSockets** |    **11.846 us** |  **0.2282 us** |  **0.3813 us** |   **1.00** |   **2.7618** |        **-** |   **11600 B** |
|    ChangeEntryPointLibraryNameJsonLab | DepsJsonWebSockets |     3.352 us |  0.0668 us |  0.0979 us |   0.28 |   0.0153 |        - |      72 B |
