### PR TITLE
Change skip* to advance*.

### DIFF
--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
@@ -49,6 +49,11 @@ namespace System.Buffers.Reader
         }
 
         /// <summary>
+        /// Return true if we're in the last segment
+        /// </summary>
+        public bool IsLastSegment => _nextPosition.GetObject() == null;
+
+        /// <summary>
         /// True when there is no more data in the <see cref="Sequence"/>.
         /// </summary>
         public bool End => !_moreData;
@@ -61,7 +66,8 @@ namespace System.Buffers.Reader
         /// <summary>
         /// The current position in the <see cref="Sequence"/>.
         /// </summary>
-        public SequencePosition Position => Sequence.GetPosition(CurrentSpanIndex, _currentPosition);
+        public SequencePosition Position
+            => new SequencePosition(_currentPosition.GetObject(), CurrentSpanIndex + (_currentPosition.GetInteger() & ~(1 << 31)));
 
         /// <summary>
         /// The current segment in the <see cref="Sequence"/>.
@@ -216,6 +222,7 @@ namespace System.Buffers.Reader
                     {
                         CurrentSpan = default;
                         CurrentSpanIndex = 0;
+                        previousNextPosition = _nextPosition;
                     }
                 }
             }

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
@@ -459,17 +459,17 @@ namespace System.Buffers.Reader
         }
 
         /// <summary>
-        /// Skip until the given <paramref name="delimiter"/>, if found.
+        /// Advance until the given <paramref name="delimiter"/>, if found.
         /// </summary>
         /// <param name="advancePastDelimiter">True to move past the <paramref name="delimiter"/> if found.</param>
         /// <returns>True if the given <paramref name="delimiter"/> was found.</returns>
-        public bool TrySkipTo(T delimiter, bool advancePastDelimiter = true)
+        public bool TryAdvanceTo(T delimiter, bool advancePastDelimiter = true)
         {
             ReadOnlySpan<T> remaining = UnreadSpan;
             int index = remaining.IndexOf(delimiter);
             if (index != -1)
             {
-                Advance(index);
+                Advance(advancePastDelimiter ? index + 1 : index);
                 return true;
             }
 
@@ -477,17 +477,17 @@ namespace System.Buffers.Reader
         }
 
         /// <summary>
-        /// Skip until any of the given <paramref name="delimiters"/>, if found.
+        /// Advance until any of the given <paramref name="delimiters"/>, if found.
         /// </summary>
         /// <param name="advancePastDelimiter">True to move past the first found instance of any of the given <paramref name="delimiters"/>.</param>
         /// <returns>True if any of the given <paramref name="delimiters"/> was found.</returns>
-        public bool TrySkipToAny(ReadOnlySpan<T> delimiters, bool advancePastDelimiter = true)
+        public bool TryAdvanceToAny(ReadOnlySpan<T> delimiters, bool advancePastDelimiter = true)
         {
             ReadOnlySpan<T> remaining = UnreadSpan;
             int index = remaining.IndexOfAny(delimiters);
             if (index != -1)
             {
-                Advance(index);
+                Advance(advancePastDelimiter ? index + 1 : index);
                 return true;
             }
 
@@ -495,16 +495,16 @@ namespace System.Buffers.Reader
         }
 
         /// <summary>
-        /// Skip consecutive instances of the given <paramref name="value"/>.
+        /// Advance past consecutive instances of the given <paramref name="value"/>.
         /// </summary>
