### PR TITLE
Measure multi-segment reading versus single-segment reading for various segment sizes

### DIFF
--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -51,6 +51,7 @@
     <ProjectReference Include="..\..\src\System.Text.Utf8String\System.Text.Utf8String.csproj" />
     <ProjectReference Include="..\System.Binary.Base64.Tests\System.Binary.Base64.Tests.csproj" />
     <ProjectReference Include="..\System.Text.Primitives.Tests\System.Text.Primitives.Tests.csproj" />
+    <ProjectReference Include="..\System.Buffers.ReaderWriter.Tests\System.Buffers.ReaderWriter.Tests.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="JsonStrings.Designer.cs">

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderMultiSegmentPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderMultiSegmentPerf.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using Benchmarks;
+using System.Buffers;
+using System.Buffers.Tests;
+using System.Collections.Generic;
+
+namespace System.Text.JsonLab.Benchmarks
+{
+    // Since there are 15 tests here (5 * 3), setting low values for the warmupCount and targetCount
+    [SimpleJob(warmupCount: 3, targetCount: 5)]
+    [MemoryDiagnoser]
+    public class JsonReaderMultiSegmentPerf
+    {
+        // Keep the JsonStrings resource names in sync with TestCaseType enum values.
+        public enum TestCaseType
+        {
+            Json4KB,
+            Json40KB,
+            Json400KB
+        }
+
+        private string _jsonString;
+        private byte[] _dataUtf8;
+        private Dictionary<int, ReadOnlySequence<byte>> _sequences;
+        private ReadOnlySequence<byte> _sequenceSingle;
+
+        [ParamsSource(nameof(TestCaseValues))]
+        public TestCaseType TestCase;
+
+        public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _jsonString = JsonStrings.ResourceManager.GetString(TestCase.ToString());
+
+            _dataUtf8 = Encoding.UTF8.GetBytes(_jsonString);
+
+            _sequenceSingle = new ReadOnlySequence<byte>(_dataUtf8);
+
+            int[] segmentSizes = { 1_000, 2_000, 4_000, 8_000 };
+
+            _sequences = new Dictionary<int, ReadOnlySequence<byte>>();
+
+            for (int i = 0; i < segmentSizes.Length; i++)
+            {
+                int segmentSize = segmentSizes[i];
+                _sequences.Add(segmentSize, GetSequence(_dataUtf8, segmentSize));
+            }
+        }
+
+        private static ReadOnlySequence<byte> GetSequence(byte[] _dataUtf8, int segmentSize)
+        {
+            int numberOfSegments = _dataUtf8.Length / segmentSize + 1;
+            byte[][] buffers = new byte[numberOfSegments][];
+
+            for (int j = 0; j < numberOfSegments - 1; j++)
+            {
+                buffers[j] = new byte[segmentSize];
+                Array.Copy(_dataUtf8, j * segmentSize, buffers[j], 0, segmentSize);
+            }
+
+            int remaining = _dataUtf8.Length % segmentSize;
+            buffers[numberOfSegments - 1] = new byte[remaining];
+            Array.Copy(_dataUtf8, _dataUtf8.Length - remaining, buffers[numberOfSegments - 1], 0, remaining);
+
+            return BufferFactory.Create(buffers);
+        }
+
+        [Benchmark]
+        public void SingleSegmentSequence()
+        {
+            var json = new Utf8JsonReader(_sequenceSingle);
+            while (json.Read()) ;
+        }
+
+        [Benchmark]
+        [Arguments(1_000)]
+        [Arguments(2_000)]
+        [Arguments(4_000)]
+        [Arguments(8_000)]
+        public void MultiSegmentSequence(int segmentSize)
+        {
+            var json = new Utf8JsonReader(_sequences[segmentSize]);
+            while (json.Read()) ;
+        }
+    }
+}

