### PR TITLE
 Add support for allowing comments within Json while reading

### DIFF
--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
@@ -149,6 +149,7 @@ namespace System.Buffers.Reader
             if (CurrentSpanIndex >= count)
             {
                 CurrentSpanIndex -= (int)count;
+                _moreData = true;
             }
             else
             {

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
@@ -425,6 +425,7 @@ namespace System.Buffers.Reader
                 peekBuffer = new Span<T>(new T[delimiter.Length]);
             }
 
+            bool advanced = false;
             while (!End)
             {
                 if (!TryReadTo(out sequence, delimiter[0], advancePastDelimiter: false))
@@ -441,6 +442,9 @@ namespace System.Buffers.Reader
                 ReadOnlySpan<T> next = Peek(peekBuffer);
                 if (next.SequenceEqual(delimiter))
                 {
+                    //TODO: Figure out a faster way to do this, potentially by avoiding the Advance in the previous TryReadTo call
+                    if (advanced)
+                        sequence = copy.Sequence.Slice(copy.Consumed, Consumed - copy.Consumed);
                     if (advancePastDelimiter)
                     {
                         Advance(delimiter.Length);
@@ -450,6 +454,7 @@ namespace System.Buffers.Reader
                 else
                 {
                     Advance(1);
+                    advanced = true;
                 }
             }
 

--- a/src/System.Text.JsonLab/ExceptionStrings.Designer.cs
+++ b/src/System.Text.JsonLab/ExceptionStrings.Designer.cs
@@ -98,6 +98,15 @@ namespace System.Text.JsonLab {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Expected either a &apos;\n&apos; or &apos;*/&apos; to indicate end of comment, but instead reached end of data..
+        /// </summary>
+        internal static string EndOfCommentNotFound {
+            get {
+                return ResourceManager.GetString("EndOfCommentNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Expected a &apos;&quot;&apos; to indicate end of string, but instead reached end of data..
         /// </summary>
         internal static string EndOfStringNotFound {

--- a/src/System.Text.JsonLab/ExceptionStrings.resx
+++ b/src/System.Text.JsonLab/ExceptionStrings.resx
@@ -129,6 +129,9 @@
   <data name="DepthMustBePositive" xml:space="preserve">
     <value>Mismatched number of start/end objects or arrays. Depth is {0} but must be greater than 0.</value>
   </data>
+  <data name="EndOfCommentNotFound" xml:space="preserve">
+    <value>Expected either a '\n' or '*/' to indicate end of comment, but instead reached end of data.</value>
+  </data>
   <data name="EndOfStringNotFound" xml:space="preserve">
     <value>Expected a '"' to indicate end of string, but instead reached end of data.</value>
   </data>

--- a/src/System.Text.JsonLab/System/Text/Json/InternalJsonTokenType.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/InternalJsonTokenType.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text.JsonLab
+{
+    // Keep this in sync with JsonTokenType since we cast between the two
+    internal enum InternalJsonTokenType : byte
+    {
+        None,
+        StartObject,
+        EndObject,
+        StartArray,
+        EndArray,
+        PropertyName,
+        Comment,
+        Value,
+    }
+}

--- a/src/System.Text.JsonLab/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonConstants.cs
@@ -43,7 +43,7 @@ namespace System.Text.JsonLab
         public static ReadOnlySpan<byte> FalseValue => new byte[] { (byte)'f', (byte)'a', (byte)'l', (byte)'s', (byte)'e' };
         public static ReadOnlySpan<byte> NullValue => new byte[] { (byte)'n', (byte)'u', (byte)'l', (byte)'l' };
 
-        public static ReadOnlySpan<byte> Delimiters => new byte[] { ListSeperator, CloseBrace, CloseBracket, Space, LineFeed, CarriageReturn, Tab };
+        public static ReadOnlySpan<byte> Delimiters => new byte[] { ListSeperator, CloseBrace, CloseBracket, Space, LineFeed, CarriageReturn, Tab, Solidus };
 
         public static ReadOnlySpan<byte> WhiteSpace => new byte[] { Space, LineFeed, CarriageReturn, Tab };
 

--- a/src/System.Text.JsonLab/System/Text/Json/JsonConstants.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonConstants.cs
@@ -47,6 +47,8 @@ namespace System.Text.JsonLab
 
         public static ReadOnlySpan<byte> WhiteSpace => new byte[] { Space, LineFeed, CarriageReturn, Tab };
 
+        public static ReadOnlySpan<byte> EndOfComment => new byte[] { (byte)'*', Solidus }; // TODO: Add a constant for '*'
+
         // Explicitly skipping ReverseSolidus since that is handled separately
         public static ReadOnlySpan<byte> EscapableChars => new byte[] { Quote, (byte)'n', (byte)'r', (byte)'t', Solidus, (byte)'u', (byte)'b', (byte)'f' };
 

--- a/src/System.Text.JsonLab/System/Text/Json/JsonReaderHelper.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReaderHelper.cs
@@ -11,6 +11,21 @@ namespace System.Text.JsonLab
 {
     internal static class JsonReaderHelper
     {
+        public static (int, int) CountNewLines(ReadOnlySpan<byte> data)
+        {
+            int lastLineFeedIndex = -1;
+            int newLines = 0;
+            for (int i = 0; i < data.Length; i++)
+            {
+                if (data[i] == JsonConstants.LineFeed)
+                {
+                    lastLineFeedIndex = i;
+                    newLines++;
+                }
+            }
+            return (newLines, lastLineFeedIndex);
+        }
+
         // https://tools.ietf.org/html/rfc8259
         // Does the span contain '\' or any control characters (i.e. 0 to 31)
         // IndexOfAny(92, < 32)

--- a/src/System.Text.JsonLab/System/Text/Json/JsonReaderState.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReaderState.cs
@@ -11,7 +11,7 @@ namespace System.Text.JsonLab
         internal ulong _containerMask;
         internal int _depth;
         internal bool _inObject;
-        internal Stack<bool> _stack;
+        internal Stack<InternalJsonTokenType> _stack;
         internal JsonTokenType _tokenType;
         internal int _lineNumber;
         internal int _position;

--- a/src/System.Text.JsonLab/System/Text/Json/JsonThrowHelper.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonThrowHelper.cs
@@ -227,6 +227,8 @@ namespace System.Text.JsonLab
                 case ExceptionResource.InvalidCharacterWithinString:
                     message = string.Format(formatString, character);
                     break;
+                case ExceptionResource.EndOfCommentNotFound:
+                    break;
             }
 
             return message;
@@ -238,6 +240,7 @@ namespace System.Text.JsonLab
             ArrayEndWithinObject,
             Default,
             DepthMustBePositive,
+            EndOfCommentNotFound,
             EndOfStringNotFound,
             ExpectedDigitNotFound,
             ExpectedDigitNotFoundEndOfData,

--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader.cs
@@ -32,15 +32,31 @@ namespace System.Text.JsonLab
                     ThrowArgumentException("Max depth must be positive.");
                 _maxDepth = value;
                 if (_maxDepth > StackFreeMaxDepth)
-                    _stack = new Stack<bool>();
+                    _stack = new Stack<InternalJsonTokenType>();
             }
         }
+
+        public bool AllowComments
+        {
+            get
+            {
+                return _allowComments;
+            }
+            set
+            {
+                _allowComments = value;
+                if (_stack == null)
+                    _stack = new Stack<InternalJsonTokenType>();
+            }
+        }
+
+        private bool _allowComments;
 
         private int _maxDepth;
 
         private BufferReader<byte> _reader;
 
-        private Stack<bool> _stack;
+        private Stack<InternalJsonTokenType> _stack;
 
         // Depth tracks the recursive depth of the nested objects / arrays within the JSON data.
         public int Depth { get; private set; }
@@ -122,6 +138,7 @@ namespace System.Text.JsonLab
             Value = ReadOnlySpan<byte>.Empty;
             ValueType = JsonValueType.Unknown;
             _isSingleValue = true;
+            _allowComments = false;
         }
 
         public Utf8JsonReader(ReadOnlySpan<byte> data, bool isFinalBlock, JsonReaderState state = default)
@@ -158,6 +175,7 @@ namespace System.Text.JsonLab
             Value = ReadOnlySpan<byte>.Empty;
             ValueType = JsonValueType.Unknown;
             _isSingleValue = true;
+            _allowComments = false;
         }
 
         /// <summary>
@@ -196,7 +214,7 @@ namespace System.Text.JsonLab
             if (Depth <= StackFreeMaxDepth)
                 _containerMask = (_containerMask << 1) | 1;
             else
-                _stack.Push(true);
+                _stack.Push(InternalJsonTokenType.StartObject);
 
             TokenType = JsonTokenType.StartObject;
             _inObject = true;
@@ -214,7 +232,7 @@ namespace System.Text.JsonLab
             }
             else
             {
-                _inObject = _stack.Pop();
+                _inObject = _stack.Pop() != InternalJsonTokenType.StartArray;
             }
 
             Depth--;
@@ -232,7 +250,7 @@ namespace System.Text.JsonLab
             if (Depth <= StackFreeMaxDepth)
                 _containerMask = _containerMask << 1;
             else
-                _stack.Push(false);
+                _stack.Push(InternalJsonTokenType.StartArray);
 
             TokenType = JsonTokenType.StartArray;
             _inObject = false;
@@ -250,7 +268,7 @@ namespace System.Text.JsonLab
             }
             else
             {
-                _inObject = _stack.Pop();
+                _inObject = _stack.Pop() != InternalJsonTokenType.StartArray;
             }
 
             Depth--;
@@ -299,7 +317,7 @@ namespace System.Text.JsonLab
 
                 return false;
 
-                Done:
+            Done:
                 if (CurrentIndex >= (uint)_buffer.Length)
                 {
                     return true;
@@ -314,6 +332,13 @@ namespace System.Text.JsonLab
                     }
                 }
 
+                if (AllowComments)
+                {
+                    if (TokenType == JsonTokenType.Comment || _buffer[CurrentIndex] == JsonConstants.Solidus)
+                    {
+                        return true;
+                    }
+                }
                 ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndAfterSingleJson, _buffer[CurrentIndex]);
             }
             return true;
