### PR TITLE
Add JsonReaderSequence wrapper to support ReadOnlySequence

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader.cs
@@ -480,7 +480,14 @@ namespace System.Text.JsonLab
                         Consumed--;
                         _position--;
                         TokenType = (JsonTokenType)_stack.Pop();
-                        return ReadSingleSegment() ? InternalResult.Success : InternalResult.FailureRollback;
+                        if (ReadSingleSegment())
+                            return InternalResult.Success;
+                        else
+                        {
+                            //TODO: Add test
+                            _stack.Push((InternalJsonTokenType)TokenType);
+                            return InternalResult.FailureRollback;
+                        }
                     }
                 }
                 else

--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReaderSequence.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReaderSequence.cs
@@ -1,0 +1,108 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+
+namespace System.Text.JsonLab
+{
+    public ref struct Utf8JsonReaderSequence
+    {
+        private Utf8JsonReader _jsonReader;
+        private ReadOnlySequence<byte> _data;
+        private Span<byte> _span;
+        private bool _isFinalBlock;
+        private JsonReaderState _state;
+        private ReadOnlySequence<byte>.Enumerator _enumerator;
+        private byte[] _buffer;
+
+        public JsonTokenType TokenType => _jsonReader.TokenType;
+        public ReadOnlySpan<byte> Value => _jsonReader.Value;
+
+        public Utf8JsonReaderSequence(in ReadOnlySequence<byte> data, ReadOnlySpan<byte> leftOver = default)
+        {
+            _data = data;
+            _enumerator = _data.GetEnumerator();
+            _enumerator.MoveNext();
+            ReadOnlySpan<byte> localSpan = _enumerator.Current.Span;
+            _buffer = ArrayPool<byte>.Shared.Rent(localSpan.Length * 2);
+
+            _span = _buffer;
+            leftOver.CopyTo(_span);
+            localSpan.CopyTo(_span.Slice(leftOver.Length));
+            _span = _span.Slice(0, localSpan.Length + leftOver.Length);
+
+            _isFinalBlock = _span.Length == 0;
+            _jsonReader = new Utf8JsonReader(_span, _isFinalBlock);
+            
+            _state = default;
+        }
+
+        public Utf8JsonReaderSequence(in ReadOnlySequence<byte> data, bool isFinalBlock, ReadOnlySpan<byte> leftOver = default, JsonReaderState state = default)
+        {
+            _data = data;
+            _enumerator = _data.GetEnumerator();
+            _enumerator.MoveNext();
+            ReadOnlySpan<byte> localSpan = _enumerator.Current.Span;
+            _buffer = ArrayPool<byte>.Shared.Rent(localSpan.Length * 2);
+
+            _span = _buffer;
+            leftOver.CopyTo(_span);
+            localSpan.CopyTo(_span.Slice(leftOver.Length));
+            _span = _span.Slice(0, _span.Length + leftOver.Length);
+
+            _isFinalBlock = _span.Length == 0 || isFinalBlock;
+            _jsonReader = new Utf8JsonReader(_span, _isFinalBlock, state);
+            
+            if (!state.IsDefault)
+            {
+                _state = state;
+            }
+            else
+            {
+                _state = default;
+            }
+        }
+
+        public bool Read()
+        {
+            bool result = _jsonReader.Read();
+            if (!result)
+            {
+                return ReadNext();
+            }
+            return result;
+        }
+
+        private bool ReadNext()
+        {
+            _isFinalBlock = !_enumerator.MoveNext();
+            if (_isFinalBlock)
+                return false;
+
+            _state = _jsonReader.State;
+
+            ReadOnlySpan<byte> leftOver = default;
+            if (_jsonReader.Consumed != _span.Length)
+            {
+                leftOver = _span.Slice((int)_jsonReader.Consumed);
+            }
+
+            _span = _buffer;
+            leftOver.CopyTo(_span);
+
+            ReadOnlySpan<byte> currentSpan = _enumerator.Current.Span;
+            currentSpan.CopyTo(_span.Slice(leftOver.Length));
+            _span = _span.Slice(0, currentSpan.Length + leftOver.Length);
+
+            _jsonReader = new Utf8JsonReader(_span, _isFinalBlock, _state);
+            return _jsonReader.Read();
+        }
+
+        public void Dispose()
+        {
+            ArrayPool<byte>.Shared.Return(_buffer);
+            _buffer = null;
+        }
+    }
+}

--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader_MultiSegment.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader_MultiSegment.cs
@@ -310,7 +310,13 @@ namespace System.Text.JsonLab
                         _position--;
                         reader.Rewind(1);
                         TokenType = (JsonTokenType)_stack.Pop();
-                        return ReadMultiSegment(ref reader) ? InternalResult.Success : InternalResult.FailureRollback;
+                        if (ReadMultiSegment(ref reader))
+                            return InternalResult.Success;
+                        else
+                        {
+                            _stack.Push((InternalJsonTokenType)TokenType);
+                            return InternalResult.FailureRollback;
+                        }
                     }
                 }
                 else

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderMultiSegmentPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderMultiSegmentPerf.cs
@@ -117,11 +117,10 @@ namespace System.Text.JsonLab.Benchmarks
                     break;
 
                 state = json.State;
-                sequenceMultiple = sequenceMultiple.Slice(json.Consumed);
 
                 if (json.Consumed != bufferSpan.Length)
                 {
-                    ReadOnlySpan<byte> leftover = sequenceMultiple.First.Span;
+                    ReadOnlySpan<byte> leftover = bufferSpan.Slice((int)json.Consumed);
                     previous = leftover.Length;
                     leftover.CopyTo(buffer);
                 }