--- a/tests/System.Buffers.Experimental.Tests/BufferFactory.cs
+++ b/tests/System.Buffers.Experimental.Tests/BufferFactory.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace System.Buffers.Tests
 {
-    internal static class BufferFactory
+    public static class BufferFactory
     {
         private class ReadOnlyBufferSegment : ReadOnlySequenceSegment<byte>
         {


### PR DESCRIPTION
As you would expect, the larger the segment size, the better the performance. 4 KB is a reasonable size. There is a 5-10% regression if you use a smaller size like 1KB.

**The multi-segment case is 50% slower than the single segment case, even with 8 KB buffers (ideally this should be under 10% as seen here: https://github.com/dotnet/corefxlab/issues/2511).**

Issue to try to improve performance: https://github.com/dotnet/corefxlab/issues/2509

``` ini

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17754
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-009460
  [Host]     : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT
  Job-KGUDKK : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT

IterationCount=5  WarmupCount=3  

```
|                Method |  TestCase | segmentSize |         Mean |       Error |      StdDev |   Gen 0 | Allocated |
|---------------------- |---------- |------------ |-------------:|------------:|------------:|--------:|----------:|
|  **MultiSegmentSequence** | **Json400KB** |        **1000** | **1,514.121 us** | **282.4030 us** |  **73.3531 us** | **11.7188** |   **52056 B** |
|  **MultiSegmentSequence** | **Json400KB** |        **2000** | **1,446.905 us** | **288.6973 us** |  **74.9880 us** |  **5.8594** |   **26440 B** |
|  **MultiSegmentSequence** | **Json400KB** |        **4000** | **1,338.191 us** | **122.2628 us** |  **31.7573 us** |  **1.9531** |   **14072 B** |
|  **MultiSegmentSequence** | **Json400KB** |        **8000** | **1,370.076 us** | **540.2406 us** | **140.3255 us** |       **-** |    **7208 B** |
| **SingleSegmentSequence** | **Json400KB** |           **?** |   **899.445 us** |  **25.3657 us** |   **6.5887 us** |       **-** |       **0 B** |
|  **MultiSegmentSequence** |  **Json40KB** |        **1000** |   **134.111 us** |   **7.3912 us** |   **1.9198 us** |  **0.9766** |    **4408 B** |
|  **MultiSegmentSequence** |  **Json40KB** |        **2000** |   **130.804 us** |   **6.9974 us** |   **1.8175 us** |  **0.4883** |    **2176 B** |
|  **MultiSegmentSequence** |  **Json40KB** |        **4000** |   **127.677 us** |   **4.3515 us** |   **1.1303 us** |  **0.2441** |    **1312 B** |
|  **MultiSegmentSequence** |  **Json40KB** |        **8000** |   **128.470 us** |   **5.8294 us** |   **1.5142 us** |       **-** |     **784 B** |
| **SingleSegmentSequence** |  **Json40KB** |           **?** |    **86.708 us** |   **1.8827 us** |   **0.4890 us** |       **-** |       **0 B** |
|  **MultiSegmentSequence** |   **Json4KB** |        **1000** |    **11.850 us** |   **1.2300 us** |   **0.3195 us** |  **0.0153** |     **112 B** |
|  **MultiSegmentSequence** |   **Json4KB** |        **2000** |    **11.375 us** |   **0.5730 us** |   **0.1488 us** |  **0.0153** |      **72 B** |
|  **MultiSegmentSequence** |   **Json4KB** |        **4000** |    **11.746 us** |   **2.1174 us** |   **0.5500 us** |       **-** |       **0 B** |
|  **MultiSegmentSequence** |   **Json4KB** |        **8000** |     **7.438 us** |   **0.0836 us** |   **0.0217 us** |       **-** |       **0 B** |
| **SingleSegmentSequence** |   **Json4KB** |           **?** |     **7.418 us** |   **0.0877 us** |   **0.0228 us** |       **-** |       **0 B** |


cc @KrzysztofCwalina,  @JeremyKuhne 