### PR TITLE
Port Benchmarks to .NET Core 3.0

### DIFF
--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <Copyright>Microsoft Corporation, All rights reserved</Copyright>
     <NoWarn>$(NoWarn);CS0618</NoWarn>

--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -10,6 +10,6 @@
     <LibuvVersion>1.9.1</LibuvVersion>
     <TestSdkVersion>15.0.0</TestSdkVersion>
     <XunitVersion>2.2.0</XunitVersion>
-    <BenchmarkDotNetVersion>0.11.1</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.11.1.739</BenchmarkDotNetVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
BDN version update is required because I had to add .NET Core 3.0 to the frameworks which BDN recognizes and supports (https://github.com/dotnet/BenchmarkDotNet/commit/2e398c89561b3b1c89ec64b94f656ae20236efd1)