### PR TITLE
Add rich error messaging and re-entrant support for multi-segment json

### DIFF
--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
@@ -28,11 +28,16 @@ namespace System.Buffers.Reader
             if (buffer.TryGet(ref _nextPosition, out ReadOnlyMemory<T> memory, advance: true))
             {
                 _moreData = true;
-                CurrentSpan = memory.Span;
-                if (CurrentSpan.Length == 0)
+                
+                if (memory.Length == 0)
                 {
+                    CurrentSpan = default;
                     // No space in the first span, move to one with space
                     GetNextSpan();
+                }
+                else
+                {
+                    CurrentSpan = memory.Span;
                 }
             }
             else
@@ -129,6 +134,63 @@ namespace System.Buffers.Reader
         }
 
         /// <summary>
+        /// Move the reader back the specified number of positions.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Retreat(int count)
+        {
+            if (count < 0)
+            {
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count);
+            }
+
+            Consumed -= count;
+
+            if (CurrentSpanIndex >= count)
+            {
+                CurrentSpanIndex -= count;
+            }
+            else
+            {
+                // Current segment doesn't have enough space, scan backward through segments
+                RetreatToPreviousSpan(count);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void RetreatToPreviousSpan(int count)
+        {
+            CurrentSpanIndex = 0;
+            Consumed = 0;
+            _currentPosition = Sequence.Start;
+            _nextPosition = _currentPosition;
+
+            if (Sequence.TryGet(ref _nextPosition, out ReadOnlyMemory<T> memory, advance: true))
+            {
+                _moreData = true;
+                
+                if (memory.Length == 0)
+                {
+                    CurrentSpan = default;
+                    // No space in the first span, move to one with space
+                    GetNextSpan();
+                }
+                else
+                {
+                    CurrentSpan = memory.Span;
+                }
+            }
+            else
+            {
+                // No space in any spans and at end of sequence
+                _moreData = false;
+                CurrentSpan = default;
+            }
+
+            Advance(Consumed);
+        }
+
+        /// <summary>
         /// Get the next segment with available space, if any.
         /// </summary>
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -160,18 +222,18 @@ namespace System.Buffers.Reader
         /// Move the reader ahead the specified number of positions.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Advance(int count)
+        public void Advance(long count)
         {
             if (count < 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count);
             }
 
             Consumed += count;
 
             if (CurrentSpanIndex < CurrentSpan.Length - count)
             {
-                CurrentSpanIndex += count;
+                CurrentSpanIndex += (int)count;
             }
             else
             {
@@ -181,7 +243,7 @@ namespace System.Buffers.Reader
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void AdvanceToNextSpan(int count)
+        private void AdvanceToNextSpan(long count)
         {
             while (_moreData)
             {
@@ -189,7 +251,7 @@ namespace System.Buffers.Reader
 
                 if (remaining > count)
                 {
-                    CurrentSpanIndex += count;
+                    CurrentSpanIndex += (int)count;
                     count = 0;
                     break;
                 }
@@ -206,7 +268,7 @@ namespace System.Buffers.Reader
 
             if (count != 0)
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.length);
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.count);
             }
         }
 

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
@@ -160,6 +160,12 @@ namespace System.Buffers.Reader
         [MethodImpl(MethodImplOptions.NoInlining)]
         private void RetreatToPreviousSpan(long consumed)
         {
+            ResetReader();
+            Advance(consumed);
+        }
+
+        private void ResetReader()
+        {
             CurrentSpanIndex = 0;
             Consumed = 0;
             _currentPosition = Sequence.Start;
@@ -186,8 +192,6 @@ namespace System.Buffers.Reader
                 _moreData = false;
                 CurrentSpan = default;
             }
