### PR TITLE
 Prototype stream wrapper around JsonReader to provide stream support

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader.cs
@@ -407,6 +407,7 @@ namespace System.Text.JsonLab
                     leftOver = _buffer.Slice(_consumed);
                 }
 
+                // TODO: Should this be a settable property?
                 if (leftOver.Length >= 1_000_000)
                 {
                     // A single JSON token exceeds 1 MB in size . In such a rare case, allocate.

--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReaderStream.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReaderStream.cs
@@ -13,30 +13,35 @@ namespace System.Text.JsonLab
         private Span<byte> _span;
         private Stream _stream;
         private byte[] _buffer;
+        private bool _isFinalBlock;
+        private long _consumed;
 
+        const int FirstSegmentSize = 1_024; //TODO: Is this necessary?
         const int StreamSegmentSize = 4_096;
 
         public JsonTokenType TokenType => _jsonReader.TokenType;
         public ReadOnlySpan<byte> Value => _jsonReader.Value;
+        public long Consumed => _consumed + _jsonReader.Consumed;
 
         public Utf8JsonReaderStream(Stream jsonStream)
         {
             if (!jsonStream.CanRead)
                 JsonThrowHelper.ThrowArgumentException("Stream must be readable");
 
-            _buffer = ArrayPool<byte>.Shared.Rent(StreamSegmentSize);
-            int numberOfBytes = jsonStream.Read(_buffer, 0, StreamSegmentSize);
+            _buffer = ArrayPool<byte>.Shared.Rent(FirstSegmentSize);
+            int numberOfBytes = jsonStream.Read(_buffer, 0, FirstSegmentSize);
             _span = _buffer.AsSpan(0, numberOfBytes);
             _stream = jsonStream;
 
-            bool isFinalBlock = numberOfBytes < StreamSegmentSize;
-            _jsonReader = new Utf8JsonReader(_span, isFinalBlock);
+            _isFinalBlock = numberOfBytes < FirstSegmentSize;
+            _jsonReader = new Utf8JsonReader(_span, _isFinalBlock);
+            _consumed = 0;
         }
 
         public bool Read()
         {
             bool result = _jsonReader.Read();
-            if (!result)
+            if (!result && !_isFinalBlock)
             {
                 return ReadNext();
             }
@@ -46,34 +51,51 @@ namespace System.Text.JsonLab
         private bool ReadNext()
         {
             bool result = false;
-            bool isFinalBlock = false;
 
             do
             {
-                ReadOnlySpan<byte> leftOver = default;
-                if (_jsonReader.Consumed < _span.Length)
+                _consumed += _jsonReader.Consumed;
+                int leftOver = _span.Length - (int)_jsonReader.Consumed;
+                int amountToRead = StreamSegmentSize;
+                if (leftOver > 0)
                 {
-                    leftOver = _span.Slice((int)_jsonReader.Consumed);
+                    _stream.Position -= leftOver;
+
+                    // TODO: Should this be a settable property?
+                    if (leftOver >= 1_000_000)
+                    {
+                        // A single JSON token exceeds 1 MB in size . In such a rare case, allocate.
+                        byte[] maxBuffer = new byte[2_000_000_000];
+                        int maxBytes = _stream.Read(maxBuffer, 0, maxBuffer.Length);
+                        _isFinalBlock = maxBytes < amountToRead;
+                        _span = maxBuffer.AsSpan(0, maxBytes);
+                        goto ReadNext;
+                    }
+                    else
+                    {
+                        if (_jsonReader.Consumed == 0)
+                        {
+                            if (leftOver > int.MaxValue - amountToRead)
+                                JsonThrowHelper.ThrowArgumentException("Cannot fit left over data from the previous chunk and the next chunk of data into a 2 GB buffer.");
+
+                            amountToRead += leftOver;   // This is gauranteed to not overflow
+                            ResizeBuffer(amountToRead);
+                        }
+                    }
                 }
 
-                if (leftOver.Length > _buffer.Length - StreamSegmentSize)
-                {
-                    if (leftOver.Length > int.MaxValue - StreamSegmentSize)
-                        JsonThrowHelper.ThrowArgumentException("Cannot fit left over data from the previous chunk and the next chunk of data into a 2 GB buffer.");
+                if (_buffer.Length < amountToRead)
+                    ResizeBuffer(amountToRead);
 
-                    ResizeBuffer(leftOver.Length + StreamSegmentSize);
-                }
+                int numberOfBytes = _stream.Read(_buffer, 0, amountToRead);
+                _isFinalBlock = numberOfBytes < amountToRead;
 
-                leftOver.CopyTo(_buffer);
+                _span = _buffer.AsSpan(0, numberOfBytes);
 
-                int numberOfBytes = _stream.Read(_buffer, leftOver.Length, StreamSegmentSize);
-                isFinalBlock = numberOfBytes < StreamSegmentSize;
-
-                _span = _buffer.AsSpan(0, leftOver.Length + numberOfBytes);   // This is gauranteed to not overflow
-
-                _jsonReader = new Utf8JsonReader(_span, isFinalBlock, _jsonReader.State);
+            ReadNext:
+                _jsonReader = new Utf8JsonReader(_span, _isFinalBlock, _jsonReader.State);
                 result = _jsonReader.Read();
-            } while (!result && !isFinalBlock);
+            } while (!result && !_isFinalBlock);
 
             return result;
         }

--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReaderStream.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReaderStream.cs
@@ -65,7 +65,13 @@ namespace System.Text.JsonLab
                     if (leftOver >= 1_000_000)
                     {
                         // A single JSON token exceeds 1 MB in size. Start doubling.
-                        amountToRead = leftOver * 2;
+                        if (leftOver > 1_000_000_000)
+                            amountToRead = 2_000_000_000;
+                        else
+                            amountToRead = leftOver * 2;
+
+                        if (leftOver >= 2_000_000_000)
+                            JsonThrowHelper.ThrowArgumentException("Cannot fit left over data from the previous chunk and the next chunk of data into a 2 GB buffer.");
                     }
                     else
                     {

--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReaderStream.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReaderStream.cs
@@ -25,8 +25,8 @@ namespace System.Text.JsonLab
 
         public Utf8JsonReaderStream(Stream jsonStream)
         {
-            if (!jsonStream.CanRead)
-                JsonThrowHelper.ThrowArgumentException("Stream must be readable");
+            if (!jsonStream.CanRead || !jsonStream.CanSeek)
+                JsonThrowHelper.ThrowArgumentException("Stream must be readable and seekable.");
 
             _buffer = ArrayPool<byte>.Shared.Rent(FirstSegmentSize);
             int numberOfBytes = jsonStream.Read(_buffer, 0, FirstSegmentSize);
@@ -90,7 +90,7 @@ namespace System.Text.JsonLab
                     ResizeBuffer(amountToRead);
 
                 int numberOfBytes = _stream.Read(_buffer, 0, amountToRead);
-                _isFinalBlock = numberOfBytes == 0;
+                _isFinalBlock = numberOfBytes == 0; // TODO: Can this be inferred differently based on leftOver and numberOfBytes
 
                 _span = _buffer.AsSpan(0, numberOfBytes);
 

--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReaderStream.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReaderStream.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.IO;
+
+namespace System.Text.JsonLab
+{
+    public ref struct Utf8JsonReaderStream
+    {
+        private Utf8JsonReader _jsonReader;
+        private Span<byte> _span;
+        private Stream _stream;
+        private byte[] _buffer;
+
+        const int StreamSegmentSize = 4_096;
+
+        public JsonTokenType TokenType => _jsonReader.TokenType;
+        public ReadOnlySpan<byte> Value => _jsonReader.Value;
+
+        public Utf8JsonReaderStream(Stream jsonStream)
+        {
+            if (!jsonStream.CanRead)
+                JsonThrowHelper.ThrowArgumentException("Stream must be readable");
+
+            _buffer = ArrayPool<byte>.Shared.Rent(StreamSegmentSize);
+            int numberOfBytes = jsonStream.Read(_buffer, 0, StreamSegmentSize);
+            _span = _buffer.AsSpan(0, numberOfBytes);
+            _stream = jsonStream;
+
+            bool isFinalBlock = numberOfBytes < StreamSegmentSize;
+            _jsonReader = new Utf8JsonReader(_span, isFinalBlock);
+        }
+
+        public bool Read()
+        {
+            bool result = _jsonReader.Read();
+            if (!result)
+            {
+                return ReadNext();
+            }
+            return result;
+        }
+
+        private bool ReadNext()
+        {
+            bool result = false;
+            bool isFinalBlock = false;
+
+            do
+            {
+                ReadOnlySpan<byte> leftOver = default;
+                if (_jsonReader.Consumed < _span.Length)
+                {
+                    leftOver = _span.Slice((int)_jsonReader.Consumed);
+                }
+
+                if (leftOver.Length > _buffer.Length - StreamSegmentSize)
+                {
+                    if (leftOver.Length > int.MaxValue - StreamSegmentSize)
+                        JsonThrowHelper.ThrowArgumentException("Cannot fit left over data from the previous chunk and the next chunk of data into a 2 GB buffer.");
+
+                    ResizeBuffer(leftOver.Length + StreamSegmentSize);
+                }
+
+                leftOver.CopyTo(_buffer);
+
+                int numberOfBytes = _stream.Read(_buffer, leftOver.Length, StreamSegmentSize);
+                isFinalBlock = numberOfBytes < StreamSegmentSize;
+
+                _span = _buffer.AsSpan(0, leftOver.Length + numberOfBytes);   // This is gauranteed to not overflow
+
+                _jsonReader = new Utf8JsonReader(_span, isFinalBlock, _jsonReader.State);
+                result = _jsonReader.Read();
+            } while (!result && !isFinalBlock);
+
+            return result;
+        }
+
+        private void ResizeBuffer(int minimumSize)
+        {
+            ArrayPool<byte>.Shared.Return(_buffer);
+            _buffer = ArrayPool<byte>.Shared.Rent(minimumSize);
+        }
+
+        public void Dispose()
+        {
+            ArrayPool<byte>.Shared.Return(_buffer);
+            _buffer = null;
+        }
+    }
+}

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -21,8 +21,8 @@ namespace System.Text.JsonLab.Benchmarks
         public enum TestCaseType
         {
             HelloWorld,
-            BasicJson,
-            BasicLargeNum,
+            //BasicJson,
+            //BasicLargeNum,
             //SpecialNumForm,
             //ProjectLockJson,
             //FullSchema1,
@@ -32,9 +32,9 @@ namespace System.Text.JsonLab.Benchmarks
             //LotsOfNumbers,
             //LotsOfStrings,
             Json400B,
-            Json4KB,
-            Json40KB,
-            Json400KB
+            //Json4KB,
+            //Json40KB,
+            //Json400KB
         }
 
         private string _jsonString;

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -121,14 +121,6 @@ namespace System.Text.JsonLab.Benchmarks
         }
 
         [Benchmark]
-        public void ReaderSystemTextJsonLabStreamEmptyLoop()
-        {
-            _stream.Seek(0, SeekOrigin.Begin);
-            var json = new Utf8JsonReader(_stream);
-            while (json.Read()) ;
-        }
-
-        [Benchmark]
         public void ReaderSystemTextJsonLabStreamTypeEmptyLoop()
         {
             _stream.Seek(0, SeekOrigin.Begin);

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -21,20 +21,20 @@ namespace System.Text.JsonLab.Benchmarks
         public enum TestCaseType
         {
             HelloWorld,
-            //BasicJson,
-            //BasicLargeNum,
-            //SpecialNumForm,
-            //ProjectLockJson,
-            //FullSchema1,
-            //FullSchema2,
-            //DeepTree,
-            //BroadTree,
-            //LotsOfNumbers,
-            //LotsOfStrings,
+            BasicJson,
+            BasicLargeNum,
+            SpecialNumForm,
+            ProjectLockJson,
+            FullSchema1,
+            FullSchema2,
+            DeepTree,
+            BroadTree,
+            LotsOfNumbers,
+            LotsOfStrings,
             Json400B,
-            //Json4KB,
-            //Json40KB,
-            //Json400KB
+            Json4KB,
+            Json40KB,
+            Json400KB
         }
 
         private string _jsonString;
@@ -85,7 +85,7 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        //[Benchmark(Baseline = true)]
+        [Benchmark(Baseline = true)]
         public void ReaderNewtonsoftReaderEmptyLoop()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -94,7 +94,7 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public string ReaderNewtonsoftReaderReturnString()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -113,14 +113,14 @@ namespace System.Text.JsonLab.Benchmarks
             return sb.ToString();
         }
 
-        //[Benchmark(Baseline = true)]
+        [Benchmark]
         public void ReaderSystemTextJsonLabSpanEmptyLoop()
         {
             var json = new Utf8JsonReader(_dataUtf8);
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderSystemTextJsonLabStreamEmptyLoop()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -137,14 +137,14 @@ namespace System.Text.JsonLab.Benchmarks
             json.Dispose();
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequenceSingle);
             while (json.Read()) ;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequence);
@@ -152,7 +152,7 @@ namespace System.Text.JsonLab.Benchmarks
             json.Dispose();
         }
 
