### PR TITLE
Add JsonObject ref enumerator

### DIFF
--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserChangeEntryPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserChangeEntryPerf.cs
@@ -55,7 +55,7 @@ namespace System.Text.JsonLab.Benchmarks
             _arrayOutput = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
         }
 
-        [Benchmark(Baseline = true)]
+        //[Benchmark(Baseline = true)]
         public void ChangeEntryPointLibraryNameNewtonsoft()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -92,22 +92,21 @@ namespace System.Text.JsonLab.Benchmarks
         {
             JsonObject obj = JsonObject.Parse(_dataUtf8);
 
-            JsonObject targets = obj["targets"];
-            if (targets.TryGetChild(out JsonObject child))
+            foreach (JsonObject target in obj["targets"])
             {
-                if (child.TryGetChild(out child))
-                    obj.Remove(child);
+                if (target.TryGetChild(out JsonObject firstChild))
+                    obj.Remove(firstChild);
             }
 
             JsonObject libraries = obj["libraries"];
-            if (libraries.TryGetChild(out child))
+            if (libraries.TryGetChild(out JsonObject child))
                 obj.Remove(child);
 
             _arrayOutput.Clear();
             var jsonUtf8 = new Utf8JsonWriter<ArrayFormatterWrapper>(_arrayOutput);
             jsonUtf8.Write(obj);
             jsonUtf8.Flush();
-            
+
             obj.Dispose();
         }
     }

--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserChangeEntryPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserChangeEntryPerf.cs
@@ -55,7 +55,7 @@ namespace System.Text.JsonLab.Benchmarks
             _arrayOutput = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
         }
 
-        //[Benchmark(Baseline = true)]
+        [Benchmark(Baseline = true)]
         public void ChangeEntryPointLibraryNameNewtonsoft()
         {
             _stream.Seek(0, SeekOrigin.Begin);

--- a/tests/System.Text.JsonLab.Tests/JsonObjectTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonObjectTests.cs
@@ -285,12 +285,14 @@ namespace System.Text.JsonLab.Tests
 
             JsonObject targets = obj[targetsString];
 
-            Assert.True(targets.TryGetChild(out JsonObject child));
-            Assert.True(child.TryGetChild(out child));
-            obj.Remove(child);
+            foreach (JsonObject target in targets)
+            {
+                Assert.True(target.TryGetChild(out JsonObject firstChild));
+                obj.Remove(firstChild);
+            }
 
             JsonObject libraries = obj[librariesString];
-            Assert.True(libraries.TryGetChild(out child));
+            Assert.True(libraries.TryGetChild(out JsonObject child));
             obj.Remove(child);
 
             string expected = ChangeEntryPointLibraryNameExpected();


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.10.14.683-nightly, OS=Windows 10.0.17738
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-20180720-2
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT


```
|                                Method |           TestCase |         Mean |      Error |     StdDev |       Median | Scaled | ScaledSD |    Gen 0 |    Gen 1 | Allocated |
|-------------------------------------- |------------------- |-------------:|-----------:|-----------:|-------------:|-------:|---------:|---------:|---------:|----------:|
| **ChangeEntryPointLibraryNameNewtonsoft** |    **DepsJsonSignalR** | **3,418.193 us** | **56.8947 us** | **50.4357 us** | **3,401.972 us** |   **1.00** |     **0.00** | **292.9688** | **144.5313** | **1789776 B** |
|    ChangeEntryPointLibraryNameJsonLab |    DepsJsonSignalR |   867.354 us |  9.1386 us |  7.6311 us |   865.187 us |   0.25 |     0.00 |        - |        - |      72 B |
|                                       |                    |              |            |            |              |        |          |          |          |           |
| **ChangeEntryPointLibraryNameNewtonsoft** |    **DepsJsonWeather** | **1,701.242 us** | **20.4579 us** | **17.0833 us** | **1,702.663 us** |   **1.00** |     **0.00** | **156.2500** |  **78.1250** |  **934720 B** |
|    ChangeEntryPointLibraryNameJsonLab |    DepsJsonWeather |   474.986 us |  6.2316 us |  5.5242 us |   475.649 us |   0.28 |     0.00 |        - |        - |      72 B |
|                                       |                    |              |            |            |              |        |          |          |          |           |
| **ChangeEntryPointLibraryNameNewtonsoft** | **DepsJsonWebSockets** |    **11.357 us** |  **0.2201 us** |  **0.2355 us** |    **11.278 us** |   **1.00** |     **0.00** |   **2.7618** |        **-** |   **11600 B** |
|    ChangeEntryPointLibraryNameJsonLab | DepsJsonWebSockets |     4.491 us |  0.1022 us |  0.2917 us |     4.396 us |   0.40 |     0.03 |   0.0153 |        - |      72 B |

Results from before:

|                             Method |           TestCase |       Mean |     Error |     StdDev |     Median |  Gen 0 | Allocated |
|----------------------------------- |------------------- |-----------:|----------:|-----------:|-----------:|-------:|----------:|
| **ChangeEntryPointLibraryNameJsonLab** |    **DepsJsonSignalR** | **873.926 us** | **7.0866 us** |  **6.6288 us** | **872.490 us** |      **-** |      **72 B** |
| **ChangeEntryPointLibraryNameJsonLab** |    **DepsJsonWeather** | **434.632 us** | **9.6031 us** | **17.0695 us** | **426.005 us** |      **-** |      **72 B** |
| **ChangeEntryPointLibraryNameJsonLab** | **DepsJsonWebSockets** |   **3.213 us** | **0.0170 us** |  **0.0159 us** |   **3.212 us** | **0.0153** |      **72 B** |

Enumeration is a little bit slower compared to the hand-written iteration, especially for small payloads.