### PR TITLE
Implement IEnumerable<T> on PrimitiveColumn.

### DIFF
--- a/src/Microsoft.Data/ArrowStringColumn.cs
+++ b/src/Microsoft.Data/ArrowStringColumn.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
@@ -17,7 +18,7 @@ namespace Microsoft.Data
     /// <summary>
     /// An immutable to hold Arrow style strings
     /// </summary>
-    public partial class ArrowStringColumn : BaseColumn
+    public partial class ArrowStringColumn : BaseColumn, IEnumerable<string>
     {
         private IList<ReadOnlyDataFrameBuffer<byte>> _dataBuffers;
         private IList<ReadOnlyDataFrameBuffer<int>> _offsetsBuffers;
@@ -232,6 +233,16 @@ namespace Microsoft.Data
             }
         }
 
+        public IEnumerator<string> GetEnumerator()
+        {
+            for (long i = 0; i < Length; i++)
+            {
+                yield return this[i];
+            }
+        }
+
+        protected override IEnumerator GetEnumeratorCore() => GetEnumerator();
+
         protected internal override Field Field() => new Field(Name, StringType.Default, NullCount != 0);
 
         protected internal override int MaxRecordBatchLength(long startIndex)
@@ -253,7 +264,6 @@ namespace Microsoft.Data
             }
             return nullCount;
         }
