### PR TITLE
Remove JsonReaderOption to track position by UTF-8 code points

### DIFF
--- a/src/System.Text.JsonLab/System/Text/Json/JsonReaderException.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReaderException.cs
@@ -7,15 +7,15 @@ namespace System.Text.JsonLab
     public class JsonReaderException : Exception
     {
         //TODO: Consider adding line number and position to the message itself
-        public JsonReaderException(string message, long lineNumber, long linePosition) : base(message)
+        public JsonReaderException(string message, long lineNumber, long bytePosition) : base(message)
         {
             LineNumber = lineNumber;
-            LinePosition = linePosition;
+            BytePosition = bytePosition;
         }
 
         public long LineNumber { get; }
 
-        public long LinePosition { get; }
+        public long BytePosition { get; }
 
         //TODO: Should we add a path string (allocating a stack/etc)?
     }

--- a/src/System.Text.JsonLab/System/Text/Json/JsonReaderOptions.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/JsonReaderOptions.cs
@@ -10,6 +10,5 @@ namespace System.Text.JsonLab
         Default = 0b0000,       // Don't allow comments, treat as invalid json if found
         AllowComments = 0b0001, // Allow comments but don't skip them
         SkipComments = 0b0011,  // Allow and Skip comments
-        TrackPositionAsCodePoints = 0b0100, // Track the position by counting UTF-8 code points
     }
 }

--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader.cs
@@ -942,14 +942,7 @@ namespace System.Text.JsonLab
                     idx = localCopy.Length;
                     // Assume everything on this line is a comment and there is no more data.
 
-                    if (_readerOptions != JsonReaderOptions.TrackPositionAsCodePoints)
-                        _position += 2 + localCopy.Length;
-                    else
-                    {
-                        OperationStatus status = Encodings.Utf8.ToUtf16Length(localCopy, out int bytesNeeded);
-                        Debug.Assert(status == OperationStatus.Done);
-                        _position += 2 + (bytesNeeded / 2);
-                    }
+                    _position += 2 + localCopy.Length;
                     goto Done;
                 }
                 else return false;
@@ -994,25 +987,11 @@ namespace System.Text.JsonLab
             _lineNumber += newLines;
             if (newLineIndex != -1)
             {
-                if (_readerOptions != JsonReaderOptions.TrackPositionAsCodePoints)
-                    _position = idx - newLineIndex;
-                else
-                {
-                    OperationStatus status = Encodings.Utf8.ToUtf16Length(span.Slice(newLineIndex), out int bytesNeeded);
-                    Debug.Assert(status == OperationStatus.Done);
-                    _position += 2 + (bytesNeeded / 2);
-                }
+                _position = idx - newLineIndex;
             }
             else
             {
-                if (_readerOptions != JsonReaderOptions.TrackPositionAsCodePoints)
-                    _position += 4 + idx - 1;
-                else
-                {
-                    OperationStatus status = Encodings.Utf8.ToUtf16Length(span, out int bytesNeeded);
-                    Debug.Assert(status == OperationStatus.Done);
-                    _position += 4 + (bytesNeeded / 2) - 1;
-                }
+                _position += 4 + idx - 1;
             }
             return true;
         }
@@ -1052,14 +1031,7 @@ namespace System.Text.JsonLab
                     // Assume everything on this line is a comment and there is no more data.
                     Value = localCopy;
 
-                    if (_readerOptions != JsonReaderOptions.TrackPositionAsCodePoints)
-                        _position += 2 + Value.Length;
-                    else
-                    {
-                        OperationStatus status = Encodings.Utf8.ToUtf16Length(Value, out int bytesNeeded);
-                        Debug.Assert(status == OperationStatus.Done);
-                        _position += 2 + (bytesNeeded / 2);
-                    }
+                    _position += 2 + Value.Length;
 
                     goto Done;
                 }
@@ -1109,25 +1081,11 @@ namespace System.Text.JsonLab
             _lineNumber += newLines;
             if (newLineIndex != -1)
             {
-                if (_readerOptions != JsonReaderOptions.TrackPositionAsCodePoints)
-                    _position = Value.Length - newLineIndex + 1;
-                else
-                {
-                    OperationStatus status = Encodings.Utf8.ToUtf16Length(Value.Slice(newLineIndex), out int bytesNeeded);
-                    Debug.Assert(status == OperationStatus.Done);
-                    _position += 2 + (bytesNeeded / 2);
-                }
+                _position = Value.Length - newLineIndex + 1;
             }
             else
             {
-                if (_readerOptions != JsonReaderOptions.TrackPositionAsCodePoints)
-                    _position += 4 + Value.Length;
-                else
-                {
-                    OperationStatus status = Encodings.Utf8.ToUtf16Length(Value, out int bytesNeeded);
-                    Debug.Assert(status == OperationStatus.Done);
-                    _position += 4 + (bytesNeeded / 2);
-                }
+                _position += 4 + Value.Length;
             }
             return true;
         }
@@ -1323,14 +1281,7 @@ namespace System.Text.JsonLab
                     return false;
                 }
 
-                if (_readerOptions != JsonReaderOptions.TrackPositionAsCodePoints)
-                    _position += idx + 1;
-                else
-                {
-                    OperationStatus status = Encodings.Utf8.ToUtf16Length(localCopy, out int bytesNeeded);
-                    Debug.Assert(status == OperationStatus.Done);
-                    _position += 1 + (bytesNeeded / 2);
-                }
+                _position += idx + 1;
 
             Done:
                 _position++;
@@ -1399,32 +1350,7 @@ namespace System.Text.JsonLab
                     ThrowJsonReaderException(ref this, ExceptionResource.InvalidCharacterWithinString, currentByte);
                 }
 
-                if (_readerOptions != JsonReaderOptions.TrackPositionAsCodePoints)
-                    _position++;
-                else
-                {
-                    if (currentByte >= 0x0 && currentByte <= 0x7F)
-                    {
-                        incrementBy = 1;
-                    }
-                    else if (currentByte >= 0xC0 && currentByte <= 0xDF)
-                    {
-                        incrementBy = 2;
-                    }
-                    else if (currentByte >= 0xE0 && currentByte <= 0xEF)
-                    {
-                        incrementBy = 3;
-                    }
-                    else if (currentByte >= 0xF0 && currentByte <= 0xF7)
-                    {
-                        incrementBy = 4;
-                    }
-                    else
-                        incrementBy--;
-
-                    if (incrementBy == 1)
-                        _position += 1;
-                }
+                _position++;
             }
             return true;
 
