### PR TITLE
Remove consumed from parse methods (per API review feedback)

### DIFF
--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
@@ -254,23 +254,6 @@ namespace System.Buffers.Reader
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void AdvanceCurrentSpan(long count)
-        {
-            Debug.Assert(count <= CurrentSpan.Length - count);
-
-            Consumed += count;
-            if (CurrentSpanIndex < CurrentSpan.Length - count)
-            {
-                CurrentSpanIndex += (int)count;
-            }
-            else
-            {
-                // Ate the whole span, grab another
-                GetNextSpan();
-            }
-        }
-
         private void AdvanceToNextSpan(long count)
         {
             while (_moreData)

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
@@ -204,26 +204,29 @@ namespace System.Buffers.Reader
         /// <summary>
         /// Get the next segment with available space, if any.
         /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
         private void GetNextSpan()
         {
-            CurrentSpanIndex = 0;
-            CurrentSpan = default;
-
-            SequencePosition previousNextPosition = _nextPosition;
-            while (_nextPosition.GetObject() != null && Sequence.TryGet(ref _nextPosition, out ReadOnlyMemory<T> memory, advance: true))
+            if (!Sequence.IsSingleSegment)
             {
-                _currentPosition = previousNextPosition;
-                if (memory.Length > 0)
+                SequencePosition previousNextPosition = _nextPosition;
+                while (Sequence.TryGet(ref _nextPosition, out ReadOnlyMemory<T> memory, advance: true))
                 {
-                    CurrentSpan = memory.Span;
-                    return;
-                }
-                else
-                {
-                    previousNextPosition = _nextPosition;
+                    _currentPosition = previousNextPosition;
+                    if (memory.Length > 0)
+                    {
+                        CurrentSpan = memory.Span;
+                        CurrentSpanIndex = 0;
+                        return;
+                    }
+                    else
+                    {
+                        CurrentSpan = default;
+                        CurrentSpanIndex = 0;
+                        previousNextPosition = _nextPosition;
+                    }
                 }
             }
-
             _moreData = false;
         }
 

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_binary.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_binary.cs
@@ -22,12 +22,14 @@ namespace System.Buffers.Reader
         public static unsafe bool TryRead<T>(ref this BufferReader<byte> reader, out T value) where T : unmanaged
         {
             ReadOnlySpan<byte> span = reader.UnreadSpan;
-            if (span.Length < sizeof(T))
-                return TryReadSlow(ref reader, out value);
+            if (span.Length >= sizeof(T))
+            {
+                value = MemoryMarshal.Read<T>(span);
+                reader.AdvanceCurrentSpan(sizeof(T));
+                return true;
+            }
 
-            value = MemoryMarshal.Read<T>(span);
-            reader.Advance(sizeof(T));
-            return true;
+            return TryReadSlow(ref reader, out value);
         }
 
         private static unsafe bool TryReadSlow<T>(ref BufferReader<byte> reader, out T value) where T : unmanaged
@@ -64,7 +66,7 @@ namespace System.Buffers.Reader
         }
 
         /// <summary>
-        /// Reads an <see cref="Int16"/> as big  endian.
+        /// Reads an <see cref="Int16"/> as big endian.
         /// </summary>
         /// <returns>False if there wasn't enough data for an <see cref="Int16"/>.</returns>
         public static bool TryReadInt16BigEndian(ref this BufferReader<byte> reader, out short value)
@@ -103,7 +105,7 @@ namespace System.Buffers.Reader
         }
 
         /// <summary>
-        /// Reads an <see cref="Int32"/> as big  endian.
+        /// Reads an <see cref="Int32"/> as big endian.
         /// </summary>
         /// <returns>False if there wasn't enough data for an <see cref="Int32"/>.</returns>
         public static bool TryReadInt32BigEndian(ref this BufferReader<byte> reader, out int value)
@@ -142,7 +144,7 @@ namespace System.Buffers.Reader
         }
 
         /// <summary>
-        /// Reads an <see cref="Int64"/> as big  endian.
+        /// Reads an <see cref="Int64"/> as big endian.
         /// </summary>
         /// <returns>False if there wasn't enough data for an <see cref="Int64"/>.</returns>
         public static bool TryReadInt64BigEndian(ref this BufferReader<byte> reader, out long value)

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_binary.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_binary.cs
@@ -25,7 +25,7 @@ namespace System.Buffers.Reader
             if (span.Length >= sizeof(T))
             {
                 value = MemoryMarshal.Read<T>(span);
-                reader.AdvanceCurrentSpan(sizeof(T));
+                reader.Advance(sizeof(T));
                 return true;
             }
 

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
@@ -20,19 +20,20 @@ namespace System.Buffers.Reader
         {
             ReadOnlySpan<T> remaining = UnreadSpan;
             int index = remaining.IndexOf(delimiter);
+
             if (index != -1)
             {
                 span = index == 0 ? default : remaining.Slice(0, index);
-                Advance(index + (advancePastDelimiter ? 1 : 0));
+                AdvanceCurrentSpan(index + (advancePastDelimiter ? 1 : 0));
                 return true;
             }
 
-            return TryReadToSlow(out span, delimiter, remaining.Length, advancePastDelimiter);
+            return TryReadToSlow(out span, delimiter, advancePastDelimiter);
         }
 