-        //[Benchmark]
+        [Benchmark]
         public byte[] ReaderSystemTextJsonLabReturnBytes()
         {
             var outputArray = new byte[_dataUtf8.Length * 2];
@@ -208,7 +208,7 @@ namespace System.Text.JsonLab.Benchmarks
             return outputArray;
         }
 
-        //[Benchmark]
+        [Benchmark]
         public void ReaderUtf8JsonEmptyLoop()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);
@@ -219,7 +219,7 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        //[Benchmark]
+        [Benchmark]
         public byte[] ReaderUtf8JsonReturnBytes()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -47,7 +47,7 @@ namespace System.Text.JsonLab.Benchmarks
         [ParamsSource(nameof(TestCaseValues))]
         public TestCaseType TestCase;
 
-        [Params(true)]
+        [Params(true, false)]
         public bool IsDataCompact;
 
         public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));

--- a/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
+++ b/tests/Benchmarks/System.Text.JsonLab/JsonReaderPerf.cs
@@ -23,14 +23,14 @@ namespace System.Text.JsonLab.Benchmarks
             HelloWorld,
             BasicJson,
             BasicLargeNum,
-            SpecialNumForm,
-            ProjectLockJson,
-            FullSchema1,
-            FullSchema2,
-            DeepTree,
-            BroadTree,
-            LotsOfNumbers,
-            LotsOfStrings,
+            //SpecialNumForm,
+            //ProjectLockJson,
+            //FullSchema1,
+            //FullSchema2,
+            //DeepTree,
+            //BroadTree,
+            //LotsOfNumbers,
+            //LotsOfStrings,
             Json400B,
             Json4KB,
             Json40KB,