-        /// <returns>Count of skipped <typeparamref name="T"/> values.</returns>
-        public long SkipPast(T value)
+        /// <returns>How many positions the reader has been advanced.</returns>
+        public long AdvancePast(T value)
         {
             long start = Consumed;
 
             do
             {
-                // Skip all matches in the current span
+                // Advance past all matches in the current span
                 int i;
                 for (i = CurrentSpanIndex; i < CurrentSpan.Length && CurrentSpan[i].Equals(value); i++)
                 {
@@ -513,7 +513,7 @@ namespace System.Buffers.Reader
                 int advanced = i - CurrentSpanIndex;
                 if (advanced == 0)
                 {
-                    // Didn't skip at all in this span, exit.
+                    // Didn't advance at all in this span, exit.
                     break;
                 }
 
@@ -529,14 +529,14 @@ namespace System.Buffers.Reader
         /// <summary>
         /// Skip consecutive instances of any of the given <paramref name="values"/>.
         /// </summary>
-        /// <returns>Count of skipped <typeparamref name="T"/> values.</returns>
-        public long SkipPastAny(ReadOnlySpan<T> values)
+        /// <returns>How many positions the reader has been advanced.</returns>
+        public long AdvancePastAny(ReadOnlySpan<T> values)
         {
             long start = Consumed;
 
             do
             {
-                // Skip all matches in the current span
+                // Advance past all matches in the current span
                 int i;
                 for (i = CurrentSpanIndex; i < CurrentSpan.Length && values.IndexOf(CurrentSpan[i]) != -1; i++)
                 {
@@ -545,7 +545,7 @@ namespace System.Buffers.Reader
                 int advanced = i - CurrentSpanIndex;
                 if (advanced == 0)
                 {
-                    // Didn't skip at all in this span, exit.
+                    // Didn't advance at all in this span, exit.
                     break;
                 }
 
@@ -559,16 +559,16 @@ namespace System.Buffers.Reader
         }
 
         /// <summary>
-        /// Skip consecutive instances of any of the given values.
+        /// Advance past consecutive instances of any of the given values.
         /// </summary>
-        /// <returns>Count of skipped <typeparamref name="T"/> values.</returns>
-        public long SkipPastAny(T value0, T value1, T value2, T value3)
+        /// <returns>How many positions the reader has been advanced.</returns>
+        public long AdvancePastAny(T value0, T value1, T value2, T value3)
         {
             long start = Consumed;
 
             do
             {
-                // Skip all matches in the current span
+                // Advance past all matches in the current span
                 int i;
                 for (i = CurrentSpanIndex; i < CurrentSpan.Length; i++)
                 {
@@ -582,7 +582,7 @@ namespace System.Buffers.Reader
                 int advanced = i - CurrentSpanIndex;
                 if (advanced == 0)
                 {
-                    // Didn't skip at all in this span, exit.
+                    // Didn't advance at all in this span, exit.
                     break;
                 }
 
@@ -596,16 +596,16 @@ namespace System.Buffers.Reader
         }
 
         /// <summary>
-        /// Skip consecutive instances of any of the given values.
+        /// Advance past consecutive instances of any of the given values.
         /// </summary>
-        /// <returns>Count of skipped <typeparamref name="T"/> values.</returns>
-        public long SkipPastAny(T value0, T value1, T value2)
+        /// <returns>How many positions the reader has been advanced.</returns>
+        public long AdvancePastAny(T value0, T value1, T value2)
         {
             long start = Consumed;
 
             do
             {
-                // Skip all matches in the current span
+                // Advance past all matches in the current span
                 int i;
                 for (i = CurrentSpanIndex; i < CurrentSpan.Length; i++)
                 {
@@ -619,7 +619,7 @@ namespace System.Buffers.Reader
                 int advanced = i - CurrentSpanIndex;
                 if (advanced == 0)
                 {
-                    // Didn't skip at all in this span, exit.
+                    // Didn't advance at all in this span, exit.
                     break;
                 }
 
@@ -633,16 +633,16 @@ namespace System.Buffers.Reader
         }
 
         /// <summary>
-        /// Skip consecutive instances of any of the given values.
+        /// Advance past consecutive instances of any of the given values.
         /// </summary>
-        /// <returns>Count of skipped <typeparamref name="T"/> values.</returns>
-        public long SkipPastAny(T value0, T value1)
+        /// <returns>How many positions the reader has been advanced.</returns>
+        public long AdvancePastAny(T value0, T value1)
         {
             long start = Consumed;
 
             do
             {
-                // Skip all matches in the current span
+                // Advance past all matches in the current span
                 int i;
                 for (i = CurrentSpanIndex; i < CurrentSpan.Length; i++)
                 {
@@ -656,7 +656,7 @@ namespace System.Buffers.Reader
                 int advanced = i - CurrentSpanIndex;
                 if (advanced == 0)
                 {
-                    // Didn't skip at all in this span, exit.
+                    // Didn't advance at all in this span, exit.
                     break;
                 }
 

--- a/tests/Benchmarks/System.Buffers/Reader_Search.cs
+++ b/tests/Benchmarks/System.Buffers/Reader_Search.cs
@@ -77,6 +77,16 @@ namespace System.Buffers.Benchmarks
         }
 
         [Benchmark]
+        public void Reader_Position()
+        {
+            BufferReader<byte> reader = new BufferReader<byte>(s_rosSplit);
+            for (int i = 0; i < 10_000; i++)
+            {
+                SequencePosition position = reader.Position;
+            }
+        }
+
+        [Benchmark]
         public void TryReadUntil_Span()
         {
             BufferReader<byte> reader = new BufferReader<byte>(s_rosSplit);
@@ -146,19 +156,19 @@ namespace System.Buffers.Benchmarks
         }
 
         [Benchmark]
-        public void TrySkipTo()
+        public void TryAdvanceTo()
         {
             BufferReader<byte> reader = new BufferReader<byte>(s_rosSplit);
-            while (reader.TrySkipTo(42))
+            while (reader.TryAdvanceTo(42))
             {
             }
         }
 
         [Benchmark]
-        public void TrySkipTo_SingleSegment()
+        public void TryAdvanceTo_SingleSegment()
         {
             BufferReader<byte> reader = new BufferReader<byte>(s_ros);
-            while (reader.TrySkipTo(42))
+            while (reader.TryAdvanceTo(42))
             {
             }
         }
@@ -169,9 +179,9 @@ namespace System.Buffers.Benchmarks
             BufferReader<byte> reader = new BufferReader<byte>(s_rosSplit);
             byte* b = stackalloc byte[] { 0x00, 0xFF };
             Span<byte> span = new Span<byte>(b, 2);
-            while (reader.TrySkipToAny(span, advancePastDelimiter: false))
+            while (reader.TryAdvanceToAny(span, advancePastDelimiter: false))
             {
-                reader.SkipPastAny(span);
+                reader.AdvancePastAny(span);
             }
         }
 
@@ -180,7 +190,7 @@ namespace System.Buffers.Benchmarks
         {
             BufferReader<byte> reader = new BufferReader<byte>(s_rosBlobsSplit);
             byte value = 0x00;
-            while (reader.SkipPast(value) != 0)
+            while (reader.AdvancePast(value) != 0)
             {
                 value++;
             }
@@ -191,7 +201,7 @@ namespace System.Buffers.Benchmarks
         {
             BufferReader<byte> reader = new BufferReader<byte>(s_rosBlobs);
             byte value = 0x00;
-            while (reader.SkipPast(value) != 0)
+            while (reader.AdvancePast(value) != 0)
             {
                 value++;
             }

--- a/tests/System.Buffers.ReaderWriter.Tests/ReaderBasicTests.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/ReaderBasicTests.cs
@@ -90,9 +90,9 @@ namespace System.Buffers.Tests
             Assert.Equal(0, reader.UnreadSpan.Length);
             Assert.Equal(0, reader.Consumed);
             Assert.Equal(0, reader.CurrentSpanIndex);
-            Assert.Equal(0, reader.SkipPast(default));
-            Assert.Equal(0, reader.SkipPastAny(array));
-            Assert.Equal(0, reader.SkipPastAny(default));
+            Assert.Equal(0, reader.AdvancePast(default));
+            Assert.Equal(0, reader.AdvancePastAny(array));
+            Assert.Equal(0, reader.AdvancePastAny(default));
             Assert.False(reader.TryReadTo(out ReadOnlySequence<T> sequence, default(T)));
             Assert.True(sequence.IsEmpty);
             Assert.False(reader.TryReadTo(out sequence, array));
@@ -103,8 +103,8 @@ namespace System.Buffers.Tests
             Assert.True(sequence.IsEmpty);
             Assert.False(reader.TryReadToAny(out span, array));
             Assert.True(span.IsEmpty);
-            Assert.False(reader.TrySkipTo(default));
-            Assert.False(reader.TrySkipToAny(array));
+            Assert.False(reader.TryAdvanceTo(default));
+            Assert.False(reader.TryAdvanceToAny(array));
         }
     }
 
@@ -393,6 +393,70 @@ namespace System.Buffers.Tests
                 reader.Advance(span.Length);
             }
             Assert.Equal(buffer.Length, reader.Consumed);
+        }
+
+        [Theory,
+            InlineData(1),
+            InlineData(2),
+            InlineData(3)]
+        public void Advance_PositionIsCorrect(int advanceBy)
+        {
+            // Check that advancing through the reader gives the same position
+            // as returned directly from the buffer.
+
+            ReadOnlySequence<T> buffer = Factory.CreateWithContent(GetInputData(10));
+            BufferReader<T> reader = new BufferReader<T>(buffer);
+
+            SequencePosition readerPosition = reader.Position;
+            SequencePosition bufferPosition = buffer.GetPosition(0);
+            Assert.Equal(readerPosition.GetInteger(), bufferPosition.GetInteger());
+            Assert.Same(readerPosition.GetObject(), readerPosition.GetObject());
+
+            for (int i = advanceBy; i <= buffer.Length; i += advanceBy)
+            {
+                reader.Advance(advanceBy);
+                readerPosition = reader.Position;
+                bufferPosition = buffer.GetPosition(i);
+                Assert.Equal(readerPosition.GetInteger(), bufferPosition.GetInteger());
+                Assert.Same(readerPosition.GetObject(), readerPosition.GetObject());
+            }
+        }
+
+        [Fact]
+        public void AdvanceTo()
+        {
+            // Ensure we can advance to each of the items in the buffer
+
+            T[] inputData = GetInputData(10);
+            ReadOnlySequence<T> buffer = Factory.CreateWithContent(inputData);
+
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                BufferReader<T> reader = new BufferReader<T>(buffer);
+                Assert.True(reader.TryAdvanceTo(inputData[i], advancePastDelimiter: false));
+                Assert.True(reader.TryPeek(out T value));
+                Assert.Equal(inputData[i], value);
+            }
+        }
+
+        [Fact]
+        public void AdvanceTo_AdvancePast()
+        {
+            // Ensure we can advance to each of the items in the buffer (skipping what we advanced to)
+
+            T[] inputData = GetInputData(10);
+            ReadOnlySequence<T> buffer = Factory.CreateWithContent(inputData);
+
+            for (int start = 0; start < 2; start++)
+            {
+                for (int i = start; i < buffer.Length - 1; i += 2)
+                {
+                    BufferReader<T> reader = new BufferReader<T>(buffer);
+                    Assert.True(reader.TryAdvanceTo(inputData[i], advancePastDelimiter: true));
+                    Assert.True(reader.TryPeek(out T value));
+                    Assert.Equal(inputData[i + 1], value);
+                }
+            }
         }
 
         [Fact]

--- a/tests/System.Buffers.ReaderWriter.Tests/ReaderBytesTests.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/ReaderBytesTests.cs
@@ -37,21 +37,21 @@ namespace System.Buffers.Tests
                 : BufferUtilities.CreateSplitBuffer(buffer, 2, 4);
 
             var skipReader = new BufferReader<byte>(bytes);
-            Assert.False(skipReader.TrySkipTo(10));
-            Assert.True(skipReader.TrySkipTo(4, advancePastDelimiter: false));
+            Assert.False(skipReader.TryAdvanceTo(10));
+            Assert.True(skipReader.TryAdvanceTo(4, advancePastDelimiter: false));
             Assert.True(skipReader.TryRead(out byte value));
             Assert.Equal(4, value);
 
-            Assert.True(skipReader.TrySkipToAny(new byte[] { 3, 12, 7 }, advancePastDelimiter: false));
+            Assert.True(skipReader.TryAdvanceToAny(new byte[] { 3, 12, 7 }, advancePastDelimiter: false));
             Assert.True(skipReader.TryRead(out value));
             Assert.Equal(7, value);
-            Assert.Equal(1, skipReader.SkipPast(8));
+            Assert.Equal(1, skipReader.AdvancePast(8));
             Assert.True(skipReader.TryRead(out value));
             Assert.Equal(9, value);
 
             skipReader = new BufferReader<byte>(bytes);
-            Assert.Equal(0, skipReader.SkipPast(2));
-            Assert.Equal(3, skipReader.SkipPastAny(new byte[] { 2, 3, 1 }));
+            Assert.Equal(0, skipReader.AdvancePast(2));
+            Assert.Equal(3, skipReader.AdvancePastAny(new byte[] { 2, 3, 1 }));
             Assert.True(skipReader.TryRead(out value));
             Assert.Equal(4, value);
         }


### PR DESCRIPTION
Fix moving past empty sequences.
Fix span advance to advancePastDelimiter handling.
Add IsLastSegment.
Add 4x faster Position property.
Add a variety of tests.