### PR TITLE
 Mark json data as readonly and remove the need to slice it while reading

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReader.cs
@@ -222,14 +222,14 @@ namespace System.Text.JsonLab
                 Depth++;
                 _containerMask = 1;
                 TokenType = JsonTokenType.StartObject;
-                buffer = buffer.Slice(1);
+                //buffer = buffer.Slice(1);
                 Index++;
             }
             else if (first == JsonConstants.OpenBracket)
             {
                 Depth++;
                 TokenType = JsonTokenType.StartArray;
-                buffer = buffer.Slice(1);
+                //buffer = buffer.Slice(1);
                 Index++;
             }
             else
@@ -239,23 +239,23 @@ namespace System.Text.JsonLab
             return true;
         }
 
-        internal bool NoMoreData => (0 >= (uint)_buffer.Length);
+        internal bool NoMoreData => (Index >= (uint)_buffer.Length);
 
         private bool ReadSingleSegment(ref ReadOnlySpan<byte> buffer)
         {
             bool retVal = false;
 
-            if (0 >= (uint)buffer.Length)
+            if (Index >= (uint)buffer.Length)
                 goto Done;
 
-            byte first = buffer[0];
+            byte first = buffer[Index];
 
             if (first <= JsonConstants.Space)
             {
                 SkipWhiteSpaceUtf8(ref buffer);
-                if (0 >= (uint)buffer.Length)
+                if (Index >= (uint)buffer.Length)
                     goto Done;
-                first = buffer[0];
+                first = buffer[Index];
             }
 
             StartLocation = Index;
@@ -267,7 +267,7 @@ namespace System.Text.JsonLab
 
             if (TokenType == JsonTokenType.StartObject)
             {
-                buffer = buffer.Slice(1);
+                //buffer = buffer.Slice(1);
                 Index++;
                 if (first == JsonConstants.CloseBrace)
                     EndObject();
@@ -282,7 +282,7 @@ namespace System.Text.JsonLab
             {
                 if (first == JsonConstants.CloseBracket)
                 {
-                    buffer = buffer.Slice(1);
+                    //buffer = buffer.Slice(1);
                     Index++;
                     EndArray();
                 }
@@ -351,7 +351,7 @@ namespace System.Text.JsonLab
             }
             else
             {
-                if (_stack.Peek() == 0 || Depth <= 0)
+                if (_stack.Peek() == 0)
                     JsonThrowHelper.ThrowJsonReaderException();
                 _stack.Pop();
             }
@@ -387,7 +387,7 @@ namespace System.Text.JsonLab
             }
             else
             {
-                if (_stack.Peek() != 0 || Depth <= 0)
+                if (_stack.Peek() != 0)
                     JsonThrowHelper.ThrowJsonReaderException();
                 _stack.Pop();
             }
@@ -449,22 +449,22 @@ namespace System.Text.JsonLab
         /// </summary>
         private void ConsumeNextUtf8(ref ReadOnlySpan<byte> buffer, byte marker)
         {
-            buffer = buffer.Slice(1);
+            //buffer = buffer.Slice(1);
             Index++;
             if (marker == JsonConstants.ListSeperator)
             {
-                if (0 >= (uint)buffer.Length)
+                if (Index >= (uint)buffer.Length)
                     JsonThrowHelper.ThrowJsonReaderException();
 
-                byte first = buffer[0];
+                byte first = buffer[Index];
 
                 if (first <= JsonConstants.Space)
                 {
                     SkipWhiteSpaceUtf8(ref buffer);
                     // The next character must be a start of a property name or value.
-                    if (0 >= (uint)buffer.Length)
+                    if (Index >= (uint)buffer.Length)
                         JsonThrowHelper.ThrowJsonReaderException();
-                    first = buffer[0];
+                    first = buffer[Index];
                 }
 
                 StartLocation = Index;
@@ -473,7 +473,7 @@ namespace System.Text.JsonLab
                     if (first != JsonConstants.Quote)
                         JsonThrowHelper.ThrowJsonReaderException();
 
-                    buffer = buffer.Slice(1);
+                    //buffer = buffer.Slice(1);
                     Index++;
                     StartLocation++;
                     ConsumePropertyNameUtf8(ref buffer);
@@ -565,21 +565,21 @@ namespace System.Text.JsonLab
 
             if (marker == JsonConstants.Quote)
             {
-                buffer = buffer.Slice(1);
+                //buffer = buffer.Slice(1);
                 Index++;
                 StartLocation++;
                 ConsumeStringUtf8(ref buffer);
             }
             else if (marker == JsonConstants.OpenBrace)
             {
-                buffer = buffer.Slice(1);
+                //buffer = buffer.Slice(1);
                 Index++;
                 StartObject();
                 ValueType = JsonValueType.Object;
             }
             else if (marker == JsonConstants.OpenBracket)
             {
-                buffer = buffer.Slice(1);
+                //buffer = buffer.Slice(1);
                 Index++;
                 StartArray();
                 ValueType = JsonValueType.Array;
@@ -590,7 +590,7 @@ namespace System.Text.JsonLab
             }
             else if (marker == '-')
             {
-                if (buffer.Length < 2) JsonThrowHelper.ThrowJsonReaderException();
+                if (buffer.Length - 2 > Index) JsonThrowHelper.ThrowJsonReaderException();
                 ConsumeNumberUtf8(ref buffer);
             }
             else if (marker == 'f')
@@ -677,7 +677,7 @@ namespace System.Text.JsonLab
 
             if (marker == JsonConstants.Quote)
             {
-                buffer = buffer.Slice(1);
+                //buffer = buffer.Slice(1);
                 Index++;
                 StartLocation++;
                 ConsumeStringUtf8(ref buffer);
@@ -735,15 +735,15 @@ namespace System.Text.JsonLab
 
         private void ConsumeNumberUtf8(ref ReadOnlySpan<byte> buffer)
         {
-            int idx = buffer.IndexOfAny(JsonConstants.Delimiters);
+            int idx = buffer.Slice(Index).IndexOfAny(JsonConstants.Delimiters);
             if (idx == -1)
             {
                 JsonThrowHelper.ThrowJsonReaderException();
             }
 
-            Value = buffer.Slice(0, idx);
+            Value = buffer.Slice(Index, idx);
             ValueType = JsonValueType.Number;
-            buffer = buffer.Slice(idx);
+            //buffer = buffer.Slice(idx);
             Index += idx;
         }
 
@@ -764,11 +764,11 @@ namespace System.Text.JsonLab
             Value = JsonConstants.NullValue;
             ValueType = JsonValueType.Null;
 
-            if (!buffer.StartsWith(Value))
+            if (!buffer.Slice(Index).StartsWith(Value))
             {
                 JsonThrowHelper.ThrowJsonReaderException();
             }
-            buffer = buffer.Slice(4);
+            //buffer = buffer.Slice(4);
             Index += 4;
         }
 
@@ -789,11 +789,11 @@ namespace System.Text.JsonLab
             Value = JsonConstants.FalseValue;
             ValueType = JsonValueType.False;
 
-            if (!buffer.StartsWith(Value))
+            if (!buffer.Slice(Index).StartsWith(Value))
             {
                 JsonThrowHelper.ThrowJsonReaderException();
             }
-            buffer = buffer.Slice(5);
+            //buffer = buffer.Slice(5);
             Index += 5;
         }
 
@@ -814,11 +814,11 @@ namespace System.Text.JsonLab
             Value = JsonConstants.TrueValue;
             ValueType = JsonValueType.True;
 
-            if (!buffer.StartsWith(Value))
+            if (!buffer.Slice(Index).StartsWith(Value))
             {
                 JsonThrowHelper.ThrowJsonReaderException();
             }
-            buffer = buffer.Slice(4);
+            //buffer = buffer.Slice(4);
             Index += 4;
         }
 
@@ -849,17 +849,17 @@ namespace System.Text.JsonLab
         {
             ConsumeStringUtf8(ref buffer);
 
-            if (0 >= (uint)buffer.Length)
+            if (Index >= (uint)buffer.Length)
                 JsonThrowHelper.ThrowJsonReaderException();
 
-            byte first = buffer[0];
+            byte first = buffer[Index];
 
             if (first <= JsonConstants.Space)
             {
                 SkipWhiteSpaceUtf8(ref buffer);
-                if (0 >= (uint)buffer.Length)
+                if (Index >= (uint)buffer.Length)
                     JsonThrowHelper.ThrowJsonReaderException();
-                first = buffer[0];
+                first = buffer[Index];
             }
 
             // The next character must be a key / value seperator. Validate and skip.
@@ -869,7 +869,7 @@ namespace System.Text.JsonLab
             }
 
             TokenType = JsonTokenType.PropertyName;
-            buffer = buffer.Slice(1);
+            //buffer = buffer.Slice(1);
             Index++;
         }
 
