### PR TITLE
 Add benchmark to test multi-segment reading using span-based JsonReader

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader_MultiSegment.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader_MultiSegment.cs
@@ -745,8 +745,7 @@ namespace System.Text.JsonLab
                 }
                 else return false;
             }
-            if (!TryGetNumber(span, out _))
-                return false;
+            ValidateNumber(span);
             Consumed += (int)(reader.Consumed - consumedBefore);
             _position += (int)(reader.Consumed - consumedBefore);
             Value = span;
@@ -934,6 +933,125 @@ namespace System.Text.JsonLab
                     _position++;
                 }
             }
+        }
+
+        // https://tools.ietf.org/html/rfc7159#section-6
+        // TODO: Avoid code duplication with TryGetNumber
+        private void ValidateNumber(ReadOnlySpan<byte> data)
+        {
+            Debug.Assert(data.Length > 0);
+
+            ReadOnlySpan<byte> delimiters = JsonConstants.Delimiters;
+
+            int i = 0;
+            byte nextByte = data[i];
+
+            if (nextByte == '-')
+            {
+                i++;
+                if (i >= data.Length)
+                {
+                    ThrowJsonReaderException(ref this, ExceptionResource.ExpectedDigitNotFoundEndOfData, nextByte);
+                }
+
+                nextByte = data[i];
+                if ((uint)(nextByte - '0') > '9' - '0')
+                    ThrowJsonReaderException(ref this, ExceptionResource.ExpectedDigitNotFound, nextByte);
+            }
+
+            Debug.Assert(nextByte >= '0' && nextByte <= '9');
+
+            if (nextByte == '0')
+            {
+                i++;
+                if (i >= data.Length)
+                {
+                    goto Done;
+                }
+                else
+                {
+                    nextByte = data[i];
+
+                    if (nextByte != '.' && nextByte != 'E' && nextByte != 'e')
+                        ThrowJsonReaderException(ref this, ExceptionResource.ExpectedNextDigitComponentNotFound, nextByte);
+                }
+            }
+            else
+            {
+                i++;
+                for (; i < data.Length; i++)
+                {
+                    nextByte = data[i];
+                    if ((uint)(nextByte - '0') > '9' - '0')
+                        break;
+                }
+                if (i >= data.Length)
+                {
+                    goto Done;
+                }
+                if (nextByte != '.' && nextByte != 'E' && nextByte != 'e')
+                    ThrowJsonReaderException(ref this, ExceptionResource.ExpectedNextDigitComponentNotFound, nextByte);
+            }
+
+            Debug.Assert(nextByte == '.' || nextByte == 'E' || nextByte == 'e');
+
+            if (nextByte == '.')
+            {
+                i++;
+                if (i >= data.Length)
+                {
+                    ThrowJsonReaderException(ref this, ExceptionResource.ExpectedDigitNotFoundEndOfData, nextByte);
+                }
+                nextByte = data[i];
+                if ((uint)(nextByte - '0') > '9' - '0')
+                    ThrowJsonReaderException(ref this, ExceptionResource.ExpectedDigitNotFound, nextByte);
+                i++;
+                for (; i < data.Length; i++)
+                {
+                    nextByte = data[i];
+                    if ((uint)(nextByte - '0') > '9' - '0')
+                        break;
+                }
+                if (i >= data.Length)
+                {
+                    goto Done;
+                }
+                if (nextByte != 'E' && nextByte != 'e')
+                    ThrowJsonReaderException(ref this, ExceptionResource.ExpectedNextDigitEValueNotFound, nextByte);
+            }
+
+            Debug.Assert(nextByte == 'E' || nextByte == 'e');
+            i++;
+
+            if (i >= data.Length)
+            {
+                ThrowJsonReaderException(ref this, ExceptionResource.ExpectedDigitNotFoundEndOfData, nextByte);
+            }
+
+            nextByte = data[i];
+            if (nextByte == '+' || nextByte == '-')
+            {
+                i++;
+                if (i >= data.Length)
+                {
+                    ThrowJsonReaderException(ref this, ExceptionResource.ExpectedDigitNotFoundEndOfData, nextByte);
+                }
+                nextByte = data[i];
+            }
+
+            if ((uint)(nextByte - '0') > '9' - '0')
+                ThrowJsonReaderException(ref this, ExceptionResource.ExpectedDigitNotFound, nextByte);
+
+            i++;
+            for (; i < data.Length; i++)
+            {
+                nextByte = data[i];
+                if ((uint)(nextByte - '0') > '9' - '0')
+                    break;
+            }
+
+        Done:
+            ;
         }
     }
 }

--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader_MultiSegment.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader_MultiSegment.cs
@@ -1050,6 +1050,14 @@ namespace System.Text.JsonLab
                     break;
             }
 