-        private bool TryReadToSlow(out ReadOnlySpan<T> span, T delimiter, int skip, bool advancePastDelimiter)
+        private bool TryReadToSlow(out ReadOnlySpan<T> span, T delimiter, bool advancePastDelimiter)
         {
-            if (!TryReadToInternal(out ReadOnlySequence<T> sequence, delimiter, advancePastDelimiter, skip))
+            if (!TryReadToInternal(out ReadOnlySequence<T> sequence, delimiter, advancePastDelimiter, CurrentSpan.Length - CurrentSpanIndex))
             {
                 span = default;
                 return false;
@@ -59,7 +60,7 @@ namespace System.Buffers.Reader
             if ((index > 0 && !remaining[index - 1].Equals(delimiterEscape)) || index == 0)
             {
                 span = remaining.Slice(0, index);
-                Advance(index + (advancePastDelimiter ? 1 : 0));
+                AdvanceCurrentSpan(index + (advancePastDelimiter ? 1 : 0));
                 return true;
             }
 
@@ -327,7 +328,7 @@ namespace System.Buffers.Reader
             if (index != -1)
             {
                 span = remaining.Slice(0, index);
-                Advance(index + (advancePastDelimiter ? 1 : 0));
+                AdvanceCurrentSpan(index + (advancePastDelimiter ? 1 : 0));
                 return true;
             }
 

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
@@ -24,7 +24,7 @@ namespace System.Buffers.Reader
             if (index != -1)
             {
                 span = index == 0 ? default : remaining.Slice(0, index);
-                AdvanceCurrentSpan(index + (advancePastDelimiter ? 1 : 0));
+                Advance(index + (advancePastDelimiter ? 1 : 0));
                 return true;
             }
 
@@ -60,7 +60,7 @@ namespace System.Buffers.Reader
             if ((index > 0 && !remaining[index - 1].Equals(delimiterEscape)) || index == 0)
             {
                 span = remaining.Slice(0, index);
-                AdvanceCurrentSpan(index + (advancePastDelimiter ? 1 : 0));
+                Advance(index + (advancePastDelimiter ? 1 : 0));
                 return true;
             }
 
@@ -328,7 +328,7 @@ namespace System.Buffers.Reader
             if (index != -1)
             {
                 span = remaining.Slice(0, index);
-                AdvanceCurrentSpan(index + (advancePastDelimiter ? 1 : 0));
+                Advance(index + (advancePastDelimiter ? 1 : 0));
                 return true;
             }
 

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_text.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_text.cs
@@ -40,7 +40,7 @@ namespace System.Buffers.Reader
             // doesn't care what follows "True" or "False" and neither should we.
             if (Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat))
             {
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
             else if (unread.Length >= MaxBoolLength)
@@ -155,7 +155,7 @@ namespace System.Buffers.Reader
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
 
@@ -203,7 +203,7 @@ namespace System.Buffers.Reader
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
 
@@ -251,7 +251,7 @@ namespace System.Buffers.Reader
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
 
@@ -293,7 +293,7 @@ namespace System.Buffers.Reader
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
 
@@ -341,7 +341,7 @@ namespace System.Buffers.Reader
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
 
@@ -383,7 +383,7 @@ namespace System.Buffers.Reader
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
 
@@ -431,7 +431,7 @@ namespace System.Buffers.Reader
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
 
@@ -473,7 +473,7 @@ namespace System.Buffers.Reader
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
 
@@ -527,7 +527,7 @@ namespace System.Buffers.Reader
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
 
@@ -582,7 +582,7 @@ namespace System.Buffers.Reader
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
 
@@ -637,7 +637,7 @@ namespace System.Buffers.Reader
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
 
@@ -668,7 +668,7 @@ namespace System.Buffers.Reader
 
             if (Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat))
             {
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
             else if (unread.Length >= MaxGuidLength)
@@ -726,7 +726,7 @@ namespace System.Buffers.Reader
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
 
@@ -757,7 +757,7 @@ namespace System.Buffers.Reader
 
             if (Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat))
             {
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
             else if (unread.Length >= MaxDateTimeLength)
@@ -793,7 +793,7 @@ namespace System.Buffers.Reader
 
             if (Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat))
             {
-                reader.AdvanceCurrentSpan(bytesConsumed);
+                reader.Advance(bytesConsumed);
                 return true;
             }
             else if (unread.Length >= MaxDateTimeLength)

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_text.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_text.cs
@@ -19,223 +19,28 @@ namespace System.Buffers.Reader
         private const int MaxDateTimeLength = 34;  // 9999-12-31T15:59:59.9999999-08:00
 
         private delegate bool ParseDelegate<T>(ReadOnlySpan<byte> source, out T value, out int consumed, char standardFormat);
-        private static ParseDelegate<bool> s_boolParse;
-        private static ParseDelegate<byte> s_byteParse;
-        private static ParseDelegate<sbyte> s_sbyteParse;
-        private static ParseDelegate<short> s_shortParse;
-        private static ParseDelegate<ushort> s_ushortParse;
-        private static ParseDelegate<int> s_intParse;
-        private static ParseDelegate<uint> s_uintParse;
-        private static ParseDelegate<long> s_longParse;
-        private static ParseDelegate<ulong> s_ulongParse;
-        private static ParseDelegate<float> s_floatParse;
-        private static ParseDelegate<double> s_doubleParse;
-        private static ParseDelegate<decimal> s_decimalParse;
-        private static ParseDelegate<Guid> s_guidParse;
-        private static ParseDelegate<TimeSpan> s_timeSpanParse;
-        private static ParseDelegate<DateTime> s_dateTimeParse;
-        private static ParseDelegate<DateTimeOffset> s_dateTimeOffsetParse;
-
-        // Note: We mark the getters as NoInlining as we want to make sure the delegate creation is lazy.
-
-        private static ParseDelegate<bool> BoolParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_boolParse == null)
-                    s_boolParse = Utf8Parser.TryParse;
-                return s_boolParse;
-            }
-        }
-
-        private static ParseDelegate<Guid> GuidParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_guidParse == null)
-                    s_guidParse = Utf8Parser.TryParse;
-                return s_guidParse;
-            }
-        }
-
-        private static ParseDelegate<TimeSpan> TimeSpanParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_timeSpanParse == null)
-                    s_timeSpanParse = Utf8Parser.TryParse;
-                return s_timeSpanParse;
-            }
-        }
-
-        private static ParseDelegate<DateTime> DateTimeParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_dateTimeParse == null)
-                    s_dateTimeParse = Utf8Parser.TryParse;
-                return s_dateTimeParse;
-            }
-        }
-
-        private static ParseDelegate<DateTimeOffset> DateTimeOffsetParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_dateTimeOffsetParse == null)
-                    s_dateTimeOffsetParse = Utf8Parser.TryParse;
-                return s_dateTimeOffsetParse;
-            }
-        }
-
-        private static ParseDelegate<byte> ByteParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_byteParse == null)
-                    s_byteParse = Utf8Parser.TryParse;
-                return s_byteParse;
-            }
-        }
-
-        private static ParseDelegate<sbyte> SByteParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_sbyteParse == null)
-                    s_sbyteParse = Utf8Parser.TryParse;
-                return s_sbyteParse;
-            }
-        }
-
-        private static ParseDelegate<short> ShortParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_shortParse == null)
-                    s_shortParse = Utf8Parser.TryParse;
-                return s_shortParse;
-            }
-        }
-
-        private static ParseDelegate<ushort> UShortParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_ushortParse == null)
-                    s_ushortParse = Utf8Parser.TryParse;
-                return s_ushortParse;
-            }
-        }
-
-        private static ParseDelegate<int> IntParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_intParse == null)
-                    s_intParse = Utf8Parser.TryParse;
-                return s_intParse;
-            }
-        }
-
-        private static ParseDelegate<uint> UIntParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_uintParse == null)
-                    s_uintParse = Utf8Parser.TryParse;
-                return s_uintParse;
-            }
-        }
-
-        private static ParseDelegate<long> LongParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_longParse == null)
-                    s_longParse = Utf8Parser.TryParse;
-                return s_longParse;
-            }
-        }
-
-        private static ParseDelegate<ulong> ULongParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_ulongParse == null)
-                    s_ulongParse = Utf8Parser.TryParse;
-                return s_ulongParse;
-            }
-        }
-
-        private static ParseDelegate<float> FloatParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_floatParse == null)
-                    s_floatParse = Utf8Parser.TryParse;
-                return s_floatParse;
-            }
-        }
-
-        private static ParseDelegate<double> DoubleParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_doubleParse == null)
-                    s_doubleParse = Utf8Parser.TryParse;
-                return s_doubleParse;
-            }
-        }
-
-        private static ParseDelegate<decimal> DecimalParser
-        {
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            get
-            {
-                if (s_decimalParse == null)
-                    s_decimalParse = Utf8Parser.TryParse;
-                return s_decimalParse;
-            }
-        }
-
+ 
         /// <summary>
         /// Try to parse a bool out of the reader (as UTF-8).
         /// </summary>
         /// <param name="value">The parsed bool value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out bool, out int, char)"/> for supported formats.
         /// </remarks>
         /// <exception cref="FormatException">Thrown if the given format isn't supported.</exception>
         /// <returns>True if successfully parsed.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryParse(ref this BufferReader<byte> reader, out bool value, out int bytesConsumed, char standardFormat = '\0')
