### PR TITLE
dropped to released version of piplelines

### DIFF
--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -6,7 +6,7 @@
     <SystemCompilerServicesUnsafeVersion>4.6.0-preview1-27018-01</SystemCompilerServicesUnsafeVersion>
     <SystemNumericsVectorsVersion>4.6.0-preview1-27018-01</SystemNumericsVectorsVersion>
     <SystemBuffersVersion>4.5.0</SystemBuffersVersion>
-    <SystemIOPipelinesVersion>4.6.0-preview1-27018-01</SystemIOPipelinesVersion>
+    <SystemIOPipelinesVersion>4.5.2</SystemIOPipelinesVersion>
     <SystemThreadingTasksExtensionsVersion>4.6.0-preview1-27018-01</SystemThreadingTasksExtensionsVersion>
     <LibuvVersion>1.9.1</LibuvVersion>
     <TestSdkVersion>15.0.0</TestSdkVersion>


### PR DESCRIPTION
The preview version of pipelines is not in corfxlab myget not on nuget.org. This means adding System.Buffers.ReaderWriter to a project fails, unless the project has pipelines myget feed (which is not common or intuitive). Since ReaderWriter (nor any components in corfxlab) needs preview of pipelines, I am dropping the pipelines dependency to the officially released on nuget.org.