### PR TITLE
Change HttpParser header parsing to span

### DIFF
--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/HttpServer.cs
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/HttpServer.cs
@@ -84,12 +84,12 @@ namespace Microsoft.Net
                 var requestBytes = new ReadOnlySequence<byte>(rootBuffer, 0, requestBuffer, requestBuffer.Memory.Length);
 
                 var request = new HttpRequest();
-                if(!s_parser.ParseRequestLine(ref request, requestBytes, out int consumed))
+                if(!s_parser.ParseRequestLine(request, requestBytes, out int consumed))
                 {
                     throw new Exception();
                 }
                 requestBytes = requestBytes.Slice(consumed);
-                if (!s_parser.ParseHeaders(ref request, requestBytes, out consumed))
+                if (!s_parser.ParseHeaders(request, requestBytes, out consumed))
                 {
                     throw new Exception();
                 }

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
@@ -40,6 +40,7 @@ namespace System.Buffers
 
         // TODO:
         // Move to helper in ReadOnlySequence
+        // https://github.com/dotnet/corefx/issues/33029
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe static void GetFirstSpan(in ReadOnlySequence<T> buffer, out ReadOnlySpan<T> first, out SequencePosition next)
         {

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
@@ -17,34 +17,97 @@ namespace System.Buffers
         /// Create a <see cref="BufferReader" over the given <see cref="ReadOnlySequence{T}"/>./>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public BufferReader(in ReadOnlySequence<T> buffer)
+        public BufferReader(ReadOnlySequence<T> buffer)
         {
             CurrentSpanIndex = 0;
             Consumed = 0;
             Sequence = buffer;
-            _currentPosition = Sequence.Start;
-            _nextPosition = _currentPosition;
+            _currentPosition = buffer.Start;
 
-            if (buffer.TryGet(ref _nextPosition, out ReadOnlyMemory<T> memory, advance: true))
+            GetFirstSpan(buffer, out ReadOnlySpan<T> first, out _nextPosition);
+            CurrentSpan = first;
+            _moreData = first.Length > 0;
+
+            if (!buffer.IsSingleSegment && !_moreData)
             {
                 _moreData = true;
+                GetNextSpan();
+            }
+        }
 
-                if (memory.Length == 0)
+        private const int FlagBitMask = 1 << 31;
+        private const int IndexBitMask = ~FlagBitMask;
+
+        // TODO:
+        // Move to helper in ReadOnlySequence
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe static void GetFirstSpan(in ReadOnlySequence<T> buffer, out ReadOnlySpan<T> first, out SequencePosition next)
+        {
+            first = default;
+            next = default;
+            SequencePosition start = buffer.Start;
+            int startIndex = start.GetInteger();
+            object startObject = start.GetObject();
+
+            if (startObject != null)
+            {
+                SequencePosition end = buffer.End;
+                int endIndex = end.GetInteger();
+                bool isMultiSegment = startObject != end.GetObject();
+
+                // A == 0 && B == 0 means SequenceType.MultiSegment
+                if (startIndex >= 0)
                 {
-                    CurrentSpan = default;
-                    // No space in the first span, move to one with space
-                    GetNextSpan();
+                    if (endIndex >= 0)  // SequenceType.MultiSegment
+                    {
+                        ReadOnlySequenceSegment<T> segment = (ReadOnlySequenceSegment<T>)startObject;
+                        next = new SequencePosition(segment.Next, 0);
+                        first = segment.Memory.Span;
+                        if (isMultiSegment)
+                        {
+                            first = first.Slice(startIndex);
+                        }
+                        else
+                        {
+                            first = first.Slice(startIndex, endIndex - startIndex);
+                        }
+                    }
+                    else
+                    {
+                        if (isMultiSegment)
+                            ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
+
+                        first = new ReadOnlySpan<T>((T[])startObject, startIndex, (endIndex & IndexBitMask) - startIndex);
+                    }
                 }
                 else
                 {
-                    CurrentSpan = memory.Span;
+                    first = GetFirstSpanSlow(startObject, startIndex, endIndex, isMultiSegment);
                 }
             }
-            else
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ReadOnlySpan<T> GetFirstSpanSlow(object startObject, int startIndex, int endIndex, bool isMultiSegment)
+        {
+            Debug.Assert(startIndex < 0 || endIndex < 0);
+            if (isMultiSegment)
+                ThrowHelper.ThrowInvalidOperationException_EndPositionNotReached();
+
+            // The type == char check here is redundant. However, we still have it to allow
+            // the JIT to see when that the code is unreachable and eliminate it.
+            // A == 1 && B == 1 means SequenceType.String
+            if (typeof(T) == typeof(char) && endIndex < 0)
             {
-                // No space in any spans and at end of sequence
-                _moreData = false;
-                CurrentSpan = default;
+                var memory = (ReadOnlyMemory<T>)(object)((string)startObject).AsMemory();
+
+                // No need to remove the FlagBitMask since (endIndex - startIndex) == (endIndex & ReadOnlySequence.IndexBitMask) - (startIndex & ReadOnlySequence.IndexBitMask)
+                return memory.Span.Slice(startIndex & IndexBitMask, endIndex - startIndex);
+            }
+            else // endIndex >= 0, A == 1 && B == 0 means SequenceType.MemoryManager
+            {
+                startIndex &= IndexBitMask;
+                return ((MemoryManager<T>)startObject).Memory.Slice(startIndex, endIndex - startIndex).Span;
             }
         }
 

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
@@ -42,7 +42,7 @@ namespace System.Buffers
         // Move to helper in ReadOnlySequence
         // https://github.com/dotnet/corefx/issues/33029
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private unsafe static void GetFirstSpan(in ReadOnlySequence<T> buffer, out ReadOnlySpan<T> first, out SequencePosition next)
+        private static void GetFirstSpan(in ReadOnlySequence<T> buffer, out ReadOnlySpan<T> first, out SequencePosition next)
         {
             first = default;
             next = default;
@@ -108,7 +108,7 @@ namespace System.Buffers
             else // endIndex >= 0, A == 1 && B == 0 means SequenceType.MemoryManager
             {
                 startIndex &= IndexBitMask;
-                return ((MemoryManager<T>)startObject).Memory.Slice(startIndex, endIndex - startIndex).Span;
+                return ((MemoryManager<T>)startObject).Memory.Span.Slice(startIndex, endIndex - startIndex);
             }
         }
 

--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader_search.cs
@@ -737,10 +737,11 @@ namespace System.Buffers
                 }
                 return true;
             }
