### PR TITLE
Add ability to set MaxDepth to JsonReader beyond 64 using stack

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/CustomStack.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/CustomStack.cs
@@ -10,14 +10,14 @@ namespace System.Text.JsonLab
 {
     internal ref struct CustomStack
     {
-        private static byte[] _initStack = new byte[Utf8JsonReader.MaxDepth * StackRow.Size];
+        private static byte[] _initStack = new byte[Utf8JsonReader.StackFreeMaxDepth * StackRow.Size];
         private byte[] _rentedBuffer;
         private Span<byte> _stackSpace;
         private int _topOfStack;
 
         public CustomStack(int initialSize)
         {
-            _rentedBuffer = initialSize <= Utf8JsonReader.MaxDepth * StackRow.Size
+            _rentedBuffer = initialSize <= Utf8JsonReader.StackFreeMaxDepth * StackRow.Size
                 ? _initStack
                 : ArrayPool<byte>.Shared.Rent(initialSize);
             _stackSpace = _rentedBuffer;
@@ -26,7 +26,7 @@ namespace System.Text.JsonLab
 
         public void Dispose()
         {
-            if (_rentedBuffer.Length > Utf8JsonReader.MaxDepth * StackRow.Size)
+            if (_rentedBuffer.Length > Utf8JsonReader.StackFreeMaxDepth * StackRow.Size)
                 ArrayPool<byte>.Shared.Return(_rentedBuffer);
             _stackSpace = Span<byte>.Empty;
             _topOfStack = 0;

--- a/src/System.Text.JsonLab/System/Text/Json/JsonParser.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonParser.cs
@@ -21,7 +21,7 @@ namespace System.Text.JsonLab
         public JsonObject Parse()
         {
             var database = new CustomDb(_pool, DbRow.Size + _utf8Json.Length);
-            var stack = new CustomStack(Utf8JsonReader.MaxDepth * StackRow.Size);
+            var stack = new CustomStack(Utf8JsonReader.StackFreeMaxDepth * StackRow.Size);
             var reader = new Utf8JsonReader(_utf8Json);
 
             bool inArray = false;

--- a/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
@@ -326,7 +326,7 @@ namespace System.Text.JsonLab
 
         private void StartObject()
         {
-            if (Depth > MaxDepth)
+            if (Depth >= MaxDepth)
                 JsonThrowHelper.ThrowJsonReaderException();
 
             Depth++;
@@ -362,7 +362,7 @@ namespace System.Text.JsonLab
 
         private void StartArray()
         {
-            if (Depth > MaxDepth)
+            if (Depth >= MaxDepth)
                 JsonThrowHelper.ThrowJsonReaderException();
 
             Depth++;

--- a/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
@@ -4,13 +4,14 @@
 
 using System.Buffers;
 using System.Buffers.Reader;
+using System.Collections.Generic;
 
 namespace System.Text.JsonLab
 {
     public ref struct Utf8JsonReader
     {
         // We are using a ulong to represent our nested state, so we can only go 64 levels deep.
-        internal const int MaxDepth = sizeof(ulong) * 8;
+        internal const int StackFreeMaxDepth = sizeof(ulong) * 8;
 
         private ReadOnlySpan<byte> _buffer;
 
@@ -18,7 +19,27 @@ namespace System.Text.JsonLab
 
         public int StartLocation { get; private set; }
 
+        public int MaxDepth
+        {
+            get
+            {
+                return _maxDepth;
+            }
+            set
+            {
+                if (value <= 0)
+                    JsonThrowHelper.ThrowArgumentException("Max depth must be positive.");
+                _maxDepth = value;
+                if (_maxDepth > StackFreeMaxDepth)
+                    _stack = new Stack<int>();
+            }
+        }
+
+        private int _maxDepth;
+
         private BufferReader<byte> _reader;
+
+        private Stack<int> _stack;
 
         // Depth tracks the recursive depth of the nested objects / arrays within the JSON data.
         public int Depth { get; private set; }
@@ -31,7 +52,7 @@ namespace System.Text.JsonLab
 
         // These properties are helpers for determining the current state of the reader
         internal bool InArray => !InObject;
-        internal bool InObject => (_containerMask & 1) != 0;
+        internal bool InObject => Depth <= StackFreeMaxDepth ? (_containerMask & 1) != 0 : _stack.Peek() != 0;
 
         /// <summary>
         /// Gets the token type of the last processed token in the JSON stream.
@@ -69,6 +90,8 @@ namespace System.Text.JsonLab
             _containerMask = 0;
             Index = 0;
             StartLocation = Index;
+            _stack = null;
+            _maxDepth = StackFreeMaxDepth;
 
             TokenType = JsonTokenType.None;
             Value = ReadOnlySpan<byte>.Empty;
@@ -84,6 +107,8 @@ namespace System.Text.JsonLab
             _containerMask = 0;
             Index = 0;
             StartLocation = Index;
+            _stack = null;
+            _maxDepth = StackFreeMaxDepth;
 
             TokenType = JsonTokenType.None;
             Value = ReadOnlySpan<byte>.Empty;
@@ -305,17 +330,33 @@ namespace System.Text.JsonLab
                 JsonThrowHelper.ThrowJsonReaderException();
 
             Depth++;
-            _containerMask = (_containerMask << 1) | 1;
+            if (Depth <= StackFreeMaxDepth)
+            {
+                _containerMask = (_containerMask << 1) | 1;
+            }
+            else
+            {
+                _stack.Push(1);
+            }
             TokenType = JsonTokenType.StartObject;
         }
 
         private void EndObject()
         {
-            if (!InObject || Depth <= 0)
-                JsonThrowHelper.ThrowJsonReaderException();
+            if (Depth <= StackFreeMaxDepth)
+            {
+                if ((_containerMask & 1) == 0 || Depth <= 0)
+                    JsonThrowHelper.ThrowJsonReaderException();
+                _containerMask >>= 1;
+            }
+            else
+            {
+                if (_stack.Peek() == 0 || Depth <= 0)
+                    JsonThrowHelper.ThrowJsonReaderException();
+                _stack.Pop();
+            }
 
             Depth--;
-            _containerMask >>= 1;
             TokenType = JsonTokenType.EndObject;
         }
 
@@ -325,17 +366,33 @@ namespace System.Text.JsonLab
                 JsonThrowHelper.ThrowJsonReaderException();
 
             Depth++;
-            _containerMask = (_containerMask << 1);
+            if (Depth <= StackFreeMaxDepth)
+            {
+                _containerMask = (_containerMask << 1);
+            }
+            else
+            {
+                _stack.Push(0);
+            }
             TokenType = JsonTokenType.StartArray;
         }
 
         private void EndArray()
         {
-            if (!InArray || Depth <= 0)
-                JsonThrowHelper.ThrowJsonReaderException();
+            if (Depth <= StackFreeMaxDepth)
+            {
+                if ((_containerMask & 1) != 0 || Depth <= 0)
+                    JsonThrowHelper.ThrowJsonReaderException();
+                _containerMask >>= 1;
+            }
+            else
+            {
+                if (_stack.Peek() != 0 || Depth <= 0)
+                    JsonThrowHelper.ThrowJsonReaderException();
+                _stack.Pop();
+            }
 
             Depth--;
-            _containerMask >>= 1;
             TokenType = JsonTokenType.EndArray;
         }
 

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderMaxDepthPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderMaxDepthPerf.cs
@@ -1,0 +1,80 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using Newtonsoft.Json;
+using System.Buffers.Text;
+using System.IO;
+using System.Text.Formatting;
+
+namespace System.Text.JsonLab.Benchmarks
+{
+    // Since there are 24 tests here (2 * 12), setting low values for the warmupCount and targetCount
+    [SimpleJob(warmupCount: 3, targetCount: 5)]
+    [MemoryDiagnoser]
+    public class JsonReaderMaxDepthPerf
+    {
+        private byte[] _dataUtf8;
+        private MemoryStream _stream;
+        private StreamReader _reader;
+
+        [Params(1, 2, 4, 8, 16, 32, 64, 65, 66, 128, 256, 512)]
+        public int Depth;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var output = new ArrayFormatterWrapper(1024, SymbolTable.InvariantUtf8);
+            var jsonUtf8 = new Utf8JsonWriter<ArrayFormatterWrapper>(output);
+
+            WriteDepth(ref jsonUtf8, Depth - 1);
+
+            ArraySegment<byte> formatted = output.Formatted;
+            string actualStr = Encoding.UTF8.GetString(formatted.Array, formatted.Offset, formatted.Count);
+
+            _dataUtf8 = Encoding.UTF8.GetBytes(actualStr);
+
+            _stream = new MemoryStream(_dataUtf8);
+            _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
+        }
+
+        [Benchmark(Baseline = true)]
+        public void ReaderNewtonsoftReaderEmptyLoop()
+        {
+            _stream.Seek(0, SeekOrigin.Begin);
+            TextReader reader = _reader;
+            var json = new JsonTextReader(reader)
+            {
+                MaxDepth = Depth
+            };
+            while (json.Read()) ;
+        }
+
+        [Benchmark]
+        public void ReaderSystemTextJsonLabSpanEmptyLoop()
+        {
+            var json = new Utf8JsonReader(_dataUtf8)
+            {
+                MaxDepth = Depth
+            };
+            while (json.Read()) ;
+        }
+
+        private static void WriteDepth(ref Utf8JsonWriter<ArrayFormatterWrapper> jsonUtf8, int depth)
+        {
+            jsonUtf8.WriteObjectStart();
+            for (int i = 0; i < depth; i++)
+            {
+                jsonUtf8.WriteObjectStart("message" + i);
+            }
+            jsonUtf8.WriteAttribute("message" + depth, "Hello, World!");
+            for (int i = 0; i < depth; i++)
+            {
+                jsonUtf8.WriteObjectEnd();
+            }
+            jsonUtf8.WriteObjectEnd();
+            jsonUtf8.Flush();
+        }
+    }
+}

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
 using Benchmarks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -12,8 +13,8 @@ using System.IO;
 
 namespace System.Text.JsonLab.Benchmarks
 {
-    // Since there are 90 tests here (6 * 15), setting low values for the warmupCount, targetCount, and invocationCount
-    [SimpleJob(-1, 3, 5)]
+    // Since there are 240 tests here (8 * 2 * 15), setting low values for the warmupCount, targetCount, and invocationCount
+    //[SimpleJob(warmupCount: 3, targetCount: 5)]
     [MemoryDiagnoser]
     public class JsonReaderPerf
     {
@@ -22,19 +23,19 @@ namespace System.Text.JsonLab.Benchmarks
         {
             HelloWorld,
             BasicJson,
-            BasicLargeNum,
-            SpecialNumForm,
-            ProjectLockJson,
-            FullSchema1,
-            FullSchema2,
-            DeepTree,
-            BroadTree,
-            LotsOfNumbers,
-            LotsOfStrings,
+            //BasicLargeNum,
+            //SpecialNumForm,
+            //ProjectLockJson,
+            //FullSchema1,
+            //FullSchema2,
+            //DeepTree,
+            //BroadTree,
+            //LotsOfNumbers,
+            //LotsOfStrings,
             Json400B,
             Json4KB,
-            Json40KB,
-            Json400KB
+            //Json40KB,
+            //Json400KB
         }
 
         private string _jsonString;
@@ -47,7 +48,7 @@ namespace System.Text.JsonLab.Benchmarks
         [ParamsSource(nameof(TestCaseValues))]
         public TestCaseType TestCase;
 
-        [Params(true, false)]
+        [Params(true)]
         public bool IsDataCompact;
 
         public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));
@@ -85,7 +86,7 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        [Benchmark(Baseline = true)]
+        //[Benchmark(Baseline = true)]
         public void ReaderNewtonsoftReaderEmptyLoop()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -94,7 +95,7 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public string ReaderNewtonsoftReaderReturnString()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -120,21 +121,21 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequenceSingle);
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequence);
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public byte[] ReaderSystemTextJsonLabReturnBytes()
         {
             var outputArray = new byte[_dataUtf8.Length * 2];
@@ -196,7 +197,7 @@ namespace System.Text.JsonLab.Benchmarks
             return outputArray;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void ReaderUtf8JsonEmptyLoop()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);
@@ -207,7 +208,7 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        [Benchmark]
+        //[Benchmark]
         public byte[] ReaderUtf8JsonReturnBytes()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Engines;
 using Benchmarks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -13,8 +12,8 @@ using System.IO;
 
 namespace System.Text.JsonLab.Benchmarks
 {
-    // Since there are 240 tests here (8 * 2 * 15), setting low values for the warmupCount, targetCount, and invocationCount
-    //[SimpleJob(warmupCount: 3, targetCount: 5)]
+    // Since there are 240 tests here (8 * 2 * 15), setting low values for the warmupCount and targetCount
+    [SimpleJob(warmupCount: 3, targetCount: 5)]
     [MemoryDiagnoser]
     public class JsonReaderPerf
     {
@@ -23,19 +22,19 @@ namespace System.Text.JsonLab.Benchmarks
         {
             HelloWorld,
             BasicJson,
-            //BasicLargeNum,
-            //SpecialNumForm,
-            //ProjectLockJson,
-            //FullSchema1,
-            //FullSchema2,
-            //DeepTree,
-            //BroadTree,
-            //LotsOfNumbers,
-            //LotsOfStrings,
+            BasicLargeNum,
+            SpecialNumForm,
+            ProjectLockJson,
+            FullSchema1,
+            FullSchema2,
+            DeepTree,
+            BroadTree,
+            LotsOfNumbers,
+            LotsOfStrings,
             Json400B,
             Json4KB,
-            //Json40KB,
-            //Json400KB
+            Json40KB,
+            Json400KB
         }
 
         private string _jsonString;
@@ -86,7 +85,7 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        //[Benchmark(Baseline = true)]
+        [Benchmark(Baseline = true)]
         public void ReaderNewtonsoftReaderEmptyLoop()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -95,7 +94,7 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public string ReaderNewtonsoftReaderReturnString()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -121,21 +120,21 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequenceSingle);
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequence);
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public byte[] ReaderSystemTextJsonLabReturnBytes()
         {
             var outputArray = new byte[_dataUtf8.Length * 2];
@@ -197,7 +196,7 @@ namespace System.Text.JsonLab.Benchmarks
             return outputArray;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderUtf8JsonEmptyLoop()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);
@@ -208,7 +207,7 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        //[Benchmark]
+        [Benchmark]
         public byte[] ReaderUtf8JsonReturnBytes()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -47,7 +47,7 @@ namespace System.Text.JsonLab.Benchmarks
         [ParamsSource(nameof(TestCaseValues))]
         public TestCaseType TestCase;
 
-        [Params(true)]
+        [Params(true, false)]
         public bool IsDataCompact;
 
         public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -241,7 +241,7 @@ namespace System.Text.JsonLab.Tests
             { }
         }
 
-        public static void WriteDepth(ref Utf8JsonWriter<ArrayFormatterWrapper> jsonUtf8, int depth)
+        private static void WriteDepth(ref Utf8JsonWriter<ArrayFormatterWrapper> jsonUtf8, int depth)
         {
             jsonUtf8.WriteObjectStart();
             for (int i = 0; i < depth; i++)


### PR DESCRIPTION
~5% perf regression due to extra checks in Start/End Object and Array.

``` ini

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17744
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-009460
  [Host]     : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT
  Job-MVZRDK : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT

IterationCount=5  WarmupCount=3  

```
|                               Method | Depth |         Mean |         Error |        StdDev | Scaled | ScaledSD |   Gen 0 | Allocated |
|------------------------------------- |------ |-------------:|--------------:|--------------:|-------:|---------:|--------:|----------:|
|      **ReaderNewtonsoftReaderEmptyLoop** |     **1** |    **465.29 ns** |     **12.358 ns** |     **3.2100 ns** |   **1.00** |     **0.00** |  **0.5660** |    **2376 B** |
| ReaderSystemTextJsonLabSpanEmptyLoop |     1 |     79.14 ns |      1.160 ns |     0.3012 ns |   0.17 |     0.00 |       - |       0 B |
|                                      |       |              |               |               |        |          |         |           |
|      **ReaderNewtonsoftReaderEmptyLoop** |     **2** |    **647.90 ns** |     **16.792 ns** |     **4.3617 ns** |   **1.00** |     **0.00** |  **0.6151** |    **2584 B** |
| ReaderSystemTextJsonLabSpanEmptyLoop |     2 |    111.56 ns |      2.847 ns |     0.7396 ns |   0.17 |     0.00 |       - |       0 B |
|                                      |       |              |               |               |        |          |         |           |
|      **ReaderNewtonsoftReaderEmptyLoop** |     **4** |    **942.29 ns** |     **98.977 ns** |    **25.7089 ns** |   **1.00** |     **0.00** |  **0.6380** |    **2680 B** |
| ReaderSystemTextJsonLabSpanEmptyLoop |     4 |    179.89 ns |     12.855 ns |     3.3390 ns |   0.19 |     0.01 |       - |       0 B |
|                                      |       |              |               |               |        |          |         |           |
|      **ReaderNewtonsoftReaderEmptyLoop** |     **8** |  **1,515.99 ns** |    **277.013 ns** |    **71.9531 ns** |   **1.00** |     **0.00** |  **0.7343** |    **3088 B** |
| ReaderSystemTextJsonLabSpanEmptyLoop |     8 |    334.10 ns |     31.402 ns |     8.1565 ns |   0.22 |     0.01 |       - |       0 B |
|                                      |       |              |               |               |        |          |         |           |
|      **ReaderNewtonsoftReaderEmptyLoop** |    **16** |  **2,844.18 ns** |    **820.057 ns** |   **213.0069 ns** |   **1.00** |     **0.00** |  **0.9232** |    **3880 B** |
| ReaderSystemTextJsonLabSpanEmptyLoop |    16 |    606.12 ns |     42.473 ns |    11.0321 ns |   0.21 |     0.01 |       - |       0 B |
|                                      |       |              |               |               |        |          |         |           |
|      **ReaderNewtonsoftReaderEmptyLoop** |    **32** |  **5,107.24 ns** |    **837.251 ns** |   **217.4729 ns** |   **1.00** |     **0.00** |  **1.2894** |    **5440 B** |
| ReaderSystemTextJsonLabSpanEmptyLoop |    32 |  1,172.19 ns |     57.789 ns |    15.0105 ns |   0.23 |     0.01 |       - |       0 B |
|                                      |       |              |               |               |        |          |         |           |
|      **ReaderNewtonsoftReaderEmptyLoop** |    **64** |  **9,949.65 ns** |  **1,224.763 ns** |   **318.1275 ns** |   **1.00** |     **0.00** |  **2.0294** |    **8536 B** |
| ReaderSystemTextJsonLabSpanEmptyLoop |    64 |  2,306.55 ns |    415.841 ns |   108.0131 ns |   0.23 |     0.01 |       - |       0 B |
|                                      |       |              |               |               |        |          |         |           |
|      **ReaderNewtonsoftReaderEmptyLoop** |    **65** |  **9,228.81 ns** |    **893.085 ns** |   **231.9756 ns** |   **1.00** |     **0.00** |  **2.0447** |    **8584 B** |
| ReaderSystemTextJsonLabSpanEmptyLoop |    65 |  2,291.23 ns |    257.841 ns |    66.9733 ns |   0.25 |     0.01 |  0.0153 |      80 B |
|                                      |       |              |               |               |        |          |         |           |
|      **ReaderNewtonsoftReaderEmptyLoop** |    **66** |  **9,267.37 ns** |    **303.329 ns** |    **78.7885 ns** |   **1.00** |     **0.00** |  **2.7924** |   **11728 B** |
| ReaderSystemTextJsonLabSpanEmptyLoop |    66 |  2,335.58 ns |    100.594 ns |    26.1290 ns |   0.25 |     0.00 |  0.0153 |      80 B |
|                                      |       |              |               |               |        |          |         |           |
|      **ReaderNewtonsoftReaderEmptyLoop** |   **128** | **17,163.51 ns** |    **648.661 ns** |   **168.4874 ns** |   **1.00** |     **0.00** |  **3.4790** |   **14704 B** |
| ReaderSystemTextJsonLabSpanEmptyLoop |   128 |  5,801.68 ns |  2,332.954 ns |   605.9762 ns |   0.34 |     0.03 |  0.1526 |     656 B |
|                                      |       |              |               |               |        |          |         |           |
|      **ReaderNewtonsoftReaderEmptyLoop** |   **256** | **43,481.24 ns** | **32,618.949 ns** | **8,472.6505 ns** |   **1.00** |     **0.00** |  **6.4087** |   **27016 B** |
| ReaderSystemTextJsonLabSpanEmptyLoop |   256 | 12,031.09 ns |  5,632.453 ns | 1,463.0087 ns |   0.28 |     0.06 |  0.5188 |    2240 B |
|                                      |       |              |               |               |        |          |         |           |
|      **ReaderNewtonsoftReaderEmptyLoop** |   **512** | **71,155.62 ns** | **12,018.752 ns** | **3,121.8261 ns** |   **1.00** |     **0.00** | **12.2070** |   **51616 B** |
| ReaderSystemTextJsonLabSpanEmptyLoop |   512 | 20,319.76 ns |  3,118.482 ns |   810.0142 ns |   0.29 |     0.02 |  1.0071 |    4312 B |
