### PR TITLE
Enable build on ubuntu 18.04

### DIFF
--- a/scripts/install-dotnet.sh
+++ b/scripts/install-dotnet.sh
@@ -100,6 +100,10 @@ get_os_download_name_from_platform() {
             echo "ubuntu.16.10"
             return 0
             ;;
+        "ubuntu.18.04")
+            echo "ubuntu"
+            return 0
+            ;;
         "alpine.3.4.3")
             echo "alpine"
             return 0


### PR DESCRIPTION
Note I have to use `ubuntu` not `ubuntu18.04` as there is no installer at that URL for .NET Core 1.0. Maybe I should return `ubuntu16.04` instead?

(Why do you still install 1.0?)