### PR TITLE
Optimize JsonReader for the multi-segment case

### DIFF
--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
@@ -73,7 +73,7 @@ namespace System.Buffers.Reader
         public ReadOnlySpan<T> UnreadSpan
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => CurrentSpanIndex == 0 ? CurrentSpan : CurrentSpan.Slice(CurrentSpanIndex);
+            get => CurrentSpan.Slice(CurrentSpanIndex);
         }
 
         /// <summary>
@@ -89,15 +89,15 @@ namespace System.Buffers.Reader
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryPeek(out T value)
         {
-            if (End)
-            {
-                value = default;
-                return false;
-            }
-            else
+            if (_moreData)
             {
                 value = CurrentSpan[CurrentSpanIndex];
                 return true;
+            }
+            else
+            {
+                value = default;
+                return false;
             }
         }
 
@@ -156,12 +156,7 @@ namespace System.Buffers.Reader
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Advance(int count)
         {
-            if (count == 0)
-            {
-                return;
-            }
-
-            if (count < 0 || End)
+            if (count < 0)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
             }
@@ -199,7 +194,7 @@ namespace System.Buffers.Reader
                 GetNextSpan();
             }
 
-            if (count > 0)
+            if (count != 0)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
             }

--- a/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
@@ -99,11 +99,6 @@ namespace System.Text.JsonLab
             return _isSingleSegment ? ReadSingleSegment(ref _buffer) : ReadMultiSegment(ref _reader);
         }
 
-        public bool Read2()
-        {
-            return !_isSingleSegment ? ReadSingleSegment(ref _buffer) : ReadMultiSegment(ref _reader);
-        }
-
         private void SkipWhiteSpace(ref BufferReader<byte> reader)
         {
             Index += reader.SkipPastAny(JsonConstants.Space, JsonConstants.CarriageReturn, JsonConstants.LineFeed, JsonConstants.Tab);

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -13,27 +13,27 @@ using System.IO;
 namespace System.Text.JsonLab.Benchmarks
 {
     // Since there are 90 tests here (6 * 15), setting low values for the warmupCount, targetCount, and invocationCount
-    [SimpleJob(-1, 3, 5, 1024)]
+    //[SimpleJob(-1, 3, 5)]
     [MemoryDiagnoser]
     public class JsonReaderPerf
     {
         // Keep the JsonStrings resource names in sync with TestCaseType enum values.
         public enum TestCaseType
         {
-            HelloWorld,
-            BasicJson,
-            BasicLargeNum,
-            SpecialNumForm,
-            ProjectLockJson,
-            FullSchema1,
-            FullSchema2,
-            DeepTree,
-            BroadTree,
-            LotsOfNumbers,
-            LotsOfStrings,
-            Json400B,
-            Json4KB,
-            Json40KB,
+            //HelloWorld,
+            //BasicJson,
+            //BasicLargeNum,
+            //SpecialNumForm,
+            //ProjectLockJson,
+            //FullSchema1,
+            //FullSchema2,
+            //DeepTree,
+            //BroadTree,
+            //LotsOfNumbers,
+            //LotsOfStrings,
+            //Json400B,
+            //Json4KB,
+            //Json40KB,
             Json400KB
         }
 
@@ -85,7 +85,7 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        [Benchmark(Baseline = true)]
+        //[Benchmark(Baseline = true)]
         public void ReaderNewtonsoftReaderEmptyLoop()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -94,7 +94,7 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public string ReaderNewtonsoftReaderReturnString()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -113,14 +113,14 @@ namespace System.Text.JsonLab.Benchmarks
             return sb.ToString();
         }
 
-        [Benchmark]
+        //[Benchmark(Baseline = true)]
         public void ReaderSystemTextJsonLabSpanEmptyLoop()
         {
             var json = new Utf8JsonReader(_dataUtf8);
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark(Baseline = true)]
         public void ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequenceSingle);
@@ -128,13 +128,20 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark]
+        public void ReaderSystemTextJsonLabSingleSpanSequence2EmptyLoop()
+        {
+            var json = new Utf8JsonReader(_sequenceSingle);
+            while (json.Read2()) ;
+        }
+
+        //[Benchmark]
         public void ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequence);
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public byte[] ReaderSystemTextJsonLabReturnBytes()
         {
             var outputArray = new byte[_dataUtf8.Length * 2];
@@ -196,7 +203,7 @@ namespace System.Text.JsonLab.Benchmarks
             return outputArray;
         }
 