+            if (i < data.Length)
+            {
+                if (delimiters.IndexOf(nextByte) == -1)
+                {
+                    ThrowJsonReaderException(ref this, ExceptionResource.ExpectedEndOfDigitNotFound, nextByte);
+                }
+            }
+
         Done:
             ;
         }

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -5,6 +5,7 @@
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Buffers;
+using System.Buffers.Tests;
 using System.Buffers.Text;
 using System.Collections.Generic;
 using System.IO;
@@ -1546,6 +1547,93 @@ namespace System.Text.JsonLab.Tests
             }
 
             Assert.Equal(dataUtf8.Length, json.Consumed);
+        }
+
+        private static ReadOnlySequence<byte> GetSequence(byte[] _dataUtf8, int segmentSize)
+        {
+            int numberOfSegments = _dataUtf8.Length / segmentSize + 1;
+            byte[][] buffers = new byte[numberOfSegments][];
+
+            for (int j = 0; j < numberOfSegments - 1; j++)
+            {
+                buffers[j] = new byte[segmentSize];
+                System.Array.Copy(_dataUtf8, j * segmentSize, buffers[j], 0, segmentSize);
+            }
+
+            int remaining = _dataUtf8.Length % segmentSize;
+            buffers[numberOfSegments - 1] = new byte[remaining];
+            System.Array.Copy(_dataUtf8, _dataUtf8.Length - remaining, buffers[numberOfSegments - 1], 0, remaining);
+
+            return BufferFactory.Create(buffers);
+        }
+
+        [Fact]
+        public void SingleSegmentSequence()
+        {
+            string jsonString = TestJson.Json400KB;
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            ReadOnlySequence<byte> sequenceSingle = new ReadOnlySequence<byte>(dataUtf8);
+            var json = new Utf8JsonReader(sequenceSingle);
+            while (json.Read()) ;
+            Assert.Equal(dataUtf8.Length, json.Consumed);
+        }
+
+        [Fact]
+        public void MultiSegmentSequence()
+        {
+            string jsonString = TestJson.Json400KB;
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            ReadOnlySequence<byte> sequenceMultiple = GetSequence(dataUtf8, 4_000);
+            var json = new Utf8JsonReader(sequenceMultiple);
+            while (json.Read()) ;
+            Assert.Equal(dataUtf8.Length, json.Consumed);
+        }
+
+        [Fact]
+        public void MultiSegmentSequenceUsingSpan()
+        {
+            string jsonString = TestJson.Json400KB;
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            ReadOnlySequence<byte> sequenceMultiple = GetSequence(dataUtf8, 4_000);
+
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(8_000);
+            JsonReaderState state = default;
+            int previous = 0;
+
+            int numberOfSegments = dataUtf8.Length / 4_000 + 1;
+            int counter = 0;
+            foreach (ReadOnlyMemory<byte> memory in sequenceMultiple)
+            {
+                ReadOnlySpan<byte> span = memory.Span;
+                Span<byte> bufferSpan = buffer;
+                span.CopyTo(bufferSpan.Slice(previous));
+                bufferSpan = bufferSpan.Slice(0, span.Length + previous);
+
+                bool isFinalBlock = bufferSpan.Length == 0;
+
+                var json = new Utf8JsonReader(bufferSpan, isFinalBlock, state);
+                while (json.Read()) ;
+
+                if (isFinalBlock)
+                    break;
+
+                state = json.State;
+                sequenceMultiple = sequenceMultiple.Slice(json.Consumed);
+
+                if (json.Consumed != bufferSpan.Length)
+                {
+                    ReadOnlySpan<byte> leftover = sequenceMultiple.First.Span;
+                    previous = leftover.Length;
+                    leftover.CopyTo(buffer);
+                }
+                else
+                {
+                    previous = 0;
+                }
+                counter++;
+            }
+            ArrayPool<byte>.Shared.Return(buffer);
+            Assert.Equal(numberOfSegments, counter);
         }
     }
 }

--- a/tests/System.Text.JsonLab.Tests/System.Text.JsonLab.Tests.csproj
+++ b/tests/System.Text.JsonLab.Tests/System.Text.JsonLab.Tests.csproj
@@ -24,6 +24,7 @@
   <!-- Project references -->
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Text.JsonLab\System.Text.JsonLab.csproj" />
+    <ProjectReference Include="..\System.Buffers.ReaderWriter.Tests\System.Buffers.ReaderWriter.Tests.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\TestJson.Designer.cs">


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17763
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-009667
  [Host]     : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT
  Job-QGLHAV : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT

IterationCount=5  WarmupCount=3  