+        public static bool TryParse(ref this BufferReader<byte> reader, out bool value, char standardFormat = '\0')
         {
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
             // For other types (int, etc) we won't know if we've consumed all of the type
             // ("235612" can be split over segments, for example). For bool, Utf8Parser
             // doesn't care what follows "True" or "False" and neither should we.
-            if (Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat))
+            if (Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat))
             {
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
             else if (unread.Length >= MaxBoolLength)
@@ -245,17 +50,20 @@ namespace System.Buffers.Reader
                 return false;
             }
 
-            return TryParseFixed(ref reader, out value, out bytesConsumed, standardFormat, MaxBoolLength, BoolParser);
+            bool TryParseBool(ref BufferReader<byte> r, out bool v, char f)
+            {
+                return TryParseFixed(ref r, out v, f, MaxBoolLength, Utf8Parser.TryParse);
+            }
+
+            return TryParseBool(ref reader, out value, standardFormat);
         }
 
         /// <summary>
         /// Parse the specified buffer size.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private unsafe static bool TryParseFixed<T>(
             ref BufferReader<byte> reader,
             out T value,
-            out int bytesConsumed,
             char standardFormat,
             int bufferSize,
             ParseDelegate<T> parseDelegate) where T : unmanaged
@@ -264,7 +72,7 @@ namespace System.Buffers.Reader
 
             byte* buffer = stackalloc byte[bufferSize];
             Span<byte> tempSpan = new Span<byte>(buffer, bufferSize);
-            if (parseDelegate(reader.PeekSlow(tempSpan), out value, out bytesConsumed, standardFormat))
+            if (parseDelegate(reader.PeekSlow(tempSpan), out value, out int bytesConsumed, standardFormat))
             {
                 reader.Advance(bytesConsumed);
                 return true;
@@ -276,11 +84,9 @@ namespace System.Buffers.Reader
         /// <summary>
         /// Try parsing until we've grabbed all available valid bytes or hit <see cref="MaxParseBytes"/>.
         /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private static unsafe bool TryParseGreedy<T>(
             ref BufferReader<byte> reader,
             out T value,
-            out int bytesConsumed,
             char standardFormat,
             int bufferSize,
             ParseDelegate<T> parseDelegate) where T: unmanaged
@@ -298,11 +104,10 @@ namespace System.Buffers.Reader
             {
                 ReadOnlySpan<byte> peekSpan = reader.Peek(stackBuffer.Slice(0, bufferSize));
 
-                if (!parseDelegate(peekSpan, out value, out bytesConsumed, standardFormat)
+                if (!parseDelegate(peekSpan, out value, out int bytesConsumed, standardFormat)
                     || bytesConsumed == MaxParseBytes)
                 {
                     // Output value overflow or we consumed more bytes than we're willing to
-                    bytesConsumed = 0;
                     return false;
                 }
 
@@ -316,7 +121,6 @@ namespace System.Buffers.Reader
 
                 if (bufferSize == MaxParseBytes)
                 {
-                    bytesConsumed = 0;
                     return false;
                 }
 
@@ -329,7 +133,6 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="byte"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out byte, out int, char)"/> for supported formats.
         /// </remarks>
@@ -339,28 +142,32 @@ namespace System.Buffers.Reader
         public static bool TryParse(
             ref this BufferReader<byte> reader,
             out byte value,
-            out int bytesConsumed,
             char standardFormat = '\0')
         {
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (!Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat)
+            if (!Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat)
                 || bytesConsumed >= MaxParseBytes)
             {
                 // Failed to parse or we consumed more than we're willing to accept
-                bytesConsumed = 0;
                 return false;
             }
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
 
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseByte(ref BufferReader<byte> r, out byte v, char f)
+            {
+                // The typical max size for a short will be less than 4 bytes ("255").
+                return TryParseGreedy(ref r, out v, f, 4, Utf8Parser.TryParse);
+            }
+
             // If we ate all of our unread there may be more valid digits.
-            // The typical max size for a short will be less than 4 bytes ("255").
-            return TryParseGreedy(ref reader, out value, out bytesConsumed, standardFormat, 4, ByteParser);
+            return TryParseByte(ref reader, out value, standardFormat);
         }
 
         /// <summary>
@@ -368,7 +175,6 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="sbyte"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out sbyte, out int, char)"/> for supported formats.
         /// </remarks>
@@ -378,12 +184,11 @@ namespace System.Buffers.Reader
         public static bool TryParse(
             ref this BufferReader<byte> reader,
             out sbyte value,
-            out int bytesConsumed,
             char standardFormat = '\0')
         {
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (!Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat)
+            if (!Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat)
                 || bytesConsumed >= MaxParseBytes)
             {
                 // Failed to parse or we consumed more than we're willing to accept
@@ -392,20 +197,25 @@ namespace System.Buffers.Reader
                 // These are all valid starts to an integer, but not by themselves.
                 if (unread.Length != 1)
                 {
-                    bytesConsumed = 0;
                     return false;
                 }
             }
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
 
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseSByte(ref BufferReader<byte> r, out sbyte v, char f)
+            {
+                // The typical max size for a short will be less than 5 bytes ("-128").
+                return TryParseGreedy(ref r, out v, f, 5, Utf8Parser.TryParse);
+            }
+
             // If we ate all of our unread there may be more valid digits.
-            // The typical max size for a short will be less than 5 bytes ("-128").
-            return TryParseGreedy(ref reader, out value, out bytesConsumed, standardFormat, 5, SByteParser);
+            return TryParseSByte(ref reader, out value, standardFormat);
         }
 
         /// <summary>
@@ -413,7 +223,6 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="short"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out short, out int, char)"/> for supported formats.
         /// </remarks>
@@ -423,12 +232,11 @@ namespace System.Buffers.Reader
         public static bool TryParse(
             ref this BufferReader<byte> reader,
             out short value,
-            out int bytesConsumed,
             char standardFormat = '\0')
         {
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (!Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat)
+            if (!Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat)
                 || bytesConsumed >= MaxParseBytes)
             {
                 // Failed to parse or we consumed more than we're willing to accept
@@ -437,20 +245,25 @@ namespace System.Buffers.Reader
                 // These are all valid starts to an integer, but not by themselves.
                 if (unread.Length != 1)
                 {
-                    bytesConsumed = 0;
                     return false;
                 }
             }
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
 
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseShort(ref BufferReader<byte> r, out short v, char f)
+            {
+                // The typical max size for a short will be less than 8 bytes ("-32,768").
+                return TryParseGreedy(ref r, out v, f, 8, Utf8Parser.TryParse);
+            }
+
             // If we ate all of our unread there may be more valid digits.
-            // The typical max size for a short will be less than 8 bytes ("-32,768").
-            return TryParseGreedy(ref reader, out value, out bytesConsumed, standardFormat, 8, ShortParser);
+            return TryParseShort(ref reader, out value, standardFormat);
         }
 
         /// <summary>