@@ -47,7 +47,7 @@ namespace System.Text.JsonLab.Benchmarks
         [ParamsSource(nameof(TestCaseValues))]
         public TestCaseType TestCase;
 
-        [Params(true, false)]
+        [Params(true)]
         public bool IsDataCompact;
 
         public static IEnumerable<TestCaseType> TestCaseValues() => (IEnumerable<TestCaseType>)Enum.GetValues(typeof(TestCaseType));
@@ -85,7 +85,7 @@ namespace System.Text.JsonLab.Benchmarks
             _reader = new StreamReader(_stream, Encoding.UTF8, false, 1024, true);
         }
 
-        [Benchmark(Baseline = true)]
+        //[Benchmark(Baseline = true)]
         public void ReaderNewtonsoftReaderEmptyLoop()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -94,7 +94,7 @@ namespace System.Text.JsonLab.Benchmarks
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public string ReaderNewtonsoftReaderReturnString()
         {
             _stream.Seek(0, SeekOrigin.Begin);
@@ -113,21 +113,38 @@ namespace System.Text.JsonLab.Benchmarks
             return sb.ToString();
         }
 
-        [Benchmark]
+        //[Benchmark(Baseline = true)]
         public void ReaderSystemTextJsonLabSpanEmptyLoop()
         {
             var json = new Utf8JsonReader(_dataUtf8);
             while (json.Read()) ;
         }
 