-
 
         protected internal override Apache.Arrow.Array AsArrowArray(long startIndex, int numberOfRows)
         {

--- a/src/Microsoft.Data/BaseColumn.cs
+++ b/src/Microsoft.Data/BaseColumn.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -14,7 +15,7 @@ namespace Microsoft.Data
     /// <summary>
     /// The base column type. All APIs should be defined here first
     /// </summary>
-    public abstract partial class BaseColumn
+    public abstract partial class BaseColumn : IEnumerable
     {
         public BaseColumn(string name, long length, Type type)
         {
@@ -59,6 +60,10 @@ namespace Microsoft.Data
         {
             get => GetValue(startIndex, length);
         }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumeratorCore();
+
+        protected abstract IEnumerator GetEnumeratorCore();
 
         /// <summary>
         /// Called internally from Merge and GroupBy. Resizes the column to the specified length to allow setting values by indexing

--- a/src/Microsoft.Data/PrimitiveColumn.cs
+++ b/src/Microsoft.Data/PrimitiveColumn.cs
@@ -3,10 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Runtime.InteropServices.ComTypes;
 using Apache.Arrow;
 using Apache.Arrow.Types;
 using Microsoft.ML;
@@ -18,7 +17,7 @@ namespace Microsoft.Data
     /// A column to hold primitive types such as int, float etc.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public partial class PrimitiveColumn<T> : BaseColumn
+    public partial class PrimitiveColumn<T> : BaseColumn, IEnumerable<T?>
         where T : unmanaged
     {
         private PrimitiveColumnContainer<T> _columnContainer;
@@ -210,6 +209,10 @@ namespace Microsoft.Data
         }
 
         public bool IsValid(long index) => _columnContainer.IsValid(index);
+
+        public IEnumerator<T?> GetEnumerator() => _columnContainer.GetEnumerator();
+
+        protected override IEnumerator GetEnumeratorCore() => GetEnumerator();
 
         public override string ToString()
         {

--- a/src/Microsoft.Data/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data/PrimitiveColumnContainer.cs
@@ -3,9 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
-using System.Text;
 using System.Diagnostics;
+using System.Text;
 
 namespace Microsoft.Data
 {
@@ -13,7 +14,7 @@ namespace Microsoft.Data
     /// PrimitiveDataFrameColumnContainer is just a store for the column data. APIs that want to change the data must be defined in PrimitiveDataFrameColumn
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal partial class PrimitiveColumnContainer<T>
+    internal partial class PrimitiveColumnContainer<T> : IEnumerable<T?>
         where T : struct
     {
         public IList<ReadOnlyDataFrameBuffer<T>> Buffers = new List<ReadOnlyDataFrameBuffer<T>>();
@@ -331,6 +332,16 @@ namespace Microsoft.Data
                 }
             }
         }
+
+        public IEnumerator<T?> GetEnumerator()
+        {
+            for (long i = 0; i < Length; i++)
+            {
+                yield return this[i];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         public override string ToString()
         {

--- a/src/Microsoft.Data/StringColumn.cs
+++ b/src/Microsoft.Data/StringColumn.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data
     /// A mutable column to hold strings
     /// </summary>
     /// <remarks> Is NOT Arrow compatible </remarks>
-    public partial class StringColumn : BaseColumn
+    public partial class StringColumn : BaseColumn, IEnumerable<string>
     {
         private List<List<string>> _stringBuffers = new List<List<string>>(); // To store more than intMax number of strings
 
@@ -139,6 +139,19 @@ namespace Microsoft.Data
                 return ret;
             }
         }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            foreach (List<string> buffer in _stringBuffers)
+            {
+                foreach (string value in buffer)
+                {
+                    yield return value;
+                }
+            }
+        }
+
+        protected override IEnumerator GetEnumeratorCore() => GetEnumerator();
 
         public override BaseColumn Sort(bool ascending = true)
         {

--- a/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Xunit;
 
 namespace Microsoft.Data.Tests
@@ -988,7 +989,85 @@ namespace Microsoft.Data.Tests
 
             df = MakeDataFrame<ushort, bool>(10, false);
             GroupCountAndAssert(df);
+        }
 
+        [Fact]
+        public void TestIEnumerable()
+        {
+            DataFrame df = MakeDataFrameWithAllColumnTypes(10);
+            
+            int totalValueCount = 0;
+            for (int i = 0; i < df.ColumnCount; i++)
+            {
+                BaseColumn baseColumn = df.Column(i);
+                foreach (object value in baseColumn)
+                {
+                    totalValueCount++;
+                }
+            }
+            Assert.Equal(10 * df.ColumnCount, totalValueCount);
+
+            // spot check a few column types:
+
+            StringColumn stringColumn = (StringColumn)df["String"];
+            StringBuilder actualStrings = new StringBuilder();
+            foreach (string value in stringColumn)
+            {
+                if (value == null)
+                {
+                    actualStrings.Append("<null>");
+                }
+                else
+                {
+                    actualStrings.Append(value);
+                }
+            }
+            Assert.Equal("01234<null>6789", actualStrings.ToString());
+
+            ArrowStringColumn arrowStringColumn = (ArrowStringColumn)df["ArrowString"];
+            actualStrings.Clear();
+            foreach (string value in arrowStringColumn)
+            {
+                if (value == null)
+                {
+                    actualStrings.Append("<null>");
+                }
+                else
+                {
+                    actualStrings.Append(value);
+                }
+            }
+            Assert.Equal("foofoofoofoofoofoofoofoofoofoo", actualStrings.ToString());
+
+            PrimitiveColumn<float> floatColumn = (PrimitiveColumn<float>)df["Float"];
+            actualStrings.Clear();
+            foreach (float? value in floatColumn)
+            {
+                if (value == null)
+                {
+                    actualStrings.Append("<null>");
+                }
+                else
+                {
+                    actualStrings.Append(value);
+                }
+            }
+            Assert.Equal("01234<null>6789", actualStrings.ToString());
+
+            PrimitiveColumn<int> intColumn = (PrimitiveColumn<int>)df["Int"];
+            actualStrings.Clear();
+            foreach (int? value in intColumn)
+            {
+                if (value == null)
+                {
+                    actualStrings.Append("<null>");
+                }
+                else
+                {
+                    actualStrings.Append(value);
+                }
+            }
+            Assert.Equal("01234<null>6789", actualStrings.ToString());
         }
     }
 }


### PR DESCRIPTION
This allows for things like XPlot to be able to show charts using code like:

```C#
    BaseColumn column = ...;

    Chart.Plot(
        new Graph.Histogram()
        {
            x = column,
            nbinsx = bins
        },
        new Layout.Layout()
        {
            title = column.Name
        }
    ).Display();
```