### PR TITLE
Change obsolete Encodings.Web.Utf8 APIs to internal and fix warnings.

### DIFF
--- a/src/System.Text.Encodings.Web.Utf8/UrlEncoder.cs
+++ b/src/System.Text.Encodings.Web.Utf8/UrlEncoder.cs
@@ -8,10 +8,9 @@ namespace System.Text.Encodings.Web.Utf8
 {
     public class UrlEncoder
     {
-        static bool[] IsAllowed = new bool[0x7F + 1];
+        static readonly bool[] IsAllowed = new bool[0x7F + 1];
 
-        [Obsolete("Use UrlEncoder.Utf8.Encode")]
-        public static bool TryEncode(ReadOnlySpan<byte> input, Span<byte> output, out int written)
+        internal static bool TryEncode(ReadOnlySpan<byte> input, Span<byte> output, out int written)
         {
             written = 0;
             for (int inputIndex = 0; inputIndex < input.Length; inputIndex++)
@@ -51,8 +50,7 @@ namespace System.Text.Encodings.Web.Utf8
         /// <param name="source">The byte span represents a UTF8 encoding url path.</param>
         /// <param name="destination">The byte span where unescaped url path is copied to.</param>
         /// <returns>The length of the byte sequence of the unescaped url path.</returns>
-        [Obsolete("Use UrlDecoder.Utf8.Decode")]
-        public static int Decode(ReadOnlySpan<byte> source, Span<byte> destination)
+        internal static int Decode(ReadOnlySpan<byte> source, Span<byte> destination)
         {
             if (destination.Length < source.Length)
             {
@@ -75,8 +73,7 @@ namespace System.Text.Encodings.Web.Utf8
         /// The unescape is done in place, which means after decoding the result is the subset of 
         /// the input span.
         /// </remarks>
-        [Obsolete("Use UrlDecoder.Utf8.DecodeInPlace")]
-        public static int DecodeInPlace(Span<byte> buffer)
+        internal static int DecodeInPlace(Span<byte> buffer)
         {
             // the slot to read the input
             var sourceIndex = 0;

--- a/tests/Benchmarks/System.Text.Encodings.Web.Utf8/UrlEncoderPerf.cs
+++ b/tests/Benchmarks/System.Text.Encodings.Web.Utf8/UrlEncoderPerf.cs
@@ -34,6 +34,6 @@ namespace System.Text.Encodings.Web.Utf8.Benchmarks
         }
 
         [Benchmark]
-        public void DecodeInPlace() => UrlEncoder.DecodeInPlace(_encodedBytes);
+        public void DecodeInPlace() => UrlDecoder.Utf8.DecodeInPlace(_encodedBytes, _encodedBytes.Length, out _);
     }
 }

--- a/tests/System.Text.Encodings.Web.Utf8.Tests/UnescapeUrlPathInPlaceTests.cs
+++ b/tests/System.Text.Encodings.Web.Utf8.Tests/UnescapeUrlPathInPlaceTests.cs
@@ -16,10 +16,10 @@ namespace System.Text.Encodings.Web.Utf8.Tests
         {
             var input = GetBytes(raw).ToArray();
 
-            var len = UrlEncoder.DecodeInPlace(input);
-            Assert.True(len <= input.Length);
+            Assert.Equal(OperationStatus.Done, UrlDecoder.Utf8.DecodeInPlace(input, input.Length, out int written));
+            Assert.True(written <= input.Length);
 
-            var outputDecoded = Encoding.UTF8.GetString(input, 0, len);
+            var outputDecoded = Encoding.UTF8.GetString(input, 0, written);
             Assert.Equal(expected, outputDecoded);
         }
     }

--- a/tests/System.Text.Encodings.Web.Utf8.Tests/UnescapeUrlPathTests.cs
+++ b/tests/System.Text.Encodings.Web.Utf8.Tests/UnescapeUrlPathTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers;
 using Xunit;
 
 namespace System.Text.Encodings.Web.Utf8.Tests
@@ -16,11 +17,11 @@ namespace System.Text.Encodings.Web.Utf8.Tests
             var input = GetBytes(raw);
             var destination = new Span<byte>(new byte[input.Length]);
 
-            var len = UrlEncoder.Decode(input, destination);
-            Assert.True(len <= input.Length);
+            Assert.Equal(OperationStatus.Done, UrlDecoder.Utf8.Decode(input, destination, out int consumed, out int written));
+            Assert.True(written <= input.Length);
 
-            var unescaped = destination.Slice(0, len);
-            Assert.False(unescaped == input.Slice(0, len));
+            var unescaped = destination.Slice(0, written);
+            Assert.False(unescaped == input.Slice(0, written));
 
             var outputDecoded = Encoding.UTF8.GetString(unescaped.ToArray());
             Assert.Equal(expected, outputDecoded);
@@ -34,7 +35,7 @@ namespace System.Text.Encodings.Web.Utf8.Tests
 
             try
             {
-                UrlEncoder.Decode(input, destination);
+                UrlDecoder.Utf8.Decode(input, destination, out _, out _);
                 Assert.True(false);
             }
             catch (Exception ex)

--- a/tools/common.props
+++ b/tools/common.props
@@ -11,6 +11,7 @@
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <SignAssembly>true</SignAssembly>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Key.snk</AssemblyOriginatorKeyFile>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
The APIs that were marked as obsolete in this PR: https://github.com/dotnet/corefxlab/pull/1741 can now be made internal (as implementation detail).

Fixes the remainder of the warnings: https://github.com/dotnet/corefxlab/issues/2585#issuecomment-441385409

```text
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

cc @danmosemsft 