+
+            // Only check the slow path if there wasn't enough to satisfy next
             return unread.Length < next.Length && IsNextSlow(next, advancePast);
         }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         private unsafe bool IsNextSlow(ReadOnlySpan<T> next, bool advancePast)
         {
             ReadOnlySpan<T> currentSpan = UnreadSpan;

--- a/src/System.Buffers.ReaderWriter/System/ThrowHelper.cs
+++ b/src/System.Buffers.ReaderWriter/System/ThrowHelper.cs
@@ -9,7 +9,6 @@ namespace System.Buffers
 {
     internal class ThrowHelper
     {
-        // For speed
         public static void ThrowArgumentOutOfRangeException(ExceptionArgument argument)
         {
             throw GetArgumentOutOfRangeException(argument);
@@ -27,6 +26,13 @@ namespace System.Buffers
                 "The enum value is not defined, please check the ExceptionArgument Enum.");
 
             return argument.ToString();
+        }
+
+        internal static void ThrowInvalidOperationException_EndPositionNotReached() { throw CreateInvalidOperationException_EndPositionNotReached(); }
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Exception CreateInvalidOperationException_EndPositionNotReached()
+        {
+            return new InvalidOperationException("EndPositionNotReached");
         }
     }
 

--- a/src/System.Text.Http/System.Text.Http.csproj
+++ b/src/System.Text.Http/System.Text.Http.csproj
@@ -4,7 +4,6 @@
     <Description>Non-allocating HTTP parser</Description>
     <TargetFramework>netstandard1.3</TargetFramework>
     <PackageTags>HTTP parser parsing .NET non-allocating corefxlab</PackageTags>
-    <LangVersion>7.2</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Text.Http/System/Text/Http/Parser/HttpParser.cs
+++ b/src/System.Text.Http/System/Text/Http/Parser/HttpParser.cs
@@ -109,7 +109,8 @@ namespace System.Text.Http.Parser
             // The absolute smallest request line is something like "Z * HTTP/1.1"
             // See https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2
 
-            if (data.Length < 11)
+            // Note that GetKnownMethod depends on the buffer having at least 9 bytes.
+            if (data.Length < 12)
             {
                 RejectRequestLine(data);
             }
@@ -250,13 +251,13 @@ namespace System.Text.Http.Parser
             }
         }
 
