### PR TITLE
Use new BufferReader.TryReadTo API to replace JsonReader string escape logic

### DIFF
--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -13,7 +13,7 @@ using System.IO;
 namespace System.Text.JsonLab.Benchmarks
 {
     // Since there are 240 tests here (8 * 2 * 15), setting low values for the warmupCount and targetCount
-    [SimpleJob(warmupCount: 3, targetCount: 5)]
+    //[SimpleJob(warmupCount: 3, targetCount: 5)]
     [MemoryDiagnoser]
     public class JsonReaderPerf
     {
@@ -85,7 +85,7 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        [Benchmark(Baseline = true)]
+        //[Benchmark(Baseline = true)]
         public void ReaderNewtonsoftReaderEmptyLoop()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -94,7 +94,7 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public string ReaderNewtonsoftReaderReturnString()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -113,14 +113,14 @@ namespace System.Text.JsonLab.Benchmarks
             return sb.ToString();
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void ReaderSystemTextJsonLabSpanEmptyLoop()
         {
             var json = new Utf8JsonReader(_dataUtf8);
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequenceSingle);
@@ -134,7 +134,7 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public byte[] ReaderSystemTextJsonLabReturnBytes()
         {
             var outputArray = new byte[_dataUtf8.Length * 2];
@@ -196,7 +196,7 @@ namespace System.Text.JsonLab.Benchmarks
             return outputArray;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void ReaderUtf8JsonEmptyLoop()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);
@@ -207,7 +207,7 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        [Benchmark]
+        //[Benchmark]
         public byte[] ReaderUtf8JsonReturnBytes()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);


### PR DESCRIPTION
~16% regression, originally.

I tried to optimize the TryReadTo implementation to drop the regression down to ~10% regression for the common case. I think we can find more ways to optimize it.

![image](https://user-images.githubusercontent.com/6527137/46330693-271b5080-c5c9-11e8-857f-2fa13c9fe749.png)


cc @KrzysztofCwalina 