@@ -1076,16 +1076,16 @@ namespace System.Text.JsonLab
 
         private void ConsumeStringUtf8(ref ReadOnlySpan<byte> buffer)
         {
-            int idx = buffer.IndexOf(JsonConstants.Quote);
+            int idx = buffer.Slice(Index).IndexOf(JsonConstants.Quote);
             if (idx < 0)
                 JsonThrowHelper.ThrowJsonReaderException();
-            if (idx == 0 || buffer[idx - 1] != JsonConstants.ReverseSolidus)
+            if (idx == 0 || buffer[idx + Index - 1] != JsonConstants.ReverseSolidus)
             {
-                Value = buffer.Slice(0, idx);
+                Value = buffer.Slice(Index, idx);
                 ValueType = JsonValueType.String;
 
                 idx++;
-                buffer = buffer.Slice(idx);
+                //buffer = buffer.Slice(idx);
                 Index += idx;
                 return;
             }
@@ -1096,7 +1096,7 @@ namespace System.Text.JsonLab
         {
             //TODO: Optimize looking for nested quotes
             //TODO: Avoid redoing first IndexOf search
-            int i = 0;
+            int i = Index;
             while (true)
             {
                 int counter = 0;
@@ -1123,22 +1123,21 @@ namespace System.Text.JsonLab
             }
 
         Done:
-            Value = buffer.Slice(0, i);
+            Value = buffer.Slice(Index, i - Index);
             ValueType = JsonValueType.String;
 
             i++;
-            buffer = buffer.Slice(i);
-            Index += i;
+            //buffer = buffer.Slice(i);
+            Index = i;
         }
 
         private void SkipWhiteSpaceUtf8(ref ReadOnlySpan<byte> buffer)
         {
             //Create local copy to avoid bounds checks.
             ReadOnlySpan<byte> bufferCopy = buffer;
-            int i = 0;
-            for (; i < bufferCopy.Length; i++)
+            for (; Index < bufferCopy.Length; Index++)
             {
-                byte val = bufferCopy[i];
+                byte val = bufferCopy[Index];
                 if (val != JsonConstants.Space &&
                     val != JsonConstants.CarriageReturn &&
                     val != JsonConstants.LineFeed &&
@@ -1147,8 +1146,7 @@ namespace System.Text.JsonLab
                     break;
                 }
             }
-            buffer = bufferCopy.Slice(i);
-            Index += i;
+            //buffer = bufferCopy.Slice(i);
         }
     }
 }

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -13,7 +13,7 @@ using System.IO;
 namespace System.Text.JsonLab.Benchmarks
 {
     // Since there are 240 tests here (8 * 2 * 15), setting low values for the warmupCount and targetCount
-    [SimpleJob(warmupCount: 3, targetCount: 5)]
+    //[SimpleJob(warmupCount: 3, targetCount: 5)]
     [MemoryDiagnoser]
     public class JsonReaderPerf
     {
@@ -47,7 +47,7 @@ namespace System.Text.JsonLab.Benchmarks
         [ParamsSource(nameof(TestCaseValues))]
         public TestCaseType TestCase;
 
-        [Params(true, false)]
+        [Params(true)]
         public bool IsDataCompact;
 
         public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));