-        public bool ParseHeaders<T>(ref T handler, ReadOnlySequence<byte> buffer, out int consumedBytes) where T : IHttpHeadersHandler
+        public bool ParseHeaders<T>(T handler, ReadOnlySequence<byte> buffer, out int consumedBytes) where T : IHttpHeadersHandler
         {
             var reader = new BufferReader<byte>(buffer);
             consumedBytes = 0;
 
             bool success = ParseHeaders(handler, ref reader);
-            if (success == true)
+            if (success)
                 consumedBytes = (int)reader.Consumed;
             return success;
         }

--- a/tests/Benchmarks/System.Buffers/Reader_Construction.cs
+++ b/tests/Benchmarks/System.Buffers/Reader_Construction.cs
@@ -5,9 +5,11 @@
 using BenchmarkDotNet.Attributes;
 using System.Buffers;
 using System.Buffers.Tests;
+using System.Runtime.CompilerServices;
 
 namespace System.Buffers.Benchmarks
 {
+    [DisassemblyDiagnoser(printPrologAndEpilog: true, recursiveDepth: 3)]
     public class Reader_Construction
     {
         private static byte[] s_array;
@@ -25,12 +27,14 @@ namespace System.Buffers.Benchmarks
         }
 
         [Benchmark]
+        [MethodImpl(MethodImplOptions.NoOptimization)]
         public void ConstructSingleSegment()
         {
             new BufferReader<byte>(s_ros);
         }
 
         [Benchmark]
+        [MethodImpl(MethodImplOptions.NoOptimization)]
         public void ConstructMultiSegment()
         {
             new BufferReader<byte>(s_rosSplit);

--- a/tests/Benchmarks/System.Buffers/Reader_Construction.cs
+++ b/tests/Benchmarks/System.Buffers/Reader_Construction.cs
@@ -9,7 +9,6 @@ using System.Runtime.CompilerServices;
 
 namespace System.Buffers.Benchmarks
 {
-    [DisassemblyDiagnoser(printPrologAndEpilog: true, recursiveDepth: 3)]
     public class Reader_Construction
     {
         private static byte[] s_array;
@@ -27,14 +26,12 @@ namespace System.Buffers.Benchmarks
         }
 
         [Benchmark]
-        [MethodImpl(MethodImplOptions.NoOptimization)]
         public void ConstructSingleSegment()
         {
             new BufferReader<byte>(s_ros);
         }
 
         [Benchmark]
-        [MethodImpl(MethodImplOptions.NoOptimization)]
         public void ConstructMultiSegment()
         {
             new BufferReader<byte>(s_rosSplit);

--- a/tests/Benchmarks/System.Text.Http.Parser/HttpParser.cs
+++ b/tests/Benchmarks/System.Text.Http.Parser/HttpParser.cs
@@ -30,23 +30,32 @@ namespace System.Text.Http.Parser.Benchmarks
         private static readonly ReadOnlySequence<byte> s_plaintextTechEmpowerRequestRos = new ReadOnlySequence<byte>(s_plaintextTechEmpowerRequestArray);
         private static readonly ReadOnlySequence<byte> s_plaintextTechEmpowerHeadersRos = new ReadOnlySequence<byte>(s_plaintextTechEmpowerHeadersArray);
 
-        private static readonly System.Text.Http.Parser.HttpParser s_parser = new System.Text.Http.Parser.HttpParser();
+        private static readonly HttpParser s_parser = new HttpParser();
 
         // new T(); is very expensive because it calls Activator.CreateInstance
         // so we create it once and keep it in the field (the benchmarks are not mutating it's state so it's fine)
         private T request = new T();
 
         [Benchmark]
-        public void RequestLine() => s_parser.ParseRequestLine(request, s_plaintextTechEmpowerRequestRos, out _, out _);
+        public void RequestLine()
+        {
+            BufferReader<byte> reader = new BufferReader<byte>(s_plaintextTechEmpowerRequestRos);
+            s_parser.ParseRequestLine(request, ref reader);
+        }
 
         [Benchmark]
-        public void Headers() => s_parser.ParseHeaders(request, s_plaintextTechEmpowerHeadersRos, out _, out _, out _);
+        public void Headers()
+        {
+            BufferReader<byte> reader = new BufferReader<byte>(s_plaintextTechEmpowerHeadersRos);
+            s_parser.ParseHeaders(request, ref reader);
+        }
 
         [Benchmark]
         public void FullRequest()
         {
-            s_parser.ParseRequestLine(request, s_plaintextTechEmpowerRequestRos, out var consumed, out _);
-            s_parser.ParseHeaders(request, s_plaintextTechEmpowerRequestRos.Slice(consumed), out consumed, out _, out _);
+            BufferReader<byte> reader = new BufferReader<byte>(s_plaintextTechEmpowerRequestRos);
+            s_parser.ParseRequestLine(request, ref reader);
+            s_parser.ParseHeaders(request, ref reader);
         }
     }
 

--- a/tests/System.Text.Http.Tests/HttpParserBasicTests.cs
+++ b/tests/System.Text.Http.Tests/HttpParserBasicTests.cs
@@ -19,10 +19,10 @@ namespace System.Text.Http.Parser.Tests
             var request = new Request();
             ReadOnlySequence<byte> buffer = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes(requestText));
 
-            Assert.True(parser.ParseRequestLine(ref request, buffer, out var consumed));
+            Assert.True(parser.ParseRequestLine(request, buffer, out var consumed));
             Assert.Equal(25, consumed);
 
-            Assert.True(parser.ParseHeaders(ref request, buffer.Slice(consumed), out consumed));
+            Assert.True(parser.ParseHeaders(request, buffer.Slice(consumed), out consumed));
             Assert.Equal(8, consumed);
 
             // request line
@@ -55,11 +55,11 @@ namespace System.Text.Http.Parser.Tests
                 var request = new Request();
 
                 try {
-                    Assert.True(parser.ParseRequestLine(ref request, buffer, out var consumed));
+                    Assert.True(parser.ParseRequestLine(request, buffer, out var consumed));
                     Assert.Equal(25, consumed);
 
                     var unconsumed = buffer.Slice(consumed);
-                    Assert.True(parser.ParseHeaders(ref request, unconsumed, out consumed));
+                    Assert.True(parser.ParseHeaders(request, unconsumed, out consumed));
                     Assert.Equal(8, consumed);
                 }
                 catch {
@@ -85,10 +85,10 @@ namespace System.Text.Http.Parser.Tests
             var request = new Request();
             ReadOnlySequence<byte> buffer = new ReadOnlySequence<byte>(_plaintextTechEmpowerRequestBytes);
 
-            Assert.True(parser.ParseRequestLine(ref request, buffer, out var consumed));
+            Assert.True(parser.ParseRequestLine(request, buffer, out var consumed));
             Assert.Equal(25, consumed);
 
-            Assert.True(parser.ParseHeaders(ref request, buffer.Slice(consumed), out consumed));
+            Assert.True(parser.ParseHeaders(request, buffer.Slice(consumed), out consumed));
             Assert.Equal(139, consumed);
 
             // request line

--- a/tests/System.Text.Http.Tests/HttpParserTests.cs
+++ b/tests/System.Text.Http.Tests/HttpParserTests.cs
@@ -28,7 +28,7 @@ namespace System.Text.Http.Parser.Tests
             var buffer = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes(requestLine));
             var requestHandler = new RequestHandler();
 
-            Assert.True(parser.ParseRequestLine(ref requestHandler, buffer, out var consumed));
+            Assert.True(parser.ParseRequestLine(requestHandler, buffer, out var consumed));
 
             Assert.Equal(requestHandler.Method, expectedMethod);
             Assert.Equal(requestHandler.Version, expectedVersion);
@@ -45,7 +45,7 @@ namespace System.Text.Http.Parser.Tests
             var buffer = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes(requestLine));
             var requestHandler = new RequestHandler();
 
-            Assert.False(parser.ParseRequestLine(ref requestHandler, buffer, out var consumed));
+            Assert.False(parser.ParseRequestLine(requestHandler, buffer, out var consumed));
         }
 
         [Theory]
