### PR TITLE
Add a skip delimiter overload to TryReadTo

### DIFF
--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
@@ -44,7 +44,7 @@ namespace System.Buffers.Reader
 
         /// <summary>
         /// Try to read everything up to the given <paramref name="delimiter"/>, ignoring delimiters that are
-        /// preceeded by <paramref name="skipDelimiter"/>.
+        /// preceeded by <paramref name="delimiterEscape"/>.
         /// </summary>
         /// <param name="span">The read data, if any.</param>
         /// <param name="delimiter">The delimiter to look for.</param>
@@ -134,7 +134,7 @@ namespace System.Buffers.Reader
 
         /// <summary>
         /// Try to read everything up to the given <paramref name="delimiter"/>, ignoring delimiters that are
-        /// preceeded by <paramref name="skipDelimiter"/>.
+        /// preceeded by <paramref name="delimiterEscape"/>.
         /// </summary>
         /// <param name="sequence">The read data, if any.</param>
         /// <param name="delimiter">The delimiter to look for.</param>
@@ -158,6 +158,7 @@ namespace System.Buffers.Reader
                         // We were in the escaped state, so skip this delimiter
                         priorEscape = false;
                         Advance(index + 1);
+                        continue;
                     }
                     else if (index > 0 && remaining[index - 1].Equals(delimiterEscape))
                     {

--- a/tests/System.Buffers.Experimental.Tests/BufferFactory.cs
+++ b/tests/System.Buffers.Experimental.Tests/BufferFactory.cs
@@ -11,7 +11,6 @@ namespace System.Buffers.Tests
     {
         private class ReadOnlyBufferSegment : ReadOnlySequenceSegment<byte>
         {
-
             public static ReadOnlySequence<byte> Create(IEnumerable<Memory<byte>> buffers)
             {
                 ReadOnlyBufferSegment segment = null;
@@ -21,12 +20,12 @@ namespace System.Buffers.Tests
                     var newSegment = new ReadOnlyBufferSegment()
                     {
                         Memory = buffer,
-                        RunningIndex = segment?.Memory.Length ?? 0
                     };
 
                     if (segment != null)
                     {
                         segment.Next = newSegment;
+                        newSegment.RunningIndex = segment.RunningIndex + segment.Memory.Length;
                     }
                     else
                     {

--- a/tests/System.Buffers.ReaderWriter.Tests/Reader_SkipDelimiter.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/Reader_SkipDelimiter.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers.Reader;
+using System.Globalization;
+using System.Text;
+using Xunit;
+
+namespace System.Buffers.Tests
+{
+    public class Reader_SkipDelimiter
+    {
+        [Fact]
+        public void TryReadTo_SkipDelimiter()
+        {
+            byte[] expected = Encoding.UTF8.GetBytes("This is our \\\"understanding\\\"");
+            ReadOnlySequence<byte> bytes = BufferFactory.CreateUtf8("This is our \\\"understanding\\\"\" you see.");
+            BufferReader<byte> reader = new BufferReader<byte>(bytes);
+            Assert.True(reader.TryReadTo(out ReadOnlySpan<byte> span, (byte)'"', (byte)'\\', advancePastDelimiter: true));
+            Assert.Equal(expected, span.ToArray());
+            Assert.True(reader.IsNext((byte)' '));
+            Assert.Equal(30, reader.Consumed);
+
+            reader = new BufferReader<byte>(bytes);
+            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: false));
+            Assert.Equal(expected, span.ToArray());
+            Assert.True(reader.IsNext((byte)'"'));
+            Assert.Equal(29, reader.Consumed);
+
+            // Put the skip delimiter in another segment
+            bytes = BufferFactory.CreateUtf8("This is our \\\"understanding", "\\\"\" you see.");
+            reader = new BufferReader<byte>(bytes);
+            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: true));
+            Assert.Equal(expected, span.ToArray());
+            Assert.True(reader.IsNext((byte)' '));
+            Assert.Equal(30, reader.Consumed);
+
+            reader = new BufferReader<byte>(bytes);
+            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: false));
+            Assert.Equal(expected, span.ToArray());
+            Assert.True(reader.IsNext((byte)'"'));
+            Assert.Equal(29, reader.Consumed);
+
+            // Put the skip delimiter at the end of the segment
+            bytes = BufferFactory.CreateUtf8("This is our \\\"understanding\\", "\"\" you see.");
+            reader = new BufferReader<byte>(bytes);
+            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: true));
+            Assert.Equal(expected, span.ToArray());
+            Assert.True(reader.IsNext((byte)' '));
+            Assert.Equal(30, reader.Consumed);
+
+            reader = new BufferReader<byte>(bytes);
+            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: false));
+            Assert.Equal(expected, span.ToArray());
+            Assert.True(reader.IsNext((byte)'"'));
+            Assert.Equal(29, reader.Consumed);
+
+            // No trailing data
+            bytes = BufferFactory.CreateUtf8("This is our \\\"understanding\\\"\"");
+            reader = new BufferReader<byte>(bytes);
+            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: false));
+            Assert.Equal(expected, span.ToArray());
+            Assert.True(reader.IsNext((byte)'"'));
+            Assert.Equal(29, reader.Consumed);
+
+            reader = new BufferReader<byte>(bytes);
+            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: true));
+            Assert.Equal(expected, span.ToArray());
+            Assert.True(reader.End);
+            Assert.Equal(30, reader.Consumed);
+
+            // All delimiters skipped
+            bytes = BufferFactory.CreateUtf8("This is our \\\"understanding\\\"");
+            reader = new BufferReader<byte>(bytes);
+            Assert.False(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: false));
+            Assert.Equal(0, reader.Consumed);
+
+            reader = new BufferReader<byte>(bytes);
+            Assert.False(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: true));
+            Assert.Equal(0, reader.Consumed);
+        }
+    }
+}