@@ -85,7 +85,7 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        [Benchmark(Baseline = true)]
+        //[Benchmark(Baseline = true)]
         public void ReaderNewtonsoftReaderEmptyLoop()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -94,7 +94,7 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public string ReaderNewtonsoftReaderReturnString()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -120,21 +120,21 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequenceSingle);
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequence);
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public byte[] ReaderSystemTextJsonLabReturnBytes()
         {
             var outputArray = new byte[_dataUtf8.Length * 2];
@@ -196,7 +196,7 @@ namespace System.Text.JsonLab.Benchmarks
             return outputArray;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void ReaderUtf8JsonEmptyLoop()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);
@@ -207,7 +207,7 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        [Benchmark]
+        //[Benchmark]
         public byte[] ReaderUtf8JsonReturnBytes()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -13,7 +13,7 @@ using System.IO;
 namespace System.Text.JsonLab.Benchmarks
 {
     // Since there are 240 tests here (8 * 2 * 15), setting low values for the warmupCount and targetCount
-    //[SimpleJob(warmupCount: 3, targetCount: 5)]
+    [SimpleJob(warmupCount: 3, targetCount: 5)]
     [MemoryDiagnoser]
     public class JsonReaderPerf
     {
@@ -47,7 +47,7 @@ namespace System.Text.JsonLab.Benchmarks
         [ParamsSource(nameof(TestCaseValues))]
         public TestCaseType TestCase;
 
-        [Params(true)]
+        [Params(true, false)]
         public bool IsDataCompact;
 
         public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));