@@ -433,6 +458,24 @@ namespace System.Text.JsonLab
         {
             CurrentIndex++;
             _position++;
+
+            if (AllowComments)
+            {
+                if (marker == JsonConstants.Solidus)
+                {
+                    CurrentIndex--;
+                    _position--;
+                    return ConsumeComment();
+                }
+                if (TokenType == JsonTokenType.Comment)
+                {
+                    CurrentIndex--;
+                    _position--;
+                    TokenType = (JsonTokenType)_stack.Pop();
+                    return ReadSingleSegment();
+                }
+            }
+
             if (marker == JsonConstants.ListSeperator)
             {
                 if (CurrentIndex >= (uint)_buffer.Length)
@@ -529,14 +572,104 @@ namespace System.Text.JsonLab
             {
                 return ConsumeNull();
             }
-            else if (marker == '/')
+            else
             {
-                // TODO: Comments?
-                ThrowNotImplementedException();
+                if (AllowComments && marker == JsonConstants.Solidus)
+                    return ConsumeComment();
+
+                ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfValueNotFound, marker);
+            }
+            return true;
+        }
+
+        private bool ConsumeComment()
+        {
+            //Create local copy to avoid bounds checks.
+            ReadOnlySpan<byte> localCopy = _buffer.Slice(CurrentIndex + 1);
+
+            if (localCopy.Length > 0)
+            {
+                byte marker = localCopy[0];
+                if (marker == JsonConstants.Solidus)
+                    return ConsumeSingleLineComment(localCopy.Slice(1));
+                else if (marker == '*')
+                    return ConsumeMultiLineComment(localCopy.Slice(1));
+                else
+                    ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfValueNotFound, marker);
+            }
+
+            if (_isFinalBlock)
+            {
+                ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfValueNotFound, JsonConstants.Solidus);
+            }
+            else return false;
+
+            return true;
+        }
+
+        private bool ConsumeSingleLineComment(ReadOnlySpan<byte> localCopy)
+        {
+            int idx = localCopy.IndexOf(JsonConstants.LineFeed);
+            if (idx == -1)
+            {
+                if (_isFinalBlock)
+                {
+                    // Assume everything on this line is a comment and there is no more data.
+                    Value = localCopy;
+                    _position += 2 + Value.Length;
+                    goto Done;
+                }
+                else return false;
+            }
+
+            Value = localCopy.Slice(0, idx);
+            CurrentIndex++;
+            _position = 0;
+            _lineNumber++;
+        Done:
+            _stack.Push((InternalJsonTokenType)TokenType);
+            TokenType = JsonTokenType.Comment;
+            CurrentIndex += 2 + Value.Length;
+            return true;
+        }
+
+        private bool ConsumeMultiLineComment(ReadOnlySpan<byte> localCopy)
+        {
+            int idx = 0;
+            while (true)
+            {
+                int foundIdx = localCopy.Slice(idx).IndexOf(JsonConstants.Solidus);
+                if (foundIdx == -1)
+                {
+                    if (_isFinalBlock)
+                    {
+                        ThrowJsonReaderException(ref this, ExceptionResource.EndOfCommentNotFound);
+                    }
+                    else return false;
+                }
+                if (foundIdx != 0 && localCopy[foundIdx + idx - 1] == '*')
+                {
+                    idx += foundIdx;
+                    break;
+                }
+                idx += foundIdx + 1;
+            }
+
+            Debug.Assert(idx >= 1);
+            _stack.Push((InternalJsonTokenType)TokenType);
+            Value = localCopy.Slice(0, idx - 1);
+            TokenType = JsonTokenType.Comment;
+            CurrentIndex += 4 + Value.Length;
+
+            (int newLines, int newLineIndex) = JsonReaderHelper.CountNewLines(Value);
+            _lineNumber += newLines;
+            if (newLineIndex != -1)
+            {
+                _position = Value.Length - newLineIndex + 1;
             }
             else
             {
-                ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfValueNotFound, marker);
+                _position += 4 + Value.Length;
             }
             return true;
         }