@@ -56,7 +56,7 @@ namespace System.Text.Http.Parser.Tests
             var buffer = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes(requestLine));
             var requestHandler = new RequestHandler();
 
-            Assert.False(parser.ParseRequestLine(ref requestHandler, buffer, out var consumed));
+            Assert.False(parser.ParseRequestLine(requestHandler, buffer, out var consumed));
         }
 
         [Theory]
@@ -68,7 +68,7 @@ namespace System.Text.Http.Parser.Tests
             var requestHandler = new RequestHandler();
 
             var exception = Assert.Throws<BadHttpRequestException>(() =>
-                parser.ParseRequestLine(ref requestHandler, buffer, out var consumed));
+                parser.ParseRequestLine(requestHandler, buffer, out var consumed));
 
             //Assert.Equal($"Invalid request line: '{requestLine.EscapeNonPrintable()}'", exception.Message);
             //Assert.Equal(StatusCodes.Status400BadRequest, (exception as BadHttpRequestException).StatusCode);
@@ -85,7 +85,7 @@ namespace System.Text.Http.Parser.Tests
             var requestHandler = new RequestHandler();
 
             var exception = Assert.Throws<BadHttpRequestException>(() =>
-                parser.ParseRequestLine(ref requestHandler, buffer, out var consumed));
+                parser.ParseRequestLine(requestHandler, buffer, out var consumed));
 
             //Assert.Equal($"Invalid request line: '{method.EscapeNonPrintable()} / HTTP/1.1\\x0D\\x0A'", exception.Message);
             //Assert.Equal(StatusCodes.Status400BadRequest, (exception as BadHttpRequestException).StatusCode);