@@ -458,7 +271,6 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="ushort"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out ushort, out int, char)"/> for supported formats.
         /// </remarks>
@@ -468,28 +280,32 @@ namespace System.Buffers.Reader
         public static bool TryParse(
             ref this BufferReader<byte> reader,
             out ushort value,
-            out int bytesConsumed,
             char standardFormat = '\0')
         {
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (!Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat)
+            if (!Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat)
                 || bytesConsumed >= MaxParseBytes)
             {
                 // Failed to parse or we consumed more than we're willing to accept
-                bytesConsumed = 0;
                 return false;
             }
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
 
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseUShort(ref BufferReader<byte> r, out ushort v, char f)
+            {
+                // The typical max size for a short will be less than 7 bytes ("65,535").
+                return TryParseGreedy(ref r, out v, f, 7, Utf8Parser.TryParse);
+            }
+
             // If we ate all of our unread there may be more valid digits.
-            // The typical max size for a short will be less than 7 bytes ("65,535").
-            return TryParseGreedy(ref reader, out value, out bytesConsumed, standardFormat, 7, UShortParser);
+            return TryParseUShort(ref reader, out value, standardFormat);
         }
 
         /// <summary>
@@ -497,7 +313,6 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="int"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out int, out int, char)"/> for supported formats.
         /// </remarks>
@@ -507,12 +322,11 @@ namespace System.Buffers.Reader
         public static bool TryParse(
             ref this BufferReader<byte> reader,
             out int value,
-            out int bytesConsumed,
             char standardFormat = '\0')
         {
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (!Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat)
+            if (!Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat)
                 || bytesConsumed >= MaxParseBytes)
             {
                 // Failed to parse or we consumed more than we're willing to accept
@@ -521,20 +335,25 @@ namespace System.Buffers.Reader
                 // These are all valid starts to an integer, but not by themselves.
                 if (unread.Length != 1)
                 {
-                    bytesConsumed = 0;
                     return false;
                 }
             }
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
 
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseInt(ref BufferReader<byte> r, out int v, char f)
+            {
+                // The typical max size for an int will be less than 15 bytes ("-2,147,483,648").
+                return TryParseGreedy(ref r, out v, f, 15, Utf8Parser.TryParse);
+            }
+
             // If we ate all of our unread there may be more valid digits
-            // The typical max size for an int will be less than 15 bytes ("-2,147,483,648").
-            return TryParseGreedy(ref reader, out value, out bytesConsumed, standardFormat, 15, IntParser);
+            return TryParseInt(ref reader, out value, standardFormat);
         }
 
         /// <summary>
@@ -542,7 +361,6 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="uint"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out int, out int, char)"/> for supported formats.
         /// </remarks>
@@ -552,28 +370,32 @@ namespace System.Buffers.Reader
         public static bool TryParse(
             ref this BufferReader<byte> reader,
             out uint value,
-            out int bytesConsumed,
             char standardFormat = '\0')
         {
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (!Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat)
+            if (!Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat)
                 || bytesConsumed >= MaxParseBytes)
             {
                 // Failed to parse or we consumed more than we're willing to accept
-                bytesConsumed = 0;
                 return false;
             }
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
 
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseUInt(ref BufferReader<byte> r, out uint v, char f)
+            {
+                // The typical max size for an int will be less than 14 bytes ("4,294,967,295").
+                return TryParseGreedy(ref r, out v, f, 14, Utf8Parser.TryParse);
+            }
+
             // If we ate all of our unread there may be more valid digits
-            // The typical max size for an int will be less than 14 bytes ("4,294,967,295").
-            return TryParseGreedy(ref reader, out value, out bytesConsumed, standardFormat, 14, UIntParser);
+            return TryParseUInt(ref reader, out value, standardFormat);
         }
 
         /// <summary>
@@ -581,7 +403,6 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="long"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out long, out int, char)"/> for supported formats.
         /// </remarks>
@@ -591,12 +412,11 @@ namespace System.Buffers.Reader
         public static bool TryParse(
             ref this BufferReader<byte> reader,
             out long value,
-            out int bytesConsumed,
             char standardFormat = '\0')
         {
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (!Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat)
+            if (!Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat)
                 || bytesConsumed >= MaxParseBytes)
             {
                 // Failed to parse or we consumed more than we're willing to accept
@@ -605,20 +425,25 @@ namespace System.Buffers.Reader
                 // These are all valid starts to an integer, but not by themselves.
                 if (unread.Length != 1)
                 {
-                    bytesConsumed = 0;
                     return false;
                 }
             }
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
 
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseLong(ref BufferReader<byte> r, out long v, char f)
+            {
+                // The typical max size for a long will be less than 27 bytes ("-9,223,372,036,854,775,808").
+                return TryParseGreedy(ref r, out v, f, 27, Utf8Parser.TryParse);
+            }
+
             // If we ate all of our unread there may be more valid digits.
-            // The typical max size for a long will be less than 27 bytes ("-9,223,372,036,854,775,808").
-            return TryParseGreedy(ref reader, out value, out bytesConsumed, standardFormat, 27, LongParser);
+            return TryParseLong(ref reader, out value, standardFormat);
         }
 
         /// <summary>
@@ -626,7 +451,6 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="ulong"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out ulong, out int, char)"/> for supported formats.
         /// </remarks>
@@ -636,28 +460,32 @@ namespace System.Buffers.Reader
         public static bool TryParse(
             ref this BufferReader<byte> reader,
             out ulong value,
-            out int bytesConsumed,
             char standardFormat = '\0')
         {
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (!Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat)
+            if (!Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat)
                 || bytesConsumed >= MaxParseBytes)
             {
                 // Failed to parse or we consumed more than we're willing to accept
-                bytesConsumed = 0;
                 return false;
             }
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
 
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseULong(ref BufferReader<byte> r, out ulong v, char f)
+            {
+                // The typical max size for a long will be less than 27 bytes ("18,446,744,073,709,551,615").
+                return TryParseGreedy(ref r, out v, f, 27, Utf8Parser.TryParse);
+            }
+
             // If we ate all of our unread there may be more valid digits.
-            // The typical max size for a long will be less than 27 bytes ("18,446,744,073,709,551,615").
-            return TryParseGreedy(ref reader, out value, out bytesConsumed, standardFormat, 27, ULongParser);
+            return TryParseULong(ref reader, out value, standardFormat);
         }
 
         /// <summary>
@@ -665,7 +493,6 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="float"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out float, out int, char)"/> for supported formats.
         /// </remarks>
@@ -675,7 +502,6 @@ namespace System.Buffers.Reader
         public static bool TryParse(
             ref this BufferReader<byte> reader,
             out float value,
-            out int bytesConsumed,
             char standardFormat = '\0')
         {
             // We have to have MaxParseBytes available when failing to parse float (or
@@ -688,28 +514,33 @@ namespace System.Buffers.Reader
 
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (!Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat)
+            if (!Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat)
                 || bytesConsumed >= MaxParseBytes)
             {
                 if (unread.Length >= MaxParseBytes)
                 {
                     // We have enough space in the current span to definitively know that
                     // we've failed or we consumed more than we're willing to.
-                    bytesConsumed = 0;
                     return false;
                 }
             }
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
 