@@ -1480,14 +1406,7 @@ namespace System.Text.JsonLab
                 return false;
             }
 
-            if (_readerOptions != JsonReaderOptions.TrackPositionAsCodePoints)
-                _position = i;
-            else
-            {
-                OperationStatus status = Encodings.Utf8.ToUtf16Length(localCopy, out int bytesNeeded);
-                Debug.Assert(status == OperationStatus.Done);
-                _position += bytesNeeded / 2;
-            }
+            _position = i;
 
         Done:
             _position++;

--- a/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader.cs
+++ b/src/System.Text.JsonLab/System/Text/Json/Utf8JsonReader.cs
@@ -981,9 +981,7 @@ namespace System.Text.JsonLab
             Debug.Assert(idx >= 1);
             _consumed += 3 + idx;
 
-            var span = localCopy.Slice(0, idx - 1);
-
-            (int newLines, int newLineIndex) = JsonReaderHelper.CountNewLines(span);
+            (int newLines, int newLineIndex) = JsonReaderHelper.CountNewLines(localCopy.Slice(0, idx - 1));
             _lineNumber += newLines;
             if (newLineIndex != -1)
             {
@@ -1300,7 +1298,6 @@ namespace System.Text.JsonLab
         private bool ValidateEscaping_AndHex(ReadOnlySpan<byte> data)
         {
             bool nextCharEscaped = false;
-            int incrementBy = 1;
             for (int i = 0; i < data.Length; i++)
             {
                 byte currentByte = data[i];

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -753,15 +753,15 @@ namespace System.Text.JsonLab.Tests
         }
 
         [Theory]
-        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false \"in漢字valid\"\r\n}", 30, 30, 3, 17, 21)]
-        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false \"in漢字valid\"\r\n}", 31, 31, 3, 17, 21)]
-        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false, \"in漢字valid\"\r\n}", 30, 30, 4, 0, 0)]
-        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false, \"in漢字valid\"\r\n}", 31, 30, 4, 0, 0)]
-        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false, \"in漢字valid\"\r\n}", 32, 30, 4, 0, 0)]
-        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false, 5\r\n}", 30, 30, 3, 18, 22)]
-        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false, 5\r\n}", 31, 30, 3, 18, 22)]
-        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false, 5\r\n}", 32, 30, 3, 18, 22)]
-        public static void InvalidJsonSplitRemainsInvalid(string jsonString, int splitLocation, int consumed, int expectedlineNumber, int expectedPosition, int expectedBytes)
+        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false \"in漢字valid\"\r\n}", 30, 30, 3, 21)]
+        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false \"in漢字valid\"\r\n}", 31, 31, 3, 21)]
+        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false, \"in漢字valid\"\r\n}", 30, 30, 4, 0)]
+        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false, \"in漢字valid\"\r\n}", 31, 30, 4, 0)]
+        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false, \"in漢字valid\"\r\n}", 32, 30, 4, 0)]
+        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false, 5\r\n}", 30, 30, 3, 22)]
+        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false, 5\r\n}", 31, 30, 3, 22)]
+        [InlineData("{\r\n\"is\\r\\nAct漢字ive\": false, 5\r\n}", 32, 30, 3, 22)]
+        public static void InvalidJsonSplitRemainsInvalid(string jsonString, int splitLocation, int consumed, int expectedlineNumber, int expectedBytePosition)
         {
             //TODO: Test multi-segment json payload
             foreach (JsonReaderOptions option in Enum.GetValues(typeof(JsonReaderOptions)))
@@ -786,39 +786,39 @@ namespace System.Text.JsonLab.Tests
                 catch (JsonReaderException ex)
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
-                    Assert.Equal(expectedBytes, ex.BytePosition);
+                    Assert.Equal(expectedBytePosition, ex.BytePosition);
                 }
             }
         }
 
         [Theory]
-        [InlineData("{]", 1, 1, 1)]
-        [InlineData("[}", 1, 1, 1)]
-        [InlineData("nulz", 1, 0, 0)]
-        [InlineData("truz", 1, 0, 0)]
-        [InlineData("falsz", 1, 0, 0)]
-        [InlineData("\"a漢字ge\":", 1, 7, 11)]
-        [InlineData("12345.1.", 1, 0, 0)]
-        [InlineData("-f", 1, 0, 0)]
-        [InlineData("1.f", 1, 0, 0)]
-        [InlineData("0.1f", 1, 0, 0)]
-        [InlineData("0.1e1f", 1, 0, 0)]
-        [InlineData("123,", 1, 3, 3)]
-        [InlineData("01", 1, 0, 0)]
-        [InlineData("-01", 1, 0, 0)]
-        [InlineData("10.5e-0.2", 1, 0, 0)]
-        [InlineData("{\"a漢字ge\":30, \"ints\":[1, 2, 3, 4, 5.1e7.3]}", 1, 33, 37)]
-        [InlineData("{\"a漢字ge\":30, \r\n \"num\":-0.e, \r\n \"ints\":[1, 2, 3, 4, 5]}", 2, 7, 7)]
-        [InlineData("{{}}", 1, 1, 1)]
-        [InlineData("[[{{}}]]", 1, 3, 3)]
-        [InlineData("[1, 2, 3, ]", 1, 10, 10)]
-        [InlineData("{\"a漢字ge\":30, \"ints\":[1, 2, 3, 4, 5}}", 1, 35, 39)]
-        [InlineData("{\r\n\"isActive\": false \"\r\n}", 2, 18, 18)]
-        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2\":[}]]]]}]]]]", 2, 24, 28)]
-        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2\":[]},[}]]]]}]]]]", 2, 28, 32)]
-        [InlineData("{\r\n\t\"isActive\": false,\r\n\t\"array\": [\r\n\t\t[{\r\n\t\t\t\"id\": 1\r\n\t\t}]\r\n\t]\r\n}", 4, 3, 3, 3)]
-        [InlineData("{\"Here is a 漢字string: \\\"\\\"\":\"Here is 漢字a\",\"Here is a back slash\\\\\":[\"Multiline\\r\\n String\\r\\n\",\"\\tMul\\r\\ntiline String\",\"\\\"somequote\\\"\\tMu\\\"\\\"l\\r\\ntiline\\\"another\\\" String\\\\\"],\"str:\"\\\"\\\"\"}", 5, 35, 35)]
-        public static void InvalidJsonWhenPartial(string jsonString, int expectedlineNumber, int expectedPosition, int expectedBytes, int maxDepth = 64)
+        [InlineData("{]", 1, 1)]
+        [InlineData("[}", 1, 1)]
+        [InlineData("nulz", 1, 0)]
+        [InlineData("truz", 1, 0)]
+        [InlineData("falsz", 1, 0)]
+        [InlineData("\"a漢字ge\":", 1, 11)]
+        [InlineData("12345.1.", 1, 0)]
+        [InlineData("-f", 1, 0)]
+        [InlineData("1.f", 1, 0)]
+        [InlineData("0.1f", 1, 0)]
+        [InlineData("0.1e1f", 1, 0)]
+        [InlineData("123,", 1, 3)]
+        [InlineData("01", 1, 0)]
+        [InlineData("-01", 1, 0)]
+        [InlineData("10.5e-0.2", 1, 0)]
+        [InlineData("{\"a漢字ge\":30, \"ints\":[1, 2, 3, 4, 5.1e7.3]}", 1, 37)]
+        [InlineData("{\"a漢字ge\":30, \r\n \"num\":-0.e, \r\n \"ints\":[1, 2, 3, 4, 5]}", 2, 7)]
+        [InlineData("{{}}", 1, 1)]
+        [InlineData("[[{{}}]]", 1, 3)]
+        [InlineData("[1, 2, 3, ]", 1, 10)]
+        [InlineData("{\"a漢字ge\":30, \"ints\":[1, 2, 3, 4, 5}}", 1, 39)]
+        [InlineData("{\r\n\"isActive\": false \"\r\n}", 2, 18)]
+        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2\":[}]]]]}]]]]", 2, 28)]
+        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2\":[]},[}]]]]}]]]]", 2, 32)]
+        [InlineData("{\r\n\t\"isActive\": false,\r\n\t\"array\": [\r\n\t\t[{\r\n\t\t\t\"id\": 1\r\n\t\t}]\r\n\t]\r\n}", 4, 3, 3)]
+        [InlineData("{\"Here is a 漢字string: \\\"\\\"\":\"Here is 漢字a\",\"Here is a back slash\\\\\":[\"Multiline\\r\\n String\\r\\n\",\"\\tMul\\r\\ntiline String\",\"\\\"somequote\\\"\\tMu\\\"\\\"l\\r\\ntiline\\\"another\\\" String\\\\\"],\"str:\"\\\"\\\"\"}", 5, 35)]
+        public static void InvalidJsonWhenPartial(string jsonString, int expectedlineNumber, int expectedBytePosition, int maxDepth = 64)
         {
             //TODO: Test multi-segment json payload
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
@@ -839,15 +839,15 @@ namespace System.Text.JsonLab.Tests
                 catch (JsonReaderException ex)
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
-                    Assert.Equal(expectedBytes, ex.BytePosition);
+                    Assert.Equal(expectedBytePosition, ex.BytePosition);
                 }
             }
         }
 
         [Theory]