@@ -102,7 +102,7 @@ namespace System.Text.Http.Parser.Tests
             var requestHandler = new RequestHandler();
 
             var exception = Assert.Throws<BadHttpRequestException>(() =>
-                parser.ParseRequestLine(ref requestHandler, buffer, out var consumed));
+                parser.ParseRequestLine(requestHandler, buffer, out var consumed));
 
             //Assert.Equal($"Unrecognized HTTP version: '{httpVersion}'", exception.Message);
             //Assert.Equal(StatusCodes.Status505HttpVersionNotsupported, (exception as BadHttpRequestException).StatusCode);
@@ -151,7 +151,7 @@ namespace System.Text.Http.Parser.Tests
 
             var buffer = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes(rawHeaders));
             var requestHandler = new RequestHandler();
-            Assert.False(parser.ParseHeaders(ref requestHandler, buffer, out var consumed));
+            Assert.False(parser.ParseHeaders(requestHandler, buffer, out var consumed));
         }
 
         [Theory]
@@ -176,7 +176,7 @@ namespace System.Text.Http.Parser.Tests
 
             var buffer = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes(rawHeaders));
             var requestHandler = new RequestHandler();
-            parser.ParseHeaders(ref requestHandler, buffer, out var consumed);
+            parser.ParseHeaders(requestHandler, buffer, out var consumed);
 
             Assert.Equal(0, consumed);
         }
