### PR TITLE
Add Signing in order to be able to publish packages to nuget

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -8,12 +8,13 @@
     nuget package source please add it to the item group in dir.props instead.
   -->
   <config>
-    <add key="repositoryPath" value="..\packages" />
+    <add key="repositoryPath" value=".nuget\packages" />
   </config>
   <packageSources>
     <add key="dotnet.myget.org dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" protocolVersion="3" />
     <add key="dotnet.myget.org dotnet-buildtools" value="https://dotnet.myget.org/F/dotnet-buildtools/" />
     <add key="dotnet.myget.org dotnet-corefxlab" value="https://dotnet.myget.org/F/dotnet-corefxlab/" />
+    <add key="dotnet blob feed" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="dotnet.myget.org dotnet-cli" value="https://dotnet.myget.org/F/dotnet-cli/" />
     <add key="coreclr-xunit" value="https://www.myget.org/F/coreclr-xunit/api/v2" />

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -1,7 +1,8 @@
 ﻿Param(
     [string]$Configuration="Debug",
     [string]$ApiKey,
-    [string]$BuildVersion=[System.DateTime]::Now.ToString('preview2-yyMMdd-1'),
+    [string]$BuildVersion=[System.DateTime]::Now.ToString('eyyMMdd-1'),
+    [string]$FilesToSignFilter="*.nupkg",
     [string]$SignType="test",
     [switch]$Sign
 )