-            // We have to pass MaxParseBytes for float as we have no idea where segments end
-            // and the exponent separators would cause a failed parse ('E' and '+') if they
-            // fail on it.
-            return TryParseGreedy(ref reader, out value, out bytesConsumed, standardFormat, MaxParseBytes, FloatParser);
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseFloat(ref BufferReader<byte> r, out float v, char f)
+            {
+                // We have to pass MaxParseBytes for float as we have no idea where segments end
+                // and the exponent separators would cause a failed parse ('E' and '+') if they
+                // fail on it.
+                return TryParseGreedy(ref r, out v, f, MaxParseBytes, Utf8Parser.TryParse);
+            }
+
+            return TryParseFloat(ref reader, out value, standardFormat);
         }
 
         /// <summary>
@@ -717,7 +548,6 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="double"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out double, out int, char)"/> for supported formats.
         /// </remarks>
@@ -727,7 +557,6 @@ namespace System.Buffers.Reader
         public static bool TryParse(
             ref this BufferReader<byte> reader,
             out double value,
-            out int bytesConsumed,
             char standardFormat = '\0')
         {
             // We have to have MaxParseBytes available when failing to parse double (or
@@ -740,28 +569,33 @@ namespace System.Buffers.Reader
 
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (!Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat)
+            if (!Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat)
                 || bytesConsumed >= MaxParseBytes)
             {
                 if (unread.Length >= MaxParseBytes)
                 {
                     // We have enough space in the current span to definitively know that
                     // we've failed or we consumed more than we're willing to.
-                    bytesConsumed = 0;
                     return false;
                 }
             }
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
 
-            // We have to pass MaxParseBytes for float as we have no idea where segments end
-            // and the exponent separators would cause a failed parse ('E' and '+') if they
-            // fail on it.
-            return TryParseGreedy(ref reader, out value, out bytesConsumed, standardFormat, MaxParseBytes, DoubleParser);
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseDouble(ref BufferReader<byte> r, out double v, char f)
+            {
+                // We have to pass MaxParseBytes for double as we have no idea where segments end
+                // and the exponent separators would cause a failed parse ('E' and '+') if they
+                // fail on it.
+                return TryParseGreedy(ref r, out v, f, MaxParseBytes, Utf8Parser.TryParse);
+            }
+
+            return TryParseDouble(ref reader, out value, standardFormat);
         }
 
         /// <summary>
@@ -769,7 +603,6 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="decimal"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out decimal, out int, char)"/> for supported formats.
         /// </remarks>
@@ -779,7 +612,6 @@ namespace System.Buffers.Reader
         public static bool TryParse(
             ref this BufferReader<byte> reader,
             out decimal value,
-            out int bytesConsumed,
             char standardFormat = '\0')
         {
             // We have to have MaxParseBytes available when failing to parse decimal (or
@@ -792,26 +624,31 @@ namespace System.Buffers.Reader
 
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (!Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat)
+            if (!Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat)
                 || bytesConsumed >= MaxParseBytes)
             {
                 if (unread.Length >= MaxParseBytes)
                 {
                     // We have enough space in the current span to definitively know that
                     // we've failed or we consumed more than we're willing to.
-                    bytesConsumed = 0;
                     return false;
                 }
             }
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
 
-            // We need to pass MaxParseBytes to ensure we fail correctly (see above).
-            return TryParseGreedy(ref reader, out value, out bytesConsumed, standardFormat, MaxParseBytes, DecimalParser);
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseDecimal(ref BufferReader<byte> r, out decimal v, char f)
+            {
+                // We need to pass MaxParseBytes to ensure we fail correctly (see above).
+                return TryParseGreedy(ref r, out v, f, MaxParseBytes, Utf8Parser.TryParse);
+            }
+
+            return TryParseDecimal(ref reader, out value, standardFormat);
         }
 
         /// <summary>
@@ -819,20 +656,19 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="Guid"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out Guid, out int, char)"/> for supported formats.
         /// </remarks>
         /// <exception cref="FormatException">Thrown if the given format isn't supported.</exception>
         /// <returns>True if successfully parsed.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryParse(ref this BufferReader<byte> reader, out Guid value, out int bytesConsumed, char standardFormat = '\0')
+        public static bool TryParse(ref this BufferReader<byte> reader, out Guid value, char standardFormat = '\0')
         {
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat))
+            if (Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat))
             {
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
             else if (unread.Length >= MaxGuidLength)
@@ -842,7 +678,13 @@ namespace System.Buffers.Reader
                 return false;
             }
 
-            return TryParseFixed(ref reader, out value, out bytesConsumed, standardFormat, MaxGuidLength, GuidParser);
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseGuid(ref BufferReader<byte> r, out Guid v, char f)
+            {
+                return TryParseFixed(ref r, out v, f, MaxGuidLength, Utf8Parser.TryParse);
+            }
+
+            return TryParseGuid(ref reader, out value, standardFormat);
         }
 
         /// <summary>
@@ -850,7 +692,6 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="TimeSpan"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out TimeSpan, out int, char)"/> for supported formats.
         /// </remarks>
@@ -860,7 +701,6 @@ namespace System.Buffers.Reader
         public static bool TryParse(
             ref this BufferReader<byte> reader,
             out TimeSpan value,
-            out int bytesConsumed,
             char standardFormat = '\0')
         {
             // We have to have MaxParseBytes available when failing to parse TimeSpans (or
@@ -873,26 +713,31 @@ namespace System.Buffers.Reader
 
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (!Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat)
+            if (!Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat)
                 || bytesConsumed >= MaxParseBytes)
             {
                 if (unread.Length >= MaxParseBytes)
                 {
                     // We have enough space in the current span to definitively know that
                     // we've failed or we consumed more than we're willing to.
-                    bytesConsumed = 0;
                     return false;
                 }
             }
             else if (bytesConsumed < unread.Length)
             {
                 // The parser found a value it wouldn't consume so we have all useful data.
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
 
-            // We need to pass MaxParseBytes to ensure we fail correctly (see above).
-            return TryParseGreedy(ref reader, out value, out bytesConsumed, standardFormat, MaxParseBytes, TimeSpanParser);
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseTimeSpan(ref BufferReader<byte> r, out TimeSpan v, char f)
+            {
+                // We need to pass MaxParseBytes to ensure we fail correctly (see above).
+                return TryParseGreedy(ref r, out v, f, MaxParseBytes, Utf8Parser.TryParse);
+            }
+
+            return TryParseTimeSpan(ref reader, out value, standardFormat);
         }
 
         /// <summary>
@@ -900,20 +745,19 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="DateTime"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out DateTime, out int, char)"/> for supported formats.
         /// </remarks>
         /// <exception cref="FormatException">Thrown if the given format isn't supported.</exception>
         /// <returns>True if successfully parsed.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryParse(ref this BufferReader<byte> reader, out DateTime value, out int bytesConsumed, char standardFormat = '\0')
+        public static bool TryParse(ref this BufferReader<byte> reader, out DateTime value, char standardFormat = '\0')
         {
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat))
+            if (Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat))
             {
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
             else if (unread.Length >= MaxDateTimeLength)
@@ -923,7 +767,13 @@ namespace System.Buffers.Reader
                 return false;
             }
 