+        //[Benchmark]
+        public void ReaderSystemTextJsonLabStreamEmptyLoop()
+        {
+            _stream.Seek(0, SeekOrigin.Begin);
+            var json = new Utf8JsonReader(_stream);
+            while (json.Read()) ;
+        }
+
         [Benchmark]
+        public void ReaderSystemTextJsonLabStreamTypeEmptyLoop()
+        {
+            _stream.Seek(0, SeekOrigin.Begin);
+            var json = new Utf8JsonReaderStream(_stream);
+            while (json.Read()) ;
+            json.Dispose();
+        }
+
+        //[Benchmark]
         public void ReaderSystemTextJsonLabSingleSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequenceSingle);
             while (json.Read()) ;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void ReaderSystemTextJsonLabMultiSpanSequenceEmptyLoop()
         {
             var json = new Utf8JsonReader(_sequence);
@@ -135,7 +152,7 @@ namespace System.Text.JsonLab.Benchmarks
             json.Dispose();
         }
 
-        [Benchmark]
+        //[Benchmark]
         public byte[] ReaderSystemTextJsonLabReturnBytes()
         {
             var outputArray = new byte[_dataUtf8.Length * 2];
@@ -191,7 +208,7 @@ namespace System.Text.JsonLab.Benchmarks
             return outputArray;
         }
 