@@ -43,7 +44,7 @@ foreach ($file in [System.IO.Directory]::EnumerateFiles("$repoRoot\src", "*.cspr
 if ($Sign)
 {
     Write-Host "** Signing packages with SignType = $SignType **"
-    & $dotnetExePath msbuild "$repoRoot\tools\signing\sign.proj" /p:SignType="$SignType" /p:PackagesPath="$packagesPath"
+    & $dotnetExePath msbuild "$repoRoot\tools\signing\sign.proj" /p:SignType="$SignType" /p:PackagesPath="$packagesPath" /p:FilesToSignFilter="$FilesToSignFilter"
 
     if (!$?) {
         Write-Error "Failed to sign the packages"

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -43,9 +43,10 @@ foreach ($file in [System.IO.Directory]::EnumerateFiles("$repoRoot\src", "*.cspr
 if ($Sign)
 {
     Write-Host "** Signing packages with SignType = $SignType **"
-    & $dotnetExePath msbuild "$repoRoot\tools\sign.proj" /p:SignType="$SignType" /p:PackagesPath="$packagesPath"
+    & $dotnetExePath msbuild "$repoRoot\tools\signing\sign.proj" /p:SignType="$SignType" /p:PackagesPath="$packagesPath"
 
     if (!$?) {
+        Write-Error "Failed to sign the packages"
         exit $lastExitCode
     }
 }

--- a/scripts/package.ps1
+++ b/scripts/package.ps1
@@ -1,7 +1,9 @@
 ﻿Param(
     [string]$Configuration="Debug",
     [string]$ApiKey,
-    [string]$BuildVersion=[System.DateTime]::Now.ToString('preview2-yyMMdd-1')
+    [string]$BuildVersion=[System.DateTime]::Now.ToString('preview2-yyMMdd-1'),
+    [string]$SignType="test",
+    [switch]$Sign
 )
 
 $repoRoot = "$PSScriptRoot\.."
@@ -35,6 +37,16 @@ foreach ($file in [System.IO.Directory]::EnumerateFiles("$repoRoot\src", "*.cspr
 
     if (!$?) {
         Write-Error "Failed to create NuGet package for project $file"
+    }
+}
+
+if ($Sign)
+{
+    Write-Host "** Signing packages with SignType = $SignType **"
+    & $dotnetExePath msbuild "$repoRoot\tools\sign.proj" /p:SignType="$SignType" /p:PackagesPath="$packagesPath"
+
+    if (!$?) {
+        exit $lastExitCode
     }
 }
 

--- a/src/Microsoft.Experimental.Collections/Microsoft.Experimental.Collections.csproj
+++ b/src/Microsoft.Experimental.Collections/Microsoft.Experimental.Collections.csproj
@@ -4,7 +4,7 @@
     <Description>This package provides collections that are being considered for future versions of .NET Core.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageTags>collections system microsoft multivaluedictionary dictionaryslim</PackageTags>
-    <VersionPrefix>1.0.5</VersionPrefix>
+    <VersionPrefix>1.0.6</VersionPrefix>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/tools/common.props
+++ b/tools/common.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <VersionSuffix Condition="$(VersionSuffix) == ''">$([System.DateTime]::Now.ToString(preview2-yyMMdd-1))</VersionSuffix>
     <Copyright>Microsoft Corporation, All rights reserved</Copyright>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
     <Authors>Microsoft Corporation</Authors>
     <PackageReleaseNotes>Pre-release package, for testing only</PackageReleaseNotes>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>

--- a/tools/dependencies.props
+++ b/tools/dependencies.props
@@ -12,5 +12,9 @@
     <TestSdkVersion>15.0.0</TestSdkVersion>
     <XunitVersion>2.2.0</XunitVersion>
     <BenchmarkDotNetVersion>0.11.3</BenchmarkDotNetVersion>
+    <SnVersion>1.0.0</SnVersion>
+    <VSWhereVersion>2.5.2</VSWhereVersion>
+    <MicroBuildCoreVersion>0.2.0</MicroBuildCoreVersion>
+    <MicrosoftDotNetSignToolVersion>1.0.0-beta.19058.5</MicrosoftDotNetSignToolVersion>
   </PropertyGroup>
 </Project>

--- a/tools/sign.proj
+++ b/tools/sign.proj
@@ -1,0 +1,14 @@
+<Project DefaultTargets="Build">
+  <PropertyGroup Condition="'$(RestorePackagesPath)' == ''">
+    <RestorePackagesPath Condition="'$(NUGET_PACKAGES)' != ''">$(NUGET_PACKAGES)</RestorePackagesPath>
+    <RestorePackagesPath Condition="'$(NUGET_PACKAGES)' == ''">$(MSBuildProjectDirectory)\..\.nuget\packages</RestorePackagesPath>
+  </PropertyGroup>
+  <Target Name="Build">
+    <MSBuild Projects="signing\sign.depproj"
+             Targets="Restore"
+             Properties="RestorePackagesPath=$(RestorePackagesPath)" />
+
+    <MSBuild Projects="signing\sign.targets" 
+             Properties="RestorePackagesPath=$(RestorePackagesPath)" />
+  </Target>
+</Project>

--- a/tools/signing/sign.depproj
+++ b/tools/signing/sign.depproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\dependencies.props" />
+
+  <PropertyGroup>
+    <!-- We need to specify a framework in order for the Restore target to work -->
+    <TargetFramework Condition="'$(TargetFramework)' == ''">netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="sn" Version="$(SnVersion)" />
+    <PackageReference Include="vswhere" Version="$(VSWhereVersion)" />
+    <PackageReference Include="MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
+    <PackageReference Include="Microsoft.DotNet.SignTool" Version="$(MicrosoftDotNetSignToolVersion)" />
+  </ItemGroup>
+</Project>

--- a/tools/signing/sign.proj
+++ b/tools/signing/sign.proj
@@ -4,11 +4,11 @@
     <RestorePackagesPath Condition="'$(NUGET_PACKAGES)' == ''">$(MSBuildProjectDirectory)\..\.nuget\packages</RestorePackagesPath>
   </PropertyGroup>
   <Target Name="Build">
-    <MSBuild Projects="signing\sign.depproj"
+    <MSBuild Projects="sign.depproj"
              Targets="Restore"
              Properties="RestorePackagesPath=$(RestorePackagesPath)" />
 
-    <MSBuild Projects="signing\sign.targets" 
+    <MSBuild Projects="sign.targets" 
              Properties="RestorePackagesPath=$(RestorePackagesPath)" />
   </Target>
 </Project>

--- a/tools/signing/sign.targets
+++ b/tools/signing/sign.targets
@@ -1,0 +1,61 @@
+<Project DefaultTargets="Sign">
+  <Import Project="..\dependencies.props" />
+  <PropertyGroup>
+    <NuGetPackageRoot>$(RestorePackagesPath)</NuGetPackageRoot>
+    <NuGetPackageRoot Condition="!HasTrailingSlash('$(NuGetPackageRoot)')">$(NuGetPackageRoot)\</NuGetPackageRoot>
+    <SignType Condition="'$(SignType)' == ''">test</SignType> 
+
+    <_DryRun>true</_DryRun>
+    <_DryRun Condition="'$(BUILD_BUILDNUMBER)' != ''">false</_DryRun>
+    <_TestSign>false</_TestSign>
+    <_TestSign Condition="'$(SignType)' == 'test'">true</_TestSign>
+
+    <_DesktopMSBuildRequired Condition="'$(_DryRun)' != 'true'">true</_DesktopMSBuildRequired>
+
+    <_SigningTempDir Condition="'$(_SigningTempDir)' == ''">$(MSBuildProjectDirectory)\obj\tmp\</_SigningTempDir>
+    <_SigningLogDir Condition="'$(_SigningLogDir)' == ''">$(MSBuildProjectDirectory)\obj\log\</_SigningLogDir>
+  </PropertyGroup>
+
+  <Import Project="$(NuGetPackageRoot)microsoft.dotnet.signtool\$(MicrosoftDotNetSignToolVersion)\build\Microsoft.DotNet.SignTool.props" />
+
+  <ItemGroup>
+    <ItemsToSign Include="$(PackagesPath)\*.nupkg" />
+
+    <FileExtensionSignInfo Include=".dll;.exe" CertificateName="Microsoft400" />
+    <FileExtensionSignInfo Include=".nupkg" CertificateName="NuGet" />
+  </ItemGroup>
+
+  <Target Name="Sign">
+
+    <!-- We only need this if we are going to use the executable version. -->
+    <Exec Command='"$(NuGetPackageRoot)vswhere\$(VSWhereVersion)\tools\vswhere.exe" -latest -prerelease -property installationPath -requires Microsoft.Component.MSBuild'
+          ConsoleToMsBuild="true"
+          StandardErrorImportance="high"
+          Condition="'$(_DesktopMSBuildRequired)' == 'true'">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_VSInstallDir" />
+    </Exec>
+
+    <PropertyGroup>
+      <_DesktopMSBuildPath Condition="'$(_DesktopMSBuildRequired)' == 'true'">$(_VSInstallDir)\MSBuild\15.0\Bin\msbuild.exe</_DesktopMSBuildPath>
+    </PropertyGroup>
+
+    <Error Condition="'$(AllowEmptySignList)' != 'true' AND '@(ItemsToSign)' == ''" 
+           Text="List of files to sign is empty. Make sure that ItemsToSign is configured correctly." />
+
+    <Microsoft.DotNet.SignTool.SignToolTask
+        DryRun="$(_DryRun)"
+        TestSign="$(_TestSign)"
+        DoStrongNameCheck="$(DoStrongNameCheck)"
+        CertificatesSignInfo="$(CertificatesSignInfo)"
+        ItemsToSign="@(ItemsToSign)"
+        StrongNameSignInfo="@(StrongNameSignInfo)"
+        FileSignInfo="@(FileSignInfo)"
+        FileExtensionSignInfo="@(FileExtensionSignInfo)"
+        TempDir="$(_SigningTempDir)"
+        LogDir="$(_SigningLogDir)"
+        MSBuildPath="$(_DesktopMSBuildPath)"
+        SNBinaryPath="$(NuGetPackageRoot)sn\$(SnVersion)\sn.exe"
+        MicroBuildCorePath="$(NuGetPackageRoot)microbuild.core\$(MicroBuildCoreVersion)"/>
+
+  </Target>
+</Project>

--- a/tools/signing/sign.targets
+++ b/tools/signing/sign.targets
@@ -19,7 +19,7 @@
   <Import Project="$(NuGetPackageRoot)microsoft.dotnet.signtool\$(MicrosoftDotNetSignToolVersion)\build\Microsoft.DotNet.SignTool.props" />
 
   <ItemGroup>
-    <ItemsToSign Include="$(PackagesPath)\*.nupkg" />
+    <ItemsToSign Include="$(PackagesPath)\$(FilesToSignFilter)" />
 
     <FileExtensionSignInfo Include=".dll;.exe" CertificateName="Microsoft400" />
     <FileExtensionSignInfo Include=".nupkg" CertificateName="NuGet" />


### PR DESCRIPTION
Add targets to be able to sign packages and its contents in order to be able to push experimental or preview packages to nuget.org

This is based on arcade's Microsoft.DotNet.SignTool package.

I will test the build definition before merging.