### PR TITLE
Update Benchmark.NET version to use EtwProfiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,9 +239,6 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
-#dotnet.exe output
-tools/
-
 *.ncrunchproject
 *.ncrunchsolution
 

--- a/src/Microsoft.Experimental.Collections/Microsoft.Experimental.Collections.csproj
+++ b/src/Microsoft.Experimental.Collections/Microsoft.Experimental.Collections.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTags>collections system microsoft multivaluedictionary</PackageTags>
     <VersionPrefix>1.0.4</VersionPrefix>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="$(BenchmarkDotNetVersion)" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.30" />
     <PackageReference Include="System.Text.Encodings.Web" Version="$(CoreFxStableVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Benchmarks/Program.cs
+++ b/tests/Benchmarks/Program.cs
@@ -14,7 +14,7 @@ namespace Benchmarks
         /// </summary>
         public static void Main(string[] args)
             => BenchmarkSwitcher
-                .FromAssemblyAndTypes(typeof(Program).Assembly, JsonBenchmarks.SerializerBenchmarks.GetTypes())         
+                .FromAssembly(typeof(Program).Assembly).With(JsonBenchmarks.SerializerBenchmarks.GetTypes())         
                 .Run(args);
     }
 }

--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -11,6 +11,6 @@
     <LibuvVersion>1.9.1</LibuvVersion>
     <TestSdkVersion>15.0.0</TestSdkVersion>
     <XunitVersion>2.2.0</XunitVersion>
-    <BenchmarkDotNetVersion>0.11.1</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.11.2</BenchmarkDotNetVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
With this change you can temporarily add `[EtwProfiler]` on your benchmark class to get an ETW file. You may need to add `using BenchmarkDotNet.Diagnostics.Windows.Configs;`

Also enabled symbols on the benchmark project for release. It's already done in Microsoft.Experimental.Collections.csproj