```
|                        Method |  TestCase | segmentSize |        Mean |         Error |      StdDev |   Gen 0 | Allocated |
|------------------------------ |---------- |------------ |------------:|--------------:|------------:|--------:|----------:|
|          **MultiSegmentSequence** | **Json400KB** |        **1000** | **2,229.47 us** | **1,979.0869 us** | **514.0605 us** | **11.7188** |   **52056 B** |
| MultiSegmentSequenceUsingSpan | Json400KB |        1000 | 1,435.48 us |    36.1777 us |   9.3970 us |       - |       0 B |
|          **MultiSegmentSequence** | **Json400KB** |        **2000** | **1,827.59 us** |   **225.7137 us** |  **58.6283 us** |  **5.8594** |   **26440 B** |
| MultiSegmentSequenceUsingSpan | Json400KB |        2000 | 1,419.92 us |    81.3662 us |  21.1346 us |       - |       0 B |
|          **MultiSegmentSequence** | **Json400KB** |        **4000** | **1,861.08 us** |   **254.6612 us** |  **66.1473 us** |  **1.9531** |   **14072 B** |
| MultiSegmentSequenceUsingSpan | Json400KB |        4000 | 1,517.30 us |   675.7307 us | 175.5185 us |       - |       0 B |
|          **MultiSegmentSequence** | **Json400KB** |        **8000** | **1,717.56 us** |   **269.9645 us** |  **70.1223 us** |       **-** |    **7208 B** |
| MultiSegmentSequenceUsingSpan | Json400KB |        8000 | 1,311.83 us |     6.6070 us |   1.7161 us |       - |       0 B |
|         **SingleSegmentSequence** | **Json400KB** |           **?** | **1,207.40 us** |   **123.4279 us** |  **32.0599 us** |       **-** |       **0 B** |
|          **MultiSegmentSequence** |  **Json40KB** |        **1000** |   **177.71 us** |     **1.5450 us** |   **0.4013 us** |  **0.9766** |    **4408 B** |
| MultiSegmentSequenceUsingSpan |  Json40KB |        1000 |   137.94 us |     7.8522 us |   2.0396 us |       - |       0 B |
|          **MultiSegmentSequence** |  **Json40KB** |        **2000** |   **172.65 us** |     **2.3742 us** |   **0.6167 us** |  **0.4883** |    **2176 B** |
| MultiSegmentSequenceUsingSpan |  Json40KB |        2000 |   132.35 us |     3.3261 us |   0.8639 us |       - |       0 B |
|          **MultiSegmentSequence** |  **Json40KB** |        **4000** |   **164.53 us** |    **19.2161 us** |   **4.9913 us** |  **0.2441** |    **1312 B** |
| MultiSegmentSequenceUsingSpan |  Json40KB |        4000 |   129.82 us |     1.7905 us |   0.4651 us |       - |       0 B |
|          **MultiSegmentSequence** |  **Json40KB** |        **8000** |   **169.16 us** |     **1.6207 us** |   **0.4210 us** |       **-** |     **784 B** |
| MultiSegmentSequenceUsingSpan |  Json40KB |        8000 |   127.73 us |    13.1184 us |   3.4075 us |       - |       0 B |
|         **SingleSegmentSequence** |  **Json40KB** |           **?** |   **114.69 us** |     **9.3377 us** |   **2.4254 us** |       **-** |       **0 B** |
|          **MultiSegmentSequence** |   **Json4KB** |        **1000** |    **15.10 us** |     **2.6399 us** |   **0.6857 us** |       **-** |     **112 B** |
| MultiSegmentSequenceUsingSpan |   Json4KB |        1000 |    11.68 us |     0.1315 us |   0.0341 us |       - |       0 B |
|          **MultiSegmentSequence** |   **Json4KB** |        **2000** |    **15.13 us** |     **0.7682 us** |   **0.1995 us** |  **0.0153** |      **72 B** |
| MultiSegmentSequenceUsingSpan |   Json4KB |        2000 |    11.29 us |     1.1112 us |   0.2886 us |       - |       0 B |
|          **MultiSegmentSequence** |   **Json4KB** |        **4000** |    **14.58 us** |     **1.3834 us** |   **0.3593 us** |       **-** |       **0 B** |
| MultiSegmentSequenceUsingSpan |   Json4KB |        4000 |    11.52 us |     0.1855 us |   0.0482 us |       - |       0 B |
|          **MultiSegmentSequence** |   **Json4KB** |        **8000** |    **10.08 us** |     **1.0172 us** |   **0.2642 us** |       **-** |       **0 B** |
| MultiSegmentSequenceUsingSpan |   Json4KB |        8000 |    10.92 us |     0.9696 us |   0.2518 us |       - |       0 B |
|         **SingleSegmentSequence** |   **Json4KB** |           **?** |    **10.49 us** |     **0.2518 us** |   **0.0654 us** |       **-** |       **0 B** |

cc @KrzysztofCwalina, @stephentoub, @JeremyKuhne 