-        [Benchmark]
+        //[Benchmark(Baseline = true)]
         public void ReaderUtf8JsonEmptyLoop()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);
@@ -207,7 +214,7 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        [Benchmark]
+        //[Benchmark]
         public byte[] ReaderUtf8JsonReturnBytes()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -47,7 +47,7 @@ namespace System.Text.JsonLab.Benchmarks
         [ParamsSource(nameof(TestCaseValues))]
         public TestCaseType TestCase;
 
-        [Params(true, false)]
+        [Params(true)]
         public bool IsDataCompact;
 
         public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -13,27 +13,27 @@ using System.IO;
 namespace System.Text.JsonLab.Benchmarks
 {
     // Since there are 90 tests here (6 * 15), setting low values for the warmupCount, targetCount, and invocationCount
-    //[SimpleJob(-1, 3, 5)]
+    [SimpleJob(-1, 3, 5)]
     [MemoryDiagnoser]
     public class JsonReaderPerf
     {
         // Keep the JsonStrings resource names in sync with TestCaseType enum values.
         public enum TestCaseType
         {
-            //HelloWorld,
-            //BasicJson,
-            //BasicLargeNum,
-            //SpecialNumForm,
-            //ProjectLockJson,
-            //FullSchema1,
-            //FullSchema2,
-            //DeepTree,
-            //BroadTree,
-            //LotsOfNumbers,
-            //LotsOfStrings,
-            //Json400B,
-            //Json4KB,
-            //Json40KB,
+            HelloWorld,
+            BasicJson,
+            BasicLargeNum,
+            SpecialNumForm,
+            ProjectLockJson,
+            FullSchema1,
+            FullSchema2,
+            DeepTree,
+            BroadTree,
+            LotsOfNumbers,
+            LotsOfStrings,
+            Json400B,
+            Json4KB,
+            Json40KB,
             Json400KB
         }
 
@@ -47,7 +47,7 @@ namespace System.Text.JsonLab.Benchmarks
         [ParamsSource(nameof(TestCaseValues))]
         public TestCaseType TestCase;
 
-        [Params(true)]
+        [Params(true, false)]
         public bool IsDataCompact;
 
         public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));
@@ -85,7 +85,7 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        //[Benchmark(Baseline = true)]
+        [Benchmark(Baseline = true)]
         public void ReaderNewtonsoftReaderEmptyLoop()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -94,7 +94,7 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public string ReaderNewtonsoftReaderReturnString()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -113,14 +113,14 @@ namespace System.Text.JsonLab.Benchmarks
             return sb.ToString();
         }
 
-        //[Benchmark(Baseline = true)]
+        [Benchmark]
         public void ReaderSystemTextJsonLabSpanEmptyLoop()
         {
             var json = new Utf8JsonReader(_dataUtf8);
             while (json.Read()) ;
         }
 
-        //[Benchmark(Baseline = true)]
+        [Benchmark]
         public void ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequenceSingle);
@@ -128,20 +128,13 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark]
-        public void ReaderSystemTextJsonLabSingleSpanSequence2EmptyLoop()
-        {
-            var json = new Utf8JsonReader(_sequenceSingle);
-            while (json.Read2()) ;
-        }
-
-        //[Benchmark]
         public void ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequence);
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public byte[] ReaderSystemTextJsonLabReturnBytes()
         {
             var outputArray = new byte[_dataUtf8.Length * 2];
@@ -203,7 +196,7 @@ namespace System.Text.JsonLab.Benchmarks
             return outputArray;
         }
 