-        [InlineData("{\"text\": \"๏ แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช\\uABCZ พระปกเกศกองบู๊กู้ขึ้นใหม่\"}", 1, 47, 109)]
-        [InlineData("{\"text\": \"๏ แผ่นดินฮั่นเสื่อมโ\\nทรมแสนสังเวช\\uABCZ พระปกเกศกองบู๊กู้ขึ้นใหม่\"}", 2, 17, 41)]
-        public static void PositionInCharacters(string jsonString, int expectedlineNumber, int expectedPosition, int expectedBytes)
+        [InlineData("{\"text\": \"๏ แผ่นดินฮั่นเสื่อมโทรมแสนสังเวช\\uABCZ พระปกเกศกองบู๊กู้ขึ้นใหม่\"}", 1, 109)]
+        [InlineData("{\"text\": \"๏ แผ่นดินฮั่นเสื่อมโ\\nทรมแสนสังเวช\\uABCZ พระปกเกศกองบู๊กู้ขึ้นใหม่\"}", 2, 41)]
+        public static void PositionInCharacters(string jsonString, int expectedlineNumber, int expectedBytePosition)
         {
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
 
@@ -866,71 +866,71 @@ namespace System.Text.JsonLab.Tests
                 catch (JsonReaderException ex)
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
-                    Assert.Equal(expectedBytes, ex.BytePosition);
+                    Assert.Equal(expectedBytePosition, ex.BytePosition);
                 }
             }
         }
 
         [Theory]
