### PR TITLE
Add support for Ubuntu 18.10

### DIFF
--- a/scripts/install-dotnet.sh
+++ b/scripts/install-dotnet.sh
@@ -104,8 +104,16 @@ get_os_download_name_from_platform() {
             echo "ubuntu18.04"
             return 0
             ;;
+        "ubuntu.18.10")
+            echo "ubuntu18.10"
+            return 0
+            ;;
         "alpine.3.4.3")
             echo "alpine"
+            return 0
+            ;;
+        *)
+            echo "_unknown_"
             return 0
             ;;
     esac


### PR DESCRIPTION
Because `ubuntu18.10` is not in this list, build cannot bootstrap on Ubuntu 18.10. By adding `ubuntu18.10` it is able to use it to construct `$alt_download_link`. The URL does not exist for 18.10 - the generic `$download_link` is used. Simply adding the list entry allows bootstrapping to complete. Since the value is not necessarily used, I also added an entry for any unknown distro.

In all the regular repos, this file is actually pulled down, from `https://dot.net/v1/dotnet-install.sh`. I will open an arcade issue to update that also.