-        //[Benchmark(Baseline = true)]
+        [Benchmark]
         public void ReaderUtf8JsonEmptyLoop()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);
@@ -214,7 +207,7 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        //[Benchmark]
+        [Benchmark]
         public byte[] ReaderUtf8JsonReturnBytes()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -27,7 +27,7 @@ namespace System.Text.JsonLab.Benchmarks
         private int[] _data;
         private byte[] _output;
 
-        [Params(false)]
+        [Params(true, false)]
         public bool Formatted;
 
         [GlobalSetup]
@@ -58,7 +58,7 @@ namespace System.Text.JsonLab.Benchmarks
             WriterSystemTextJsonBasicUtf8(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void WriterNewtonsoftBasic()
         {
             WriterNewtonsoftBasic(Formatted, GetWriter(), _data.AsSpan(0, 10));
@@ -77,7 +77,7 @@ namespace System.Text.JsonLab.Benchmarks
             WriterSystemTextJsonHelloWorldUtf8(Formatted, _arrayFormatterWrapper);
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void WriterNewtonsoftHelloWorld()
         {
             WriterNewtonsoftHelloWorld(Formatted, GetWriter());

--- a/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonWriterPerf.cs
@@ -27,7 +27,7 @@ namespace System.Text.JsonLab.Benchmarks
         private int[] _data;
         private byte[] _output;
 
-        [Params(true, false)]
+        [Params(false)]
         public bool Formatted;
 
         [GlobalSetup]
@@ -58,7 +58,7 @@ namespace System.Text.JsonLab.Benchmarks
             WriterSystemTextJsonBasicUtf8(Formatted, _arrayFormatterWrapper, _data.AsSpan(0, 10));
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void WriterNewtonsoftBasic()
         {
             WriterNewtonsoftBasic(Formatted, GetWriter(), _data.AsSpan(0, 10));
@@ -77,7 +77,7 @@ namespace System.Text.JsonLab.Benchmarks
             WriterSystemTextJsonHelloWorldUtf8(Formatted, _arrayFormatterWrapper);
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void WriterNewtonsoftHelloWorld()
         {
             WriterNewtonsoftHelloWorld(Formatted, GetWriter());


### PR DESCRIPTION
**20-40% improvement from master for the multi-segment case.**
- Ported over several of the recent single-segment optimizations for the mutli-segment case.
- Optimized certain BufferReader APIs.
- Pass BufferReader around by ref instead.
- It may be possible to improve the performance of the ConsumeStringUtf8MultiSegment implementation a bit.

The multi-segment case is now roughly 15-30% slower than the single-segment case (as long as the JSON payload is sufficiently large for the boundary crossing to get amortized). If, however, a small payload (like hello world, i.e. less than 256 bytes) is split into 1+ segments, it will be costly.

Removing the use of BufferReader and using ReadOnlySequence directly only saves about 10% in most cases (and hence not worth it). This is similar to the previous findings: https://github.com/dotnet/corefxlab/pull/2425

``` ini

BenchmarkDotNet=v0.10.14.683-nightly, OS=Windows 10.0.17738
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-20180720-2
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  Job-OQDBHZ : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT

IterationCount=5  WarmupCount=3  

```
**This PR:**

|                                                      Method | IsDataCompact |   TestCase |            Mean |          Error |         StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
|------------------------------------------------------------ |-------------- |----------- |----------------:|---------------:|---------------:|-------:|---------:|-------:|----------:|
|                        **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **BasicJson** |       **388.74 ns** |       **5.241 ns** |      **1.3613 ns** |   **0.49** |     **0.01** |      **-** |       **0 B** |
|          ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop |          True |  BasicJson |       431.36 ns |      17.851 ns |      4.6367 ns |   0.54 |     0.01 |      - |       0 B |
| ReaderSystemTextJsonLabSingleSpanSequenceMultiCodeEmptyLoop |          True |  BasicJson |       527.22 ns |      28.716 ns |      7.4589 ns |   0.67 |     0.02 |      - |       0 B |
|           ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |  BasicJson |       726.90 ns |      14.259 ns |      3.7037 ns |   0.92 |     0.02 | 0.0086 |      40 B |
|                                     ReaderUtf8JsonEmptyLoop |          True |  BasicJson |       791.90 ns |      71.466 ns |     18.5629 ns |   1.00 |     0.00 |      - |       0 B |
|                                                             |               |            |                 |                |                |        |          |        |           |
|                        **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** | **HelloWorld** |        **59.62 ns** |       **2.345 ns** |      **0.6090 ns** |   **0.50** |     **0.06** |      **-** |       **0 B** |
|          ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop |          True | HelloWorld |       118.78 ns |      22.003 ns |      5.7152 ns |   0.99 |     0.13 |      - |       0 B |
| ReaderSystemTextJsonLabSingleSpanSequenceMultiCodeEmptyLoop |          True | HelloWorld |       144.32 ns |      58.210 ns |     15.1198 ns |   1.20 |     0.19 |      - |       0 B |
|           ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True | HelloWorld |       325.87 ns |      45.868 ns |     11.9139 ns |   2.72 |     0.35 | 0.0091 |      40 B |
|                                     ReaderUtf8JsonEmptyLoop |          True | HelloWorld |       121.86 ns |      72.019 ns |     18.7066 ns |   1.00 |     0.00 |      - |       0 B |
|                                                             |               |            |                 |                |                |        |          |        |           |
|                        **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json400B** |       **618.47 ns** |      **28.465 ns** |      **7.3936 ns** |   **0.45** |     **0.01** |      **-** |       **0 B** |
|          ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop |          True |   Json400B |       654.25 ns |       8.186 ns |      2.1263 ns |   0.48 |     0.01 |      - |       0 B |
| ReaderSystemTextJsonLabSingleSpanSequenceMultiCodeEmptyLoop |          True |   Json400B |       793.71 ns |      10.497 ns |      2.7266 ns |   0.58 |     0.01 |      - |       0 B |
|           ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |   Json400B |       850.82 ns |      91.125 ns |     23.6695 ns |   0.62 |     0.02 |      - |       0 B |
|                                     ReaderUtf8JsonEmptyLoop |          True |   Json400B |     1,375.26 ns |     139.113 ns |     36.1340 ns |   1.00 |     0.00 |      - |       0 B |
|                                                             |               |            |                 |                |                |        |          |        |           |
|                        **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **Json400KB** |   **631,819.49 ns** |   **7,578.181 ns** |  **1,968.4042 ns** |   **0.55** |     **0.00** |      **-** |       **0 B** |
|          ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop |          True |  Json400KB |   632,726.96 ns |  22,224.108 ns |  5,772.6293 ns |   0.56 |     0.01 |      - |       0 B |
| ReaderSystemTextJsonLabSingleSpanSequenceMultiCodeEmptyLoop |          True |  Json400KB |   753,017.68 ns | 147,643.428 ns | 38,349.8310 ns |   0.66 |     0.03 |      - |       0 B |
|           ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |  Json400KB |   740,364.28 ns |  51,362.459 ns | 13,341.2076 ns |   0.65 |     0.01 |      - |     440 B |
|                                     ReaderUtf8JsonEmptyLoop |          True |  Json400KB | 1,138,527.25 ns |  33,796.065 ns |  8,778.4022 ns |   1.00 |     0.00 |      - |       0 B |
|                                                             |               |            |                 |                |                |        |          |        |           |
|                        **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json40KB** |    **57,189.08 ns** |   **1,428.657 ns** |    **371.0883 ns** |   **0.48** |     **0.02** |      **-** |       **0 B** |
|          ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop |          True |   Json40KB |    57,567.33 ns |   1,242.911 ns |    322.8414 ns |   0.48 |     0.02 |      - |       0 B |
| ReaderSystemTextJsonLabSingleSpanSequenceMultiCodeEmptyLoop |          True |   Json40KB |    68,489.22 ns |   1,933.066 ns |    502.1068 ns |   0.58 |     0.02 |      - |       0 B |
|           ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |   Json40KB |    68,298.64 ns |     931.751 ns |    242.0187 ns |   0.58 |     0.02 |      - |      40 B |
|                                     ReaderUtf8JsonEmptyLoop |          True |   Json40KB |   118,842.28 ns |  16,927.757 ns |  4,396.9218 ns |   1.00 |     0.00 |      - |       0 B |
|                                                             |               |            |                 |                |                |        |          |        |           |
|                        **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |    **Json4KB** |     **4,366.33 ns** |     **304.355 ns** |     **79.0551 ns** |   **0.38** |     **0.01** |      **-** |       **0 B** |
|          ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop |          True |    Json4KB |     4,460.58 ns |     237.439 ns |     61.6738 ns |   0.38 |     0.01 |      - |       0 B |
| ReaderSystemTextJsonLabSingleSpanSequenceMultiCodeEmptyLoop |          True |    Json4KB |     5,351.83 ns |     248.505 ns |     64.5484 ns |   0.46 |     0.01 |      - |       0 B |
|           ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |    Json4KB |     5,591.61 ns |     107.271 ns |     27.8632 ns |   0.48 |     0.01 | 0.0916 |     416 B |
|                                     ReaderUtf8JsonEmptyLoop |          True |    Json4KB |    11,599.01 ns |     967.223 ns |    251.2326 ns |   1.00 |     0.00 |      - |       0 B |

**Master:**

|                                                      Method | IsDataCompact |   TestCase |          Mean |          Error |         StdDev |  Gen 0 | Allocated |
|------------------------------------------------------------ |-------------- |----------- |--------------:|---------------:|---------------:|-------:|----------:|
|                        **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **BasicJson** |     **397.74 ns** |       **4.755 ns** |      **1.2350 ns** |      **-** |       **0 B** |
|          ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop |          True |  BasicJson |     443.06 ns |      21.678 ns |      5.6308 ns |      - |       0 B |
| ReaderSystemTextJsonLabSingleSpanSequenceMultiCodeEmptyLoop |          True |  BasicJson |     721.20 ns |     205.099 ns |     53.2737 ns |      - |       0 B |
|           ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |  BasicJson |     889.83 ns |      35.992 ns |      9.3488 ns | 0.0086 |      40 B |
|                        **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** | **HelloWorld** |      **59.62 ns** |       **1.642 ns** |      **0.4265 ns** |      **-** |       **0 B** |
|          ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop |          True | HelloWorld |     110.70 ns |      18.864 ns |      4.9000 ns |      - |       0 B |
| ReaderSystemTextJsonLabSingleSpanSequenceMultiCodeEmptyLoop |          True | HelloWorld |     159.35 ns |      23.419 ns |      6.0831 ns |      - |       0 B |
|           ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True | HelloWorld |     347.64 ns |      20.649 ns |      5.3634 ns | 0.0091 |      40 B |
|                        **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json400B** |     **619.01 ns** |      **12.040 ns** |      **3.1273 ns** |      **-** |       **0 B** |
|          ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop |          True |   Json400B |     666.74 ns |      13.375 ns |      3.4740 ns |      - |       0 B |
| ReaderSystemTextJsonLabSingleSpanSequenceMultiCodeEmptyLoop |          True |   Json400B |   1,014.74 ns |      45.902 ns |     11.9230 ns |      - |       0 B |
|           ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |   Json400B |   1,024.68 ns |       8.238 ns |      2.1397 ns |      - |       0 B |
|                        **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **Json400KB** | **647,580.71 ns** | **115,480.845 ns** | **29,995.7198 ns** |      **-** |       **0 B** |
|          ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop |          True |  Json400KB | 638,600.37 ns | 119,088.979 ns | 30,932.9192 ns |      - |       0 B |
| ReaderSystemTextJsonLabSingleSpanSequenceMultiCodeEmptyLoop |          True |  Json400KB | 898,746.63 ns |  26,264.627 ns |  6,822.1392 ns |      - |       0 B |
|           ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |  Json400KB | 905,516.17 ns |  41,832.821 ns | 10,865.9195 ns |      - |     440 B |
|                        **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json40KB** |  **57,794.39 ns** |     **536.675 ns** |    **139.3994 ns** |      **-** |       **0 B** |
|          ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop |          True |   Json40KB |  58,168.81 ns |   2,442.825 ns |    634.5147 ns |      - |       0 B |
| ReaderSystemTextJsonLabSingleSpanSequenceMultiCodeEmptyLoop |          True |   Json40KB |  88,883.90 ns |   6,191.182 ns |  1,608.1364 ns |      - |       0 B |
|           ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |   Json40KB |  89,394.07 ns |   3,836.745 ns |    996.5803 ns |      - |      40 B |
|                        **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |    **Json4KB** |   **4,429.76 ns** |     **284.692 ns** |     **73.9476 ns** |      **-** |       **0 B** |
|          ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop |          True |    Json4KB |   4,789.49 ns |     593.542 ns |    154.1704 ns |      - |       0 B |
| ReaderSystemTextJsonLabSingleSpanSequenceMultiCodeEmptyLoop |          True |    Json4KB |   7,986.94 ns |   1,640.578 ns |    426.1339 ns |      - |       0 B |
|           ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |    Json4KB |   7,690.52 ns |     233.650 ns |     60.6896 ns | 0.0916 |     416 B |

**Json.NET:**

|                          Method | IsDataCompact |   TestCase |           Mean |         Error |         StdDev | Scaled |    Gen 0 |  Allocated |
|-------------------------------- |-------------- |----------- |---------------:|--------------:|---------------:|-------:|---------:|-----------:|
| **ReaderNewtonsoftReaderEmptyLoop** |          **True** |  **BasicJson** |     **1,734.3 ns** |      **32.53 ns** |       **8.450 ns** |   **1.00** |   **0.7343** |    **3.02 KB** |
|                                 |               |            |                |               |                |        |          |            |
| **ReaderNewtonsoftReaderEmptyLoop** |          **True** | **HelloWorld** |       **576.4 ns** |     **357.33 ns** |      **92.814 ns** |   **1.00** |   **0.5636** |    **2.31 KB** |
|                                 |               |            |                |               |                |        |          |            |
| **ReaderNewtonsoftReaderEmptyLoop** |          **True** |   **Json400B** |     **3,052.6 ns** |     **482.98 ns** |     **125.452 ns** |   **1.00** |   **0.8812** |    **3.62 KB** |
|                                 |               |            |                |               |                |        |          |            |
| **ReaderNewtonsoftReaderEmptyLoop** |          **True** |  **Json400KB** | **2,341,519.6 ns** | **958,218.48 ns** | **248,893.685 ns** |   **1.00** | **261.7188** | **1082.53 KB** |
|                                 |               |            |                |               |                |        |          |            |
| **ReaderNewtonsoftReaderEmptyLoop** |          **True** |   **Json40KB** |   **208,153.8 ns** |  **25,718.44 ns** |   **6,680.268 ns** |   **1.00** |  **28.8086** |  **118.31 KB** |
|                                 |               |            |                |               |                |        |          |            |
| **ReaderNewtonsoftReaderEmptyLoop** |          **True** |    **Json4KB** |    **21,992.0 ns** |   **1,166.73 ns** |     **303.054 ns** |   **1.00** |   **6.1340** |   **25.21 KB** |
