### PR TITLE
 Adding BufferReader TryReadTo benchmark with alternatives.

### DIFF
--- a/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
+++ b/src/System.Buffers.ReaderWriter/System/Buffers/Reader/BufferReader.cs
@@ -254,6 +254,13 @@ namespace System.Buffers.Reader
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void UnsafeAdvance(long count)
+        {
+            Consumed += count;
+            CurrentSpanIndex += (int)count;
+        }
+
         private void AdvanceToNextSpan(long count)
         {
             while (_moreData)

--- a/tests/Benchmarks/System.Text.JsonLab/BufferReaderTryReadTo.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/BufferReaderTryReadTo.cs
@@ -49,7 +49,7 @@ namespace System.Text.JsonLab.Benchmarks
                 ConsumeString_original_opt(ref reader);
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void SingleSegmentBufferReaderSkipAdvance()
         {
             var reader = new BufferReader<byte>(_sequenceSingle);

--- a/tests/Benchmarks/System.Text.JsonLab/BufferReaderTryReadTo.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/BufferReaderTryReadTo.cs
@@ -1,0 +1,178 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using System.Buffers;
+using System.Buffers.Reader;
+
+namespace System.Text.JsonLab.Benchmarks
+{
+    [DisassemblyDiagnoser(printAsm: true, printPrologAndEpilog: true, recursiveDepth: 2)]
+    [MemoryDiagnoser]
+    public class BufferReaderTryReadTo
+    {
+        private string _jsonString;
+        private byte[] _dataUtf8;
+        private ReadOnlySequence<byte> _sequenceSingle;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var builder = new StringBuilder();
+            for (int j = 0; j < 1_000; j++)
+            {
+                builder.Append('\"');
+                for (int i = 0; i < 10; i++)
+                {
+                    builder.Append('a');
+                }
+                builder.Append('\"');
+            }
+            _jsonString = builder.ToString();   // "aaaaaaaaaa""aaaaaaaaaa"...."aaaaaaaaaa""aaaaaaaaaa"
+
+            _dataUtf8 = Encoding.UTF8.GetBytes(_jsonString);
+
+            _sequenceSingle = new ReadOnlySequence<byte>(_dataUtf8);
+        }
+
+        [Benchmark]
+        public void SingleSegmentBufferReader_original()
+        {
+            var reader = new BufferReader<byte>(_sequenceSingle);
+            for (int i = 0; i < 1_000; i++)
+                ConsumeString_original(ref reader);
+        }
+
+        [Benchmark]
+        public void SingleSegmentBufferReader1()
+        {
+            var reader = new BufferReader<byte>(_sequenceSingle);
+            for (int i = 0; i < 1_000; i++)
+                ConsumeString1(ref reader);
+        }
+
+        [Benchmark]
+        public void SingleSegmentBufferReader2()
+        {
+            var reader = new BufferReader<byte>(_sequenceSingle);
+            for (int i = 0; i < 1_000; i++)
+                ConsumeString2(ref reader);
+        }
+
+        [Benchmark]
+        public void SingleSegmentBufferReader3()
+        {
+            var reader = new BufferReader<byte>(_sequenceSingle);
+            for (int i = 0; i < 1_000; i++)
+                ConsumeString3(ref reader);
+        }
+
+        [Benchmark(Baseline = true)]
+        public void SingleSegmentSpan()
+        {
+            ReadOnlySpan<byte> reader = _sequenceSingle.First.Span;
+            for (int i = 0; i < 1_000; i++)
+                ConsumeString(reader);
+        }
+
+        private bool ConsumeString1(ref BufferReader<byte> reader)
+        {
+            if (reader.TryReadToAndAdvanceSkipOne(out ReadOnlySpan<byte> value, (byte)'\"', (byte)'\\'))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        private bool ConsumeString2(ref BufferReader<byte> reader)
+        {
+            reader.Advance(1);
+            if (reader.TryReadToAndAdvance(out ReadOnlySpan<byte> value, (byte)'\"', (byte)'\\'))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        private bool ConsumeString3(ref BufferReader<byte> reader)
+        {
+            reader.UnsafeAdvance(1);
+            if (reader.TryReadToAndAdvance(out ReadOnlySpan<byte> value, (byte)'\"', (byte)'\\'))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        private bool ConsumeString_original(ref BufferReader<byte> reader)
+        {
+            reader.Advance(1);
+            if (reader.TryReadTo(out ReadOnlySpan<byte> value, (byte)'\"', (byte)'\\', advancePastDelimiter: true))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        private bool ConsumeString(ReadOnlySpan<byte> _buffer)
+        {
+            //Create local copy to avoid bounds checks.
+            ReadOnlySpan<byte> localCopy = _buffer;
+
+            int idx = localCopy.Slice(1).IndexOf((byte)'\"');
+            if (idx < 0)
+            {
+                return false;
+            }
+
+            if (localCopy[idx] != '\\')
+            {
+                localCopy = localCopy.Slice(1, idx);
+                return true;
+            }
+            else
+            {
+                return ConsumeStringWithNestedQuotes(_buffer);
+            }
+        }
+
+        private bool ConsumeStringWithNestedQuotes(ReadOnlySpan<byte> _buffer)
+        {
+            //TODO: Optimize looking for nested quotes
+            //TODO: Avoid redoing first IndexOf search
+            long i = 0 + 1;
+            while (true)
+            {
+                int counter = 0;
+                int foundIdx = _buffer.Slice((int)i).IndexOf((byte)'\"');
+                if (foundIdx == -1)
+                {
+                    return false;
+                }
+                if (foundIdx == 0)
+                    break;
+                for (long j = i + foundIdx - 1; j >= i; j--)
+                {
+                    if (_buffer[(int)j] != '\\')
+                    {
+                        if (counter % 2 == 0)
+                        {
+                            i += foundIdx;
+                            goto FoundEndOfString;
+                        }
+                        break;
+                    }
+                    else
+                        counter++;
+                }
+                i += foundIdx + 1;
+            }
+
+        FoundEndOfString:
+            long startIndex = 1;
+            ReadOnlySpan<byte> localCopy = _buffer.Slice((int)startIndex, (int)(i - startIndex));
+            return true;
+        }
+    }
+}

--- a/tests/Benchmarks/System.Text.JsonLab/BufferReaderTryReadTo.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/BufferReaderTryReadTo.cs
@@ -42,6 +42,14 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark]
+        public void SingleSegmentBufferReader_original_with_opts()
+        {
+            var reader = new BufferReader<byte>(_sequenceSingle);
+            for (int i = 0; i < NumberOfStrings; i++)
+                ConsumeString_original_opt(ref reader);
+        }
+
+        //[Benchmark]
         public void SingleSegmentBufferReaderSkipAdvance()
         {
             var reader = new BufferReader<byte>(_sequenceSingle);
@@ -75,7 +83,7 @@ namespace System.Text.JsonLab.Benchmarks
 
         private bool ConsumeStringSkipAdvance(ref BufferReader<byte> reader)
         {
-            if (reader.TryReadToAndAdvanceSkipOne(out ReadOnlySpan<byte> value, (byte)'\"', (byte)'\\'))
+            if (reader.TryReadToAndAdvanceSkipN(out ReadOnlySpan<byte> value, (byte)'\"', (byte)'\\'))
             {
                 return true;
             }
@@ -106,6 +114,15 @@ namespace System.Text.JsonLab.Benchmarks
         {
             reader.Advance(1);
             if (reader.TryReadTo(out ReadOnlySpan<byte> value, (byte)'\"', (byte)'\\', advancePastDelimiter: true))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        private bool ConsumeString_original_opt(ref BufferReader<byte> reader)
+        {
+            if (reader.TryReadTo_opt(out ReadOnlySpan<byte> value, (byte)'\"', (byte)'\\', startIndex: 1, advancePastDelimiter: true))
             {
                 return true;
             }


### PR DESCRIPTION
``` ini

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17763
Intel Core i7-6700 CPU 3.40GHz (Max: 2.50GHz) (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-009667
  [Host]     : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT


```
|                                 Method |      Mean |     Error |    StdDev | Scaled | ScaledSD | Allocated |
|--------------------------------------- |----------:|----------:|----------:|-------:|---------:|----------:|
|     SingleSegmentBufferReader_original | 13.263 us | 0.1038 us | 0.0920 us |   1.60 |     0.02 |       0 B |
|   SingleSegmentBufferReaderSkipAdvance | 10.344 us | 0.0755 us | 0.0670 us |   1.25 |     0.02 |       0 B |
| SingleSegmentBufferReaderNoOptionalArg | 12.053 us | 0.2347 us | 0.2883 us |   1.45 |     0.04 |       0 B |
| SingleSegmentBufferReaderUnsafeAdvance | 11.738 us | 0.0901 us | 0.0799 us |   1.42 |     0.02 |       0 B |
|                      SingleSegmentSpan |  8.295 us | 0.1311 us | 0.1162 us |   1.00 |     0.00 |       0 B |