@@ -735,7 +868,7 @@ namespace System.Text.JsonLab
                         goto Done;
                     return false;
                 }
-                
+
                 _position += idx + 1;
 
             Done:

--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader.cs
@@ -18,7 +18,7 @@ namespace System.Text.JsonLab
 
         public int CurrentIndex { get; private set; }
 
-        public int TokenStartIndex { get; private set; }
+        internal int TokenStartIndex { get; private set; }
 
         public int MaxDepth
         {

--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader_MultiSegment.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader_MultiSegment.cs
@@ -34,6 +34,7 @@ namespace System.Text.JsonLab
             Value = ReadOnlySpan<byte>.Empty;
             ValueType = JsonValueType.Unknown;
             _isSingleValue = true;
+            _allowComments = false;
         }
 
         public Utf8JsonReader(in ReadOnlySequence<byte> data, bool isFinalBlock, JsonReaderState state = default)
@@ -70,6 +71,7 @@ namespace System.Text.JsonLab
             Value = ReadOnlySpan<byte>.Empty;
             ValueType = JsonValueType.Unknown;
             _isSingleValue = true;
+            _allowComments = false;
         }
 
         private bool ReadFirstToken(ref BufferReader<byte> reader, byte first)
@@ -141,6 +143,16 @@ namespace System.Text.JsonLab
                             return true;
                         }
                     }