-            return TryParseFixed(ref reader, out value, out bytesConsumed, standardFormat, MaxDateTimeLength, DateTimeParser);
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseDateTime(ref BufferReader<byte> r, out DateTime v, char f)
+            {
+                return TryParseFixed(ref r, out v, f, MaxGuidLength, Utf8Parser.TryParse);
+            }
+
+            return TryParseDateTime(ref reader, out value, standardFormat);
         }
 
         /// <summary>
@@ -931,20 +781,19 @@ namespace System.Buffers.Reader
         /// </summary>
         /// <param name="value">The parsed <see cref="DateTimeOffset"/> value or default if failed.</param>
         /// <param name="standardFormat">Expected format.</param>
-        /// <param name="bytesConsumed">The number of bytes advanced by the reader.</param>
         /// <remarks>
         /// <see cref="Utf8Parser.TryParse(ReadOnlySpan{byte}, out DateTimeOffset, out int, char)"/> for supported formats.
         /// </remarks>
         /// <exception cref="FormatException">Thrown if the given format isn't supported.</exception>
         /// <returns>True if successfully parsed.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryParse(ref this BufferReader<byte> reader, out DateTimeOffset value, out int bytesConsumed, char standardFormat = '\0')
+        public static bool TryParse(ref this BufferReader<byte> reader, out DateTimeOffset value, char standardFormat = '\0')
         {
             ReadOnlySpan<byte> unread = reader.UnreadSpan;
 
-            if (Utf8Parser.TryParse(unread, out value, out bytesConsumed, standardFormat))
+            if (Utf8Parser.TryParse(unread, out value, out int bytesConsumed, standardFormat))
             {
-                reader.Advance(bytesConsumed);
+                reader.AdvanceCurrentSpan(bytesConsumed);
                 return true;
             }
             else if (unread.Length >= MaxDateTimeLength)
@@ -954,7 +803,13 @@ namespace System.Buffers.Reader
                 return false;
             }
 
-            return TryParseFixed(ref reader, out value, out bytesConsumed, standardFormat, MaxDateTimeLength, DateTimeOffsetParser);
+            // Avoid creating the delegate unless we really need it by putting in another method
+            bool TryParseDateTimeOffset(ref BufferReader<byte> r, out DateTimeOffset v, char f)
+            {
+                return TryParseFixed(ref r, out v, f, MaxGuidLength, Utf8Parser.TryParse);
+            }
+
+            return TryParseDateTimeOffset(ref reader, out value, standardFormat);
         }
     }
 }