--- a/tests/System.Buffers.ReaderWriter.Tests/Reader_SkipDelimiter.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/Reader_SkipDelimiter.cs
@@ -13,112 +13,149 @@ namespace System.Buffers.Tests
         [Fact]
         public void TryReadTo_SkipDelimiter()
         {
-            byte[] expected = Encoding.UTF8.GetBytes("This is our \\\"understanding\\\"");
-            ReadOnlySequence<byte> bytes = BufferFactory.CreateUtf8("This is our \\\"understanding\\\"\" you see.");
+            byte[] expected = Encoding.UTF8.GetBytes("This is our ^|understanding^|");
+            ReadOnlySequence<byte> bytes = BufferFactory.CreateUtf8("This is our ^|understanding^|| you see.");
             BufferReader<byte> reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out ReadOnlySpan<byte> span, (byte)'"', (byte)'\\', advancePastDelimiter: true));
+            Assert.True(reader.TryReadTo(out ReadOnlySpan<byte> span, (byte)'|', (byte)'^', advancePastDelimiter: true));
             Assert.Equal(expected, span.ToArray());
             Assert.True(reader.IsNext((byte)' '));
             Assert.Equal(30, reader.Consumed);
 
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: false));
+            Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
             Assert.Equal(expected, span.ToArray());
-            Assert.True(reader.IsNext((byte)'"'));
+            Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(29, reader.Consumed);
 
             // Put the skip delimiter in another segment
-            bytes = BufferFactory.CreateUtf8("This is our \\\"understanding", "\\\"\" you see.");
+            bytes = BufferFactory.CreateUtf8("This is our ^|understanding", "^|| you see.");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: true));
+            Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: true));
             Assert.Equal(expected, span.ToArray());
             Assert.True(reader.IsNext((byte)' '));
             Assert.Equal(30, reader.Consumed);
 
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: false));
+            Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
             Assert.Equal(expected, span.ToArray());
-            Assert.True(reader.IsNext((byte)'"'));
+            Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(29, reader.Consumed);
 
             // Put the skip delimiter at the end of the segment
-            bytes = BufferFactory.CreateUtf8("This is our \\\"understanding\\", "\"\" you see.");
+            bytes = BufferFactory.CreateUtf8("This is our ^|understanding^", "|| you see.");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: true));
+            Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: true));
             Assert.Equal(expected, span.ToArray());
             Assert.True(reader.IsNext((byte)' '));
             Assert.Equal(30, reader.Consumed);
 
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: false));
+            Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
             Assert.Equal(expected, span.ToArray());
-            Assert.True(reader.IsNext((byte)'"'));
+            Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(29, reader.Consumed);
 
             // No trailing data
-            bytes = BufferFactory.CreateUtf8("This is our \\\"understanding\\\"\"");
+            bytes = BufferFactory.CreateUtf8("This is our ^|understanding^||");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: false));
+            Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
             Assert.Equal(expected, span.ToArray());
-            Assert.True(reader.IsNext((byte)'"'));
+            Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(29, reader.Consumed);
 
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: true));
+            Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: true));
             Assert.Equal(expected, span.ToArray());
             Assert.True(reader.End);
             Assert.Equal(30, reader.Consumed);
 
             // All delimiters skipped
-            bytes = BufferFactory.CreateUtf8("This is our \\\"understanding\\\"");
+            bytes = BufferFactory.CreateUtf8("This is our ^|understanding^|");
             reader = new BufferReader<byte>(bytes);
-            Assert.False(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: false));
+            Assert.False(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
             Assert.Equal(0, reader.Consumed);
 
             reader = new BufferReader<byte>(bytes);
-            Assert.False(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: true));
+            Assert.False(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: true));
             Assert.Equal(0, reader.Consumed);
 