-        [Benchmark]
+        //[Benchmark]
         public void ReaderUtf8JsonEmptyLoop()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);
@@ -202,7 +219,7 @@ namespace System.Text.JsonLab.Benchmarks
             }
         }
 
-        [Benchmark]
+        //[Benchmark]
         public byte[] ReaderUtf8JsonReturnBytes()
         {
             var json = new Utf8Json.JsonReader(_dataUtf8);

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -96,6 +96,11 @@ namespace System.Text.JsonLab.Tests
             string actualStr = Encoding.UTF8.GetString(result.AsSpan(0, length));
             byte[] resultSequence = JsonLabSequenceReturnBytesHelper(dataUtf8, out length);
             string actualStrSequence = Encoding.UTF8.GetString(resultSequence.AsSpan(0, length));
+            byte[] resultStream = JsonLabStreamReturnBytesHelper(dataUtf8, out length);
+            string actualStrStream = Encoding.UTF8.GetString(resultStream.AsSpan(0, length));
+
+            byte[] resultStream2 = JsonLabStream2ReturnBytesHelper(dataUtf8, out length);
+            string actualStrStream2 = Encoding.UTF8.GetString(resultStream2.AsSpan(0, length));
 
             Stream stream = new MemoryStream(dataUtf8);
             TextReader reader = new StreamReader(stream, Encoding.UTF8, false, 1024, true);
@@ -103,6 +108,8 @@ namespace System.Text.JsonLab.Tests
 
             Assert.Equal(expectedStr, actualStr);
             Assert.Equal(expectedStr, actualStrSequence);
+            Assert.Equal(expectedStr, actualStrStream);
+            Assert.Equal(expectedStr, actualStrStream2);
 
             // Json payload contains numbers that are too large for .NET (need BigInteger+)
             if (type != TestCaseType.FullSchema1)

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -99,9 +99,6 @@ namespace System.Text.JsonLab.Tests
             byte[] resultStream = JsonLabStreamReturnBytesHelper(dataUtf8, out length);
             string actualStrStream = Encoding.UTF8.GetString(resultStream.AsSpan(0, length));
 
-            byte[] resultStream2 = JsonLabStream2ReturnBytesHelper(dataUtf8, out length);
-            string actualStrStream2 = Encoding.UTF8.GetString(resultStream2.AsSpan(0, length));
-
             Stream stream = new MemoryStream(dataUtf8);
             TextReader reader = new StreamReader(stream, Encoding.UTF8, false, 1024, true);
             string expectedStr = NewtonsoftReturnStringHelper(reader);
@@ -109,7 +106,6 @@ namespace System.Text.JsonLab.Tests
             Assert.Equal(expectedStr, actualStr);
             Assert.Equal(expectedStr, actualStrSequence);
             Assert.Equal(expectedStr, actualStrStream);
-            Assert.Equal(expectedStr, actualStrStream2);
 
             // Json payload contains numbers that are too large for .NET (need BigInteger+)
             if (type != TestCaseType.FullSchema1)

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -2501,6 +2501,12 @@ namespace System.Text.JsonLab.Tests
             while (json.Read()) ;
             Assert.Equal(dataUtf8.Length, json.Consumed);
             json.Dispose();
+
+            var stream = new MemoryStream(dataUtf8);
+            var jsonStream = new Utf8JsonReaderStream(stream);
+            while (jsonStream.Read()) ;
+            Assert.Equal(dataUtf8.Length, jsonStream.Consumed);
+            json.Dispose();
         }
 
         [Theory]
@@ -2550,6 +2556,12 @@ namespace System.Text.JsonLab.Tests
             var json = new Utf8JsonReader(sequenceMultiple);
             while (json.Read()) ;
             Assert.Equal(sequenceMultiple.Length, json.Consumed);
+            json.Dispose();
+
+            var stream = new MemoryStream(sequenceMultiple.ToArray());
+            var jsonStream = new Utf8JsonReaderStream(stream);
+            while (jsonStream.Read()) ;
+            Assert.Equal(sequenceMultiple.Length, jsonStream.Consumed);
             json.Dispose();
         }
     }

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -2501,11 +2501,30 @@ namespace System.Text.JsonLab.Tests
             while (json.Read()) ;
             Assert.Equal(dataUtf8.Length, json.Consumed);
             json.Dispose();