-        [InlineData("\"", 1, 0, 0)]
-        [InlineData("{]", 1, 1, 1)]
-        [InlineData("[}", 1, 1, 1)]
-        [InlineData("nul", 1, 0, 0)]
-        [InlineData("tru", 1, 0, 0)]
-        [InlineData("fals", 1, 0, 0)]
-        [InlineData("\"a漢字ge\":", 1, 7, 11)]
-        [InlineData("{\"a漢字ge\":", 1, 9, 13)]
-        [InlineData("{\"name\":\"A漢字hso", 1, 8, 8)]
-        [InlineData("12345.1.", 1, 0, 0)]
-        [InlineData("-", 1, 0, 0)]
-        [InlineData("-f", 1, 0, 0)]
-        [InlineData("1.f", 1, 0, 0)]
-        [InlineData("0.", 1, 0, 0)]
-        [InlineData("0.1f", 1, 0, 0)]
-        [InlineData("0.1e1f", 1, 0, 0)]
-        [InlineData("123,", 1, 3, 3)]
-        [InlineData("false,", 1, 5, 5)]
-        [InlineData("true,", 1, 4, 4)]
-        [InlineData("null,", 1, 4, 4)]
-        [InlineData("\"h漢字ello\",", 1, 9, 13)]
-        [InlineData("01", 1, 0, 0)]
-        [InlineData("1a", 1, 0, 0)]
-        [InlineData("-01", 1, 0, 0)]
-        [InlineData("10.5e", 1, 0, 0)]
-        [InlineData("10.5e-", 1, 0, 0)]
-        [InlineData("10.5e-0.2", 1, 0, 0)]
-        [InlineData("{\"age\":30, \"ints\":[1, 2, 3, 4, 5.1e7.3]}", 1, 31, 31)]
-        [InlineData("{\"age\":30, \r\n \"num\":-0.e, \r\n \"ints\":[1, 2, 3, 4, 5]}", 2, 7, 7)]
-        [InlineData("{{}}", 1, 1, 1)]
-        [InlineData("[[{{}}]]", 1, 3, 3)]
-        [InlineData("[1, 2, 3, ]", 1, 10, 10)]
-        [InlineData("{\"ints\":[1, 2, 3, 4, 5", 1, 21, 21)]
-        [InlineData("{\"s漢字trings\":[\"a漢字bc\", \"def\"", 1, 28, 36)]
-        [InlineData("{\"age\":30, \"ints\":[1, 2, 3, 4, 5}}", 1, 33, 33)]
-        [InlineData("{\"age\":30, \"name\":\"test}", 1, 18, 18)]
-        [InlineData("{\r\n\"isActive\": false \"\r\n}", 2, 18, 18)]
-        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2\":[}]]]]}]]]]", 2, 24, 28)]
-        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2:[]}]]]]}]]]]", 2, 15, 19)]
-        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2\":[]},[}]]]]}]]]]", 2, 28, 32)]
-        [InlineData("{\r\n\t\"isActive\": false,\r\n\t\"array\": [\r\n\t\t[{\r\n\t\t\t\"id\": 1\r\n\t\t}]\r\n\t]\r\n}", 4, 3, 3, 3)]
-        [InlineData("{\"Here is a 漢字string: \\\"\\\"\":\"Here is 漢字a\",\"Here is a back slash\\\\\":[\"Multiline\\r\\n String\\r\\n\",\"\\tMul\\r\\ntiline String\",\"\\\"somequote\\\"\\tMu\\\"\\\"l\\r\\ntiline\\\"another\\\" String\\\\\"],\"str:\"\\\"\\\"\"}", 5, 35, 35)]
-        [InlineData("\"hel\rlo\"", 1, 4, 4)]
-        [InlineData("\"hel\nlo\"", 1, 4, 4)]
-        [InlineData("\"hel\\uABCXlo\"", 1, 9, 9)]
-        [InlineData("\"hel\\\tlo\"", 1, 5, 5)]
-        [InlineData("\"hel\rlo\\\"\"", 1, 4, 4)]
-        [InlineData("\"hel\nlo\\\"\"", 1, 4, 4)]
-        [InlineData("\"hel\\uABCXlo\\\"\"", 1, 9, 9)]
-        [InlineData("\"hel\\\tlo\\\"\"", 1, 5, 5)]
-        [InlineData("\"he\\nl\rlo\\\"\"", 2, 1, 1)]
-        [InlineData("\"he\\nl\nlo\\\"\"", 2, 1, 1)]
-        [InlineData("\"he\\nl\\uABCXlo\\\"\"", 2, 6, 6)]
-        [InlineData("\"he\\nl\\\tlo\\\"\"", 2, 2, 2)]
-        [InlineData("\"he\\nl\rlo", 1, 0, 0)]
-        [InlineData("\"he\\nl\nlo", 1, 0, 0)]
-        [InlineData("\"he\\nl\\uABCXlo", 1, 0, 0)]
-        [InlineData("\"he\\nl\\\tlo", 1, 0, 0)]
-        public static void InvalidJson(string jsonString, int expectedlineNumber, int expectedPosition, int expectedBytes, int maxDepth = 64)
+        [InlineData("\"", 1, 0)]
+        [InlineData("{]", 1, 1)]
+        [InlineData("[}", 1, 1)]
+        [InlineData("nul", 1, 0)]
+        [InlineData("tru", 1, 0)]
+        [InlineData("fals", 1, 0)]
+        [InlineData("\"a漢字ge\":", 1, 11)]
+        [InlineData("{\"a漢字ge\":", 1, 13)]
+        [InlineData("{\"name\":\"A漢字hso", 1, 8)]
+        [InlineData("12345.1.", 1, 0)]
+        [InlineData("-", 1, 0)]
+        [InlineData("-f", 1, 0)]
+        [InlineData("1.f", 1, 0)]
+        [InlineData("0.", 1, 0)]
+        [InlineData("0.1f", 1, 0)]
+        [InlineData("0.1e1f", 1, 0)]
+        [InlineData("123,", 1, 3)]
+        [InlineData("false,", 1, 5)]
+        [InlineData("true,", 1, 4)]
+        [InlineData("null,", 1, 4)]
+        [InlineData("\"h漢字ello\",", 1, 13)]
+        [InlineData("01", 1, 0)]
+        [InlineData("1a", 1, 0)]
+        [InlineData("-01", 1, 0)]
+        [InlineData("10.5e", 1, 0)]
+        [InlineData("10.5e-", 1, 0)]
+        [InlineData("10.5e-0.2", 1, 0)]
+        [InlineData("{\"age\":30, \"ints\":[1, 2, 3, 4, 5.1e7.3]}", 1, 31)]
+        [InlineData("{\"age\":30, \r\n \"num\":-0.e, \r\n \"ints\":[1, 2, 3, 4, 5]}", 2, 7)]
+        [InlineData("{{}}", 1, 1)]
+        [InlineData("[[{{}}]]", 1, 3)]
+        [InlineData("[1, 2, 3, ]", 1, 10)]
+        [InlineData("{\"ints\":[1, 2, 3, 4, 5", 1, 21)]
+        [InlineData("{\"s漢字trings\":[\"a漢字bc\", \"def\"", 1, 36)]
+        [InlineData("{\"age\":30, \"ints\":[1, 2, 3, 4, 5}}", 1, 33)]
+        [InlineData("{\"age\":30, \"name\":\"test}", 1, 18)]
+        [InlineData("{\r\n\"isActive\": false \"\r\n}", 2, 18)]
+        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2\":[}]]]]}]]]]", 2, 28)]
+        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2:[]}]]]]}]]]]", 2, 19)]
+        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2\":[]},[}]]]]}]]]]", 2, 32)]
+        [InlineData("{\r\n\t\"isActive\": false,\r\n\t\"array\": [\r\n\t\t[{\r\n\t\t\t\"id\": 1\r\n\t\t}]\r\n\t]\r\n}", 4, 3, 3)]
+        [InlineData("{\"Here is a 漢字string: \\\"\\\"\":\"Here is 漢字a\",\"Here is a back slash\\\\\":[\"Multiline\\r\\n String\\r\\n\",\"\\tMul\\r\\ntiline String\",\"\\\"somequote\\\"\\tMu\\\"\\\"l\\r\\ntiline\\\"another\\\" String\\\\\"],\"str:\"\\\"\\\"\"}", 5, 35)]
+        [InlineData("\"hel\rlo\"", 1, 4)]
+        [InlineData("\"hel\nlo\"", 1, 4)]
+        [InlineData("\"hel\\uABCXlo\"", 1, 9)]
+        [InlineData("\"hel\\\tlo\"", 1, 5)]
+        [InlineData("\"hel\rlo\\\"\"", 1, 4)]
+        [InlineData("\"hel\nlo\\\"\"", 1, 4)]
+        [InlineData("\"hel\\uABCXlo\\\"\"", 1, 9)]
+        [InlineData("\"hel\\\tlo\\\"\"", 1, 5)]
+        [InlineData("\"he\\nl\rlo\\\"\"", 2, 1)]
+        [InlineData("\"he\\nl\nlo\\\"\"", 2, 1)]
+        [InlineData("\"he\\nl\\uABCXlo\\\"\"", 2, 6)]
+        [InlineData("\"he\\nl\\\tlo\\\"\"", 2, 2)]
+        [InlineData("\"he\\nl\rlo", 1, 0)]
+        [InlineData("\"he\\nl\nlo", 1, 0)]
+        [InlineData("\"he\\nl\\uABCXlo", 1, 0)]
+        [InlineData("\"he\\nl\\\tlo", 1, 0)]
+        public static void InvalidJson(string jsonString, int expectedlineNumber, int expectedBytePosition, int maxDepth = 64)
         {
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
 
@@ -950,7 +950,7 @@ namespace System.Text.JsonLab.Tests
                 catch (JsonReaderException ex)
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
-                    Assert.Equal(expectedBytes, ex.BytePosition);
+                    Assert.Equal(expectedBytePosition, ex.BytePosition);
                 }
 
                 ReadOnlyMemory<byte> dataMemory = dataUtf8;
