### PR TITLE
Add JsonWriteObject perf tests and cleanup use of var

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/JsonObject.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonObject.cs
@@ -505,25 +505,26 @@ namespace System.Text.JsonLab
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public bool MoveNext()
             {
-                int index = _index + 1;
-                if (index < _obj.Size)
+                if (_index < _obj.Size - 1)
                 {
-                    DbRow row = _obj.GetRow(index);
+                    _index++;
+                    DbRow row = _obj.GetRow(_index);
                     if (row.JsonType != JsonValueType.String)
                         JsonThrowHelper.ThrowInvalidOperationException();
 
-                    index++;
-                    int length = DbRow.Size;
+                    _index++;
 
-                    DbRow nextRow = _obj.GetRow(index);
+                    DbRow nextRow = _obj.GetRow(_index);
 
                     if (!nextRow.IsSimpleValue && nextRow.SizeOrLength != 0)
                     {
+                        Current = _obj.CreateJsonObject(_index * DbRow.Size, DbRow.Size * (nextRow.NumberOfRows + 1));
                         _index += nextRow.NumberOfRows;
-                        length = DbRow.Size * (nextRow.NumberOfRows + 1);
                     }
-                    Current = _obj.CreateJsonObject(index * DbRow.Size, length);
-                    _index += 2;
+                    else
+                    {
+                        Current = _obj.CreateJsonObject(_index * DbRow.Size, DbRow.Size);
+                    }
                     return true;
                 }
                 return false;

--- a/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonWriter.cs
@@ -1780,7 +1780,14 @@ namespace System.Text.JsonLab
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private Span<byte> EnsureBuffer(int needed = 256)
+        private Span<byte> EnsureBuffer()
+        {
+            _bufferWriter.Ensure(_bufferWriter.Buffer.Length + 1);
+            return _bufferWriter.Buffer;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private Span<byte> EnsureBuffer(int needed)
         {
             _bufferWriter.Ensure(needed);
             Span<byte> buffer = _bufferWriter.Buffer;

--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserEnumeratePerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserEnumeratePerf.cs
@@ -17,17 +17,21 @@ namespace System.Text.JsonLab.Benchmarks
         private MemoryStream _stream;
         private StreamReader _reader;
 
+        private const int ArrayLength = 300; // We know Json400KB has a 300 length array within the payload.
+
+        private const int IterationCount = 1000;
+
         [GlobalSetup]
         public void Setup()
         {
             string jsonString = JsonStrings.Json400KB;
 
             // Remove all formatting/indendation
-            using (JsonTextReader jsonReader = new JsonTextReader(new StringReader(jsonString)))
+            using (var jsonReader = new JsonTextReader(new StringReader(jsonString)))
             {
                 JToken obj = JToken.ReadFrom(jsonReader);
                 var stringWriter = new StringWriter();
-                using (JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter))
+                using (var jsonWriter = new JsonTextWriter(stringWriter))
                 {
                     obj.WriteTo(jsonWriter);
                     jsonString = stringWriter.ToString();
@@ -40,14 +44,14 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark(Baseline = true)]
-        public void ParseNewtonsoftEnumerate()
+        public void ParseNewtonsoftEnumerateArray()
         {
             _stream.Seek(0, SeekOrigin.Begin);
-            using (JsonTextReader jsonReader = new JsonTextReader(_reader))
+            using (var jsonReader = new JsonTextReader(_reader))
             {
                 JToken obj = JToken.ReadFrom(jsonReader);
 
-                for (int j = 0; j < 100; j++)
+                for (int j = 0; j < IterationCount; j++)
                 {
                     foreach (JToken token in obj)
                     {
@@ -57,16 +61,16 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark]
-        public void ParseNewtonsoftEnumerateReverse()
+        public void ParseNewtonsoftEnumerateArrayReverse()
         {
             _stream.Seek(0, SeekOrigin.Begin);
-            using (JsonTextReader jsonReader = new JsonTextReader(_reader))
+            using (var jsonReader = new JsonTextReader(_reader))
             {
                 JToken obj = JToken.ReadFrom(jsonReader);
 
-                for (int j = 0; j < 100; j++)
+                for (int j = 0; j < IterationCount; j++)
                 {
-                    for (int i = 299; i >= 0; i--)
+                    for (int i = ArrayLength - 1; i >= 0; i--)
                     {
                         JToken token = obj[i];
                     }
@@ -75,16 +79,16 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark]
-        public void ParseNewtonsoftFirst()
+        public void ParseNewtonsoftArrayFirst()
         {
             _stream.Seek(0, SeekOrigin.Begin);
-            using (JsonTextReader jsonReader = new JsonTextReader(_reader))
+            using (var jsonReader = new JsonTextReader(_reader))
             {
                 JToken obj = JToken.ReadFrom(jsonReader);
 
-                for (int j = 0; j < 100; j++)
+                for (int j = 0; j < IterationCount; j++)
                 {
-                    for (int i = 0; i < 300; i++)
+                    for (int i = 0; i < ArrayLength; i++)
                     {
                         JToken token = obj[0];
                     }
@@ -93,29 +97,46 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark]
-        public void ParseNewtonsoftMiddle()
+        public void ParseNewtonsoftArrayMiddle()
         {
             _stream.Seek(0, SeekOrigin.Begin);
-            using (JsonTextReader jsonReader = new JsonTextReader(_reader))
+            using (var jsonReader = new JsonTextReader(_reader))
             {
                 JToken obj = JToken.ReadFrom(jsonReader);
 
-                for (int j = 0; j < 100; j++)
+                for (int j = 0; j < IterationCount; j++)
                 {
-                    for (int i = 0; i < 300; i++)
+                    for (int i = 0; i < ArrayLength; i++)
                     {
-                        JToken token = obj[150];
+                        JToken token = obj[ArrayLength / 2];
                     }
                 }
             }
         }
 
         [Benchmark]
-        public void ParseSystemTextJsonLabEnumerate()
+        public void ParseNewtonsoftEnumerate()
+        {
+            _stream.Seek(0, SeekOrigin.Begin);
+            using (var jsonReader = new JsonTextReader(_reader))
+            {
+                JToken obj = JToken.ReadFrom(jsonReader);
+                JToken withinArray = obj[0];
+                for (int j = 0; j < IterationCount; j++)
+                {
+                    foreach (JToken childObject in withinArray)
+                    {
+                    }
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ParseSystemTextJsonLabEnumerateArray()
         {
             JsonObject obj = JsonObject.Parse(_dataUtf8);
 
-            for (int j = 0; j < 100; j++)
+            for (int j = 0; j < IterationCount; j++)
             {
                 for (int i = 0; i < obj.ArrayLength; i++)
                 {
@@ -127,11 +148,11 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark]
-        public void ParseSystemTextJsonLabEnumerateReverse()
+        public void ParseSystemTextJsonLabEnumerateArrayReverse()
         {
             JsonObject obj = JsonObject.Parse(_dataUtf8);
 
-            for (int j = 0; j < 100; j++)
+            for (int j = 0; j < IterationCount; j++)
             {
                 for (int i = obj.ArrayLength - 1; i >= 0; i--)
                 {
@@ -143,11 +164,11 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark]
-        public void ParseSystemTextJsonLabFirst()
+        public void ParseSystemTextJsonLabArrayFirst()
         {
             JsonObject obj = JsonObject.Parse(_dataUtf8);
 
-            for (int j = 0; j < 100; j++)
+            for (int j = 0; j < IterationCount; j++)
             {
                 for (int i = 0; i < obj.ArrayLength; i++)
                 {
@@ -159,15 +180,31 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark]
-        public void ParseSystemTextJsonLabMiddle()
+        public void ParseSystemTextJsonLabArrayMiddle()
         {
             JsonObject obj = JsonObject.Parse(_dataUtf8);
 
-            for (int j = 0; j < 100; j++)
+            for (int j = 0; j < IterationCount; j++)
             {
                 for (int i = 0; i < obj.ArrayLength; i++)
                 {
-                    JsonObject withinArray = obj[150];
+                    JsonObject withinArray = obj[obj.ArrayLength / 2];
+                }
+            }
+
+            obj.Dispose();
+        }
+
+        [Benchmark]
+        public void ParseSystemTextJsonLabEnumerate()
+        {
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
+            JsonObject withinArray = obj[0];
+
+            for (int j = 0; j < IterationCount; j++)
+            {
+                foreach (JsonObject childObject in withinArray)
+                {
                 }
             }
 

--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserEnumeratePerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserEnumeratePerf.cs
@@ -148,6 +148,21 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark]
+        public void ParseSystemTextJsonLabEnumerateForeachArray()
+        {
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
+
+            for (int j = 0; j < IterationCount; j++)
+            {
+                foreach(JsonObject withinArray in obj)
+                {
+                }
+            }
+
+            obj.Dispose();
+        }
+
+        [Benchmark]
         public void ParseSystemTextJsonLabEnumerateArrayReverse()
         {
             JsonObject obj = JsonObject.Parse(_dataUtf8);

--- a/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonParserPerf.cs
@@ -60,11 +60,11 @@ namespace System.Text.JsonLab.Benchmarks
             // Remove all formatting/indendation
             if (IsDataCompact)
             {
-                using (JsonTextReader jsonReader = new JsonTextReader(new StringReader(jsonString)))
+                using (var jsonReader = new JsonTextReader(new StringReader(jsonString)))
                 {
                     JToken obj = JToken.ReadFrom(jsonReader);
                     var stringWriter = new StringWriter();
-                    using (JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter))
+                    using (var jsonWriter = new JsonTextWriter(stringWriter))
                     {
                         obj.WriteTo(jsonWriter);
                         jsonString = stringWriter.ToString();
@@ -82,7 +82,7 @@ namespace System.Text.JsonLab.Benchmarks
         public void ParseNewtonsoft()
         {
             _stream.Seek(0, SeekOrigin.Begin);
-            using (JsonTextReader jsonReader = new JsonTextReader(_reader))
+            using (var jsonReader = new JsonTextReader(_reader))
             {
                 JToken obj = JToken.ReadFrom(jsonReader);
 

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -60,11 +60,11 @@ namespace System.Text.JsonLab.Benchmarks
             // Remove all formatting/indendation
             if (IsDataCompact)
             {
-                using (JsonTextReader jsonReader = new JsonTextReader(new StringReader(_jsonString)))
+                using (var jsonReader = new JsonTextReader(new StringReader(_jsonString)))
                 {
                     JToken obj = JToken.ReadFrom(jsonReader);
                     var stringWriter = new StringWriter();
-                    using (JsonTextWriter jsonWriter = new JsonTextWriter(stringWriter))
+                    using (var jsonWriter = new JsonTextWriter(stringWriter))
                     {
                         obj.WriteTo(jsonWriter);
                         _jsonString = stringWriter.ToString();
@@ -100,7 +100,7 @@ namespace System.Text.JsonLab.Benchmarks
             _stream.Seek(0, SeekOrigin.Begin);
             TextReader reader = _reader;
 
-            StringBuilder sb = new StringBuilder();
+            var sb = new StringBuilder();
             var json = new JsonTextReader(reader);
             while (json.Read())
             {
@@ -137,7 +137,7 @@ namespace System.Text.JsonLab.Benchmarks
         [Benchmark]
         public byte[] ReaderSystemTextJsonLabReturnBytes()
         {
-            byte[] outputArray = new byte[_dataUtf8.Length * 2];
+            var outputArray = new byte[_dataUtf8.Length * 2];
 
             Span<byte> destination = outputArray;
             var json = new Utf8JsonReader(_dataUtf8);
@@ -199,7 +199,7 @@ namespace System.Text.JsonLab.Benchmarks
         [Benchmark]
         public void ReaderUtf8JsonEmptyLoop()
         {
-            Utf8Json.JsonReader json = new Utf8Json.JsonReader(_dataUtf8);
+            var json = new Utf8Json.JsonReader(_dataUtf8);
 
             while (json.GetCurrentJsonToken() != Utf8Json.JsonToken.None)
             {
@@ -210,9 +210,9 @@ namespace System.Text.JsonLab.Benchmarks
         [Benchmark]
         public byte[] ReaderUtf8JsonReturnBytes()
         {
-            Utf8Json.JsonReader json = new Utf8Json.JsonReader(_dataUtf8);
+            var json = new Utf8Json.JsonReader(_dataUtf8);
 
-            byte[] outputArray = new byte[_dataUtf8.Length * 2];
+            var outputArray = new byte[_dataUtf8.Length * 2];
             Span<byte> destination = outputArray;
 
             Utf8Json.JsonToken token = json.GetCurrentJsonToken();

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriteObjectPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriteObjectPerf.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using Benchmarks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Buffers.Text;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Formatting;
+
+namespace System.Text.JsonLab.Benchmarks
+{
+    // Since there are 60 tests here (4 * 15), setting low values for the warmupCount and targetCount
+    [SimpleJob(-1, 3, 5)]
+    [MemoryDiagnoser]
+    public class JsonWriteObjectPerf
+    {
+        // Keep the JsonStrings resource names in sync with TestCaseType enum values.
+        public enum TestCaseType
+        {
+            HelloWorld,
+            BasicJson,
+            BasicLargeNum,
+            SpecialNumForm,
+            ProjectLockJson,
+            FullSchema1,
+            FullSchema2,
+            DeepTree,
+            BroadTree,
+            LotsOfNumbers,
+            LotsOfStrings,
+            Json400B,
+            Json4KB,
+            Json40KB,
+            Json400KB
+        }
+
+        private byte[] _dataUtf8;
+        private MemoryStream _stream;
+        private StreamReader _reader;
+
+        private byte[] _output;
+        private MemoryStream _outputStream;
+        private StreamWriter _writer;
+
+        private ArrayFormatterWrapper _arrayOutput;
+
+        [ParamsSource(nameof(TestCaseValues))]
+        public TestCaseType TestCase;
+
+        [Params(true, false)]
+        public bool IsDataCompact;
+
+        public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            string jsonString = JsonStrings.ResourceManager.GetString(TestCase.ToString());
+
+            // Remove all formatting/indendation
+            if (IsDataCompact)
+            {
+                using (var jsonReader = new JsonTextReader(new StringReader(jsonString)))
+                {
+                    JToken obj = JToken.ReadFrom(jsonReader);
+                    var stringWriter = new StringWriter();
+                    using (var jsonWriter = new JsonTextWriter(stringWriter))
+                    {
+                        obj.WriteTo(jsonWriter);
+                        jsonString = stringWriter.ToString();
+                    }
+                }
+            }
+
+            _dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+
+            _stream = new MemoryStream(_dataUtf8);
+            _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
+
+            _output = new byte[_dataUtf8.Length];
+
+            _outputStream = new MemoryStream(_output);
+            _writer = new StreamWriter(_outputStream, new UTF8Encoding(), 1024, true); // Do not output the BOM
+
+            _arrayOutput = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
+        }
+
+        [Benchmark(Baseline = true)]
+        public void ParseAndWriteNewtonsoft()
+        {
+            _stream.Seek(0, SeekOrigin.Begin);
+            using (var jsonReader = new JsonTextReader(_reader))
+            {
+                JToken obj = JToken.ReadFrom(jsonReader);
+
+                _outputStream.Seek(0, SeekOrigin.Begin);
+                TextWriter writer = _writer;
+                using (var jsonWriter = new JsonTextWriter(writer))
+                {
+                    obj.WriteTo(jsonWriter);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ParseAndWriteSystemTextJsonLab()
+        {
+            JsonObject obj = JsonObject.Parse(_dataUtf8);
+
+            _arrayOutput.Clear();
+            var jsonUtf8 = new Utf8JsonWriter<ArrayFormatterWrapper>(_arrayOutput);
+            jsonUtf8.Write(obj);
+            jsonUtf8.Flush();
+
+            obj.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
- Also fixed possible integer overflow in JsonObject enumerator

``` ini

BenchmarkDotNet=v0.10.14.683-nightly, OS=Windows 10.0.17738
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-20180720-2
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  Job-HSTSEQ : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT

IterationCount=5  WarmupCount=3  

```
|                 Method | IsDataCompact |        TestCase |            Mean |            Error |           StdDev | Scaled | ScaledSD |    Gen 0 |    Gen 1 | Allocated |
|----------------------- |-------------- |---------------- |----------------:|-----------------:|-----------------:|-------:|---------:|---------:|---------:|----------:|
|        **ParseNewtonsoft** |         **False** |       **BasicJson** |      **7,629.8 ns** |       **785.641 ns** |       **204.067 ns** |   **1.00** |     **0.00** |   **1.6556** |        **-** |    **6952 B** |
| ParseSystemTextJsonLab |         False |       BasicJson |      2,268.8 ns |        35.949 ns |         9.338 ns |   0.30 |     0.01 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |         **False** |   **BasicLargeNum** |      **9,489.8 ns** |     **3,857.743 ns** |     **1,002.034 ns** |   **1.00** |     **0.00** |   **1.8311** |        **-** |    **7688 B** |
| ParseSystemTextJsonLab |         False |   BasicLargeNum |      2,962.1 ns |     1,245.689 ns |       323.563 ns |   0.31 |     0.04 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |         **False** |       **BroadTree** |    **109,718.4 ns** |     **8,932.745 ns** |     **2,320.247 ns** |   **1.00** |     **0.00** |  **17.2119** |   **0.1221** |   **72472 B** |
| ParseSystemTextJsonLab |         False |       BroadTree |     42,258.2 ns |       935.076 ns |       242.883 ns |   0.39 |     0.01 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |         **False** |        **DeepTree** |     **59,158.8 ns** |     **3,970.720 ns** |     **1,031.380 ns** |   **1.00** |     **0.00** |   **9.3994** |        **-** |   **39464 B** |
| ParseSystemTextJsonLab |         False |        DeepTree |     20,723.9 ns |       308.751 ns |        80.197 ns |   0.35 |     0.01 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |         **False** |     **FullSchema1** |     **25,473.8 ns** |     **3,397.109 ns** |       **882.386 ns** |   **1.00** |     **0.00** |   **4.1504** |        **-** |   **17448 B** |
| ParseSystemTextJsonLab |         False |     FullSchema1 |      7,725.0 ns |     1,229.440 ns |       319.342 ns |   0.30 |     0.01 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |         **False** |     **FullSchema2** |     **37,091.7 ns** |     **3,662.184 ns** |       **951.239 ns** |   **1.00** |     **0.00** |   **5.1880** |        **-** |   **21880 B** |
| ParseSystemTextJsonLab |         False |     FullSchema2 |     10,143.3 ns |     1,752.572 ns |       455.224 ns |   0.27 |     0.01 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |         **False** |      **HelloWorld** |      **1,352.6 ns** |        **46.715 ns** |        **12.134 ns** |   **1.00** |     **0.00** |   **0.7973** |        **-** |    **3352 B** |
| ParseSystemTextJsonLab |         False |      HelloWorld |        459.6 ns |        20.158 ns |         5.236 ns |   0.34 |     0.00 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |         **False** |        **Json400B** |     **12,289.8 ns** |     **4,093.774 ns** |     **1,063.343 ns** |   **1.00** |     **0.00** |   **2.0905** |        **-** |    **8816 B** |
| ParseSystemTextJsonLab |         False |        Json400B |      2,832.1 ns |        59.877 ns |        15.553 ns |   0.23 |     0.02 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |         **False** |       **Json400KB** | **14,186,215.6 ns** | **4,502,145.001 ns** | **1,169,415.414 ns** |   **1.00** |     **0.00** | **765.6250** | **375.0000** | **4750992 B** |
| ParseSystemTextJsonLab |         False |       Json400KB |  2,654,094.3 ns |   355,177.352 ns |    92,255.996 ns |   0.19 |     0.02 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |         **False** |        **Json40KB** |    **899,055.5 ns** |    **27,849.393 ns** |     **7,233.776 ns** |   **1.00** |     **0.00** |  **87.8906** |  **35.1563** |  **485664 B** |
| ParseSystemTextJsonLab |         False |        Json40KB |    238,496.0 ns |     2,927.313 ns |       760.359 ns |   0.27 |     0.00 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |         **False** |         **Json4KB** |     **87,564.1 ns** |    **10,895.589 ns** |     **2,830.089 ns** |   **1.00** |     **0.00** |  **11.9629** |        **-** |   **50448 B** |
| ParseSystemTextJsonLab |         False |         Json4KB |     28,571.3 ns |     7,754.461 ns |     2,014.192 ns |   0.33 |     0.02 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |         **False** |   **LotsOfNumbers** |     **32,444.3 ns** |     **1,378.241 ns** |       **357.993 ns** |   **1.00** |     **0.00** |   **5.0049** |        **-** |   **21176 B** |
| ParseSystemTextJsonLab |         False |   LotsOfNumbers |      9,558.0 ns |     2,234.103 ns |       580.300 ns |   0.29 |     0.02 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |         **False** |   **LotsOfStrings** |     **16,267.6 ns** |     **1,178.193 ns** |       **306.031 ns** |   **1.00** |     **0.00** |   **2.6550** |        **-** |   **11248 B** |
| ParseSystemTextJsonLab |         False |   LotsOfStrings |      6,063.4 ns |     1,401.160 ns |       363.946 ns |   0.37 |     0.02 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |         **False** | **ProjectLockJson** |  **4,043,952.7 ns** |   **380,001.439 ns** |    **98,703.960 ns** |   **1.00** |     **0.00** | **312.5000** | **156.2500** | **1875216 B** |
| ParseSystemTextJsonLab |         False | ProjectLockJson |  1,034,580.2 ns |   291,964.228 ns |    75,836.622 ns |   0.26 |     0.02 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |         **False** |  **SpecialNumForm** |     **23,634.9 ns** |     **5,937.653 ns** |     **1,542.283 ns** |   **1.00** |     **0.00** |   **2.5635** |        **-** |   **10864 B** |
| ParseSystemTextJsonLab |         False |  SpecialNumForm |      4,006.6 ns |     1,075.846 ns |       279.447 ns |   0.17 |     0.02 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** |       **BasicJson** |      **7,018.6 ns** |       **720.062 ns** |       **187.033 ns** |   **1.00** |     **0.00** |   **1.6479** |        **-** |    **6952 B** |
| ParseSystemTextJsonLab |          True |       BasicJson |      2,159.5 ns |       152.311 ns |        39.562 ns |   0.31 |     0.01 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** |   **BasicLargeNum** |      **9,333.2 ns** |     **1,156.587 ns** |       **300.419 ns** |   **1.00** |     **0.00** |   **1.8311** |        **-** |    **7688 B** |
| ParseSystemTextJsonLab |          True |   BasicLargeNum |      3,124.7 ns |       974.773 ns |       253.194 ns |   0.34 |     0.03 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** |       **BroadTree** |    **105,319.1 ns** |    **28,410.273 ns** |     **7,379.463 ns** |   **1.00** |     **0.00** |  **17.2119** |   **0.1221** |   **72472 B** |
| ParseSystemTextJsonLab |          True |       BroadTree |     39,019.5 ns |       512.602 ns |       133.147 ns |   0.37 |     0.02 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** |        **DeepTree** |     **50,659.7 ns** |     **1,957.997 ns** |       **508.582 ns** |   **1.00** |     **0.00** |   **9.3994** |        **-** |   **39464 B** |
| ParseSystemTextJsonLab |          True |        DeepTree |     17,965.4 ns |     4,283.136 ns |     1,112.529 ns |   0.35 |     0.02 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** |     **FullSchema1** |     **23,555.6 ns** |     **1,667.606 ns** |       **433.155 ns** |   **1.00** |     **0.00** |   **4.1504** |        **-** |   **17448 B** |
| ParseSystemTextJsonLab |          True |     FullSchema1 |      7,002.8 ns |       121.992 ns |        31.687 ns |   0.30 |     0.01 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** |     **FullSchema2** |     **34,105.1 ns** |     **1,431.616 ns** |       **371.857 ns** |   **1.00** |     **0.00** |   **5.1880** |        **-** |   **21856 B** |
| ParseSystemTextJsonLab |          True |     FullSchema2 |      9,462.6 ns |       229.205 ns |        59.535 ns |   0.28 |     0.00 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** |      **HelloWorld** |      **1,322.1 ns** |        **35.136 ns** |         **9.126 ns** |   **1.00** |     **0.00** |   **0.7973** |        **-** |    **3352 B** |
| ParseSystemTextJsonLab |          True |      HelloWorld |        441.9 ns |         6.403 ns |         1.663 ns |   0.33 |     0.00 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** |        **Json400B** |     **11,492.2 ns** |       **920.510 ns** |       **239.099 ns** |   **1.00** |     **0.00** |   **2.0905** |        **-** |    **8816 B** |
| ParseSystemTextJsonLab |          True |        Json400B |      3,005.8 ns |       762.206 ns |       197.980 ns |   0.26 |     0.02 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** |       **Json400KB** | **11,984,788.8 ns** | **1,395,163.874 ns** |   **362,388.626 ns** |   **1.00** |     **0.00** | **765.6250** | **375.0000** | **4751008 B** |
| ParseSystemTextJsonLab |          True |       Json400KB |  2,426,463.3 ns |    69,750.584 ns |    18,117.455 ns |   0.20 |     0.01 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** |        **Json40KB** |    **955,530.3 ns** |    **49,337.410 ns** |    **12,815.209 ns** |   **1.00** |     **0.00** |  **87.8906** |  **36.1328** |  **485664 B** |
| ParseSystemTextJsonLab |          True |        Json40KB |    246,657.7 ns |    38,410.243 ns |     9,976.918 ns |   0.26 |     0.01 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** |         **Json4KB** |     **91,080.2 ns** |     **5,859.291 ns** |     **1,521.929 ns** |   **1.00** |     **0.00** |  **14.8926** |   **0.1221** |   **62784 B** |
| ParseSystemTextJsonLab |          True |         Json4KB |     20,822.1 ns |       400.634 ns |       104.063 ns |   0.23 |     0.00 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** |   **LotsOfNumbers** |     **35,476.9 ns** |     **4,935.948 ns** |     **1,282.094 ns** |   **1.00** |     **0.00** |   **5.0049** |        **-** |   **21176 B** |
| ParseSystemTextJsonLab |          True |   LotsOfNumbers |      8,768.5 ns |       566.235 ns |       147.077 ns |   0.25 |     0.01 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** |   **LotsOfStrings** |     **14,857.4 ns** |       **175.201 ns** |        **45.508 ns** |   **1.00** |     **0.00** |   **2.6703** |        **-** |   **11248 B** |
| ParseSystemTextJsonLab |          True |   LotsOfStrings |      5,585.4 ns |        68.474 ns |        17.786 ns |   0.38 |     0.00 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** | **ProjectLockJson** |  **3,850,608.7 ns** |   **113,889.235 ns** |    **29,582.305 ns** |   **1.00** |     **0.00** | **312.5000** | **156.2500** | **1875216 B** |
| ParseSystemTextJsonLab |          True | ProjectLockJson |    954,620.4 ns |    40,028.296 ns |    10,397.201 ns |   0.25 |     0.00 |        - |        - |       0 B |
|                        |               |                 |                 |                  |                  |        |          |          |          |           |
|        **ParseNewtonsoft** |          **True** |  **SpecialNumForm** |     **19,898.0 ns** |       **422.190 ns** |       **109.662 ns** |   **1.00** |     **0.00** |   **2.5635** |        **-** |   **10784 B** |
| ParseSystemTextJsonLab |          True |  SpecialNumForm |      3,742.6 ns |        79.041 ns |        20.531 ns |   0.19 |     0.00 |        - |        - |       0 B |


|                          Method |     Mean |     Error |    StdDev |    Gen 0 |    Gen 1 | Allocated |
|-------------------------------- |---------:|----------:|----------:|---------:|---------:|----------:|
|        ParseNewtonsoftEnumerate | 9.292 ms | 0.1660 ms | 0.1386 ms | 765.6250 | 375.0000 | 4761848 B |
| ParseSystemTextJsonLabEnumerate | 2.633 ms | 0.0513 ms | 0.0480 ms |        - |        - |       0 B |