+        }
+
+        [Theory]
+        [InlineData(10_000)]
+        [InlineData(100_000)]
+        [InlineData(1_000_000)]
+        [InlineData(10_000_000)]
+        [InlineData(1_000_000_000)]
+        public void StreamMaxTokenSize(int tokenSize)
+        {
+            var builder = new StringBuilder();
+            builder.Append("\"");
+            for (int i = 0; i < tokenSize; i++)
+            {
+                builder.Append("a");
+            }
+            builder.Append("\"");
+            string jsonString = builder.ToString();
+            byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
 
             var stream = new MemoryStream(dataUtf8);
-            var jsonStream = new Utf8JsonReaderStream(stream);
-            while (jsonStream.Read()) ;
-            Assert.Equal(dataUtf8.Length, jsonStream.Consumed);
+            var json = new Utf8JsonReaderStream(stream);
+            while (json.Read()) ;
+            Assert.Equal(dataUtf8.Length, json.Consumed);
             json.Dispose();
         }
 

--- a/tests/System.Text.JsonLab.Tests/JsonTestHelper.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonTestHelper.cs
@@ -417,6 +417,62 @@ namespace System.Text.JsonLab.Tests
             return result;
         }
 
+        public static byte[] JsonLabReaderLoop(int inpuDataLength, out int length, ref Utf8JsonReaderStream json)
+        {
+            byte[] outputArray = new byte[inpuDataLength];
+            Span<byte> destination = outputArray;
+
+            while (json.Read())
+            {
+                JsonTokenType tokenType = json.TokenType;
+                ReadOnlySpan<byte> valueSpan = json.Value;
+                switch (tokenType)
+                {
+                    case JsonTokenType.PropertyName:
+                        valueSpan.CopyTo(destination);
+                        destination[valueSpan.Length] = (byte)',';
+                        destination[valueSpan.Length + 1] = (byte)' ';
+                        destination = destination.Slice(valueSpan.Length + 2);
+                        break;
+                    case JsonTokenType.Number:
+                    case JsonTokenType.String:
+                    case JsonTokenType.Comment:
+                        valueSpan.CopyTo(destination);
+                        destination[valueSpan.Length] = (byte)',';
+                        destination[valueSpan.Length + 1] = (byte)' ';
+                        destination = destination.Slice(valueSpan.Length + 2);
+                        break;
+                    case JsonTokenType.True:
+                        // Special casing True/False so that the casing matches with Json.NET
+                        destination[0] = (byte)'T';
+                        destination[1] = (byte)'r';
+                        destination[2] = (byte)'u';
+                        destination[3] = (byte)'e';
+                        destination[valueSpan.Length] = (byte)',';
+                        destination[valueSpan.Length + 1] = (byte)' ';
+                        destination = destination.Slice(valueSpan.Length + 2);
+                        break;
+                    case JsonTokenType.False:
+                        destination[0] = (byte)'F';
+                        destination[1] = (byte)'a';
+                        destination[2] = (byte)'l';
+                        destination[3] = (byte)'s';
+                        destination[4] = (byte)'e';
+                        destination[valueSpan.Length] = (byte)',';
+                        destination[valueSpan.Length + 1] = (byte)' ';
+                        destination = destination.Slice(valueSpan.Length + 2);
+                        break;
+                    case JsonTokenType.Null:
+                        // Special casing Null so that it matches what JSON.NET does
+                        break;
+                    default:
+                        break;
+                }
+            }
+            length = outputArray.Length - destination.Length;
+            return outputArray;
+        }
+
         public static byte[] JsonLabReaderLoop(int inpuDataLength, out int length, ref Utf8JsonReader json)
         {
             byte[] outputArray = new byte[inpuDataLength];
@@ -663,6 +719,26 @@ namespace System.Text.JsonLab.Tests
                 Options = options
             };
             return JsonLabReaderLoop(data.Length, out length, ref reader);
+        }
+
+        public static byte[] JsonLabStreamReturnBytesHelper(byte[] data, out int length)
+        {
+            Stream stream = new MemoryStream(data);
+            var reader = new Utf8JsonReaderStream(stream);
+
+            byte[] result = JsonLabReaderLoop(data.Length, out length, ref reader);
+            reader.Dispose();
+            return result;
+        }
+
+        public static byte[] JsonLabStream2ReturnBytesHelper(byte[] data, out int length)
+        {
+            Stream stream = new MemoryStream(data);
+            var reader = new Utf8JsonReader(stream);
+
+            byte[] result = JsonLabReaderLoop(data.Length, out length, ref reader);
+            reader.Dispose();
+            return result;
         }
 
         public static object JsonLabReturnObjectHelper(byte[] data, JsonReaderOptions options = JsonReaderOptions.Default)