@@ -264,12 +264,12 @@ namespace System.Text.Http.Parser.Tests
             const string headerLine = "Header: value\r\n\r";
             var buffer = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes(headerLine));
             var requestHandler = new RequestHandler();
-            Assert.False(parser.ParseHeaders(ref requestHandler, buffer, out var consumed));
+            Assert.False(parser.ParseHeaders(requestHandler, buffer, out var consumed));
 
             Assert.Equal(headerLine.Length - 1, consumed);
 
             var buffer2 = new ReadOnlySequence<byte>(Encoding.ASCII.GetBytes("\r\n"));
-            Assert.True(parser.ParseHeaders(ref requestHandler, buffer2, out consumed));
+            Assert.True(parser.ParseHeaders(requestHandler, buffer2, out consumed));
 
             Assert.Equal(2, consumed);
         }
@@ -298,7 +298,7 @@ namespace System.Text.Http.Parser.Tests
             var requestHandler = new RequestHandler();
 
             var exception = Assert.Throws<BadHttpRequestException>(() =>
-                parser.ParseHeaders(ref requestHandler, buffer, out var consumed));
+                parser.ParseHeaders(requestHandler, buffer, out var consumed));
 
             //Assert.Equal(expectedExceptionMessage, exception.Message);
             //Assert.Equal(StatusCodes.Status400BadRequest, exception.StatusCode);


### PR DESCRIPTION
- Optimize Header parser BufferReader usage
- Optimize reader TryReadToAny for two items
- Optimize reader TryRead<T>

Goal here is to make sure the reader is working well for the parser.

**Parser before**
```
      Method |      Mean |     Error |    StdDev |
------------ |----------:|----------:|----------:|
 RequestLine |  69.73 ns | 0.3118 ns | 0.2917 ns |
     Headers | 147.80 ns | 0.6158 ns | 0.5459 ns |
 FullRequest | 230.65 ns | 0.6696 ns | 0.6264 ns |
```

**Parser after (no new reader aggressive inlining)**
```
      Method |      Mean |     Error |    StdDev |
------------ |----------:|----------:|----------:|
 RequestLine |  66.01 ns | 0.2759 ns | 0.2581 ns |
     Headers | 151.10 ns | 0.6065 ns | 0.5673 ns |
 FullRequest | 227.00 ns | 0.9968 ns | 0.9324 ns |
```

Slightly slower reading just the headers, but _much_ easier to follow. If the reader's `TryReadToAny` is marked as `AggressiveInlining` it would end up notably faster than it started:

**Parser after (reader TryRead AggressiveInlining)**
```
      Method |      Mean |     Error |    StdDev |
------------ |----------:|----------:|----------:|
 RequestLine |  66.05 ns | 0.4254 ns | 0.3979 ns |
     Headers | 137.62 ns | 0.9707 ns | 0.9080 ns |
 FullRequest | 219.71 ns | 0.6370 ns | 0.5958 ns |
```

At a 10% impact it seems like we should keep the `AggressiveInlining`.

For the binary reader it is another 17% faster than it was:

**Before**
```
                 Method |      Mean |    Error |   StdDev |
----------------------- |----------:|---------:|---------:|
              ReadInt32 |  74.46 us | 1.462 us | 2.746 us |
    ReadInt32_BigEndian | 121.07 us | 1.324 us | 1.238 us |
 ReadInt32_LittleEndian |  89.43 us | 1.756 us | 2.221 us |
```

**After**
```
                 Method |      Mean |     Error |    StdDev |
----------------------- |----------:|----------:|----------:|
              ReadInt32 |  63.58 us | 1.2667 us | 2.0812 us |
    ReadInt32_BigEndian | 112.13 us | 0.7395 us | 0.6917 us |
 ReadInt32_LittleEndian |  75.97 us | 1.4968 us | 1.4001 us |
```