### PR TITLE
Remove tests that measure allocations on current thread since it isn't reliable

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonConstants.cs
@@ -37,13 +37,15 @@ namespace System.Text.JsonLab
 
         #region Common values
 
-        public static readonly byte[] TrueValue = { (byte)'t', (byte)'r', (byte)'u', (byte)'e' };
-        public static readonly byte[] FalseValue = { (byte)'f', (byte)'a', (byte)'l', (byte)'s', (byte)'e' };
-        public static readonly byte[] NullValue = { (byte)'n', (byte)'u', (byte)'l', (byte)'l' };
+        public static ReadOnlySpan<byte> TrueValue => new byte[] { (byte)'t', (byte)'r', (byte)'u', (byte)'e' };
 
-        public static readonly byte[] Delimiters = { ListSeperator, CloseBrace, CloseBracket, CarriageReturn, LineFeed, Space, Tab };
+        public static ReadOnlySpan<byte> FalseValue => new byte[] { (byte)'f', (byte)'a', (byte)'l', (byte)'s', (byte)'e' };
 
-        public static readonly byte[] WhiteSpace = { Space, CarriageReturn, LineFeed, Tab };
+        public static ReadOnlySpan<byte> NullValue => new byte[] { (byte)'n', (byte)'u', (byte)'l', (byte)'l' };
+
+        public static ReadOnlySpan<byte> Delimiters => new byte[] { ListSeperator, CloseBrace, CloseBracket, CarriageReturn, LineFeed, Space, Tab };
+
+        public static ReadOnlySpan<byte> WhiteSpace => new byte[] { Space, CarriageReturn, LineFeed, Tab };
 
         #endregion Common values
     }

--- a/src/System.Text.JsonLab/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonConstants.cs
@@ -38,9 +38,7 @@ namespace System.Text.JsonLab
         #region Common values
 
         public static ReadOnlySpan<byte> TrueValue => new byte[] { (byte)'t', (byte)'r', (byte)'u', (byte)'e' };
-
         public static ReadOnlySpan<byte> FalseValue => new byte[] { (byte)'f', (byte)'a', (byte)'l', (byte)'s', (byte)'e' };
-
         public static ReadOnlySpan<byte> NullValue => new byte[] { (byte)'n', (byte)'u', (byte)'l', (byte)'l' };
 
         public static ReadOnlySpan<byte> Delimiters => new byte[] { ListSeperator, CloseBrace, CloseBracket, CarriageReturn, LineFeed, Space, Tab };

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -121,11 +121,6 @@ namespace System.Text.JsonLab.Tests
 
             Assert.Equal(expectedStr, actualStr);
             Assert.Equal(expectedStr, actualStrSequence);
-
-            long memoryBefore = GC.GetAllocatedBytesForCurrentThread();
-            JsonLabEmptyLoopHelper(dataUtf8);
-            long memoryAfter = GC.GetAllocatedBytesForCurrentThread();
-            Assert.Equal(0, memoryAfter - memoryBefore);
         }
 
         [Theory]
@@ -147,11 +142,6 @@ namespace System.Text.JsonLab.Tests
             // TODO: Adjust test accordingly
             //Assert.Equal(expectedStr, actualStr);
             Assert.Equal(actualStr, actualStrSequence);
-
-            long memoryBefore = GC.GetAllocatedBytesForCurrentThread();
-            JsonLabEmptyLoopHelper(dataUtf8);
-            long memoryAfter = GC.GetAllocatedBytesForCurrentThread();
-            Assert.Equal(0, memoryAfter - memoryBefore);
         }
 
         [Theory]


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefxlab/issues/2497

This appears more often in debug. For example, the first Debug.Assert call allocates 64 bytes.