+
+                    if (AllowComments)
+                    {
+                        reader.TryPeek(out first);
+                        if (TokenType == JsonTokenType.Comment || first == JsonConstants.Solidus)
+                        {
+                            return true;
+                        }
+                    }
+
                     ThrowJsonReaderException(ref this);
                 }
                 return false;
@@ -261,6 +273,26 @@ namespace System.Text.JsonLab
             reader.Advance(1);
             CurrentIndex++;
             _position++;
+
+            if (AllowComments)
+            {
+                if (marker == JsonConstants.Solidus)
+                {
+                    CurrentIndex--;
+                    _position--;
+                    reader.Rewind(1);
+                    return ConsumeComment(ref reader);
+                }
+                if (TokenType == JsonTokenType.Comment)
+                {
+                    CurrentIndex--;
+                    _position--;
+                    reader.Rewind(1);
+                    TokenType = (JsonTokenType)_stack.Pop();
+                    return ReadMultiSegment(ref reader);
+                }
+            }
+
             if (marker == JsonConstants.ListSeperator)
             {
                 if (!reader.TryPeek(out byte first))
@@ -377,14 +409,133 @@ namespace System.Text.JsonLab
             {
                 return ConsumeNull(ref reader);
             }
-            else if (marker == '/')
+            else
             {
-                // TODO: Comments?
-                ThrowNotImplementedException();
+                if (AllowComments && marker == JsonConstants.Solidus)
+                    return ConsumeComment(ref reader);
+
+                ThrowJsonReaderException(ref this);
+            }
+            return true;
+        }
+
+        private bool ConsumeComment(ref BufferReader<byte> reader)
+        {
+            //TODO: Re-evaluate recovery mechanism if this fails. Do we need to rewind?
+            reader.Advance(1);
+            if (reader.TryPeek(out byte marker))
+            {
+                if (marker == JsonConstants.Solidus)
+                {
+                    reader.Advance(1);
+                    return ConsumeSingleLineComment(ref reader);
+                }
+                else if (marker == '*')
+                {
+                    reader.Advance(1);
+                    return ConsumeMultiLineComment(ref reader);
+                }
+                else
+                    ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfValueNotFound, marker);
+            }
+
+            if (_isFinalBlock)
+            {
+                ThrowJsonReaderException(ref this, ExceptionResource.ExpectedStartOfValueNotFound, JsonConstants.Solidus);
+            }
+            else return false;
+
+            return true;
+        }
+
+        private bool ConsumeSingleLineComment(ref BufferReader<byte> reader)
+        {
+            if (!reader.TryReadTo(out ReadOnlySpan<byte> span, JsonConstants.LineFeed, advancePastDelimiter: true))
+            {
+                if (_isFinalBlock)
+                {
+                    // Assume everything on this line is a comment and there is no more data.
+                    ReadOnlySequence<byte> sequence = reader.Sequence.Slice(reader.Position);
+                    Value = sequence.IsSingleSegment ? sequence.First.Span : sequence.ToArray();
+                    _position += 2 + Value.Length;
+                    reader.Advance(Value.Length);
+                    goto Done;
+                }
+                else return false;
+            }
+
+            Value = span;
+            CurrentIndex++;
+            _position = 0;
+            _lineNumber++;
+        Done:
+            _stack.Push((InternalJsonTokenType)TokenType);
+            TokenType = JsonTokenType.Comment;
+            CurrentIndex += 2 + Value.Length;
+            return true;
+        }
+
+        // TODO: Fix allocations
+        private bool ConsumeMultiLineComment(ref BufferReader<byte> reader)
+        {
+            long consumedBefore = reader.Consumed;
+
+            byte[] partialComment = null;
+            ReadOnlySpan<byte> span = default;
+            while (true)
+            {
+                if (reader.TryReadTo(out span, JsonConstants.Solidus, advancePastDelimiter: true))
+                {
+                    if (span.Length > 0 && span[span.Length - 1] == '*')
+                    {
+                        if (partialComment != null)
+                        {
+                            if (partialComment.Length == 0)
+                                partialComment = new byte[] { JsonConstants.Solidus };
+                            byte[] temp = span.Slice(0, span.Length - 1).ToArray();
+                            var newArray = new byte[partialComment.Length + temp.Length];
+                            Array.Copy(partialComment, newArray, partialComment.Length);
+                            Array.Copy(temp, 0, newArray, partialComment.Length, temp.Length);
+                            partialComment = newArray;
+                        }
+                        break;
+                    }
+
+                    if (partialComment == null)
+                        partialComment = span.ToArray();
+                    else
+                    {
+                        byte[] temp = span.ToArray();
+                        var newArray = new byte[partialComment.Length + temp.Length];
+                        Array.Copy(partialComment, newArray, partialComment.Length);
+                        Array.Copy(temp, 0, newArray, partialComment.Length, temp.Length);
+                        partialComment = newArray;
+                    }
+                }
+                else
+                {
+                    if (_isFinalBlock)
+                    {
+                        ThrowJsonReaderException(ref this, ExceptionResource.EndOfCommentNotFound);
+                    }
+                    else return false;
+                }
+            }
+
+            _stack.Push((InternalJsonTokenType)TokenType);
+            Value = partialComment == null ? span.Slice(0, span.Length - 1) : partialComment;
+            TokenType = JsonTokenType.Comment;
+            CurrentIndex += 4 + Value.Length;
+
+            (int newLines, int newLineIndex) = JsonReaderHelper.CountNewLines(Value);
+            _lineNumber += newLines;
+            if (newLineIndex != -1)
+            {
+                _position = Value.Length - newLineIndex + 1;
             }
             else
             {
-                ThrowJsonReaderException(ref this);
+                _position += 4 + Value.Length;
             }
             return true;
         }