-            bytes = BufferFactory.CreateUtf8("abc\\\"de\"");
+            bytes = BufferFactory.CreateUtf8("abc^|de|");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: true));
-            Assert.Equal(Encoding.UTF8.GetBytes("abc\\\"de"), span.ToArray());
+            Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: true));
+            Assert.Equal(Encoding.UTF8.GetBytes("abc^|de"), span.ToArray());
             Assert.True(reader.End);
             Assert.Equal(8, reader.Consumed);
+
+            // Escape leads
+            bytes = BufferFactory.CreateUtf8("^|a|b");
+            reader = new BufferReader<byte>(bytes);
+            Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: true));
+            Assert.Equal(Encoding.UTF8.GetBytes("^|a"), span.ToArray());
+            Assert.True(reader.IsNext((byte)'b'));
+            Assert.Equal(4, reader.Consumed);
         }
 
         [Fact]
         public void TryReadTo_SkipDelimiter_Runs()
         {
-            ReadOnlySequence<byte> bytes = BufferFactory.CreateUtf8("abc\\\\\"def");
+            ReadOnlySequence<byte> bytes = BufferFactory.CreateUtf8("abc^^|def");
             BufferReader<byte> reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out ReadOnlySpan<byte> span, (byte)'"', (byte)'\\', advancePastDelimiter: false));
-            Assert.Equal(Encoding.UTF8.GetBytes("abc\\\\"), span.ToArray());
-            Assert.True(reader.IsNext((byte)'"'));
+            Assert.True(reader.TryReadTo(out ReadOnlySpan<byte> span, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.Equal(Encoding.UTF8.GetBytes("abc^^"), span.ToArray());
+            Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(5, reader.Consumed);
 
             // Split after escape char
-            bytes = BufferFactory.CreateUtf8("abc\\\\", "\"def");
+            bytes = BufferFactory.CreateUtf8("abc^^", "|def");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: false));
-            Assert.Equal(Encoding.UTF8.GetBytes("abc\\\\"), span.ToArray());
-            Assert.True(reader.IsNext((byte)'"'));
+            Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.Equal(Encoding.UTF8.GetBytes("abc^^"), span.ToArray());
+            Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(5, reader.Consumed);
 
             // Split before and after escape char
-            bytes = BufferFactory.CreateUtf8("abc\\", "\\", "\"def");
+            bytes = BufferFactory.CreateUtf8("abc^", "^", "|def");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: false));
-            Assert.Equal(Encoding.UTF8.GetBytes("abc\\\\"), span.ToArray());
-            Assert.True(reader.IsNext((byte)'"'));
+            Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.Equal(Encoding.UTF8.GetBytes("abc^^"), span.ToArray());
+            Assert.True(reader.IsNext((byte)'|'));
             Assert.Equal(5, reader.Consumed);
 
             // Check advance past delimiter
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryReadTo(out span, (byte)'"', (byte)'\\', advancePastDelimiter: true));
-            Assert.Equal(Encoding.UTF8.GetBytes("abc\\\\"), span.ToArray());
+            Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: true));
+            Assert.Equal(Encoding.UTF8.GetBytes("abc^^"), span.ToArray());
             Assert.True(reader.IsNext((byte)'d'));
             Assert.Equal(6, reader.Consumed);
+
+            // Leading run of 2
+            bytes = BufferFactory.CreateUtf8("^^|abc");
+            reader = new BufferReader<byte>(bytes);
+            Assert.True(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.Equal(Encoding.UTF8.GetBytes("^^"), span.ToArray());
+            Assert.True(reader.IsNext((byte)'|'));
+            Assert.Equal(2, reader.Consumed);
+
+            // Leading run of 3
+            bytes = BufferFactory.CreateUtf8("^^^|abc");
+            reader = new BufferReader<byte>(bytes);
+            Assert.False(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.True(reader.IsNext((byte)'^'));
+            Assert.Equal(0, reader.Consumed);
+
+            // Trailing run of 3
+            bytes = BufferFactory.CreateUtf8("abc^^^|");
+            reader = new BufferReader<byte>(bytes);
+            Assert.False(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.True(reader.IsNext((byte)'a'));
+            Assert.Equal(0, reader.Consumed);
+
+            // Trailing run of 3, split
+            bytes = BufferFactory.CreateUtf8("abc^^^", "|");
+            reader = new BufferReader<byte>(bytes);
+            Assert.False(reader.TryReadTo(out span, (byte)'|', (byte)'^', advancePastDelimiter: false));
+            Assert.True(reader.IsNext((byte)'a'));
+            Assert.Equal(0, reader.Consumed);
         }
     }
 }


### PR DESCRIPTION
This allows you to handle escaping. Unescaping would be considered the callers responsibility. We could combine `TryReadToInternal` if we introduce additional condition checks.