--- a/tests/Benchmarks/System.Buffers/Reader.cs
+++ b/tests/Benchmarks/System.Buffers/Reader.cs
@@ -45,7 +45,7 @@ namespace System.Buffers.Benchmarks
         {
             BufferReader<byte> reader = new BufferReader<byte>(s_ros);
 
-            while (reader.TryParse(out int value, out _))
+            while (reader.TryParse(out int value))
             {
                 reader.Advance(1); // advance past the delimiter
             }

--- a/tests/Benchmarks/System.Buffers/Reader_ParseInt.cs
+++ b/tests/Benchmarks/System.Buffers/Reader_ParseInt.cs
@@ -30,7 +30,7 @@ namespace System.Buffers.Benchmarks
         {
             BufferReader<byte> reader = new BufferReader<byte>(s_ros);
 
-            while (reader.TryParse(out int value, out _))
+            while (reader.TryParse(out int value))
             {
                 // Skip the delimiter
                 reader.Advance(1);
@@ -42,7 +42,7 @@ namespace System.Buffers.Benchmarks
         {
             BufferReader<byte> reader = new BufferReader<byte>(s_rosSplit);
 
-            while (reader.TryParse(out int value, out _))
+            while (reader.TryParse(out int value))
             {
                 // Skip the delimiter
                 reader.Advance(1);

--- a/tests/System.Buffers.ReaderWriter.Tests/ReaderBytesTests.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/ReaderBytesTests.cs
@@ -146,22 +146,22 @@ namespace System.Buffers.Tests
             ReadOnlySequence<byte> bytes = BufferFactory.Parse("12|3Tr|ue|456Tr|ue7|89False|");
             var reader = new BufferReader<byte>(bytes);
 
-            Assert.True(reader.TryParse(out long l64, out _));
+            Assert.True(reader.TryParse(out long l64));
             Assert.Equal(123, l64);
 
-            Assert.True(reader.TryParse(out bool b, out _));
+            Assert.True(reader.TryParse(out bool b));
             Assert.Equal(true, b);
 
-            Assert.True(reader.TryParse(out l64, out _));
+            Assert.True(reader.TryParse(out l64));
             Assert.Equal(456, l64);
 
-            Assert.True(reader.TryParse(out b, out _));
+            Assert.True(reader.TryParse(out b));
             Assert.Equal(true, b);
 
-            Assert.True(reader.TryParse(out l64, out _));
+            Assert.True(reader.TryParse(out l64));
             Assert.Equal(789, l64);
 
-            Assert.True(reader.TryParse(out b, out _));
+            Assert.True(reader.TryParse(out b));
             Assert.Equal(false, b);
         }
     }

--- a/tests/System.Buffers.ReaderWriter.Tests/Reader_ParseFloatingPoint.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/Reader_ParseFloatingPoint.cs
@@ -10,7 +10,7 @@ namespace System.Buffers.Tests
 {
     public class Reader_ParseFloatingPoint
     {
-        private delegate bool ParseDelegate<T>(ref BufferReader<byte> reader, out T value, out int bytesConsumed, char standardFormat = '\0');
+        private delegate bool ParseDelegate<T>(ref BufferReader<byte> reader, out T value,  char standardFormat = '\0');
 
         [Fact]
         public void TryParse_FloatSpecial()
@@ -29,33 +29,33 @@ namespace System.Buffers.Tests
         {
             ReadOnlySequence<byte> bytes = BufferFactory.CreateUtf8("Infinity");
             BufferReader<byte> reader = new BufferReader<byte>(bytes);
-            Assert.True(parser(ref reader, out T value, out int consumed));
+            Assert.True(parser(ref reader, out T value));
             Assert.Equal(positiveInfinity, value);
-            Assert.Equal(8, consumed);
+            Assert.Equal(8, reader.Consumed);
 
             bytes = BufferFactory.CreateUtf8("I", "n", "finity", "-");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(parser(ref reader, out value, out consumed));
+            Assert.True(parser(ref reader, out value));
             Assert.Equal(positiveInfinity, value);
-            Assert.Equal(8, consumed);
+            Assert.Equal(8, reader.Consumed);
 
             bytes = BufferFactory.CreateUtf8("-Infinity");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(parser(ref reader, out value, out consumed));
+            Assert.True(parser(ref reader, out value));
             Assert.Equal(negativeInfinity, value);
-            Assert.Equal(9, consumed);
+            Assert.Equal(9, reader.Consumed);
 
             bytes = BufferFactory.CreateUtf8("-", "Infinit", "y");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(parser(ref reader, out value, out consumed));
+            Assert.True(parser(ref reader, out value));
             Assert.Equal(negativeInfinity, value);
-            Assert.Equal(9, consumed);
+            Assert.Equal(9, reader.Consumed);
 
             bytes = BufferFactory.CreateUtf8("NaN");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(parser(ref reader, out value, out consumed));
+            Assert.True(parser(ref reader, out value));
             Assert.Equal(nan, value);
-            Assert.Equal(3, consumed);
+            Assert.Equal(3, reader.Consumed);
         }
 
         [Theory,
@@ -144,7 +144,7 @@ namespace System.Buffers.Tests
             string text = expected.ToString(formatString, CultureInfo.InvariantCulture);
             ReadOnlySequence<byte> bytes = BufferFactory.CreateUtf8(text);
             BufferReader<byte> reader = new BufferReader<byte>(bytes);
-            Assert.True(parser(ref reader, out T value, out _, standardFormat));
+            Assert.True(parser(ref reader, out T value, standardFormat));
             Assert.Equal(text, value.ToString(formatString, CultureInfo.InvariantCulture));
         }
     }

--- a/tests/System.Buffers.ReaderWriter.Tests/Reader_ParseInteger.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/Reader_ParseInteger.cs
@@ -18,7 +18,7 @@ namespace System.Buffers.Tests
         private static readonly ReadOnlySequence<byte> s_rosSigned;
         private static readonly ReadOnlySequence<byte> s_rosSignedSplit;
 
-        private delegate bool ParseDelegate<T>(ref BufferReader<byte> reader, out T value, out int bytesConsumed, char standardFormat = '\0');
+        private delegate bool ParseDelegate<T>(ref BufferReader<byte> reader, out T value, char standardFormat = '\0');
 
         static Reader_ParseInteger()
         {
@@ -71,7 +71,7 @@ namespace System.Buffers.Tests
             var reader = new BufferReader<byte>(sequence);
 
             int count = 0;
-            while (parser(ref reader, out T value, out _))
+            while (parser(ref reader, out T value))
             {
                 // advance past the delimiter
                 reader.Advance(1);
@@ -81,7 +81,7 @@ namespace System.Buffers.Tests
             }
 
             reader = new BufferReader<byte>(splitSequence);
-            while (parser(ref reader, out T value, out _))
+            while (parser(ref reader, out T value))
             {
                 // advance past the delimiter
                 reader.Advance(1);
@@ -99,47 +99,47 @@ namespace System.Buffers.Tests
         {
             ReadOnlySequence<byte> bytes = BufferFactory.CreateUtf8("-123", "45");
             BufferReader<byte> reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryParse(out int value, out int consumed));
+            Assert.True(reader.TryParse(out int value));
             Assert.Equal(-12345, value);
-            Assert.Equal(6, consumed);
+            Assert.Equal(6, reader.Consumed);
 
             // With group separators
             bytes = BufferFactory.CreateUtf8("-1,2,3", "4,5.0000000000NewData");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryParse(out value, out consumed));
+            Assert.True(reader.TryParse(out value));
             Assert.Equal(-1, value);
-            Assert.Equal(2, consumed);
+            Assert.Equal(2, reader.Consumed);
 
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryParse(out value, out consumed, 'N'));
+            Assert.True(reader.TryParse(out value, 'N'));
             Assert.Equal(-12345, value);
-            Assert.Equal(20, consumed);
+            Assert.Equal(20, reader.Consumed);
             Assert.True(reader.IsNext((byte)'N'));
 
             reader = new BufferReader<byte>(bytes);
-            Assert.False(reader.TryParse(out value, out consumed, 'X'));
-            Assert.Equal(0, consumed);
+            Assert.False(reader.TryParse(out value, 'X'));
+            Assert.Equal(0, reader.Consumed);
             reader.Advance(1);
-            Assert.True(reader.TryParse(out value, out consumed));
+            Assert.True(reader.TryParse(out value));
             Assert.Equal(1, value);
-            Assert.Equal(1, consumed);
+            Assert.Equal(2, reader.Consumed);
 
             bytes = BufferFactory.CreateUtf8("FEE", "D");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryParse(out value, out consumed, 'X'));
+            Assert.True(reader.TryParse(out value, 'X'));
             Assert.Equal(0xFEED, value);
-            Assert.Equal(4, consumed);
+            Assert.Equal(4, reader.Consumed);
 
             // Overflow
             bytes = BufferFactory.CreateUtf8("FE", "ED", "BEEFBEE");
             reader = new BufferReader<byte>(bytes);
-            Assert.False(reader.TryParse(out value, out consumed, 'X'));
-            Assert.Equal(0, consumed);
+            Assert.False(reader.TryParse(out value, 'X'));
+            Assert.Equal(0, reader.Consumed);
 
             reader.Advance(3);
-            Assert.True(reader.TryParse(out value, out consumed, 'X'));
+            Assert.True(reader.TryParse(out value, 'X'));
             Assert.Equal(unchecked((int)0xDBEEFBEE), value);
-            Assert.Equal(8, consumed);
+            Assert.Equal(11, reader.Consumed);
         }
 
         [Theory,
@@ -252,12 +252,12 @@ namespace System.Buffers.Tests
             BufferReader<byte> reader = new BufferReader<byte>(bytes);
 
             // Too many bytes
-            Assert.False(parser(ref reader, out T value, out int consumed, standardFormat));
+            Assert.False(parser(ref reader, out T value, standardFormat));
             reader.Advance(140);
-            Assert.Equal(0, consumed);
-            Assert.True(parser(ref reader, out value, out consumed, standardFormat));
+            Assert.Equal(0, reader.Consumed);
+            Assert.True(parser(ref reader, out value, standardFormat));
             Assert.Equal(expected, value);
-            Assert.True(consumed > 20, "should have consumed all of the leading zeroes");
+            Assert.True(reader.Consumed > 20, "should have consumed all of the leading zeroes");
 
             // Overflow
             bytes = BufferFactory.CreateUtf8(
@@ -272,8 +272,8 @@ namespace System.Buffers.Tests
                 "1234567891"
             );
 
-            Assert.False(parser(ref reader, out value, out consumed, standardFormat));
-            Assert.Equal(0, consumed);
+            Assert.False(parser(ref reader, out value, standardFormat));
+            Assert.Equal(0, reader.Consumed);
         }
 
         [Fact]
@@ -283,29 +283,26 @@ namespace System.Buffers.Tests
 
             ReadOnlySequence<byte> bytes = BufferFactory.CreateUtf8("-", "123");
             var reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryParse(out int value, out int consumed));
+            Assert.True(reader.TryParse(out int value));
             Assert.Equal(-123, value);
-            Assert.Equal(4, consumed);
-            Assert.True(reader.End);
             Assert.Equal(4, reader.Consumed);
+            Assert.True(reader.End);
 
             bytes = BufferFactory.CreateUtf8("+", "123");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryParse(out value, out consumed));
+            Assert.True(reader.TryParse(out value));
             Assert.Equal(123, value);
-            Assert.Equal(4, consumed);
-            Assert.True(reader.End);
             Assert.Equal(4, reader.Consumed);
+            Assert.True(reader.End);
 
             bytes = BufferFactory.CreateUtf8(".", "0");
             reader = new BufferReader<byte>(bytes);