@@ -979,9 +979,9 @@ namespace System.Text.JsonLab.Tests
                         string secondSegmentString = Encodings.Utf8.ToString(secondMem.Span);
                         errorMessage += " | " + firstSegmentString + " | " + secondSegmentString;
                         Assert.True(expectedlineNumber == ex.LineNumber, errorMessage);
-                        errorMessage = $"expectedBytes: {expectedBytes} | actual: {ex.BytePosition} | index: {i} | option: {option}";
+                        errorMessage = $"expectedBytePosition: {expectedBytePosition} | actual: {ex.BytePosition} | index: {i} | option: {option}";
                         errorMessage += " | " + firstSegmentString + " | " + secondSegmentString;
-                        Assert.True(expectedBytes == ex.BytePosition, errorMessage);
+                        Assert.True(expectedBytePosition == ex.BytePosition, errorMessage);
                         jsonMultiSegment.Dispose();
                     }
                 }
@@ -989,65 +989,65 @@ namespace System.Text.JsonLab.Tests
         }
 
         [Theory]
-        [InlineData("\"", 1, 0, 0)]
-        [InlineData("{]", 1, 1, 1)]
-        [InlineData("[}", 1, 1, 1)]
-        [InlineData("nul", 1, 0, 0)]
-        [InlineData("tru", 1, 0, 0)]
-        [InlineData("fals", 1, 0, 0)]
-        [InlineData("\"a漢字ge\":", 1, 7, 11)]
-        [InlineData("{\"a漢字ge\":", 1, 9, 13)]
-        [InlineData("{\"name\":\"A漢字hso", 1, 8, 8)]
-        [InlineData("12345.1.", 1, 0, 0)]
-        [InlineData("-", 1, 0, 0)]
-        [InlineData("-f", 1, 0, 0)]
-        [InlineData("1.f", 1, 0, 0)]
-        [InlineData("0.", 1, 0, 0)]
-        [InlineData("0.1f", 1, 0, 0)]
-        [InlineData("0.1e1f", 1, 0, 0)]
-        [InlineData("123,", 1, 3, 3)]
-        [InlineData("false,", 1, 5, 5)]
-        [InlineData("true,", 1, 4, 4)]
-        [InlineData("null,", 1, 4, 4)]
-        [InlineData("\"h漢字ello\",", 1, 9, 13)]
-        [InlineData("01", 1, 0, 0)]
-        [InlineData("1a", 1, 0, 0)]
-        [InlineData("-01", 1, 0, 0)]
-        [InlineData("10.5e", 1, 0, 0)]
-        [InlineData("10.5e-", 1, 0, 0)]
-        [InlineData("10.5e-0.2", 1, 0, 0)]
-        [InlineData("{\"age\":30, \"ints\":[1, 2, 3, 4, 5.1e7.3]}", 1, 31, 31)]
-        [InlineData("{\"age\":30, \r\n \"num\":-0.e, \r\n \"ints\":[1, 2, 3, 4, 5]}", 2, 7, 7)]
+        [InlineData("\"", 1, 0)]
+        [InlineData("{]", 1, 1)]
+        [InlineData("[}", 1, 1)]
+        [InlineData("nul", 1, 0)]
+        [InlineData("tru", 1, 0)]
+        [InlineData("fals", 1, 0)]
+        [InlineData("\"a漢字ge\":", 1, 11)]
+        [InlineData("{\"a漢字ge\":", 1, 13)]
+        [InlineData("{\"name\":\"A漢字hso", 1, 8)]
+        [InlineData("12345.1.", 1, 0)]
+        [InlineData("-", 1, 0)]
+        [InlineData("-f", 1, 0)]
+        [InlineData("1.f", 1, 0)]
+        [InlineData("0.", 1, 0)]
+        [InlineData("0.1f", 1, 0)]
+        [InlineData("0.1e1f", 1, 0)]
+        [InlineData("123,", 1, 3)]
+        [InlineData("false,", 1, 5)]
+        [InlineData("true,", 1, 4)]
+        [InlineData("null,", 1, 4)]
+        [InlineData("\"h漢字ello\",", 1, 13)]
+        [InlineData("01", 1, 0)]
+        [InlineData("1a", 1, 0)]
+        [InlineData("-01", 1, 0)]
+        [InlineData("10.5e", 1, 0)]
+        [InlineData("10.5e-", 1, 0)]
+        [InlineData("10.5e-0.2", 1, 0)]
+        [InlineData("{\"age\":30, \"ints\":[1, 2, 3, 4, 5.1e7.3]}", 1, 31)]
+        [InlineData("{\"age\":30, \r\n \"num\":-0.e, \r\n \"ints\":[1, 2, 3, 4, 5]}", 2, 7)]
         [InlineData("{{}}", 1, 1, 1)]