@@ -85,7 +85,7 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        //[Benchmark(Baseline = true)]
+        [Benchmark(Baseline = true)]
         public void ReaderNewtonsoftReaderEmptyLoop()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -94,7 +94,7 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public string ReaderNewtonsoftReaderReturnString()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -120,21 +120,21 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequenceSingle);
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequence);
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public byte[] ReaderSystemTextJsonLabReturnBytes()
         {
             var outputArray = new byte[_dataUtf8.Length * 2];
@@ -196,7 +196,7 @@ namespace System.Text.JsonLab.Benchmarks
             return outputArray;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderUtf8JsonEmptyLoop()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);
@@ -207,7 +207,7 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        //[Benchmark]
+        [Benchmark]
         public byte[] ReaderUtf8JsonReturnBytes()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);


### PR DESCRIPTION
Also removed unnecessary Depth check and cached InObject (turning it into a field): 
https://github.com/dotnet/corefxlab/pull/2483#discussion_r218522745
https://github.com/dotnet/corefxlab/pull/2483#discussion_r218519322

~5% improvement when data is "compact"

+ Changed stack from int to bool to save space. No need to store 4 bytes (int), when 1 is sufficient (bool).

``` ini

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17744
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-009460
  [Host]     : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT


```

**Before:**

|                               Method | IsDataCompact |        TestCase |          Mean |          Error |         StdDev | Allocated |
|------------------------------------- |-------------- |---------------- |--------------:|---------------:|---------------:|----------:|
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |       **BasicJson** |     **387.54 ns** |      **6.2077 ns** |      **5.8067 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **BasicLargeNum** |     **596.10 ns** |      **8.7268 ns** |      **8.1631 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |       **BroadTree** |   **7,469.65 ns** |     **98.1945 ns** |     **87.0468 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |        **DeepTree** |   **3,112.37 ns** |     **16.3954 ns** |     **12.8004 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |     **FullSchema1** |   **1,372.18 ns** |     **26.6702 ns** |     **24.9473 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |     **FullSchema2** |   **1,830.70 ns** |     **34.7344 ns** |     **37.1654 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |      **HelloWorld** |      **57.73 ns** |      **0.9430 ns** |      **0.8359 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |        **Json400B** |     **597.69 ns** |      **7.6057 ns** |      **7.1143 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |       **Json400KB** | **632,769.16 ns** | **12,332.3930 ns** | **14,680.8366 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |        **Json40KB** |  **58,137.78 ns** |  **1,153.4816 ns** |  **2,194.6187 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |         **Json4KB** |   **4,346.46 ns** |     **36.6541 ns** |     **32.4929 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **LotsOfNumbers** |   **2,790.77 ns** |     **37.2210 ns** |     **34.8166 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **LotsOfStrings** |     **937.60 ns** |     **17.5883 ns** |     **18.0619 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** | **ProjectLockJson** | **228,159.13 ns** |  **2,278.1924 ns** |  **1,902.3937 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **SpecialNumForm** |   **1,330.42 ns** |     **25.8794 ns** |     **25.4171 ns** |       **0 B** |

**After:**

|                               Method | IsDataCompact |        TestCase |          Mean |          Error |         StdDev | Allocated |
|------------------------------------- |-------------- |---------------- |--------------:|---------------:|---------------:|----------:|
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |       **BasicJson** |     **367.59 ns** |      **7.2716 ns** |      **8.0824 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **BasicLargeNum** |     **556.06 ns** |      **7.4098 ns** |      **6.9311 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |       **BroadTree** |   **7,015.26 ns** |     **40.8206 ns** |     **34.0871 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |        **DeepTree** |   **3,096.43 ns** |     **59.3949 ns** |     **68.3992 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |     **FullSchema1** |   **1,272.49 ns** |     **12.0228 ns** |     **11.2462 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |     **FullSchema2** |   **1,794.53 ns** |     **34.0180 ns** |     **33.4102 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |      **HelloWorld** |      **58.19 ns** |      **0.7608 ns** |      **0.6744 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |        **Json400B** |     **581.46 ns** |     **11.3057 ns** |     **13.4587 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |       **Json400KB** | **610,963.23 ns** | **22,499.5760 ns** | **22,097.5899 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |        **Json40KB** |  **55,488.30 ns** |  **1,825.6843 ns** |  **3,245.1520 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |         **Json4KB** |   **4,110.18 ns** |     **77.1468 ns** |     **72.1632 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **LotsOfNumbers** |   **2,716.84 ns** |     **41.8256 ns** |     **39.1237 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **LotsOfStrings** |     **911.44 ns** |      **3.6986 ns** |      **2.8876 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** | **ProjectLockJson** | **213,966.40 ns** |  **1,168.3763 ns** |    **912.1913 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **SpecialNumForm** |   **1,246.48 ns** |      **8.2556 ns** |      **6.8938 ns** |       **0 B** |