--- a/tests/System.Buffers.ReaderWriter.Tests/Reader_Rewind.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/Reader_Rewind.cs
@@ -25,15 +25,36 @@ namespace System.Buffers.Tests
             for (int i = 1; i < bytes.Length; i++)
             {
                 reader.Advance(i);
-                if (reader.End)
+                reader.Rewind(i);
+
+                Assert.Equal(copy.Position, reader.Position);
+                Assert.Equal(copy.Consumed, reader.Consumed);
+                Assert.Equal(copy.CurrentSpanIndex, reader.CurrentSpanIndex);
+                Assert.Equal(copy.End, reader.End);
+                Assert.True(copy.CurrentSpan.SequenceEqual(reader.CurrentSpan));
+            }
+        }
+
+        [Fact]
+        public void Rewind_ByOne()
+        {
+            ReadOnlySequence<byte> bytes = BufferFactory.Create(new byte[][] {
+                new byte[] { 0          },
+                new byte[] { 1, 2       },
+                new byte[] { 3, 4       },
+                new byte[] { 5, 6, 7, 8 }
+            });
+
+            BufferReader<byte> reader = new BufferReader<byte>(bytes);
+            reader.Advance(1);
+            BufferReader<byte> copy = reader;
+            for (int i = 1; i < bytes.Length; i++)
+            {
+                reader.Advance(i);
+                for (int j = 0; j < i; j++)
                 {
                     reader.Rewind(1);
                     Assert.False(reader.End);
-                    reader.Rewind(i - 1);
-                }
-                else
-                {
-                    reader.Rewind(i);
                 }
 
                 Assert.Equal(copy.Position, reader.Position);

--- a/tests/System.Buffers.ReaderWriter.Tests/Reader_Rewind.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/Reader_Rewind.cs
@@ -25,7 +25,16 @@ namespace System.Buffers.Tests
             for (int i = 1; i < bytes.Length; i++)
             {
                 reader.Advance(i);
-                reader.Rewind(i);
+                if (reader.End)
+                {
+                    reader.Rewind(1);
+                    Assert.False(reader.End);
+                    reader.Rewind(i - 1);
+                }
+                else
+                {
+                    reader.Rewind(i);
+                }
 
                 Assert.Equal(copy.Position, reader.Position);
                 Assert.Equal(copy.Consumed, reader.Consumed);


### PR DESCRIPTION
**TODO:**
- Should we just ignore comments or should we support users actually reading the comment values?