@@ -131,6 +130,20 @@ namespace System.Text.JsonLab.Benchmarks
                 }
             }
             ArrayPool<byte>.Shared.Return(buffer);
+        }
+
+        [Benchmark]
+        [Arguments(1_000)]
+        [Arguments(2_000)]
+        [Arguments(4_000)]
+        [Arguments(8_000)]
+        public void MultiSegmentSequenceUsingReaderSequence(int segmentSize)
+        {
+            ReadOnlySequence<byte> sequenceMultiple = _sequences[segmentSize];
+
+            var json = new Utf8JsonReaderSequence(sequenceMultiple);
+            while (json.Read()) ;
+            json.Dispose();
         }
     }
 }

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -1672,11 +1672,10 @@ namespace System.Text.JsonLab.Tests
                     break;
 
                 state = json.State;
-                sequenceMultiple = sequenceMultiple.Slice(json.Consumed);
 
                 if (json.Consumed != bufferSpan.Length)
                 {
-                    ReadOnlySpan<byte> leftover = sequenceMultiple.First.Span;
+                    ReadOnlySpan<byte> leftover = bufferSpan.Slice((int)json.Consumed);
                     previous = leftover.Length;
                     leftover.CopyTo(buffer);
                 }
@@ -1694,6 +1693,77 @@ namespace System.Text.JsonLab.Tests
             Stream stream = new MemoryStream(dataUtf8);
             TextReader reader = new StreamReader(stream, Encoding.UTF8, false, 1024, true);
             string expectedStr = NewtonsoftReturnStringHelper(reader);
+
+            Assert.Equal(expectedStr, actualStr);
+        }
+
+        [Fact]
+        public void MultiSegmentSequenceReaderSequence()
+        {
+            string jsonString = TestJson.Json400KB;
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
+            ReadOnlySequence<byte> sequenceMultiple = GetSequence(dataUtf8, 4_000);
+
+            var reader = new Utf8JsonReaderSequence(sequenceMultiple);
+
+            byte[] outputArray = new byte[dataUtf8.Length];
+            Span<byte> destination = outputArray;
+
+            while (reader.Read())
+            {
+                JsonTokenType tokenType = reader.TokenType;
+                ReadOnlySpan<byte> valueSpan = reader.Value;
+                switch (tokenType)
+                {
+                    case JsonTokenType.PropertyName:
+                        valueSpan.CopyTo(destination);
+                        destination[valueSpan.Length] = (byte)',';
+                        destination[valueSpan.Length + 1] = (byte)' ';
+                        destination = destination.Slice(valueSpan.Length + 2);
+                        break;
+                    case JsonTokenType.Number:
+                    case JsonTokenType.String:
+                    case JsonTokenType.Comment:
+                        valueSpan.CopyTo(destination);
+                        destination[valueSpan.Length] = (byte)',';
+                        destination[valueSpan.Length + 1] = (byte)' ';
+                        destination = destination.Slice(valueSpan.Length + 2);
+                        break;
+                    case JsonTokenType.True:
+                        // Special casing True/False so that the casing matches with Json.NET
+                        destination[0] = (byte)'T';
+                        destination[1] = (byte)'r';
+                        destination[2] = (byte)'u';
+                        destination[3] = (byte)'e';
+                        destination[valueSpan.Length] = (byte)',';
+                        destination[valueSpan.Length + 1] = (byte)' ';
+                        destination = destination.Slice(valueSpan.Length + 2);
+                        break;
+                    case JsonTokenType.False:
+                        destination[0] = (byte)'F';
+                        destination[1] = (byte)'a';
+                        destination[2] = (byte)'l';
+                        destination[3] = (byte)'s';
+                        destination[4] = (byte)'e';
+                        destination[valueSpan.Length] = (byte)',';
+                        destination[valueSpan.Length + 1] = (byte)' ';
+                        destination = destination.Slice(valueSpan.Length + 2);
+                        break;
+                    case JsonTokenType.Null:
+                        // Special casing Null so that it matches what JSON.NET does
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            reader.Dispose();
+
+            string actualStr = Encoding.UTF8.GetString(outputArray.AsSpan(0, outputArray.Length - destination.Length));
+
+            Stream stream = new MemoryStream(dataUtf8);
+            TextReader textReader = new StreamReader(stream, Encoding.UTF8, false, 1024, true);
+            string expectedStr = NewtonsoftReturnStringHelper(textReader);
 
             Assert.Equal(expectedStr, actualStr);
         }


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17763
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-009667
  [Host]     : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT
  Job-KQEXQO : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT

IterationCount=5  WarmupCount=3  

```
|                                  Method |  TestCase | segmentSize |     Mean |     Error |    StdDev |  Gen 0 | Allocated |
|---------------------------------------- |---------- |------------ |---------:|----------:|----------:|-------:|----------:|
|                    **MultiSegmentSequence** | **Json400KB** |        **4000** | **1.764 ms** | **0.0826 ms** | **0.0215 ms** | **1.9531** |   **14072 B** |
|           MultiSegmentSequenceUsingSpan | Json400KB |        4000 | 1.356 ms | 0.0884 ms | 0.0230 ms |      - |       0 B |
| MultiSegmentSequenceUsingReaderSequence | Json400KB |        4000 | 1.311 ms | 0.0369 ms | 0.0096 ms |      - |       0 B |
|                   **SingleSegmentSequence** | **Json400KB** |           **?** | **1.275 ms** | **0.0845 ms** | **0.0219 ms** |      **-** |       **0 B** |
