### PR TITLE
Revert S.T.JsonLab TFMs back to netstandard1.1

### DIFF
--- a/src/System.Text.JsonLab.Dynamic/System.Text.JsonLab.Dynamic.csproj
+++ b/src/System.Text.JsonLab.Dynamic/System.Text.JsonLab.Dynamic.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>JSON dynamic object</Description>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>.NET json non-allocating corefxlab</PackageTags>
   </PropertyGroup>

--- a/src/System.Text.JsonLab/System.Text.JsonLab.csproj
+++ b/src/System.Text.JsonLab/System.Text.JsonLab.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Non-allocating JSON reader and writer</Description>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard1.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTags>.NET json non-allocating corefxlab</PackageTags>
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
I had accidentally upgraded the TFM to netcoreapp2.1 here: https://github.com/dotnet/corefxlab/pull/2612.

Reverting back to netstandard1.1.