-        [InlineData("[[{{}}]]", 1, 3, 3)]
-        [InlineData("[1, 2, 3, ]", 1, 10, 10)]
-        [InlineData("{\"ints\":[1, 2, 3, 4, 5", 1, 21, 21)]
-        [InlineData("{\"s漢字trings\":[\"a漢字bc\", \"def\"", 1, 28, 36)]
-        [InlineData("{\"age\":30, \"ints\":[1, 2, 3, 4, 5}}", 1, 33, 33)]
-        [InlineData("{\"age\":30, \"name\":\"test}", 1, 18, 18)]
-        [InlineData("{\r\n\"isActive\": false \"\r\n}", 2, 18, 18)]
-        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2\":[}]]]]}]]]]", 2, 24, 28)]
-        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2:[]}]]]]}]]]]", 2, 15, 19)]
-        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2\":[]},[}]]]]}]]]]", 2, 28, 32)]
-        [InlineData("{\r\n\t\"isActive\": false,\r\n\t\"array\": [\r\n\t\t[{\r\n\t\t\t\"id\": 1\r\n\t\t}]\r\n\t]\r\n}", 4, 3, 3, 3)]
-        [InlineData("{\"Here is a 漢字string: \\\"\\\"\":\"Here is 漢字a\",\"Here is a back slash\\\\\":[\"Multiline\\r\\n String\\r\\n\",\"\\tMul\\r\\ntiline String\",\"\\\"somequote\\\"\\tMu\\\"\\\"l\\r\\ntiline\\\"another\\\" String\\\\\"],\"str:\"\\\"\\\"\"}", 5, 35, 35)]
-        [InlineData("\"hel\rlo\"", 1, 4, 4)]
-        [InlineData("\"hel\nlo\"", 1, 4, 4)]
-        [InlineData("\"hel\\uABCXlo\"", 1, 9, 9)]
-        [InlineData("\"hel\\\tlo\"", 1, 5, 5)]
-        [InlineData("\"hel\rlo\\\"\"", 1, 4, 4)]
-        [InlineData("\"hel\nlo\\\"\"", 1, 4, 4)]
-        [InlineData("\"hel\\uABCXlo\\\"\"", 1, 9, 9)]
-        [InlineData("\"hel\\\tlo\\\"\"", 1, 5, 5)]
-        [InlineData("\"he\\nl\rlo\\\"\"", 2, 1, 1)]
-        [InlineData("\"he\\nl\nlo\\\"\"", 2, 1, 1)]
-        [InlineData("\"he\\nl\\uABCXlo\\\"\"", 2, 6, 6)]
-        [InlineData("\"he\\nl\\\tlo\\\"\"", 2, 2, 2)]
-        [InlineData("\"he\\nl\rlo", 1, 0, 0)]
-        [InlineData("\"he\\nl\nlo", 1, 0, 0)]
-        [InlineData("\"he\\nl\\uABCXlo", 1, 0, 0)]
-        [InlineData("\"he\\nl\\\tlo", 1, 0, 0)]
-        public static void InvalidJsonSingleSegment(string jsonString, int expectedlineNumber, int expectedPosition, int expectedBytes, int maxDepth = 64)
+        [InlineData("[[{{}}]]", 1, 3)]
+        [InlineData("[1, 2, 3, ]", 1, 10)]
+        [InlineData("{\"ints\":[1, 2, 3, 4, 5", 1, 21)]
+        [InlineData("{\"s漢字trings\":[\"a漢字bc\", \"def\"", 1, 36)]
+        [InlineData("{\"age\":30, \"ints\":[1, 2, 3, 4, 5}}", 1, 33)]
+        [InlineData("{\"age\":30, \"name\":\"test}", 1, 18)]
+        [InlineData("{\r\n\"isActive\": false \"\r\n}", 2, 18)]
+        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2\":[}]]]]}]]]]", 2, 28)]
+        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2:[]}]]]]}]]]]", 2, 19)]
+        [InlineData("[[[[{\r\n\"t漢字emp1\":[[[[{\"temp2\":[]},[}]]]]}]]]]", 2, 32)]
+        [InlineData("{\r\n\t\"isActive\": false,\r\n\t\"array\": [\r\n\t\t[{\r\n\t\t\t\"id\": 1\r\n\t\t}]\r\n\t]\r\n}", 4, 3, 3)]
+        [InlineData("{\"Here is a 漢字string: \\\"\\\"\":\"Here is 漢字a\",\"Here is a back slash\\\\\":[\"Multiline\\r\\n String\\r\\n\",\"\\tMul\\r\\ntiline String\",\"\\\"somequote\\\"\\tMu\\\"\\\"l\\r\\ntiline\\\"another\\\" String\\\\\"],\"str:\"\\\"\\\"\"}", 5, 35)]
+        [InlineData("\"hel\rlo\"", 1, 4)]
+        [InlineData("\"hel\nlo\"", 1, 4)]
+        [InlineData("\"hel\\uABCXlo\"", 1, 9)]
+        [InlineData("\"hel\\\tlo\"", 1, 5)]
+        [InlineData("\"hel\rlo\\\"\"", 1, 4)]
+        [InlineData("\"hel\nlo\\\"\"", 1, 4)]
+        [InlineData("\"hel\\uABCXlo\\\"\"", 1, 9)]
+        [InlineData("\"hel\\\tlo\\\"\"", 1, 5)]
+        [InlineData("\"he\\nl\rlo\\\"\"", 2, 1)]
+        [InlineData("\"he\\nl\nlo\\\"\"", 2, 1)]
+        [InlineData("\"he\\nl\\uABCXlo\\\"\"", 2, 6)]
+        [InlineData("\"he\\nl\\\tlo\\\"\"", 2, 2)]
+        [InlineData("\"he\\nl\rlo", 1, 0)]
+        [InlineData("\"he\\nl\nlo", 1, 0)]
+        [InlineData("\"he\\nl\\uABCXlo", 1, 0)]
+        [InlineData("\"he\\nl\\\tlo", 1, 0)]
+        public static void InvalidJsonSingleSegment(string jsonString, int expectedlineNumber, int expectedBytePosition, int maxDepth = 64)
         {
             byte[] dataUtf8 = Encoding.UTF8.GetBytes(jsonString);
 
@@ -1067,7 +1067,7 @@ namespace System.Text.JsonLab.Tests
                 catch (JsonReaderException ex)
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
-                    Assert.Equal(expectedBytes, ex.BytePosition);
+                    Assert.Equal(expectedBytePosition, ex.BytePosition);
                 }
 
                 for (int i = 0; i < dataUtf8.Length; i++)
@@ -1100,9 +1100,9 @@ namespace System.Text.JsonLab.Tests
                         string secondSegmentString = Encodings.Utf8.ToString(dataUtf8.AsSpan(i));
                         errorMessage += " | " + firstSegmentString + " | " + secondSegmentString;
                         Assert.True(expectedlineNumber == ex.LineNumber, errorMessage);
-                        errorMessage = $"expectedBytes: {expectedBytes} | actual: {ex.BytePosition} | index: {i} | option: {option}";
+                        errorMessage = $"expectedBytePosition: {expectedBytePosition} | actual: {ex.BytePosition} | index: {i} | option: {option}";
                         errorMessage += " | " + firstSegmentString + " | " + secondSegmentString;
