### PR TITLE
Fix handling of signature types in MakeGenericType

### DIFF
--- a/src/System.Reflection.TypeLoader/src/System/Reflection/TypeLoading/Types/RoDefinitionType.cs
+++ b/src/System.Reflection.TypeLoader/src/System/Reflection/TypeLoading/Types/RoDefinitionType.cs
@@ -104,14 +104,18 @@ namespace System.Reflection.TypeLoading
                 if (typeArgument == null)
                     throw new ArgumentNullException();
                 if (typeArgument.IsSignatureType())
+                {
                     foundSigType = true;
-                if (!(typeArgument is RoType roTypeArgument && roTypeArgument.Loader == Loader))
-                    throw new ArgumentException(SR.Format(SR.MakeGenericType_NotLoadedByTypeLoader, typeArgument));
-                runtimeTypeArguments[i] = roTypeArgument;
+                }
+                else
+                {
+                    if (!(typeArgument is RoType roTypeArgument && roTypeArgument.Loader == Loader))
+                        throw new ArgumentException(SR.Format(SR.MakeGenericType_NotLoadedByTypeLoader, typeArgument));
+                    runtimeTypeArguments[i] = roTypeArgument;
+                }
             }
-
             if (foundSigType)
-                return this.MakeSignatureGenericType(runtimeTypeArguments);
+                return this.MakeSignatureGenericType(typeArguments);
 
             // We are intentionally not validating constraints as constraint validation is an execution-time issue that does not block our 
             // library and should not block a metadata inspection tool.


### PR DESCRIPTION
Since the underlying api support didn't exist yet,
we had to write this blind. With predictable results.