--- a/tests/System.Text.JsonLab.Tests/JsonTestHelper.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonTestHelper.cs
@@ -731,16 +731,6 @@ namespace System.Text.JsonLab.Tests
             return result;
         }
 
-        public static byte[] JsonLabStream2ReturnBytesHelper(byte[] data, out int length)
-        {
-            Stream stream = new MemoryStream(data);
-            var reader = new Utf8JsonReader(stream);
-
-            byte[] result = JsonLabReaderLoop(data.Length, out length, ref reader);
-            reader.Dispose();
-            return result;
-        }
-
         public static object JsonLabReturnObjectHelper(byte[] data, JsonReaderOptions options = JsonReaderOptions.Default)
         {
             var reader = new Utf8JsonReader(data)


### PR DESCRIPTION
- ~10-15% overhead for streams for payloads that aren't too small (say over 500 bytes).

``` ini

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17763
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-009667
  [Host]     : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT
  Job-CMDZZD : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT

IterationCount=5  WarmupCount=3  

```
|                                     Method | IsDataCompact |        TestCase |           Mean |         Error |        StdDev | Scaled | ScaledSD |  Gen 0 | Allocated |
|------------------------------------------- |-------------- |---------------- |---------------:|--------------:|--------------:|-------:|---------:|-------:|----------:|
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |       **BasicJson** |       **621.6 ns** |     **54.643 ns** |     **14.193 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True |       BasicJson |       806.9 ns |     45.472 ns |     11.811 ns |   1.30 |     0.03 | 0.2489 |    1048 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True |       BasicJson |       797.5 ns |     27.472 ns |      7.136 ns |   1.28 |     0.03 |      - |       0 B |
|                                            |               |                 |                |               |               |        |          |        |           |
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **BasicLargeNum** |       **790.8 ns** |     **61.442 ns** |     **15.959 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True |   BasicLargeNum |       995.0 ns |     32.717 ns |      8.498 ns |   1.26 |     0.02 | 0.2480 |    1048 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True |   BasicLargeNum |       982.6 ns |     68.919 ns |     17.901 ns |   1.24 |     0.03 |      - |       0 B |
|                                            |               |                 |                |               |               |        |          |        |           |
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |       **BroadTree** |    **10,782.8 ns** |    **820.137 ns** |    **213.027 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True |       BroadTree |    11,715.6 ns |    376.188 ns |     97.713 ns |   1.09 |     0.02 | 0.9766 |    4120 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True |       BroadTree |    11,545.7 ns |  1,739.501 ns |    451.829 ns |   1.07 |     0.04 |      - |       0 B |
|                                            |               |                 |                |               |               |        |          |        |           |
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |        **DeepTree** |     **4,605.7 ns** |    **200.181 ns** |     **51.996 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True |        DeepTree |     5,324.4 ns |    205.609 ns |     53.406 ns |   1.16 |     0.02 | 0.9766 |    4120 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True |        DeepTree |     5,180.3 ns |    318.687 ns |     82.778 ns |   1.12 |     0.02 |      - |       0 B |
|                                            |               |                 |                |               |               |        |          |        |           |
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |     **FullSchema1** |     **1,916.6 ns** |     **72.013 ns** |     **18.705 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True |     FullSchema1 |     2,167.3 ns |     38.368 ns |      9.966 ns |   1.13 |     0.01 | 0.2480 |    1048 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True |     FullSchema1 |     2,094.7 ns |     22.581 ns |      5.865 ns |   1.09 |     0.01 |      - |       0 B |
|                                            |               |                 |                |               |               |        |          |        |           |
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |     **FullSchema2** |     **2,596.6 ns** |     **42.989 ns** |     **11.166 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True |     FullSchema2 |     2,931.8 ns |     84.667 ns |     21.992 ns |   1.13 |     0.01 | 0.2480 |    1048 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True |     FullSchema2 |     2,846.0 ns |    149.108 ns |     38.730 ns |   1.10 |     0.01 |      - |       0 B |
|                                            |               |                 |                |               |               |        |          |        |           |
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |      **HelloWorld** |       **113.0 ns** |      **4.655 ns** |      **1.209 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True |      HelloWorld |       237.6 ns |     13.493 ns |      3.505 ns |   2.10 |     0.03 | 0.2494 |    1048 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True |      HelloWorld |       238.7 ns |     15.931 ns |      4.138 ns |   2.11 |     0.04 |      - |       0 B |
|                                            |               |                 |                |               |               |        |          |        |           |
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |        **Json400B** |       **924.7 ns** |      **6.145 ns** |      **1.596 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True |        Json400B |     1,145.4 ns |     96.670 ns |     25.110 ns |   1.24 |     0.02 | 0.2480 |    1048 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True |        Json400B |     1,106.0 ns |    233.919 ns |     60.760 ns |   1.20 |     0.06 |      - |       0 B |
|                                            |               |                 |                |               |               |        |          |        |           |
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |       **Json400KB** |   **954,469.4 ns** | **69,067.746 ns** | **17,940.090 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True |       Json400KB | 1,007,522.4 ns | 75,978.287 ns | 19,735.077 ns |   1.06 |     0.03 |      - |    4120 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True |       Json400KB | 1,016,858.4 ns | 83,565.053 ns | 21,705.711 ns |   1.07 |     0.03 |      - |       0 B |
|                                            |               |                 |                |               |               |        |          |        |           |
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |        **Json40KB** |    **90,793.7 ns** |  **5,553.991 ns** |  **1,442.629 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True |        Json40KB |   101,162.3 ns |  7,745.726 ns |  2,011.923 ns |   1.11 |     0.03 | 0.9766 |    4120 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True |        Json40KB |    95,215.8 ns |  7,796.122 ns |  2,025.014 ns |   1.05 |     0.02 |      - |       0 B |
|                                            |               |                 |                |               |               |        |          |        |           |
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |         **Json4KB** |     **7,094.4 ns** |     **66.391 ns** |     **17.245 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True |         Json4KB |     8,542.6 ns |    292.085 ns |     75.868 ns |   1.20 |     0.01 | 0.9766 |    4120 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True |         Json4KB |     7,670.4 ns |    722.620 ns |    187.698 ns |   1.08 |     0.02 |      - |       0 B |
|                                            |               |                 |                |               |               |        |          |        |           |
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **LotsOfNumbers** |     **2,777.3 ns** |    **143.238 ns** |     **37.206 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True |   LotsOfNumbers |     3,164.5 ns |     62.225 ns |     16.163 ns |   1.14 |     0.01 | 0.2480 |    1048 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True |   LotsOfNumbers |     3,026.1 ns |     24.924 ns |      6.474 ns |   1.09 |     0.01 |      - |       0 B |
|                                            |               |                 |                |               |               |        |          |        |           |
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **LotsOfStrings** |     **1,763.4 ns** |    **123.180 ns** |     **31.996 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True |   LotsOfStrings |     2,066.0 ns |     76.852 ns |     19.962 ns |   1.17 |     0.02 | 0.2480 |    1048 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True |   LotsOfStrings |     2,012.6 ns |     81.691 ns |     21.219 ns |   1.14 |     0.02 |      - |       0 B |
|                                            |               |                 |                |               |               |        |          |        |           |
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** | **ProjectLockJson** |   **429,495.4 ns** | **10,127.444 ns** |  **2,630.566 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True | ProjectLockJson |   440,013.7 ns | 33,610.981 ns |  8,730.327 ns |   1.02 |     0.02 | 0.9766 |    4120 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True | ProjectLockJson |   437,319.1 ns | 25,249.637 ns |  6,558.499 ns |   1.02 |     0.01 |      - |       0 B |
|                                            |               |                 |                |               |               |        |          |        |           |
|       **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **SpecialNumForm** |     **1,419.4 ns** |     **26.249 ns** |      **6.818 ns** |   **1.00** |     **0.00** |      **-** |       **0 B** |
|     ReaderSystemTextJsonLabStreamEmptyLoop |          True |  SpecialNumForm |     1,717.0 ns |     72.037 ns |     18.711 ns |   1.21 |     0.01 | 0.2480 |    1048 B |
| ReaderSystemTextJsonLabStreamTypeEmptyLoop |          True |  SpecialNumForm |     1,606.5 ns |    178.848 ns |     46.455 ns |   1.13 |     0.03 |      - |       0 B |