-                        Assert.True(expectedBytes == ex.BytePosition, errorMessage);
+                        Assert.True(expectedBytePosition == ex.BytePosition, errorMessage);
                     }
                 }
             }

--- a/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
+++ b/tests/System.Text.JsonLab.Tests/JsonReaderTests.cs
@@ -786,10 +786,7 @@ namespace System.Text.JsonLab.Tests
                 catch (JsonReaderException ex)
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
-                    if (option == JsonReaderOptions.TrackPositionAsCodePoints)
-                        Assert.Equal(expectedPosition, ex.LinePosition);
-                    else
-                        Assert.Equal(expectedBytes, ex.LinePosition);
+                    Assert.Equal(expectedBytes, ex.BytePosition);
                 }
             }
         }
@@ -842,10 +839,7 @@ namespace System.Text.JsonLab.Tests
                 catch (JsonReaderException ex)
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
-                    if (option == JsonReaderOptions.TrackPositionAsCodePoints)
-                        Assert.Equal(expectedPosition, ex.LinePosition);
-                    else
-                        Assert.Equal(expectedBytes, ex.LinePosition);
+                    Assert.Equal(expectedBytes, ex.BytePosition);
                 }
             }
         }
@@ -872,10 +866,7 @@ namespace System.Text.JsonLab.Tests
                 catch (JsonReaderException ex)
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
-                    if (option == JsonReaderOptions.TrackPositionAsCodePoints)
-                        Assert.Equal(expectedPosition, ex.LinePosition);
-                    else
-                        Assert.Equal(expectedBytes, ex.LinePosition);
+                    Assert.Equal(expectedBytes, ex.BytePosition);
                 }
             }
         }
@@ -959,10 +950,7 @@ namespace System.Text.JsonLab.Tests
                 catch (JsonReaderException ex)
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
-                    if (option == JsonReaderOptions.TrackPositionAsCodePoints)
-                        Assert.Equal(expectedPosition, ex.LinePosition);
-                    else
-                        Assert.Equal(expectedBytes, ex.LinePosition);
+                    Assert.Equal(expectedBytes, ex.BytePosition);
                 }
 
                 ReadOnlyMemory<byte> dataMemory = dataUtf8;
@@ -991,18 +979,9 @@ namespace System.Text.JsonLab.Tests
                         string secondSegmentString = Encodings.Utf8.ToString(secondMem.Span);
                         errorMessage += " | " + firstSegmentString + " | " + secondSegmentString;
                         Assert.True(expectedlineNumber == ex.LineNumber, errorMessage);
-                        if (option == JsonReaderOptions.TrackPositionAsCodePoints)
-                        {
-                            errorMessage = $"expectedPosition: {expectedPosition} | actual: {ex.LinePosition} | index: {i} | option: {option}";
-                            errorMessage += " | " + firstSegmentString + " | " + secondSegmentString;
-                            Assert.True(expectedPosition == ex.LinePosition, errorMessage);
-                        }
-                        else
-                        {
-                            errorMessage = $"expectedBytes: {expectedBytes} | actual: {ex.LinePosition} | index: {i} | option: {option}";
-                            errorMessage += " | " + firstSegmentString + " | " + secondSegmentString;
-                            Assert.True(expectedBytes == ex.LinePosition, errorMessage);
-                        }
+                        errorMessage = $"expectedBytes: {expectedBytes} | actual: {ex.BytePosition} | index: {i} | option: {option}";
+                        errorMessage += " | " + firstSegmentString + " | " + secondSegmentString;
+                        Assert.True(expectedBytes == ex.BytePosition, errorMessage);
                         jsonMultiSegment.Dispose();
                     }
                 }
@@ -1088,10 +1067,7 @@ namespace System.Text.JsonLab.Tests
                 catch (JsonReaderException ex)
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
-                    if (option == JsonReaderOptions.TrackPositionAsCodePoints)
-                        Assert.Equal(expectedPosition, ex.LinePosition);
-                    else
-                        Assert.Equal(expectedBytes, ex.LinePosition);
+                    Assert.Equal(expectedBytes, ex.BytePosition);
                 }
 
                 for (int i = 0; i < dataUtf8.Length; i++)
@@ -1124,18 +1100,9 @@ namespace System.Text.JsonLab.Tests
                         string secondSegmentString = Encodings.Utf8.ToString(dataUtf8.AsSpan(i));
                         errorMessage += " | " + firstSegmentString + " | " + secondSegmentString;
                         Assert.True(expectedlineNumber == ex.LineNumber, errorMessage);
-                        if (option == JsonReaderOptions.TrackPositionAsCodePoints)
-                        {
-                            errorMessage = $"expectedPosition: {expectedPosition} | actual: {ex.LinePosition} | index: {i} | option: {option}";
-                            errorMessage += " | " + firstSegmentString + " | " + secondSegmentString;
-                            Assert.True(expectedPosition == ex.LinePosition, errorMessage);
-                        }
-                        else
-                        {
-                            errorMessage = $"expectedBytes: {expectedBytes} | actual: {ex.LinePosition} | index: {i} | option: {option}";
-                            errorMessage += " | " + firstSegmentString + " | " + secondSegmentString;
-                            Assert.True(expectedBytes == ex.LinePosition, errorMessage);
-                        }
+                        errorMessage = $"expectedBytes: {expectedBytes} | actual: {ex.BytePosition} | index: {i} | option: {option}";
+                        errorMessage += " | " + firstSegmentString + " | " + secondSegmentString;
+                        Assert.True(expectedBytes == ex.BytePosition, errorMessage);
                     }
                 }
             }
@@ -1604,7 +1571,7 @@ namespace System.Text.JsonLab.Tests
             catch (JsonReaderException ex)
             {
                 Assert.Equal(expectedlineNumber, ex.LineNumber);
-                Assert.Equal(expectedPosition, ex.LinePosition);
+                Assert.Equal(expectedPosition, ex.BytePosition);
             }
 
             ReadOnlyMemory<byte> dataMemory = dataUtf8;
@@ -1633,7 +1600,7 @@ namespace System.Text.JsonLab.Tests
                 catch (JsonReaderException ex)
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
-                    Assert.Equal(expectedPosition, ex.LinePosition);
+                    Assert.Equal(expectedPosition, ex.BytePosition);
                     jsonMultiSegment.Dispose();
                 }
             }