-            Assert.False(reader.TryParse(out value, out consumed, 'd'));
-            Assert.Equal(0, consumed);
-            Assert.True(reader.TryParse(out value, out consumed, 'n'));
-            Assert.Equal(2, consumed);
+            Assert.False(reader.TryParse(out value, 'd'));
+            Assert.Equal(0, reader.Consumed);
+            Assert.True(reader.TryParse(out value, 'n'));
+            Assert.Equal(2, reader.Consumed);
             Assert.Equal(0, value);
             Assert.True(reader.End);
-            Assert.Equal(2, reader.Consumed);
         }
     }
 }

--- a/tests/System.Buffers.ReaderWriter.Tests/Reader_ParseInteger.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/Reader_ParseInteger.cs
@@ -254,10 +254,12 @@ namespace System.Buffers.Tests
             // Too many bytes
             Assert.False(parser(ref reader, out T value, standardFormat));
             reader.Advance(140);
-            Assert.Equal(0, reader.Consumed);
+            Assert.Equal(140, reader.Consumed);
             Assert.True(parser(ref reader, out value, standardFormat));
             Assert.Equal(expected, value);
             Assert.True(reader.Consumed > 20, "should have consumed all of the leading zeroes");
+
+            long priorConsumed = reader.Consumed;
 
             // Overflow
             bytes = BufferFactory.CreateUtf8(
@@ -273,7 +275,7 @@ namespace System.Buffers.Tests
             );
 
             Assert.False(parser(ref reader, out value, standardFormat));
-            Assert.Equal(0, reader.Consumed);
+            Assert.Equal(priorConsumed, reader.Consumed);
         }
 
         [Fact]

--- a/tests/System.Buffers.ReaderWriter.Tests/Reader_ParseStruct.cs
+++ b/tests/System.Buffers.ReaderWriter.Tests/Reader_ParseStruct.cs
@@ -10,7 +10,7 @@ namespace System.Buffers.Tests
 {
     public class Reader_ParseStruct
     {
-        private delegate bool ParseDelegate<T>(ref BufferReader<byte> reader, out T value, out int bytesConsumed, char standardFormat = '\0');
+        private delegate bool ParseDelegate<T>(ref BufferReader<byte> reader, out T value, char standardFormat = '\0');
 
         [Fact]
         public void TryParseGuid_MultiSegment()
@@ -18,64 +18,64 @@ namespace System.Buffers.Tests
             Guid expected = new Guid("9f21bcb9-f5c2-4b54-9b1c-9e0869bf9c16");
             ReadOnlySequence<byte> bytes = BufferFactory.CreateUtf8("9f21bcb9-f5c2-4b54-9b1c-9e0869bf9c16");
             BufferReader<byte> reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryParse(out Guid value, out int consumed));
+            Assert.True(reader.TryParse(out Guid value));
             Assert.Equal(expected, value);
-            Assert.Equal(36, consumed);
+            Assert.Equal(36, reader.Consumed);
 
             // Leading zero fails
             bytes = BufferFactory.CreateUtf8("09f21bcb9-f5c2-4b54-9b1c-9e0869bf9c16");
             reader = new BufferReader<byte>(bytes);
-            Assert.False(reader.TryParse(out value, out consumed));
+            Assert.False(reader.TryParse(out value));
             Assert.Equal(default, value);
-            Assert.Equal(0, consumed);
+            Assert.Equal(0, reader.Consumed);
 
             // Extra digit on the end fails
             bytes = BufferFactory.CreateUtf8("9f21bcb9-f5c2-4b54-9b1c-9e0869bf9c160");
             reader = new BufferReader<byte>(bytes);
-            Assert.False(reader.TryParse(out value, out consumed));
+            Assert.False(reader.TryParse(out value));
             Assert.Equal(default, value);
-            Assert.Equal(0, consumed);
+            Assert.Equal(0, reader.Consumed);
 
             // Non digit OK
             bytes = BufferFactory.CreateUtf8("9f21bcb9-f5c2-4b54-9b1c-9e0869bf9c16}");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryParse(out value, out consumed));
+            Assert.True(reader.TryParse(out value));
             Assert.Equal(expected, value);
-            Assert.Equal(36, consumed);
+            Assert.Equal(36, reader.Consumed);
 
             // Split
             bytes = BufferFactory.CreateUtf8("9f21bcb9-f5c2-4b54-9b1c-", "9e0869bf9c16");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryParse(out value, out consumed));
+            Assert.True(reader.TryParse(out value));
             Assert.Equal(expected, value);
-            Assert.Equal(36, consumed);
+            Assert.Equal(36, reader.Consumed);
 
             // Extra digit on the end fails
             bytes = BufferFactory.CreateUtf8("9f21bcb9-f5c2-4b54-", "9b1c-9e0869bf9c160A");
             reader = new BufferReader<byte>(bytes);
-            Assert.False(reader.TryParse(out value, out consumed));
+            Assert.False(reader.TryParse(out value));
             Assert.Equal(default, value);
-            Assert.Equal(0, consumed);
+            Assert.Equal(0, reader.Consumed);
 
             // Bracket match
             bytes = BufferFactory.CreateUtf8("{9f21bcb9-f5c2-4b54-9b1c-9e0869bf9c16}");
             reader = new BufferReader<byte>(bytes);
-            Assert.True(reader.TryParse(out value, out consumed, 'B'));
+            Assert.True(reader.TryParse(out value, 'B'));
             Assert.Equal(expected, value);
-            Assert.Equal(38, consumed);
+            Assert.Equal(38, reader.Consumed);
 
             // Bracket mismatch
             bytes = BufferFactory.CreateUtf8("{9f21bcb9-f5c2-4b54-9b1c-9e0869bf9c16{");
             reader = new BufferReader<byte>(bytes);
-            Assert.False(reader.TryParse(out value, out consumed, 'B'));
+            Assert.False(reader.TryParse(out value, 'B'));
             Assert.Equal(default, value);
-            Assert.Equal(0, consumed);
+            Assert.Equal(0, reader.Consumed);
 
             bytes = BufferFactory.CreateUtf8("{9f21bcb9-f5c2-4b54-9b1c-9e0869bf9c16)");
             reader = new BufferReader<byte>(bytes);
-            Assert.False(reader.TryParse(out value, out consumed, 'B'));
+            Assert.False(reader.TryParse(out value, 'B'));
             Assert.Equal(default, value);
-            Assert.Equal(0, consumed);
+            Assert.Equal(0, reader.Consumed);
         }
 
         [Theory,
@@ -107,7 +107,7 @@ namespace System.Buffers.Tests
             string text = expected.ToString(formatString, CultureInfo.InvariantCulture);
             ReadOnlySequence<byte> bytes = BufferFactory.CreateUtf8(text);
             BufferReader<byte> reader = new BufferReader<byte>(bytes);
-            Assert.True(parser(ref reader, out T value, out _, standardFormat));
+            Assert.True(parser(ref reader, out T value, standardFormat));
             Assert.Equal(text, value.ToString(formatString, CultureInfo.InvariantCulture));
         }
     }


### PR DESCRIPTION
- Move delegate creation to internal methods
- Add internal Advance for current span and tweak GetNextSpan
- Flip logic in binary read (now 15% faster)