### PR TITLE
Pin System.Memory and System.Buffers to last OOB version and no longer update them

### DIFF
--- a/scripts/update-dependencies/Program.cs
+++ b/scripts/update-dependencies/Program.cs
@@ -100,10 +100,9 @@ namespace Microsoft.Dotnet.Scripts
         private static IEnumerable<IDependencyUpdater> GetUpdaters()
         {
             yield return CreateRegexPropertyUpdater(config.DependencyFilePath, "SystemCompilerServicesUnsafeVersion", "System.Runtime.CompilerServices.Unsafe");
-            yield return CreateRegexPropertyUpdater(config.DependencyFilePath, "SystemMemoryVersion", "System.Memory");
             yield return CreateRegexPropertyUpdater(config.DependencyFilePath, "SystemNumericsVectorsVersion", "System.Numerics.Vectors");
-            yield return CreateRegexPropertyUpdater(config.DependencyFilePath, "SystemBuffersVersion", "System.Buffers");
             yield return CreateRegexPropertyUpdater(config.DependencyFilePath, "SystemIOPipelinesVersion", "System.IO.Pipelines");
+            yield return CreateRegexPropertyUpdater(config.DependencyFilePath, "SystemThreadingTasksExtensionsVersion", "System.Threading.Tasks.Extensions");
             yield return CreateFileUpdater(config.CLIVersionFilePath, "core-sdk");
         }
 

--- a/src/System.Memory.Polyfill/System.Memory.Polyfill.csproj
+++ b/src/System.Memory.Polyfill/System.Memory.Polyfill.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="$(SystemMemoryVersion)" />
-    <PackageReference Include="System.Buffers" Version="$(SystemMemoryVersion)" />
+    <PackageReference Include="System.Buffers" Version="$(SystemBuffersVersion)" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="$(SystemCompilerServicesUnsafeVersion)" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemMemoryVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="$(SystemThreadingTasksExtensionsVersion)" />
   </ItemGroup>
 </Project>

--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -2,11 +2,12 @@
   <PropertyGroup>
     <CoreFxStableVersion>4.3.0</CoreFxStableVersion>
     <RoslynVersion>2.8.0-beta4</RoslynVersion>
-    <SystemMemoryVersion>4.6.0-preview1-26717-04</SystemMemoryVersion>
+    <SystemMemoryVersion>4.5.1</SystemMemoryVersion>
     <SystemCompilerServicesUnsafeVersion>4.6.0-preview1-27018-01</SystemCompilerServicesUnsafeVersion>
     <SystemNumericsVectorsVersion>4.6.0-preview1-27018-01</SystemNumericsVectorsVersion>
-    <SystemBuffersVersion>4.6.0-preview1-26912-03</SystemBuffersVersion>
+    <SystemBuffersVersion>4.5.0</SystemBuffersVersion>
     <SystemIOPipelinesVersion>4.6.0-preview1-27018-01</SystemIOPipelinesVersion>
+    <SystemThreadingTasksExtensionsVersion>4.6.0-preview1-27018-01</SystemThreadingTasksExtensionsVersion>
     <LibuvVersion>1.9.1</LibuvVersion>
     <TestSdkVersion>15.0.0</TestSdkVersion>
     <XunitVersion>2.2.0</XunitVersion>


### PR DESCRIPTION
From https://github.com/dotnet/corefx/pull/32967#issuecomment-432334823