### PR TITLE
Revert "Port Benchmarks to .NET Core 3.0 (#2472)"

### DIFF
--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <Copyright>Microsoft Corporation, All rights reserved</Copyright>
     <NoWarn>$(NoWarn);CS0618</NoWarn>

--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -10,6 +10,6 @@
     <LibuvVersion>1.9.1</LibuvVersion>
     <TestSdkVersion>15.0.0</TestSdkVersion>
     <XunitVersion>2.2.0</XunitVersion>
-    <BenchmarkDotNetVersion>0.11.1.739</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.11.1</BenchmarkDotNetVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This reverts commit 98ea133b2a3d36d377b59ec44437ae780f8529a7.

Using the latest BDN version, I am unable to build the benchmarks locally. The build is passing in CI though, so it will require some investigation to figure out why I can't build them locally.

```text
Microsoft.Experimental.Collections\MultiValueDictionaryPerformanceTests.cs(7,23): error CS0234: The type or namespace name 'Attributes' does not exist in the namespace 'BenchmarkDotNet' (are you missing an assembly reference?) [E:\GitHub\Fork\corefxlab\tests\Benchmarks\Benchmarks.csproj]
Program.cs(5,23): error CS0234: The type or namespace name 'Running' does not exist in the namespace 'BenchmarkDotNet' (are you missing an assembly reference?) [E:\GitHub\Fork\corefxlab\tests\Benchmarks\Benchmarks.csproj]
System.Azure.Experimental\CosmosDb.cs(15,23): error CS0234: The type or namespace name 'Attributes' does not exist in the namespace 'BenchmarkDotNet' (are you missing an assembly reference?) [E:\GitHub\Fork\corefxlab\tests\Benchmarks\Benchmarks.csproj]
System.Azure.Experimental\Storage.cs(5,23): error CS0234: The type or namespace name 'Attributes' does not exist in the namespace 'BenchmarkDotNet' (are you missing an assembly reference?) [E:\GitHub\Fork\corefxlab\tests\Benchmarks\Benchmarks.csproj]
System.Binary.Base64\Base64Encode.cs(7,23): error CS0234: The type or namespace name 'Attributes' does not exist in the namespace 'BenchmarkDotNet' (are you missing an assembly reference?) [E:\GitHub\Fork\corefxlab\tests\Benchmarks\Benchmarks.csproj]
System.Binary.Base64\Stiching.cs(5,23): error CS0234: The type or namespace name 'Attributes' does not exist in the namespace 'BenchmarkDotNet' (are you missing an assembly reference?) [E:\GitHub\Fork\corefxlab\tests\Benchmarks\Benchmarks.csproj]
System.Buffers.Experimental\RangeEnumeration.cs(5,23): error CS0234: The type or namespace name 'Attributes' does not exist in the namespace 'BenchmarkDotNet' (are you missing an assembly reference?) [E:\GitHub\Fork\corefxlab\tests\Benchmarks\Benchmarks.csproj]
System.Buffers\Reader.cs(5,23): error CS0234: The type or namespace name 'Attributes' does not exist in the namespace 'BenchmarkDotNet' (are you missing an assembly reference?) [E:\GitHub\Fork\corefxlab\tests\Benchmarks\Benchmarks.csproj]
System.Buffers\Reader_Binary.cs(5,23): error CS0234: The type or namespace name 'Attributes' does not exist in the namespace 'BenchmarkDotNet' (are you missing an assembly reference?) [E:\GitHub\Fork\corefxlab\tests\Benchmarks\Benchmarks.csproj]
System.Buffers\Reader_Construction.cs(5,23): error CS0234: The type or namespace name 'Attributes' does not exist in the namespace 'BenchmarkDotNet' (are you missing an assembly reference?) [E:\GitHub\Fork\corefxlab\tests\Benchmarks\Benchmarks.csproj]
...
```

@JeremyKuhne, were you able to run benchmarks on your machine from master?