@@ -1695,7 +1662,7 @@ namespace System.Text.JsonLab.Tests
             catch (JsonReaderException ex)
             {
                 Assert.Equal(expectedlineNumber, ex.LineNumber);
-                Assert.Equal(expectedPosition, ex.LinePosition);
+                Assert.Equal(expectedPosition, ex.BytePosition);
             }
 
             for (int i = 0; i < dataUtf8.Length; i++)
@@ -1731,7 +1698,7 @@ namespace System.Text.JsonLab.Tests
                 catch (JsonReaderException ex)
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
-                    Assert.Equal(expectedPosition, ex.LinePosition);
+                    Assert.Equal(expectedPosition, ex.BytePosition);
                 }
             }
         }
@@ -1804,7 +1771,7 @@ namespace System.Text.JsonLab.Tests
             catch (JsonReaderException ex)
             {
                 Assert.Equal(expectedlineNumber, ex.LineNumber);
-                Assert.Equal(expectedPosition, ex.LinePosition);
+                Assert.Equal(expectedPosition, ex.BytePosition);
             }
 
             ReadOnlyMemory<byte> dataMemory = dataUtf8;
@@ -1828,7 +1795,7 @@ namespace System.Text.JsonLab.Tests
                 catch (JsonReaderException ex)
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
-                    Assert.Equal(expectedPosition, ex.LinePosition);
+                    Assert.Equal(expectedPosition, ex.BytePosition);
                     jsonMultiSegment.Dispose();
                 }
             }
@@ -1902,7 +1869,7 @@ namespace System.Text.JsonLab.Tests
             catch (JsonReaderException ex)
             {
                 Assert.Equal(expectedlineNumber, ex.LineNumber);
-                Assert.Equal(expectedPosition, ex.LinePosition);
+                Assert.Equal(expectedPosition, ex.BytePosition);
             }
 
             ReadOnlyMemory<byte> dataMemory = dataUtf8;
@@ -1929,7 +1896,7 @@ namespace System.Text.JsonLab.Tests
                 catch (JsonReaderException ex)
                 {
                     Assert.Equal(expectedlineNumber, ex.LineNumber);
-                    Assert.Equal(expectedPosition, ex.LinePosition);
+                    Assert.Equal(expectedPosition, ex.BytePosition);
                 }
             }
         }


### PR DESCRIPTION
Essentially reverts https://github.com/dotnet/corefxlab/pull/2540.

Gain back ~20%.

``` ini

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17763
Intel Core i7-6700 CPU 3.40GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.0.100-alpha1-009701
  [Host]     : .NET Core 2.1.2 (CoreCLR 4.6.26628.05, CoreFX 4.6.26629.01), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.3 (CoreCLR 4.6.26725.06, CoreFX 4.6.26725.05), 64bit RyuJIT

```

**Before:**

|                               Method | IsDataCompact |   TestCase |           Mean |         Error |        StdDev |         Median | Scaled | ScaledSD | Allocated |
|------------------------------------- |-------------- |----------- |---------------:|--------------:|--------------:|---------------:|-------:|---------:|----------:|
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **BasicJson** |       **606.9 ns** |     **12.031 ns** |     **15.215 ns** |       **614.6 ns** |   **0.82** |     **0.03** |       **0 B** |
|              ReaderUtf8JsonEmptyLoop |          True |  BasicJson |       742.5 ns |     14.832 ns |     23.525 ns |       743.6 ns |   1.00 |     0.00 |       0 B |
|                                      |               |            |                |               |               |                |        |          |           |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** | **HelloWorld** |       **112.0 ns** |      **1.779 ns** |      **1.664 ns** |       **111.9 ns** |   **1.06** |     **0.04** |       **0 B** |
|              ReaderUtf8JsonEmptyLoop |          True | HelloWorld |       106.0 ns |      2.132 ns |      4.057 ns |       104.8 ns |   1.00 |     0.00 |       0 B |
|                                      |               |            |                |               |               |                |        |          |           |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json400B** |       **979.2 ns** |     **19.473 ns** |     **53.307 ns** |       **961.1 ns** |   **0.75** |     **0.04** |       **0 B** |
|              ReaderUtf8JsonEmptyLoop |          True |   Json400B |     1,313.1 ns |     25.600 ns |     25.142 ns |     1,311.0 ns |   1.00 |     0.00 |       0 B |
|                                      |               |            |                |               |               |                |        |          |           |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **Json400KB** |   **994,164.2 ns** | **20,174.711 ns** | **28,282.127 ns** |   **982,818.3 ns** |   **0.91** |     **0.03** |       **0 B** |
|              ReaderUtf8JsonEmptyLoop |          True |  Json400KB | 1,095,538.9 ns |  8,554.799 ns |  7,583.606 ns | 1,095,355.6 ns |   1.00 |     0.00 |       0 B |
|                                      |               |            |                |               |               |                |        |          |           |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json40KB** |    **92,671.9 ns** |  **1,332.915 ns** |  **1,113.044 ns** |    **92,388.6 ns** |   **0.80** |     **0.07** |       **0 B** |
|              ReaderUtf8JsonEmptyLoop |          True |   Json40KB |   116,364.3 ns |  3,623.939 ns | 10,685.267 ns |   113,176.6 ns |   1.00 |     0.00 |       0 B |
|                                      |               |            |                |               |               |                |        |          |           |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |    **Json4KB** |     **7,224.4 ns** |    **113.743 ns** |     **94.981 ns** |     **7,256.9 ns** |   **0.68** |     **0.01** |       **0 B** |
|              ReaderUtf8JsonEmptyLoop |          True |    Json4KB |    10,628.9 ns |    176.690 ns |    156.631 ns |    10,570.9 ns |   1.00 |     0.00 |       0 B |

**Now:**

|                               Method | IsDataCompact |   TestCase |          Mean |        Error |       StdDev | Allocated |
|------------------------------------- |-------------- |----------- |--------------:|-------------:|-------------:|----------:|
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **BasicJson** |     **505.52 ns** |    **11.100 ns** |    **13.214 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** | **HelloWorld** |      **94.34 ns** |     **1.657 ns** |     **1.469 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json400B** |     **762.27 ns** |     **5.404 ns** |     **4.791 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |  **Json400KB** | **827,304.21 ns** | **3,062.236 ns** | **2,390.793 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |   **Json40KB** |  **77,472.61 ns** |   **390.856 ns** |   **365.607 ns** |       **0 B** |
| **ReaderSystemTextJsonLabSpanEmptyLoop** |          **True** |    **Json4KB** |   **5,831.29 ns** |   **115.613 ns** |   **133.140 ns** |       **0 B** |