-
-            Advance(consumed);
         }
 
         /// <summary>

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
@@ -28,7 +28,7 @@ namespace System.Buffers.Reader
             if (buffer.TryGet(ref _nextPosition, out ReadOnlyMemory<T> memory, advance: true))
             {
                 _moreData = true;
-                
+
                 if (memory.Length == 0)
                 {
                     CurrentSpan = default;
@@ -137,7 +137,7 @@ namespace System.Buffers.Reader
         /// Move the reader back the specified number of positions.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Retreat(int count)
+        public void Rewind(long count)
         {
             if (count < 0)
             {
@@ -148,17 +148,17 @@ namespace System.Buffers.Reader
 
             if (CurrentSpanIndex >= count)
             {
-                CurrentSpanIndex -= count;
+                CurrentSpanIndex -= (int)count;
             }
             else
             {
                 // Current segment doesn't have enough space, scan backward through segments
-                RetreatToPreviousSpan(count);
+                RetreatToPreviousSpan(Consumed);
             }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void RetreatToPreviousSpan(int count)
+        private void RetreatToPreviousSpan(long consumed)
         {
             CurrentSpanIndex = 0;
             Consumed = 0;
@@ -168,7 +168,7 @@ namespace System.Buffers.Reader
             if (Sequence.TryGet(ref _nextPosition, out ReadOnlyMemory<T> memory, advance: true))
             {
                 _moreData = true;
-                
+
                 if (memory.Length == 0)
                 {
                     CurrentSpan = default;
@@ -187,7 +187,7 @@ namespace System.Buffers.Reader
                 CurrentSpan = default;
             }
 
-            Advance(Consumed);
+            Advance(consumed);
         }
 
         /// <summary>

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
@@ -141,7 +141,7 @@ namespace System.Buffers.Reader
                 else
                 {
                     // No delimiter, need to check the end of the span for odd number of escapes then advance
-                    if (remaining[remaining.Length - 1].Equals(delimiterEscape))
+                    if (remaining.Length > 0 && remaining[remaining.Length - 1].Equals(delimiterEscape))
                     {
                         int escapeCount = 1;
                         int i = remaining.Length - 2;

--- a/src/System.Buffers.ReaderWriter/System/ThrowHelper.cs
+++ b/src/System.Buffers.ReaderWriter/System/ThrowHelper.cs
@@ -31,7 +31,7 @@ namespace System.Buffers
 
     internal enum ExceptionArgument
     {
-
+        count,
         length,
 
     }

--- a/src/System.Text.JsonLab/System/Text/Json/JsonReaderState.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReaderState.cs
@@ -22,7 +22,7 @@ namespace System.Text.JsonLab
             _inObject == default &&
             _stack == null &&
             _tokenType == default &&
-            _lineNumber == default &&
+            //_lineNumber == default && // the default _lineNumber is 1, we want IsDefault to return true for default(JsonReaderState)
             _position == default;
     }
 }

--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader_MultiSegment.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader_MultiSegment.cs
@@ -118,6 +118,7 @@ namespace System.Text.JsonLab
                         reader.Advance(Value.Length);
                         CurrentIndex += Value.Length;
                         _position += Value.Length;
+                        return true;
                     }
                     else return false;
                 }

--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader_MultiSegment.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader_MultiSegment.cs
@@ -211,7 +211,7 @@ namespace System.Text.JsonLab
                     CurrentIndex = prevCurrentIndex;
                     TokenType = JsonTokenType.StartObject;
                     _position = prevPosition;
-                    reader.Retreat(1);
+                    reader.Rewind(1);
                     return false;
                 }
             }
@@ -242,7 +242,7 @@ namespace System.Text.JsonLab
                 {
                     return true;
                 }
-                reader.Retreat(CurrentIndex - prevCurrentIndex);
+                reader.Rewind(CurrentIndex - prevCurrentIndex);
                 CurrentIndex = prevCurrentIndex;
                 TokenType = prevTokenType;
                 _position = prevPosition;
@@ -333,7 +333,7 @@ namespace System.Text.JsonLab
                 {
                     CurrentIndex = prevCurrentIndex;
                     _position = prevPosition;
-                    reader.Retreat(1);
+                    reader.Rewind(1);
                     return false;
                 }
                 return true;

--- a/tests/System.Buffers.ReaderWriter.Tests/Reader_ReadTo.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/Reader_ReadTo.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers.Reader;
+using Xunit;
+
+namespace System.Buffers.Tests
+{
+    public class Reader_ReadTo
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TryReadTo_Span(bool advancePastDelimiter)
+        {
+            ReadOnlySequence<byte> bytes = BufferFactory.Create(new byte[][] {
+                new byte[] { 0 },
+                new byte[] { 1, 2 },
+                new byte[] { },
+                new byte[] { 3, 4, 5, 6 }
+            });
+
+            BufferReader<byte> reader = new BufferReader<byte>(bytes);
+            for (byte i = 0; i < bytes.Length - 1; i++)
+            {
+                BufferReader<byte> copy = reader;
+                Assert.True(copy.TryReadTo(out ReadOnlySpan<byte> span, i, 255, advancePastDelimiter));
+                Assert.True(copy.TryReadTo(out span, 6, 255, advancePastDelimiter));
+                Assert.Equal(!advancePastDelimiter, copy.TryReadTo(out span, 6, 255, advancePastDelimiter));
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TryReadTo_Sequence(bool advancePastDelimiter)
+        {
+            ReadOnlySequence<byte> bytes = BufferFactory.Create(new byte[][] {
+                new byte[] { 0 },
+                new byte[] { 1, 2 },
+                new byte[] { },
+                new byte[] { 3, 4, 5, 6 }
+            });
+
+            BufferReader<byte> reader = new BufferReader<byte>(bytes);
+            for (byte i = 0; i < bytes.Length - 1; i++)
+            {
+                BufferReader<byte> copy = reader;
+                Assert.True(copy.TryReadTo(out ReadOnlySequence<byte> span, i, 255, advancePastDelimiter));
+                Assert.True(copy.TryReadTo(out span, 6, 255, advancePastDelimiter));
+                Assert.Equal(!advancePastDelimiter, copy.TryReadTo(out span, 6, 255, advancePastDelimiter));
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TryReadTo_NotFound_Span(bool advancePastDelimiter)
+        {
+            ReadOnlySequence<byte> bytes = BufferFactory.Create(new byte[][] {
+                new byte[] { 1 },
+                new byte[] { 2, 3, 255 }
+            });
+
+            BufferReader<byte> reader = new BufferReader<byte>(bytes);
+            reader.Advance(4);
+            Assert.False(reader.TryReadTo(out ReadOnlySpan<byte> span, 255, 0, advancePastDelimiter));
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TryReadTo_NotFound_Sequence(bool advancePastDelimiter)
+        {
+            ReadOnlySequence<byte> bytes = BufferFactory.Create(new byte[][] {
+                new byte[] { 1 },
+                new byte[] { 2, 3, 255 }
+            });
+
+            BufferReader<byte> reader = new BufferReader<byte>(bytes);
+            reader.Advance(4);
+            Assert.False(reader.TryReadTo(out ReadOnlySequence<byte> span, 255, 0, advancePastDelimiter));
+        }
+    }
+}

--- a/tests/System.Buffers.ReaderWriter.Tests/Reader_Rewind.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/Reader_Rewind.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers.Reader;
+using Xunit;
+
+namespace System.Buffers.Tests
+{
+    public class Reader_Rewind
+    {
+        [Fact]
+        public void Rewind()
+        {
+            ReadOnlySequence<byte> bytes = BufferFactory.Create(new byte[][] {
+                new byte[] { 0          },
+                new byte[] { 1, 2       },
+                new byte[] { 3, 4       },
+                new byte[] { 5, 6, 7, 8 }
+            });
+
+            BufferReader<byte> reader = new BufferReader<byte>(bytes);
+            reader.Advance(1);
+            BufferReader<byte> copy = reader;
+            for (int i = 1; i < bytes.Length; i++)
+            {
+                reader.Advance(i);
+                reader.Rewind(i);
+
+                Assert.Equal(copy.Position, reader.Position);
+                Assert.Equal(copy.Consumed, reader.Consumed);
+                Assert.Equal(copy.CurrentSpanIndex, reader.CurrentSpanIndex);
+                Assert.Equal(copy.End, reader.End);
+                Assert.True(copy.CurrentSpan.SequenceEqual(reader.CurrentSpan));
+            }
+        }
+    }
+}


### PR DESCRIPTION
BufferReader does not provide a reset/recovery mechanism which results in the new re-entrant JsonReader tests to fail.

For example, if I see the start of a property name (i.e. `"`), I advance past the quote and call ConsumeString, which ends up calling `if (reader.TryReadTo(out ReadOnlySpan<byte> value, JsonConstants.Quote, (byte)'\\', advancePastDelimiter: true))`

However, if that returns false because we don't have all the data yet, I need to undo the advance I did (to move the cursor back before the first `"`).

To work around this, I have to copy the BufferReader before advancing to rollback the change. This results in significant perf regression. **How can I do this in a sane way while still using the BufferReader APIs?**

**TODO:** Add more test cases (especially for invalid data with isFinalBlock true/false and check that _position and _lineNumber are set correctly).

cc @KrzysztofCwalina, @JeremyKuhne 


**Multi-segment is 2.3x - 2.8x slower than single-segment.** Previously, it was 1.5x - 1.7x slower.

``` ini

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17754
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-009460
  [Host]     : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT
  Job-WKNCWB : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT

IterationCount=5  WarmupCount=3  

```
**NOW:**

|                                            Method | IsDataCompact |   TestCase |            Mean |         Error |         StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
|-------------------------------------------------- |-------------- |----------- |----------------:|--------------:|---------------:|-------:|---------:|-------:|----------:|
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **BasicJson** |       **460.45 ns** |     **32.342 ns** |      **8.4008 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |  BasicJson |     1,492.66 ns |     28.555 ns |      7.4172 ns |   3.24 |     0.05 | 0.0076 |      40 B |
|                                                   |               |            |                 |               |                |        |          |        |           |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** | **HelloWorld** |        **72.93 ns** |      **2.589 ns** |      **0.6724 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True | HelloWorld |       468.30 ns |      7.660 ns |      1.9896 ns |   6.42 |     0.06 | 0.0086 |      40 B |
|                                                   |               |            |                 |               |                |        |          |        |           |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json400B** |       **647.95 ns** |     **92.892 ns** |     **24.1285 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |   Json400B |     1,770.08 ns |     53.784 ns |     13.9703 ns |   2.73 |     0.09 |      - |       0 B |
|                                                   |               |            |                 |               |                |        |          |        |           |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **Json400KB** |   **674,107.19 ns** | **16,212.198 ns** |  **4,211.0581 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |  Json400KB | 1,529,843.71 ns | 19,541.360 ns |  5,075.7955 ns |   2.27 |     0.01 |      - |     440 B |
|                                                   |               |            |                 |               |                |        |          |        |           |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json40KB** |    **62,572.23 ns** |  **1,253.872 ns** |    **325.6885 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |   Json40KB |   163,639.15 ns | 55,185.637 ns | 14,334.2640 ns |   2.62 |     0.21 |      - |      40 B |
|                                                   |               |            |                 |               |                |        |          |        |           |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |    **Json4KB** |     **4,886.29 ns** |  **1,397.445 ns** |    **362.9812 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |    Json4KB |    13,672.74 ns |  1,170.834 ns |    304.1198 ns |   2.81 |     0.18 | 0.0916 |     416 B |

|                Method |  TestCase | segmentSize |         Mean |         Error |      StdDev |   Gen 0 | Allocated |
|---------------------- |---------- |------------ |-------------:|--------------:|------------:|--------:|----------:|
|  **MultiSegmentSequence** | **Json400KB** |        **1000** | **2,277.556 us** |   **614.6865 us** | **159.6625 us** | **11.7188** |   **52056 B** |
|  **MultiSegmentSequence** | **Json400KB** |        **2000** | **2,284.465 us** | **2,527.7209 us** | **656.5661 us** |  **5.8594** |   **26440 B** |
|  **MultiSegmentSequence** | **Json400KB** |        **4000** | **1,870.355 us** |    **23.9744 us** |   **6.2273 us** |  **1.9531** |   **14072 B** |
|  **MultiSegmentSequence** | **Json400KB** |        **8000** | **1,974.490 us** |   **411.5267 us** | **106.8925 us** |       **-** |    **7208 B** |
| **SingleSegmentSequence** | **Json400KB** |           **?** |   **975.793 us** |   **326.4452 us** |  **84.7929 us** |       **-** |       **0 B** |
|  **MultiSegmentSequence** |  **Json40KB** |        **1000** |   **208.756 us** |    **67.1059 us** |  **17.4305 us** |  **0.9766** |    **4408 B** |
|  **MultiSegmentSequence** |  **Json40KB** |        **2000** |   **188.887 us** |    **22.7712 us** |   **5.9147 us** |  **0.4883** |    **2176 B** |
|  **MultiSegmentSequence** |  **Json40KB** |        **4000** |   **185.975 us** |    **11.2977 us** |   **2.9345 us** |  **0.2441** |    **1312 B** |
|  **MultiSegmentSequence** |  **Json40KB** |        **8000** |   **193.254 us** |    **73.5458 us** |  **19.1033 us** |       **-** |     **784 B** |
| **SingleSegmentSequence** |  **Json40KB** |           **?** |    **94.631 us** |    **34.9899 us** |   **9.0885 us** |       **-** |       **0 B** |
|  **MultiSegmentSequence** |   **Json4KB** |        **1000** |    **17.845 us** |     **1.1112 us** |   **0.2886 us** |       **-** |     **112 B** |
|  **MultiSegmentSequence** |   **Json4KB** |        **2000** |    **17.567 us** |     **1.7424 us** |   **0.4526 us** |       **-** |      **72 B** |
|  **MultiSegmentSequence** |   **Json4KB** |        **4000** |    **18.052 us** |     **6.4056 us** |   **1.6638 us** |       **-** |       **0 B** |
|  **MultiSegmentSequence** |   **Json4KB** |        **8000** |     **7.394 us** |     **0.4464 us** |   **0.1159 us** |       **-** |       **0 B** |
| **SingleSegmentSequence** |   **Json4KB** |           **?** |     **7.466 us** |     **0.2275 us** |   **0.0591 us** |       **-** |       **0 B** |


**BEFORE:**

|                                            Method | IsDataCompact |   TestCase |            Mean |           Error |         StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
|-------------------------------------------------- |-------------- |----------- |----------------:|----------------:|---------------:|-------:|---------:|-------:|----------:|
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **BasicJson** |       **418.88 ns** |      **22.2616 ns** |      **5.7824 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |  BasicJson |       953.00 ns |      24.8139 ns |      6.4453 ns |   2.28 |     0.03 | 0.0086 |      40 B |
|                                                   |               |            |                 |                 |                |        |          |        |           |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** | **HelloWorld** |        **71.34 ns** |       **0.7378 ns** |      **0.1916 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True | HelloWorld |       404.76 ns |     121.1304 ns |     31.4632 ns |   5.67 |     0.39 | 0.0091 |      40 B |
|                                                   |               |            |                 |                 |                |        |          |        |           |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json400B** |       **639.78 ns** |      **50.9402 ns** |     **13.2315 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |   Json400B |     1,119.68 ns |      28.5724 ns |      7.4216 ns |   1.75 |     0.03 |      - |       0 B |
|                                                   |               |            |                 |                 |                |        |          |        |           |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **Json400KB** |   **666,694.11 ns** |  **31,682.0832 ns** |  **8,229.3032 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |  Json400KB | 1,022,328.20 ns | 348,547.6500 ns | 90,533.9553 ns |   1.53 |     0.12 |      - |     440 B |
|                                                   |               |            |                 |                 |                |        |          |        |           |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json40KB** |    **64,289.09 ns** |   **4,376.6212 ns** |  **1,136.8111 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |   Json40KB |    91,749.92 ns |   6,529.2427 ns |  1,695.9465 ns |   1.43 |     0.03 |      - |      40 B |
|                                                   |               |            |                 |                 |                |        |          |        |           |
|              **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |    **Json4KB** |     **4,800.40 ns** |     **269.5291 ns** |     **70.0092 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
| ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop |          True |    Json4KB |     7,880.91 ns |     113.0941 ns |     29.3758 ns |   1.64 |     0.02 | 0.0916 |     416 B |

https://github.com/dotnet/corefxlab/pull/2512