### PR TITLE
Benchmarks and Perf improvements

### DIFF
--- a/corefxlab.sln
+++ b/corefxlab.sln
@@ -123,6 +123,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ALCProxy.TestInterfaceUpdat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ALCProxy.TestInterface", "tests\ALCProxy.TestInterface\ALCProxy.TestInterface.csproj", "{6435C875-F526-45E1-97E1-B5BF8C4F9A55}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "System.Text.CaseFolding", "src\System.Text.CaseFolding\System.Text.CaseFolding.csproj", "{6B8DAAD7-6CC3-4138-B719-02AE81BEC535}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -781,6 +783,18 @@ Global
 		{6435C875-F526-45E1-97E1-B5BF8C4F9A55}.Release|x64.Build.0 = Release|Any CPU
 		{6435C875-F526-45E1-97E1-B5BF8C4F9A55}.Release|x86.ActiveCfg = Release|Any CPU
 		{6435C875-F526-45E1-97E1-B5BF8C4F9A55}.Release|x86.Build.0 = Release|Any CPU
+		{6B8DAAD7-6CC3-4138-B719-02AE81BEC535}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B8DAAD7-6CC3-4138-B719-02AE81BEC535}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B8DAAD7-6CC3-4138-B719-02AE81BEC535}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6B8DAAD7-6CC3-4138-B719-02AE81BEC535}.Debug|x64.Build.0 = Debug|Any CPU
+		{6B8DAAD7-6CC3-4138-B719-02AE81BEC535}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6B8DAAD7-6CC3-4138-B719-02AE81BEC535}.Debug|x86.Build.0 = Debug|Any CPU
+		{6B8DAAD7-6CC3-4138-B719-02AE81BEC535}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B8DAAD7-6CC3-4138-B719-02AE81BEC535}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6B8DAAD7-6CC3-4138-B719-02AE81BEC535}.Release|x64.ActiveCfg = Release|Any CPU
+		{6B8DAAD7-6CC3-4138-B719-02AE81BEC535}.Release|x64.Build.0 = Release|Any CPU
+		{6B8DAAD7-6CC3-4138-B719-02AE81BEC535}.Release|x86.ActiveCfg = Release|Any CPU
+		{6B8DAAD7-6CC3-4138-B719-02AE81BEC535}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -840,6 +854,7 @@ Global
 		{8F6F600E-5EFB-44B3-80DE-808974A2998A} = {3079E458-D0E6-4F99-8CAB-80011D35C7DA}
 		{14FDEB76-14AE-4332-819C-1E8054855469} = {3079E458-D0E6-4F99-8CAB-80011D35C7DA}
 		{6435C875-F526-45E1-97E1-B5BF8C4F9A55} = {3079E458-D0E6-4F99-8CAB-80011D35C7DA}
+		{6B8DAAD7-6CC3-4138-B719-02AE81BEC535} = {4B000021-5278-4F2A-B734-DE49F55D4024}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9DD4022C-A010-4A9B-BCC5-171566D4CB17}

--- a/src/Microsoft.Data/ArrowStringColumn.cs
+++ b/src/Microsoft.Data/ArrowStringColumn.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Data
                     mutableOffsetsBuffer.Append(0);
                 }
                 mutableDataBuffer.EnsureCapacity(value.Length);
-                value.CopyTo(mutableDataBuffer.Span.Slice(mutableDataBuffer.Length));
+                value.CopyTo(mutableDataBuffer.RawSpan.Slice(mutableDataBuffer.Length));
                 mutableDataBuffer.Length += value.Length;
                 mutableOffsetsBuffer.Append(mutableOffsetsBuffer[mutableOffsetsBuffer.Length - 1] + value.Length);
             }

--- a/src/Microsoft.Data/DataFrame.cs
+++ b/src/Microsoft.Data/DataFrame.cs
@@ -233,6 +233,8 @@ namespace Microsoft.Data
             OnColumnsChanged();
         }
 
+        internal int GetColumnIndex(string columnName) => _table.GetColumnIndex(columnName);
+
         #region Operators
         public object this[long rowIndex, int columnIndex]
         {

--- a/src/Microsoft.Data/DataFrameBuffer.cs
+++ b/src/Microsoft.Data/DataFrameBuffer.cs
@@ -27,6 +27,12 @@ namespace Microsoft.Data
         public Span<T> Span
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => (MemoryMarshal.Cast<byte, T>(Memory.Span)).Slice(0, Length);
+        }
+
+        public Span<T> RawSpan
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => MemoryMarshal.Cast<byte, T>(Memory.Span);
         }
 
@@ -45,9 +51,9 @@ namespace Microsoft.Data
                 throw new ArgumentException("Current buffer is full", nameof(value));
             }
             EnsureCapacity(1);
-            Span[Length] = value;
             if (Length < MaxCapacity)
                 ++Length;
+            Span[Length - 1] = value;
         }
 
         public void EnsureCapacity(int numberOfValues)
@@ -73,7 +79,7 @@ namespace Microsoft.Data
             {
                 if (index > Length)
                     throw new ArgumentOutOfRangeException(nameof(index));
-                Span[index] = value;
+                RawSpan[index] = value;
             }
         }
 

--- a/src/Microsoft.Data/GroupBy.cs
+++ b/src/Microsoft.Data/GroupBy.cs
@@ -435,6 +435,7 @@ namespace Microsoft.Data
 
             return ret;
         }
+
         public override DataFrame Mean(params string[] columnNames)
         {
             DataFrame ret = new DataFrame();

--- a/src/Microsoft.Data/GroupBy.cs
+++ b/src/Microsoft.Data/GroupBy.cs
@@ -303,8 +303,7 @@ namespace Microsoft.Data
             return ret;
         }
 
-        private delegate BaseColumn GetColumn(string name);
-        private BaseColumn ResizeAndInsertColumn(int columnIndex, long rowIndex, bool firstGroup, DataFrame ret, PrimitiveColumn<long> empty, GetColumn getColumn = null)
+        private BaseColumn ResizeAndInsertColumn(int columnIndex, long rowIndex, bool firstGroup, DataFrame ret, PrimitiveColumn<long> empty, Func<string, BaseColumn> getColumn = null)
         {
             if (columnIndex == _groupByColumnIndex)
                 return null;
@@ -448,11 +447,10 @@ namespace Microsoft.Data
                 firstColumn[rowIndex] = key;
             });
 
-            GetColumn getColumn = new GetColumn((string name) => new PrimitiveColumn<double>(name));
 
             ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, ICollection<long> rowEnumerable, TKey key, bool firstGroup) =>
             {
-                BaseColumn retColumn = ResizeAndInsertColumn(columnIndex, rowIndex, firstGroup, ret, empty, getColumn);
+                BaseColumn retColumn = ResizeAndInsertColumn(columnIndex, rowIndex, firstGroup, ret, empty, (name) => new PrimitiveColumn<double>(name));
 
                 if (!(retColumn is null))
                 {

--- a/src/Microsoft.Data/GroupBy.cs
+++ b/src/Microsoft.Data/GroupBy.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Data
                 groupByColumnDelegate(rowNumber, pairs.Key);
                 ICollection<long> rows = pairs.Value;
                 IEnumerable<string> columns = columnNames;
-                if (columnNames.Length == 0)
+                if (columnNames == null || columnNames.Length == 0)
                     columns = _dataFrame.Columns;
                 // Assuming that the dataframe has not been modified after the groupby call
                 foreach (string columnName in columns)

--- a/src/Microsoft.Data/GroupBy.cs
+++ b/src/Microsoft.Data/GroupBy.cs
@@ -42,11 +42,32 @@ namespace Microsoft.Data
         /// <summary>
         /// Compute the max of group values
         /// </summary>
-        /// <returns></returns>
-        public abstract DataFrame Max();
-        public abstract DataFrame Min();
-        public abstract DataFrame Product();
-        public abstract DataFrame Sum();
+        /// <param name="columnNames">The columns to find the max of. A default value finds the max of all columns</param>
+        public abstract DataFrame Max(params string[] columnNames);
+
+        /// <summary>
+        /// Compute the min of group values
+        /// </summary>
+        /// <param name="columnNames">The columns to find the min of. A default value finds the min of all columns</param>
+        public abstract DataFrame Min(params string[] columnNames);
+
+        /// <summary>
+        /// Compute the product of group values
+        /// </summary>
+        /// <param name="columnNames">The columns to find the product of. A default value finds the product of all columns</param>
+        public abstract DataFrame Product(params string[] columnNames);
+
+        /// <summary>
+        /// Compute the sum of group values
+        /// </summary>
+        /// <param name="columnNames">The columns to sum. A Default value sums up all columns</param>
+        public abstract DataFrame Sum(params string[] columnNames);
+
+        /// <summary>
+        /// Compute the mean of group values
+        /// </summary>
+        /// <param name="columnNames">The columns to find the mean of. A Default value finds the mean of all columns</param>
+        public abstract DataFrame Mean(params string[] columnNames);
     }
 
     public class GroupBy<TKey> : GroupBy
@@ -64,9 +85,9 @@ namespace Microsoft.Data
             _dataFrame = dataFrame ?? throw new ArgumentException(nameof(dataFrame));
         }
 
-        private delegate void ColumnDelegate(int columnIndex, long rowIndex, IEnumerable<long> rows, TKey key, bool firstGroup);
+        private delegate void ColumnDelegate(int columnIndex, long rowIndex, ICollection<long> rows, TKey key, bool firstGroup);
         private delegate void GroupByColumnDelegate(long rowNumber, TKey key);
-        private void EnumerateColumnsWithRows(GroupByColumnDelegate groupByColumnDelegate, ColumnDelegate columnDelegate)
+        private void EnumerateColumnsWithRows(GroupByColumnDelegate groupByColumnDelegate, ColumnDelegate columnDelegate, params string[] columnNames)
         {
             long rowNumber = 0;
             bool firstGroup = true;
@@ -74,11 +95,14 @@ namespace Microsoft.Data
             {
                 groupByColumnDelegate(rowNumber, pairs.Key);
                 ICollection<long> rows = pairs.Value;
+                IEnumerable<string> columns = columnNames;
+                if (columnNames.Length == 0)
+                    columns = _dataFrame.Columns;
                 // Assuming that the dataframe has not been modified after the groupby call
-                int numberOfColumns = _dataFrame.ColumnCount;
-                for (int i = 0; i < numberOfColumns; i++)
+                foreach (string columnName in columns)
                 {
-                    columnDelegate(i, rowNumber, rows, pairs.Key, firstGroup);
+                    int columnIndex = _dataFrame.GetColumnIndex(columnName);
+                    columnDelegate(columnIndex, rowNumber, rows, pairs.Key, firstGroup);
                 }
                 firstGroup = false;
                 rowNumber++;
@@ -97,7 +121,7 @@ namespace Microsoft.Data
                 firstColumn.Resize(rowIndex + 1);
                 firstColumn[rowIndex] = key;
             });
-            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, IEnumerable<long> rowEnumerable, TKey key, bool firstGroup) =>
+            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, ICollection<long> rowEnumerable, TKey key, bool firstGroup) =>
             {
                 if (columnIndex == _groupByColumnIndex)
                     return;
@@ -142,31 +166,27 @@ namespace Microsoft.Data
                 firstColumn[rowIndex] = key;
             });
 
-            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, IEnumerable<long> rowEnumerable, TKey key, bool firstGroup) =>
+            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, ICollection<long> rowEnumerable, TKey key, bool firstGroup) =>
             {
                 if (columnIndex == _groupByColumnIndex)
                     return;
                 BaseColumn column = _dataFrame.Column(columnIndex);
-                long count = 0;
                 foreach (long row in rowEnumerable)
                 {
-                    if (count < 1)
+                    BaseColumn retColumn;
+                    if (firstGroup)
                     {
-                        count++;
-                        BaseColumn retColumn;
-                        if (firstGroup)
-                        {
-                            retColumn = column.Clone(empty);
-                            ret.InsertColumn(ret.ColumnCount, retColumn);
-                        }
-                        else
-                        {
-                            // Assuming non duplicate column names
-                            retColumn = ret[column.Name];
-                        }
-                        retColumn.Resize(rowIndex + 1);
-                        retColumn[rowIndex] = column[row];
+                        retColumn = column.Clone(empty);
+                        ret.InsertColumn(ret.ColumnCount, retColumn);
                     }
+                    else
+                    {
+                        // Assuming non duplicate column names
+                        retColumn = ret[column.Name];
+                    }
+                    retColumn.Resize(rowIndex + 1);
+                    retColumn[rowIndex] = column[row];
+                    break;
                 }
             });
 
@@ -186,7 +206,7 @@ namespace Microsoft.Data
             {
             });
 
-            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, IEnumerable<long> rowEnumerable, TKey key, bool firstGroup) =>
+            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, ICollection<long> rowEnumerable, TKey key, bool firstGroup) =>
             {
                 if (columnIndex == _groupByColumnIndex)
                     return;
@@ -219,6 +239,8 @@ namespace Microsoft.Data
                         firstColumn[retColumnLength] = key;
                         count++;
                     }
+                    if (count == numberOfRows)
+                        break;
                 }
             });
 
@@ -238,7 +260,7 @@ namespace Microsoft.Data
             {
             });
 
-            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, IEnumerable<long> rowEnumerable, TKey key, bool firstGroup) =>
+            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, ICollection<long> rowEnumerable, TKey key, bool firstGroup) =>
             {
                 if (columnIndex == _groupByColumnIndex)
                     return;
@@ -281,7 +303,8 @@ namespace Microsoft.Data
             return ret;
         }
 
-        private BaseColumn ResizeAndInsertColumn(int columnIndex, long rowIndex, bool firstGroup, DataFrame ret, PrimitiveColumn<long> empty)
+        private delegate BaseColumn GetColumn(string name);
+        private BaseColumn ResizeAndInsertColumn(int columnIndex, long rowIndex, bool firstGroup, DataFrame ret, PrimitiveColumn<long> empty, GetColumn getColumn = null)
         {
             if (columnIndex == _groupByColumnIndex)
                 return null;
@@ -289,7 +312,7 @@ namespace Microsoft.Data
             BaseColumn retColumn;
             if (firstGroup)
             {
-                retColumn = column.Clone(empty);
+                retColumn = getColumn == null ? column.Clone(empty) : getColumn(column.Name);
                 ret.InsertColumn(ret.ColumnCount, retColumn);
             }
             else
@@ -301,7 +324,7 @@ namespace Microsoft.Data
             return retColumn;
         }
 
-        public override DataFrame Max()
+        public override DataFrame Max(params string[] columnNames)
         {
             DataFrame ret = new DataFrame();
             PrimitiveColumn<long> empty = new PrimitiveColumn<long>("Empty");
@@ -313,7 +336,7 @@ namespace Microsoft.Data
                 firstColumn[rowIndex] = key;
             });
 
-            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, IEnumerable<long> rowEnumerable, TKey key, bool firstGroup) =>
+            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, ICollection<long> rowEnumerable, TKey key, bool firstGroup) =>
             {
                 BaseColumn retColumn = ResizeAndInsertColumn(columnIndex, rowIndex, firstGroup, ret, empty);
 
@@ -323,13 +346,13 @@ namespace Microsoft.Data
                 }
             });
 
-            EnumerateColumnsWithRows(groupByColumnDelegate, columnDelegate);
+            EnumerateColumnsWithRows(groupByColumnDelegate, columnDelegate, columnNames);
             ret.SetTableRowCount(firstColumn.Length);
 
             return ret;
         }
 
-        public override DataFrame Min()
+        public override DataFrame Min(params string[] columnNames)
         {
             DataFrame ret = new DataFrame();
             PrimitiveColumn<long> empty = new PrimitiveColumn<long>("Empty");
@@ -341,7 +364,7 @@ namespace Microsoft.Data
                 firstColumn[rowIndex] = key;
             });
 
-            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, IEnumerable<long> rowEnumerable, TKey key, bool firstGroup) =>
+            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, ICollection<long> rowEnumerable, TKey key, bool firstGroup) =>
             {
                 BaseColumn retColumn = ResizeAndInsertColumn(columnIndex, rowIndex, firstGroup, ret, empty);
 
@@ -351,13 +374,13 @@ namespace Microsoft.Data
                 }
             });
 
-            EnumerateColumnsWithRows(groupByColumnDelegate, columnDelegate);
+            EnumerateColumnsWithRows(groupByColumnDelegate, columnDelegate, columnNames);
             ret.SetTableRowCount(firstColumn.Length);
 
             return ret;
         }
 
-        public override DataFrame Product()
+        public override DataFrame Product(params string[] columnNames)
         {
             DataFrame ret = new DataFrame();
             PrimitiveColumn<long> empty = new PrimitiveColumn<long>("Empty");
@@ -369,7 +392,7 @@ namespace Microsoft.Data
                 firstColumn[rowIndex] = key;
             });
 
-            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, IEnumerable<long> rowEnumerable, TKey key, bool firstGroup) =>
+            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, ICollection<long> rowEnumerable, TKey key, bool firstGroup) =>
             {
                 BaseColumn retColumn = ResizeAndInsertColumn(columnIndex, rowIndex, firstGroup, ret, empty);
 
@@ -379,13 +402,13 @@ namespace Microsoft.Data
                 }
             });
 
-            EnumerateColumnsWithRows(groupByColumnDelegate, columnDelegate);
+            EnumerateColumnsWithRows(groupByColumnDelegate, columnDelegate, columnNames);
             ret.SetTableRowCount(firstColumn.Length);
 
             return ret;
         }
 
-        public override DataFrame Sum()
+        public override DataFrame Sum(params string[] columnNames)
         {
             DataFrame ret = new DataFrame();
             PrimitiveColumn<long> empty = new PrimitiveColumn<long>("Empty");
@@ -397,7 +420,7 @@ namespace Microsoft.Data
                 firstColumn[rowIndex] = key;
             });
 
-            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, IEnumerable<long> rowEnumerable, TKey key, bool firstGroup) =>
+            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, ICollection<long> rowEnumerable, TKey key, bool firstGroup) =>
             {
                 BaseColumn retColumn = ResizeAndInsertColumn(columnIndex, rowIndex, firstGroup, ret, empty);
 
@@ -407,7 +430,36 @@ namespace Microsoft.Data
                 }
             });
 
-            EnumerateColumnsWithRows(groupByColumnDelegate, columnDelegate);
+            EnumerateColumnsWithRows(groupByColumnDelegate, columnDelegate, columnNames);
+            ret.SetTableRowCount(firstColumn.Length);
+
+            return ret;
+        }
+        public override DataFrame Mean(params string[] columnNames)
+        {
+            DataFrame ret = new DataFrame();
+            PrimitiveColumn<long> empty = new PrimitiveColumn<long>("Empty");
+            BaseColumn firstColumn = _dataFrame.Column(_groupByColumnIndex).Clone(empty);
+            ret.InsertColumn(ret.ColumnCount, firstColumn);
+            GroupByColumnDelegate groupByColumnDelegate = new GroupByColumnDelegate((long rowIndex, TKey key) =>
+            {
+                firstColumn.Resize(rowIndex + 1);
+                firstColumn[rowIndex] = key;
+            });
+
+            GetColumn getColumn = new GetColumn((string name) => new PrimitiveColumn<double>(name));
+
+            ColumnDelegate columnDelegate = new ColumnDelegate((int columnIndex, long rowIndex, ICollection<long> rowEnumerable, TKey key, bool firstGroup) =>
+            {
+                BaseColumn retColumn = ResizeAndInsertColumn(columnIndex, rowIndex, firstGroup, ret, empty, getColumn);
+
+                if (!(retColumn is null))
+                {
+                    retColumn[rowIndex] = (double)Convert.ChangeType(_dataFrame.Column(columnIndex).Sum(rowEnumerable), typeof(double)) / rowEnumerable.Count;
+                }
+            });
+
+            EnumerateColumnsWithRows(groupByColumnDelegate, columnDelegate, columnNames);
             ret.SetTableRowCount(firstColumn.Length);
 
             return ret;

--- a/src/Microsoft.Data/PrimitiveColumn.cs
+++ b/src/Microsoft.Data/PrimitiveColumn.cs
@@ -434,7 +434,7 @@ namespace Microsoft.Data
                     ReadOnlyDataFrameBuffer<T> buffer = _columnContainer.Buffers[b];
                     ReadOnlySpan<T> readOnlySpan = buffer.ReadOnlySpan;
                     long previousLength = b * ReadOnlyDataFrameBuffer<T>.MaxCapacity;
-                    for (int i = 0; i < buffer.Length; i++)
+                    for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                     {
                         long currentLength = i + previousLength;
                         bool containsKey = multimap.TryGetValue(readOnlySpan[i], out ICollection<long> values);
@@ -444,7 +444,7 @@ namespace Microsoft.Data
                         }
                         else
                         {
-                            multimap.Add(readOnlySpan[i], new List<long>() { i });
+                            multimap.Add(readOnlySpan[i], new List<long>() { currentLength });
                         }
                     }
                 }

--- a/src/Microsoft.Data/PrimitiveColumn.cs
+++ b/src/Microsoft.Data/PrimitiveColumn.cs
@@ -434,7 +434,7 @@ namespace Microsoft.Data
                     ReadOnlyDataFrameBuffer<T> buffer = _columnContainer.Buffers[b];
                     ReadOnlySpan<T> readOnlySpan = buffer.ReadOnlySpan;
                     long previousLength = b * ReadOnlyDataFrameBuffer<T>.MaxCapacity;
-                    for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                    for (int i = 0; i < readOnlySpan.Length; i++)
                     {
                         long currentLength = i + previousLength;
                         bool containsKey = multimap.TryGetValue(readOnlySpan[i], out ICollection<long> values);

--- a/src/Microsoft.Data/PrimitiveColumn.cs
+++ b/src/Microsoft.Data/PrimitiveColumn.cs
@@ -429,16 +429,23 @@ namespace Microsoft.Data
             if (typeof(TKey) == typeof(T))
             {
                 Dictionary<T, ICollection<long>> multimap = new Dictionary<T, ICollection<long>>(EqualityComparer<T>.Default);
-                for (long i = 0; i < Length; i++)
+                for (int b = 0; b < _columnContainer.Buffers.Count; b++)
                 {
-                    bool containsKey = multimap.TryGetValue(this[i] ?? default, out ICollection<long> values);
-                    if (containsKey)
+                    ReadOnlyDataFrameBuffer<T> buffer = _columnContainer.Buffers[b];
+                    ReadOnlySpan<T> readOnlySpan = buffer.ReadOnlySpan;
+                    long previousLength = b * ReadOnlyDataFrameBuffer<T>.MaxCapacity;
+                    for (int i = 0; i < buffer.Length; i++)
                     {
-                        values.Add(i);
-                    }
-                    else
-                    {
-                        multimap.Add(this[i] ?? default, new List<long>() { i });
+                        long currentLength = i + previousLength;
+                        bool containsKey = multimap.TryGetValue(readOnlySpan[i], out ICollection<long> values);
+                        if (containsKey)
+                        {
+                            values.Add(currentLength);
+                        }
+                        else
+                        {
+                            multimap.Add(readOnlySpan[i], new List<long>() { i });
+                        }
                     }
                 }
                 return multimap as Dictionary<TKey, ICollection<long>>;

--- a/src/Microsoft.Data/PrimitiveColumnArithmetic.cs
+++ b/src/Microsoft.Data/PrimitiveColumnArithmetic.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (bool)(span[i] & otherSpan[i]);
                 }
@@ -177,7 +177,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (bool)(span[i] & scalar);
                 }
@@ -192,7 +192,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (bool)(span[i] | otherSpan[i]);
                 }
@@ -206,7 +206,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (bool)(span[i] | scalar);
                 }
@@ -221,7 +221,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (bool)(span[i] ^ otherSpan[i]);
                 }
@@ -235,7 +235,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (bool)(span[i] ^ scalar);
                 }
@@ -258,7 +258,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == otherSpan[i]);
                 }
@@ -272,7 +272,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
                 }
@@ -287,7 +287,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != otherSpan[i]);
                 }
@@ -301,7 +301,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
                 }
@@ -351,7 +351,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] + otherSpan[i]);
                 }
@@ -365,7 +365,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] + scalar);
                 }
@@ -380,7 +380,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] - otherSpan[i]);
                 }
@@ -394,7 +394,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] - scalar);
                 }
@@ -409,7 +409,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] * otherSpan[i]);
                 }
@@ -423,7 +423,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] * scalar);
                 }
@@ -438,7 +438,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] / otherSpan[i]);
                 }
@@ -452,7 +452,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] / scalar);
                 }
@@ -467,7 +467,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] % otherSpan[i]);
                 }
@@ -481,7 +481,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] % scalar);
                 }
@@ -496,7 +496,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] & otherSpan[i]);
                 }
@@ -510,7 +510,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] & scalar);
                 }
@@ -525,7 +525,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] | otherSpan[i]);
                 }
@@ -539,7 +539,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] | scalar);
                 }
@@ -554,7 +554,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] ^ otherSpan[i]);
                 }
@@ -568,7 +568,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] ^ scalar);
                 }
@@ -582,7 +582,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] << value);
                 }
@@ -596,7 +596,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (byte)(span[i] >> value);
                 }
@@ -611,7 +611,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == otherSpan[i]);
                 }
@@ -625,7 +625,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
                 }
@@ -640,7 +640,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != otherSpan[i]);
                 }
@@ -654,7 +654,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
                 }
@@ -669,7 +669,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= otherSpan[i]);
                 }
@@ -683,7 +683,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
                 }
@@ -698,7 +698,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= otherSpan[i]);
                 }
@@ -712,7 +712,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
                 }
@@ -727,7 +727,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > otherSpan[i]);
                 }
@@ -741,7 +741,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
                 }
@@ -756,7 +756,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < otherSpan[i]);
                 }
@@ -770,7 +770,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
                 }
@@ -788,7 +788,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] + otherSpan[i]);
                 }
@@ -802,7 +802,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] + scalar);
                 }
@@ -817,7 +817,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] - otherSpan[i]);
                 }
@@ -831,7 +831,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] - scalar);
                 }
@@ -846,7 +846,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] * otherSpan[i]);
                 }
@@ -860,7 +860,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] * scalar);
                 }
@@ -875,7 +875,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] / otherSpan[i]);
                 }
@@ -889,7 +889,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] / scalar);
                 }
@@ -904,7 +904,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] % otherSpan[i]);
                 }
@@ -918,7 +918,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] % scalar);
                 }
@@ -933,7 +933,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] & otherSpan[i]);
                 }
@@ -947,7 +947,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] & scalar);
                 }
@@ -962,7 +962,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] | otherSpan[i]);
                 }
@@ -976,7 +976,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] | scalar);
                 }
@@ -991,7 +991,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] ^ otherSpan[i]);
                 }
@@ -1005,7 +1005,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] ^ scalar);
                 }
@@ -1019,7 +1019,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] << value);
                 }
@@ -1033,7 +1033,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (char)(span[i] >> value);
                 }
@@ -1048,7 +1048,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == otherSpan[i]);
                 }
@@ -1062,7 +1062,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
                 }
@@ -1077,7 +1077,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != otherSpan[i]);
                 }
@@ -1091,7 +1091,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
                 }
@@ -1106,7 +1106,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= otherSpan[i]);
                 }
@@ -1120,7 +1120,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
                 }
@@ -1135,7 +1135,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= otherSpan[i]);
                 }
@@ -1149,7 +1149,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
                 }
@@ -1164,7 +1164,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > otherSpan[i]);
                 }
@@ -1178,7 +1178,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
                 }
@@ -1193,7 +1193,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < otherSpan[i]);
                 }
@@ -1207,7 +1207,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
                 }
@@ -1225,7 +1225,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(span[i] + otherSpan[i]);
                 }
@@ -1239,7 +1239,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(span[i] + scalar);
                 }
@@ -1254,7 +1254,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(span[i] - otherSpan[i]);
                 }
@@ -1268,7 +1268,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(span[i] - scalar);
                 }
@@ -1283,7 +1283,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(span[i] * otherSpan[i]);
                 }
@@ -1297,7 +1297,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(span[i] * scalar);
                 }
@@ -1312,7 +1312,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(span[i] / otherSpan[i]);
                 }
@@ -1326,7 +1326,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(span[i] / scalar);
                 }
@@ -1341,7 +1341,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(span[i] % otherSpan[i]);
                 }
@@ -1355,7 +1355,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (decimal)(span[i] % scalar);
                 }
@@ -1402,7 +1402,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == otherSpan[i]);
                 }
@@ -1416,7 +1416,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
                 }
@@ -1431,7 +1431,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != otherSpan[i]);
                 }
@@ -1445,7 +1445,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
                 }
@@ -1460,7 +1460,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= otherSpan[i]);
                 }
@@ -1474,7 +1474,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
                 }
@@ -1489,7 +1489,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= otherSpan[i]);
                 }
@@ -1503,7 +1503,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
                 }
@@ -1518,7 +1518,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > otherSpan[i]);
                 }
@@ -1532,7 +1532,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
                 }
@@ -1547,7 +1547,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < otherSpan[i]);
                 }
@@ -1561,7 +1561,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
                 }
@@ -1579,7 +1579,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(span[i] + otherSpan[i]);
                 }
@@ -1593,7 +1593,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(span[i] + scalar);
                 }
@@ -1608,7 +1608,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(span[i] - otherSpan[i]);
                 }
@@ -1622,7 +1622,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(span[i] - scalar);
                 }
@@ -1637,7 +1637,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(span[i] * otherSpan[i]);
                 }
@@ -1651,7 +1651,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(span[i] * scalar);
                 }
@@ -1666,7 +1666,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(span[i] / otherSpan[i]);
                 }
@@ -1680,7 +1680,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(span[i] / scalar);
                 }
@@ -1695,7 +1695,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(span[i] % otherSpan[i]);
                 }
@@ -1709,7 +1709,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (double)(span[i] % scalar);
                 }
@@ -1756,7 +1756,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == otherSpan[i]);
                 }
@@ -1770,7 +1770,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
                 }
@@ -1785,7 +1785,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != otherSpan[i]);
                 }
@@ -1799,7 +1799,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
                 }
@@ -1814,7 +1814,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= otherSpan[i]);
                 }
@@ -1828,7 +1828,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
                 }
@@ -1843,7 +1843,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= otherSpan[i]);
                 }
@@ -1857,7 +1857,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
                 }
@@ -1872,7 +1872,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > otherSpan[i]);
                 }
@@ -1886,7 +1886,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
                 }
@@ -1901,7 +1901,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < otherSpan[i]);
                 }
@@ -1915,7 +1915,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
                 }
@@ -1933,7 +1933,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(span[i] + otherSpan[i]);
                 }
@@ -1947,7 +1947,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(span[i] + scalar);
                 }
@@ -1962,7 +1962,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(span[i] - otherSpan[i]);
                 }
@@ -1976,7 +1976,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(span[i] - scalar);
                 }
@@ -1991,7 +1991,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(span[i] * otherSpan[i]);
                 }
@@ -2005,7 +2005,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(span[i] * scalar);
                 }
@@ -2020,7 +2020,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(span[i] / otherSpan[i]);
                 }
@@ -2034,7 +2034,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(span[i] / scalar);
                 }
@@ -2049,7 +2049,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(span[i] % otherSpan[i]);
                 }
@@ -2063,7 +2063,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (float)(span[i] % scalar);
                 }
@@ -2110,7 +2110,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == otherSpan[i]);
                 }
@@ -2124,7 +2124,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
                 }
@@ -2139,7 +2139,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != otherSpan[i]);
                 }
@@ -2153,7 +2153,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
                 }
@@ -2168,7 +2168,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= otherSpan[i]);
                 }
@@ -2182,7 +2182,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
                 }
@@ -2197,7 +2197,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= otherSpan[i]);
                 }
@@ -2211,7 +2211,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
                 }
@@ -2226,7 +2226,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > otherSpan[i]);
                 }
@@ -2240,7 +2240,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
                 }
@@ -2255,7 +2255,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < otherSpan[i]);
                 }
@@ -2269,7 +2269,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
                 }
@@ -2287,7 +2287,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] + otherSpan[i]);
                 }
@@ -2301,7 +2301,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] + scalar);
                 }
@@ -2316,7 +2316,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] - otherSpan[i]);
                 }
@@ -2330,7 +2330,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] - scalar);
                 }
@@ -2345,7 +2345,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] * otherSpan[i]);
                 }
@@ -2359,7 +2359,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] * scalar);
                 }
@@ -2374,7 +2374,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] / otherSpan[i]);
                 }
@@ -2388,7 +2388,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] / scalar);
                 }
@@ -2403,7 +2403,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] % otherSpan[i]);
                 }
@@ -2417,7 +2417,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] % scalar);
                 }
@@ -2432,7 +2432,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] & otherSpan[i]);
                 }
@@ -2446,7 +2446,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] & scalar);
                 }
@@ -2461,7 +2461,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] | otherSpan[i]);
                 }
@@ -2475,7 +2475,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] | scalar);
                 }
@@ -2490,7 +2490,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] ^ otherSpan[i]);
                 }
@@ -2504,7 +2504,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] ^ scalar);
                 }
@@ -2518,7 +2518,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] << value);
                 }
@@ -2532,7 +2532,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (int)(span[i] >> value);
                 }
@@ -2547,7 +2547,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == otherSpan[i]);
                 }
@@ -2561,7 +2561,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
                 }
@@ -2576,7 +2576,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != otherSpan[i]);
                 }
@@ -2590,7 +2590,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
                 }
@@ -2605,7 +2605,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= otherSpan[i]);
                 }
@@ -2619,7 +2619,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
                 }
@@ -2634,7 +2634,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= otherSpan[i]);
                 }
@@ -2648,7 +2648,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
                 }
@@ -2663,7 +2663,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > otherSpan[i]);
                 }
@@ -2677,7 +2677,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
                 }
@@ -2692,7 +2692,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < otherSpan[i]);
                 }
@@ -2706,7 +2706,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
                 }
@@ -2724,7 +2724,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] + otherSpan[i]);
                 }
@@ -2738,7 +2738,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] + scalar);
                 }
@@ -2753,7 +2753,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] - otherSpan[i]);
                 }
@@ -2767,7 +2767,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] - scalar);
                 }
@@ -2782,7 +2782,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] * otherSpan[i]);
                 }
@@ -2796,7 +2796,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] * scalar);
                 }
@@ -2811,7 +2811,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] / otherSpan[i]);
                 }
@@ -2825,7 +2825,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] / scalar);
                 }
@@ -2840,7 +2840,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] % otherSpan[i]);
                 }
@@ -2854,7 +2854,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] % scalar);
                 }
@@ -2869,7 +2869,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] & otherSpan[i]);
                 }
@@ -2883,7 +2883,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] & scalar);
                 }
@@ -2898,7 +2898,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] | otherSpan[i]);
                 }
@@ -2912,7 +2912,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] | scalar);
                 }
@@ -2927,7 +2927,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] ^ otherSpan[i]);
                 }
@@ -2941,7 +2941,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] ^ scalar);
                 }
@@ -2955,7 +2955,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] << value);
                 }
@@ -2969,7 +2969,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (long)(span[i] >> value);
                 }
@@ -2984,7 +2984,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == otherSpan[i]);
                 }
@@ -2998,7 +2998,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
                 }
@@ -3013,7 +3013,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != otherSpan[i]);
                 }
@@ -3027,7 +3027,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
                 }
@@ -3042,7 +3042,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= otherSpan[i]);
                 }
@@ -3056,7 +3056,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
                 }
@@ -3071,7 +3071,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= otherSpan[i]);
                 }
@@ -3085,7 +3085,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
                 }
@@ -3100,7 +3100,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > otherSpan[i]);
                 }
@@ -3114,7 +3114,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
                 }
@@ -3129,7 +3129,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < otherSpan[i]);
                 }
@@ -3143,7 +3143,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
                 }
@@ -3161,7 +3161,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] + otherSpan[i]);
                 }
@@ -3175,7 +3175,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] + scalar);
                 }
@@ -3190,7 +3190,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] - otherSpan[i]);
                 }
@@ -3204,7 +3204,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] - scalar);
                 }
@@ -3219,7 +3219,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] * otherSpan[i]);
                 }
@@ -3233,7 +3233,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] * scalar);
                 }
@@ -3248,7 +3248,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] / otherSpan[i]);
                 }
@@ -3262,7 +3262,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] / scalar);
                 }
@@ -3277,7 +3277,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] % otherSpan[i]);
                 }
@@ -3291,7 +3291,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] % scalar);
                 }
@@ -3306,7 +3306,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] & otherSpan[i]);
                 }
@@ -3320,7 +3320,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] & scalar);
                 }
@@ -3335,7 +3335,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] | otherSpan[i]);
                 }
@@ -3349,7 +3349,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] | scalar);
                 }
@@ -3364,7 +3364,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] ^ otherSpan[i]);
                 }
@@ -3378,7 +3378,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] ^ scalar);
                 }
@@ -3392,7 +3392,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] << value);
                 }
@@ -3406,7 +3406,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (sbyte)(span[i] >> value);
                 }
@@ -3421,7 +3421,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == otherSpan[i]);
                 }
@@ -3435,7 +3435,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
                 }
@@ -3450,7 +3450,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != otherSpan[i]);
                 }
@@ -3464,7 +3464,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
                 }
@@ -3479,7 +3479,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= otherSpan[i]);
                 }
@@ -3493,7 +3493,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
                 }
@@ -3508,7 +3508,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= otherSpan[i]);
                 }
@@ -3522,7 +3522,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
                 }
@@ -3537,7 +3537,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > otherSpan[i]);
                 }
@@ -3551,7 +3551,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
                 }
@@ -3566,7 +3566,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < otherSpan[i]);
                 }
@@ -3580,7 +3580,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
                 }
@@ -3598,7 +3598,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] + otherSpan[i]);
                 }
@@ -3612,7 +3612,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] + scalar);
                 }
@@ -3627,7 +3627,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] - otherSpan[i]);
                 }
@@ -3641,7 +3641,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] - scalar);
                 }
@@ -3656,7 +3656,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] * otherSpan[i]);
                 }
@@ -3670,7 +3670,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] * scalar);
                 }
@@ -3685,7 +3685,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] / otherSpan[i]);
                 }
@@ -3699,7 +3699,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] / scalar);
                 }
@@ -3714,7 +3714,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] % otherSpan[i]);
                 }
@@ -3728,7 +3728,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] % scalar);
                 }
@@ -3743,7 +3743,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] & otherSpan[i]);
                 }
@@ -3757,7 +3757,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] & scalar);
                 }
@@ -3772,7 +3772,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] | otherSpan[i]);
                 }
@@ -3786,7 +3786,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] | scalar);
                 }
@@ -3801,7 +3801,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] ^ otherSpan[i]);
                 }
@@ -3815,7 +3815,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] ^ scalar);
                 }
@@ -3829,7 +3829,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] << value);
                 }
@@ -3843,7 +3843,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (short)(span[i] >> value);
                 }
@@ -3858,7 +3858,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == otherSpan[i]);
                 }
@@ -3872,7 +3872,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
                 }
@@ -3887,7 +3887,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != otherSpan[i]);
                 }
@@ -3901,7 +3901,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
                 }
@@ -3916,7 +3916,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= otherSpan[i]);
                 }
@@ -3930,7 +3930,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
                 }
@@ -3945,7 +3945,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= otherSpan[i]);
                 }
@@ -3959,7 +3959,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
                 }
@@ -3974,7 +3974,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > otherSpan[i]);
                 }
@@ -3988,7 +3988,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
                 }
@@ -4003,7 +4003,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < otherSpan[i]);
                 }
@@ -4017,7 +4017,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
                 }
@@ -4035,7 +4035,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] + otherSpan[i]);
                 }
@@ -4049,7 +4049,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] + scalar);
                 }
@@ -4064,7 +4064,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] - otherSpan[i]);
                 }
@@ -4078,7 +4078,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] - scalar);
                 }
@@ -4093,7 +4093,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] * otherSpan[i]);
                 }
@@ -4107,7 +4107,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] * scalar);
                 }
@@ -4122,7 +4122,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] / otherSpan[i]);
                 }
@@ -4136,7 +4136,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] / scalar);
                 }
@@ -4151,7 +4151,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] % otherSpan[i]);
                 }
@@ -4165,7 +4165,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] % scalar);
                 }
@@ -4180,7 +4180,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] & otherSpan[i]);
                 }
@@ -4194,7 +4194,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] & scalar);
                 }
@@ -4209,7 +4209,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] | otherSpan[i]);
                 }
@@ -4223,7 +4223,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] | scalar);
                 }
@@ -4238,7 +4238,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] ^ otherSpan[i]);
                 }
@@ -4252,7 +4252,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] ^ scalar);
                 }
@@ -4266,7 +4266,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] << value);
                 }
@@ -4280,7 +4280,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (uint)(span[i] >> value);
                 }
@@ -4295,7 +4295,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == otherSpan[i]);
                 }
@@ -4309,7 +4309,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
                 }
@@ -4324,7 +4324,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != otherSpan[i]);
                 }
@@ -4338,7 +4338,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
                 }
@@ -4353,7 +4353,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= otherSpan[i]);
                 }
@@ -4367,7 +4367,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
                 }
@@ -4382,7 +4382,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= otherSpan[i]);
                 }
@@ -4396,7 +4396,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
                 }
@@ -4411,7 +4411,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > otherSpan[i]);
                 }
@@ -4425,7 +4425,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
                 }
@@ -4440,7 +4440,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < otherSpan[i]);
                 }
@@ -4454,7 +4454,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
                 }
@@ -4472,7 +4472,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] + otherSpan[i]);
                 }
@@ -4486,7 +4486,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] + scalar);
                 }
@@ -4501,7 +4501,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] - otherSpan[i]);
                 }
@@ -4515,7 +4515,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] - scalar);
                 }
@@ -4530,7 +4530,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] * otherSpan[i]);
                 }
@@ -4544,7 +4544,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] * scalar);
                 }
@@ -4559,7 +4559,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] / otherSpan[i]);
                 }
@@ -4573,7 +4573,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] / scalar);
                 }
@@ -4588,7 +4588,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] % otherSpan[i]);
                 }
@@ -4602,7 +4602,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] % scalar);
                 }
@@ -4617,7 +4617,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] & otherSpan[i]);
                 }
@@ -4631,7 +4631,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] & scalar);
                 }
@@ -4646,7 +4646,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] | otherSpan[i]);
                 }
@@ -4660,7 +4660,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] | scalar);
                 }
@@ -4675,7 +4675,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] ^ otherSpan[i]);
                 }
@@ -4689,7 +4689,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] ^ scalar);
                 }
@@ -4703,7 +4703,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] << value);
                 }
@@ -4717,7 +4717,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ulong)(span[i] >> value);
                 }
@@ -4732,7 +4732,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == otherSpan[i]);
                 }
@@ -4746,7 +4746,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
                 }
@@ -4761,7 +4761,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != otherSpan[i]);
                 }
@@ -4775,7 +4775,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
                 }
@@ -4790,7 +4790,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= otherSpan[i]);
                 }
@@ -4804,7 +4804,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
                 }
@@ -4819,7 +4819,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= otherSpan[i]);
                 }
@@ -4833,7 +4833,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
                 }
@@ -4848,7 +4848,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > otherSpan[i]);
                 }
@@ -4862,7 +4862,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
                 }
@@ -4877,7 +4877,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < otherSpan[i]);
                 }
@@ -4891,7 +4891,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
                 }
@@ -4909,7 +4909,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] + otherSpan[i]);
                 }
@@ -4923,7 +4923,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] + scalar);
                 }
@@ -4938,7 +4938,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] - otherSpan[i]);
                 }
@@ -4952,7 +4952,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] - scalar);
                 }
@@ -4967,7 +4967,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] * otherSpan[i]);
                 }
@@ -4981,7 +4981,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] * scalar);
                 }
@@ -4996,7 +4996,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] / otherSpan[i]);
                 }
@@ -5010,7 +5010,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] / scalar);
                 }
@@ -5025,7 +5025,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] % otherSpan[i]);
                 }
@@ -5039,7 +5039,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] % scalar);
                 }
@@ -5054,7 +5054,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] & otherSpan[i]);
                 }
@@ -5068,7 +5068,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] & scalar);
                 }
@@ -5083,7 +5083,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] | otherSpan[i]);
                 }
@@ -5097,7 +5097,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] | scalar);
                 }
@@ -5112,7 +5112,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] ^ otherSpan[i]);
                 }
@@ -5126,7 +5126,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] ^ scalar);
                 }
@@ -5140,7 +5140,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] << value);
                 }
@@ -5154,7 +5154,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     span[i] = (ushort)(span[i] >> value);
                 }
@@ -5169,7 +5169,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == otherSpan[i]);
                 }
@@ -5183,7 +5183,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] == scalar);
                 }
@@ -5198,7 +5198,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != otherSpan[i]);
                 }
@@ -5212,7 +5212,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] != scalar);
                 }
@@ -5227,7 +5227,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= otherSpan[i]);
                 }
@@ -5241,7 +5241,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] >= scalar);
                 }
@@ -5256,7 +5256,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= otherSpan[i]);
                 }
@@ -5270,7 +5270,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] <= scalar);
                 }
@@ -5285,7 +5285,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > otherSpan[i]);
                 }
@@ -5299,7 +5299,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] > scalar);
                 }
@@ -5314,7 +5314,7 @@ namespace Microsoft.Data
                 left.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
                 var otherSpan = right.Buffers[b].ReadOnlySpan;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < otherSpan[i]);
                 }
@@ -5328,7 +5328,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 column.Buffers[b] = mutableBuffer;
                 var span = mutableBuffer.Span;
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     ret[i] = (span[i] < scalar);
                 }

--- a/src/Microsoft.Data/PrimitiveColumnArithmetic.cs
+++ b/src/Microsoft.Data/PrimitiveColumnArithmetic.cs
@@ -156,79 +156,88 @@ namespace Microsoft.Data
         }
         public void And(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (bool)(mutableBuffer.Span[i] & right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (bool)(span[i] & otherSpan[i]);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<bool> column, bool scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (bool)(mutableBuffer.Span[i] & scalar);
+                    span[i] = (bool)(span[i] & scalar);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (bool)(mutableBuffer.Span[i] | right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (bool)(span[i] | otherSpan[i]);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<bool> column, bool scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (bool)(mutableBuffer.Span[i] | scalar);
+                    span[i] = (bool)(span[i] | scalar);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (bool)(mutableBuffer.Span[i] ^ right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (bool)(span[i] ^ otherSpan[i]);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<bool> column, bool scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (bool)(mutableBuffer.Span[i] ^ scalar);
+                    span[i] = (bool)(span[i] ^ scalar);
                 }
             }
         }
@@ -242,53 +251,59 @@ namespace Microsoft.Data
         }
         public void Equals(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<bool> column, bool scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == scalar);
+                    ret[i] = (span[i] == scalar);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<bool> left, PrimitiveColumnContainer<bool> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<bool> column, bool scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<bool>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != scalar);
+                    ret[i] = (span[i] != scalar);
                 }
             }
         }
@@ -329,391 +344,435 @@ namespace Microsoft.Data
     {
         public void Add(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] + right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (byte)(span[i] + otherSpan[i]);
                 }
             }
         }
         public void Add(PrimitiveColumnContainer<byte> column, byte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] + scalar);
+                    span[i] = (byte)(span[i] + scalar);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] - right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (byte)(span[i] - otherSpan[i]);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<byte> column, byte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] - scalar);
+                    span[i] = (byte)(span[i] - scalar);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] * right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (byte)(span[i] * otherSpan[i]);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<byte> column, byte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] * scalar);
+                    span[i] = (byte)(span[i] * scalar);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] / right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (byte)(span[i] / otherSpan[i]);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<byte> column, byte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] / scalar);
+                    span[i] = (byte)(span[i] / scalar);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] % right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (byte)(span[i] % otherSpan[i]);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<byte> column, byte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] % scalar);
+                    span[i] = (byte)(span[i] % scalar);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] & right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (byte)(span[i] & otherSpan[i]);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<byte> column, byte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] & scalar);
+                    span[i] = (byte)(span[i] & scalar);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] | right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (byte)(span[i] | otherSpan[i]);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<byte> column, byte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] | scalar);
+                    span[i] = (byte)(span[i] | scalar);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] ^ right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (byte)(span[i] ^ otherSpan[i]);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<byte> column, byte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] ^ scalar);
+                    span[i] = (byte)(span[i] ^ scalar);
                 }
             }
         }
         public void LeftShift(PrimitiveColumnContainer<byte> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] << value);
+                    span[i] = (byte)(span[i] << value);
                 }
             }
         }
         public void RightShift(PrimitiveColumnContainer<byte> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (byte)(mutableBuffer.Span[i] >> value);
+                    span[i] = (byte)(span[i] >> value);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<byte> column, byte scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == scalar);
+                    ret[i] = (span[i] == scalar);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<byte> column, byte scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != scalar);
+                    ret[i] = (span[i] != scalar);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<byte> column, byte scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= scalar);
+                    ret[i] = (span[i] >= scalar);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<byte> column, byte scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= scalar);
+                    ret[i] = (span[i] <= scalar);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<byte> column, byte scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > scalar);
+                    ret[i] = (span[i] > scalar);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<byte> left, PrimitiveColumnContainer<byte> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<byte> column, byte scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < scalar);
+                    ret[i] = (span[i] < scalar);
                 }
             }
         }
@@ -722,391 +781,435 @@ namespace Microsoft.Data
     {
         public void Add(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] + right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (char)(span[i] + otherSpan[i]);
                 }
             }
         }
         public void Add(PrimitiveColumnContainer<char> column, char scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] + scalar);
+                    span[i] = (char)(span[i] + scalar);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] - right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (char)(span[i] - otherSpan[i]);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<char> column, char scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] - scalar);
+                    span[i] = (char)(span[i] - scalar);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] * right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (char)(span[i] * otherSpan[i]);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<char> column, char scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] * scalar);
+                    span[i] = (char)(span[i] * scalar);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] / right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (char)(span[i] / otherSpan[i]);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<char> column, char scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] / scalar);
+                    span[i] = (char)(span[i] / scalar);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] % right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (char)(span[i] % otherSpan[i]);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<char> column, char scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] % scalar);
+                    span[i] = (char)(span[i] % scalar);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] & right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (char)(span[i] & otherSpan[i]);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<char> column, char scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] & scalar);
+                    span[i] = (char)(span[i] & scalar);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] | right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (char)(span[i] | otherSpan[i]);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<char> column, char scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] | scalar);
+                    span[i] = (char)(span[i] | scalar);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] ^ right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (char)(span[i] ^ otherSpan[i]);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<char> column, char scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] ^ scalar);
+                    span[i] = (char)(span[i] ^ scalar);
                 }
             }
         }
         public void LeftShift(PrimitiveColumnContainer<char> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] << value);
+                    span[i] = (char)(span[i] << value);
                 }
             }
         }
         public void RightShift(PrimitiveColumnContainer<char> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (char)(mutableBuffer.Span[i] >> value);
+                    span[i] = (char)(span[i] >> value);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<char> column, char scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == scalar);
+                    ret[i] = (span[i] == scalar);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<char> column, char scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != scalar);
+                    ret[i] = (span[i] != scalar);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<char> column, char scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= scalar);
+                    ret[i] = (span[i] >= scalar);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<char> column, char scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= scalar);
+                    ret[i] = (span[i] <= scalar);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<char> column, char scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > scalar);
+                    ret[i] = (span[i] > scalar);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<char> left, PrimitiveColumnContainer<char> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<char> column, char scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < scalar);
+                    ret[i] = (span[i] < scalar);
                 }
             }
         }
@@ -1115,131 +1218,146 @@ namespace Microsoft.Data
     {
         public void Add(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (decimal)(mutableBuffer.Span[i] + right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (decimal)(span[i] + otherSpan[i]);
                 }
             }
         }
         public void Add(PrimitiveColumnContainer<decimal> column, decimal scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (decimal)(mutableBuffer.Span[i] + scalar);
+                    span[i] = (decimal)(span[i] + scalar);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (decimal)(mutableBuffer.Span[i] - right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (decimal)(span[i] - otherSpan[i]);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<decimal> column, decimal scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (decimal)(mutableBuffer.Span[i] - scalar);
+                    span[i] = (decimal)(span[i] - scalar);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (decimal)(mutableBuffer.Span[i] * right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (decimal)(span[i] * otherSpan[i]);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<decimal> column, decimal scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (decimal)(mutableBuffer.Span[i] * scalar);
+                    span[i] = (decimal)(span[i] * scalar);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (decimal)(mutableBuffer.Span[i] / right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (decimal)(span[i] / otherSpan[i]);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<decimal> column, decimal scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (decimal)(mutableBuffer.Span[i] / scalar);
+                    span[i] = (decimal)(span[i] / scalar);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (decimal)(mutableBuffer.Span[i] % right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (decimal)(span[i] % otherSpan[i]);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<decimal> column, decimal scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (decimal)(mutableBuffer.Span[i] % scalar);
+                    span[i] = (decimal)(span[i] % scalar);
                 }
             }
         }
@@ -1277,157 +1395,175 @@ namespace Microsoft.Data
         }
         public void Equals(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<decimal> column, decimal scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == scalar);
+                    ret[i] = (span[i] == scalar);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<decimal> column, decimal scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != scalar);
+                    ret[i] = (span[i] != scalar);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<decimal> column, decimal scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= scalar);
+                    ret[i] = (span[i] >= scalar);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<decimal> column, decimal scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= scalar);
+                    ret[i] = (span[i] <= scalar);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<decimal> column, decimal scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > scalar);
+                    ret[i] = (span[i] > scalar);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<decimal> left, PrimitiveColumnContainer<decimal> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<decimal> column, decimal scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < scalar);
+                    ret[i] = (span[i] < scalar);
                 }
             }
         }
@@ -1436,131 +1572,146 @@ namespace Microsoft.Data
     {
         public void Add(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (double)(mutableBuffer.Span[i] + right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (double)(span[i] + otherSpan[i]);
                 }
             }
         }
         public void Add(PrimitiveColumnContainer<double> column, double scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (double)(mutableBuffer.Span[i] + scalar);
+                    span[i] = (double)(span[i] + scalar);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (double)(mutableBuffer.Span[i] - right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (double)(span[i] - otherSpan[i]);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<double> column, double scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (double)(mutableBuffer.Span[i] - scalar);
+                    span[i] = (double)(span[i] - scalar);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (double)(mutableBuffer.Span[i] * right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (double)(span[i] * otherSpan[i]);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<double> column, double scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (double)(mutableBuffer.Span[i] * scalar);
+                    span[i] = (double)(span[i] * scalar);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (double)(mutableBuffer.Span[i] / right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (double)(span[i] / otherSpan[i]);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<double> column, double scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (double)(mutableBuffer.Span[i] / scalar);
+                    span[i] = (double)(span[i] / scalar);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (double)(mutableBuffer.Span[i] % right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (double)(span[i] % otherSpan[i]);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<double> column, double scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (double)(mutableBuffer.Span[i] % scalar);
+                    span[i] = (double)(span[i] % scalar);
                 }
             }
         }
@@ -1598,157 +1749,175 @@ namespace Microsoft.Data
         }
         public void Equals(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<double> column, double scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == scalar);
+                    ret[i] = (span[i] == scalar);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<double> column, double scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != scalar);
+                    ret[i] = (span[i] != scalar);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<double> column, double scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= scalar);
+                    ret[i] = (span[i] >= scalar);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<double> column, double scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= scalar);
+                    ret[i] = (span[i] <= scalar);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<double> column, double scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > scalar);
+                    ret[i] = (span[i] > scalar);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<double> left, PrimitiveColumnContainer<double> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<double> column, double scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < scalar);
+                    ret[i] = (span[i] < scalar);
                 }
             }
         }
@@ -1757,131 +1926,146 @@ namespace Microsoft.Data
     {
         public void Add(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (float)(mutableBuffer.Span[i] + right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (float)(span[i] + otherSpan[i]);
                 }
             }
         }
         public void Add(PrimitiveColumnContainer<float> column, float scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (float)(mutableBuffer.Span[i] + scalar);
+                    span[i] = (float)(span[i] + scalar);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (float)(mutableBuffer.Span[i] - right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (float)(span[i] - otherSpan[i]);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<float> column, float scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (float)(mutableBuffer.Span[i] - scalar);
+                    span[i] = (float)(span[i] - scalar);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (float)(mutableBuffer.Span[i] * right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (float)(span[i] * otherSpan[i]);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<float> column, float scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (float)(mutableBuffer.Span[i] * scalar);
+                    span[i] = (float)(span[i] * scalar);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (float)(mutableBuffer.Span[i] / right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (float)(span[i] / otherSpan[i]);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<float> column, float scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (float)(mutableBuffer.Span[i] / scalar);
+                    span[i] = (float)(span[i] / scalar);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (float)(mutableBuffer.Span[i] % right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (float)(span[i] % otherSpan[i]);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<float> column, float scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (float)(mutableBuffer.Span[i] % scalar);
+                    span[i] = (float)(span[i] % scalar);
                 }
             }
         }
@@ -1919,157 +2103,175 @@ namespace Microsoft.Data
         }
         public void Equals(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<float> column, float scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == scalar);
+                    ret[i] = (span[i] == scalar);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<float> column, float scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != scalar);
+                    ret[i] = (span[i] != scalar);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<float> column, float scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= scalar);
+                    ret[i] = (span[i] >= scalar);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<float> column, float scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= scalar);
+                    ret[i] = (span[i] <= scalar);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<float> column, float scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > scalar);
+                    ret[i] = (span[i] > scalar);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<float> left, PrimitiveColumnContainer<float> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<float> column, float scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < scalar);
+                    ret[i] = (span[i] < scalar);
                 }
             }
         }
@@ -2078,391 +2280,435 @@ namespace Microsoft.Data
     {
         public void Add(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] + right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (int)(span[i] + otherSpan[i]);
                 }
             }
         }
         public void Add(PrimitiveColumnContainer<int> column, int scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] + scalar);
+                    span[i] = (int)(span[i] + scalar);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] - right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (int)(span[i] - otherSpan[i]);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<int> column, int scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] - scalar);
+                    span[i] = (int)(span[i] - scalar);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] * right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (int)(span[i] * otherSpan[i]);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<int> column, int scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] * scalar);
+                    span[i] = (int)(span[i] * scalar);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] / right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (int)(span[i] / otherSpan[i]);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<int> column, int scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] / scalar);
+                    span[i] = (int)(span[i] / scalar);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] % right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (int)(span[i] % otherSpan[i]);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<int> column, int scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] % scalar);
+                    span[i] = (int)(span[i] % scalar);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] & right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (int)(span[i] & otherSpan[i]);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<int> column, int scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] & scalar);
+                    span[i] = (int)(span[i] & scalar);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] | right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (int)(span[i] | otherSpan[i]);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<int> column, int scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] | scalar);
+                    span[i] = (int)(span[i] | scalar);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] ^ right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (int)(span[i] ^ otherSpan[i]);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<int> column, int scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] ^ scalar);
+                    span[i] = (int)(span[i] ^ scalar);
                 }
             }
         }
         public void LeftShift(PrimitiveColumnContainer<int> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] << value);
+                    span[i] = (int)(span[i] << value);
                 }
             }
         }
         public void RightShift(PrimitiveColumnContainer<int> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (int)(mutableBuffer.Span[i] >> value);
+                    span[i] = (int)(span[i] >> value);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<int> column, int scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == scalar);
+                    ret[i] = (span[i] == scalar);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<int> column, int scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != scalar);
+                    ret[i] = (span[i] != scalar);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<int> column, int scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= scalar);
+                    ret[i] = (span[i] >= scalar);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<int> column, int scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= scalar);
+                    ret[i] = (span[i] <= scalar);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<int> column, int scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > scalar);
+                    ret[i] = (span[i] > scalar);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<int> left, PrimitiveColumnContainer<int> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<int> column, int scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < scalar);
+                    ret[i] = (span[i] < scalar);
                 }
             }
         }
@@ -2471,391 +2717,435 @@ namespace Microsoft.Data
     {
         public void Add(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] + right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (long)(span[i] + otherSpan[i]);
                 }
             }
         }
         public void Add(PrimitiveColumnContainer<long> column, long scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] + scalar);
+                    span[i] = (long)(span[i] + scalar);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] - right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (long)(span[i] - otherSpan[i]);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<long> column, long scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] - scalar);
+                    span[i] = (long)(span[i] - scalar);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] * right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (long)(span[i] * otherSpan[i]);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<long> column, long scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] * scalar);
+                    span[i] = (long)(span[i] * scalar);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] / right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (long)(span[i] / otherSpan[i]);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<long> column, long scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] / scalar);
+                    span[i] = (long)(span[i] / scalar);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] % right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (long)(span[i] % otherSpan[i]);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<long> column, long scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] % scalar);
+                    span[i] = (long)(span[i] % scalar);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] & right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (long)(span[i] & otherSpan[i]);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<long> column, long scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] & scalar);
+                    span[i] = (long)(span[i] & scalar);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] | right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (long)(span[i] | otherSpan[i]);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<long> column, long scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] | scalar);
+                    span[i] = (long)(span[i] | scalar);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] ^ right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (long)(span[i] ^ otherSpan[i]);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<long> column, long scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] ^ scalar);
+                    span[i] = (long)(span[i] ^ scalar);
                 }
             }
         }
         public void LeftShift(PrimitiveColumnContainer<long> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] << value);
+                    span[i] = (long)(span[i] << value);
                 }
             }
         }
         public void RightShift(PrimitiveColumnContainer<long> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (long)(mutableBuffer.Span[i] >> value);
+                    span[i] = (long)(span[i] >> value);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<long> column, long scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == scalar);
+                    ret[i] = (span[i] == scalar);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<long> column, long scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != scalar);
+                    ret[i] = (span[i] != scalar);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<long> column, long scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= scalar);
+                    ret[i] = (span[i] >= scalar);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<long> column, long scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= scalar);
+                    ret[i] = (span[i] <= scalar);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<long> column, long scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > scalar);
+                    ret[i] = (span[i] > scalar);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<long> left, PrimitiveColumnContainer<long> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<long> column, long scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < scalar);
+                    ret[i] = (span[i] < scalar);
                 }
             }
         }
@@ -2864,391 +3154,435 @@ namespace Microsoft.Data
     {
         public void Add(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] + right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (sbyte)(span[i] + otherSpan[i]);
                 }
             }
         }
         public void Add(PrimitiveColumnContainer<sbyte> column, sbyte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] + scalar);
+                    span[i] = (sbyte)(span[i] + scalar);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] - right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (sbyte)(span[i] - otherSpan[i]);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<sbyte> column, sbyte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] - scalar);
+                    span[i] = (sbyte)(span[i] - scalar);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] * right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (sbyte)(span[i] * otherSpan[i]);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<sbyte> column, sbyte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] * scalar);
+                    span[i] = (sbyte)(span[i] * scalar);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] / right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (sbyte)(span[i] / otherSpan[i]);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<sbyte> column, sbyte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] / scalar);
+                    span[i] = (sbyte)(span[i] / scalar);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] % right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (sbyte)(span[i] % otherSpan[i]);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<sbyte> column, sbyte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] % scalar);
+                    span[i] = (sbyte)(span[i] % scalar);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] & right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (sbyte)(span[i] & otherSpan[i]);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<sbyte> column, sbyte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] & scalar);
+                    span[i] = (sbyte)(span[i] & scalar);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] | right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (sbyte)(span[i] | otherSpan[i]);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<sbyte> column, sbyte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] | scalar);
+                    span[i] = (sbyte)(span[i] | scalar);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] ^ right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (sbyte)(span[i] ^ otherSpan[i]);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<sbyte> column, sbyte scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] ^ scalar);
+                    span[i] = (sbyte)(span[i] ^ scalar);
                 }
             }
         }
         public void LeftShift(PrimitiveColumnContainer<sbyte> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] << value);
+                    span[i] = (sbyte)(span[i] << value);
                 }
             }
         }
         public void RightShift(PrimitiveColumnContainer<sbyte> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (sbyte)(mutableBuffer.Span[i] >> value);
+                    span[i] = (sbyte)(span[i] >> value);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<sbyte> column, sbyte scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == scalar);
+                    ret[i] = (span[i] == scalar);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<sbyte> column, sbyte scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != scalar);
+                    ret[i] = (span[i] != scalar);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<sbyte> column, sbyte scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= scalar);
+                    ret[i] = (span[i] >= scalar);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<sbyte> column, sbyte scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= scalar);
+                    ret[i] = (span[i] <= scalar);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<sbyte> column, sbyte scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > scalar);
+                    ret[i] = (span[i] > scalar);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<sbyte> left, PrimitiveColumnContainer<sbyte> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<sbyte> column, sbyte scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < scalar);
+                    ret[i] = (span[i] < scalar);
                 }
             }
         }
@@ -3257,391 +3591,435 @@ namespace Microsoft.Data
     {
         public void Add(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] + right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (short)(span[i] + otherSpan[i]);
                 }
             }
         }
         public void Add(PrimitiveColumnContainer<short> column, short scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] + scalar);
+                    span[i] = (short)(span[i] + scalar);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] - right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (short)(span[i] - otherSpan[i]);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<short> column, short scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] - scalar);
+                    span[i] = (short)(span[i] - scalar);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] * right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (short)(span[i] * otherSpan[i]);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<short> column, short scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] * scalar);
+                    span[i] = (short)(span[i] * scalar);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] / right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (short)(span[i] / otherSpan[i]);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<short> column, short scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] / scalar);
+                    span[i] = (short)(span[i] / scalar);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] % right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (short)(span[i] % otherSpan[i]);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<short> column, short scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] % scalar);
+                    span[i] = (short)(span[i] % scalar);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] & right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (short)(span[i] & otherSpan[i]);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<short> column, short scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] & scalar);
+                    span[i] = (short)(span[i] & scalar);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] | right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (short)(span[i] | otherSpan[i]);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<short> column, short scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] | scalar);
+                    span[i] = (short)(span[i] | scalar);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] ^ right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (short)(span[i] ^ otherSpan[i]);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<short> column, short scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] ^ scalar);
+                    span[i] = (short)(span[i] ^ scalar);
                 }
             }
         }
         public void LeftShift(PrimitiveColumnContainer<short> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] << value);
+                    span[i] = (short)(span[i] << value);
                 }
             }
         }
         public void RightShift(PrimitiveColumnContainer<short> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (short)(mutableBuffer.Span[i] >> value);
+                    span[i] = (short)(span[i] >> value);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<short> column, short scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == scalar);
+                    ret[i] = (span[i] == scalar);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<short> column, short scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != scalar);
+                    ret[i] = (span[i] != scalar);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<short> column, short scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= scalar);
+                    ret[i] = (span[i] >= scalar);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<short> column, short scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= scalar);
+                    ret[i] = (span[i] <= scalar);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<short> column, short scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > scalar);
+                    ret[i] = (span[i] > scalar);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<short> left, PrimitiveColumnContainer<short> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<short> column, short scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < scalar);
+                    ret[i] = (span[i] < scalar);
                 }
             }
         }
@@ -3650,391 +4028,435 @@ namespace Microsoft.Data
     {
         public void Add(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] + right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (uint)(span[i] + otherSpan[i]);
                 }
             }
         }
         public void Add(PrimitiveColumnContainer<uint> column, uint scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] + scalar);
+                    span[i] = (uint)(span[i] + scalar);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] - right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (uint)(span[i] - otherSpan[i]);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<uint> column, uint scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] - scalar);
+                    span[i] = (uint)(span[i] - scalar);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] * right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (uint)(span[i] * otherSpan[i]);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<uint> column, uint scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] * scalar);
+                    span[i] = (uint)(span[i] * scalar);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] / right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (uint)(span[i] / otherSpan[i]);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<uint> column, uint scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] / scalar);
+                    span[i] = (uint)(span[i] / scalar);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] % right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (uint)(span[i] % otherSpan[i]);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<uint> column, uint scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] % scalar);
+                    span[i] = (uint)(span[i] % scalar);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] & right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (uint)(span[i] & otherSpan[i]);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<uint> column, uint scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] & scalar);
+                    span[i] = (uint)(span[i] & scalar);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] | right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (uint)(span[i] | otherSpan[i]);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<uint> column, uint scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] | scalar);
+                    span[i] = (uint)(span[i] | scalar);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] ^ right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (uint)(span[i] ^ otherSpan[i]);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<uint> column, uint scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] ^ scalar);
+                    span[i] = (uint)(span[i] ^ scalar);
                 }
             }
         }
         public void LeftShift(PrimitiveColumnContainer<uint> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] << value);
+                    span[i] = (uint)(span[i] << value);
                 }
             }
         }
         public void RightShift(PrimitiveColumnContainer<uint> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (uint)(mutableBuffer.Span[i] >> value);
+                    span[i] = (uint)(span[i] >> value);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<uint> column, uint scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == scalar);
+                    ret[i] = (span[i] == scalar);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<uint> column, uint scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != scalar);
+                    ret[i] = (span[i] != scalar);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<uint> column, uint scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= scalar);
+                    ret[i] = (span[i] >= scalar);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<uint> column, uint scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= scalar);
+                    ret[i] = (span[i] <= scalar);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<uint> column, uint scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > scalar);
+                    ret[i] = (span[i] > scalar);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<uint> left, PrimitiveColumnContainer<uint> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<uint> column, uint scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < scalar);
+                    ret[i] = (span[i] < scalar);
                 }
             }
         }
@@ -4043,391 +4465,435 @@ namespace Microsoft.Data
     {
         public void Add(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] + right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ulong)(span[i] + otherSpan[i]);
                 }
             }
         }
         public void Add(PrimitiveColumnContainer<ulong> column, ulong scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] + scalar);
+                    span[i] = (ulong)(span[i] + scalar);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] - right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ulong)(span[i] - otherSpan[i]);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<ulong> column, ulong scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] - scalar);
+                    span[i] = (ulong)(span[i] - scalar);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] * right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ulong)(span[i] * otherSpan[i]);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<ulong> column, ulong scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] * scalar);
+                    span[i] = (ulong)(span[i] * scalar);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] / right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ulong)(span[i] / otherSpan[i]);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<ulong> column, ulong scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] / scalar);
+                    span[i] = (ulong)(span[i] / scalar);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] % right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ulong)(span[i] % otherSpan[i]);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<ulong> column, ulong scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] % scalar);
+                    span[i] = (ulong)(span[i] % scalar);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] & right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ulong)(span[i] & otherSpan[i]);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<ulong> column, ulong scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] & scalar);
+                    span[i] = (ulong)(span[i] & scalar);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] | right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ulong)(span[i] | otherSpan[i]);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<ulong> column, ulong scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] | scalar);
+                    span[i] = (ulong)(span[i] | scalar);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] ^ right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ulong)(span[i] ^ otherSpan[i]);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<ulong> column, ulong scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] ^ scalar);
+                    span[i] = (ulong)(span[i] ^ scalar);
                 }
             }
         }
         public void LeftShift(PrimitiveColumnContainer<ulong> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] << value);
+                    span[i] = (ulong)(span[i] << value);
                 }
             }
         }
         public void RightShift(PrimitiveColumnContainer<ulong> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ulong)(mutableBuffer.Span[i] >> value);
+                    span[i] = (ulong)(span[i] >> value);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<ulong> column, ulong scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == scalar);
+                    ret[i] = (span[i] == scalar);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<ulong> column, ulong scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != scalar);
+                    ret[i] = (span[i] != scalar);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<ulong> column, ulong scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= scalar);
+                    ret[i] = (span[i] >= scalar);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<ulong> column, ulong scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= scalar);
+                    ret[i] = (span[i] <= scalar);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<ulong> column, ulong scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > scalar);
+                    ret[i] = (span[i] > scalar);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<ulong> left, PrimitiveColumnContainer<ulong> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<ulong> column, ulong scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < scalar);
+                    ret[i] = (span[i] < scalar);
                 }
             }
         }
@@ -4436,391 +4902,435 @@ namespace Microsoft.Data
     {
         public void Add(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] + right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ushort)(span[i] + otherSpan[i]);
                 }
             }
         }
         public void Add(PrimitiveColumnContainer<ushort> column, ushort scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] + scalar);
+                    span[i] = (ushort)(span[i] + scalar);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] - right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ushort)(span[i] - otherSpan[i]);
                 }
             }
         }
         public void Subtract(PrimitiveColumnContainer<ushort> column, ushort scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] - scalar);
+                    span[i] = (ushort)(span[i] - scalar);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] * right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ushort)(span[i] * otherSpan[i]);
                 }
             }
         }
         public void Multiply(PrimitiveColumnContainer<ushort> column, ushort scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] * scalar);
+                    span[i] = (ushort)(span[i] * scalar);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] / right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ushort)(span[i] / otherSpan[i]);
                 }
             }
         }
         public void Divide(PrimitiveColumnContainer<ushort> column, ushort scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] / scalar);
+                    span[i] = (ushort)(span[i] / scalar);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] % right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ushort)(span[i] % otherSpan[i]);
                 }
             }
         }
         public void Modulo(PrimitiveColumnContainer<ushort> column, ushort scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] % scalar);
+                    span[i] = (ushort)(span[i] % scalar);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] & right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ushort)(span[i] & otherSpan[i]);
                 }
             }
         }
         public void And(PrimitiveColumnContainer<ushort> column, ushort scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] & scalar);
+                    span[i] = (ushort)(span[i] & scalar);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] | right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ushort)(span[i] | otherSpan[i]);
                 }
             }
         }
         public void Or(PrimitiveColumnContainer<ushort> column, ushort scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] | scalar);
+                    span[i] = (ushort)(span[i] | scalar);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] ^ right.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (ushort)(span[i] ^ otherSpan[i]);
                 }
             }
         }
         public void Xor(PrimitiveColumnContainer<ushort> column, ushort scalar)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] ^ scalar);
+                    span[i] = (ushort)(span[i] ^ scalar);
                 }
             }
         }
         public void LeftShift(PrimitiveColumnContainer<ushort> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] << value);
+                    span[i] = (ushort)(span[i] << value);
                 }
             }
         }
         public void RightShift(PrimitiveColumnContainer<ushort> column, int value)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (ushort)(mutableBuffer.Span[i] >> value);
+                    span[i] = (ushort)(span[i] >> value);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] == otherSpan[i]);
                 }
             }
         }
         public void Equals(PrimitiveColumnContainer<ushort> column, ushort scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] == scalar);
+                    ret[i] = (span[i] == scalar);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] != otherSpan[i]);
                 }
             }
         }
         public void NotEquals(PrimitiveColumnContainer<ushort> column, ushort scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] != scalar);
+                    ret[i] = (span[i] != scalar);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] >= otherSpan[i]);
                 }
             }
         }
         public void GreaterThanOrEqual(PrimitiveColumnContainer<ushort> column, ushort scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] >= scalar);
+                    ret[i] = (span[i] >= scalar);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] <= otherSpan[i]);
                 }
             }
         }
         public void LessThanOrEqual(PrimitiveColumnContainer<ushort> column, ushort scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] <= scalar);
+                    ret[i] = (span[i] <= scalar);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] > otherSpan[i]);
                 }
             }
         }
         public void GreaterThan(PrimitiveColumnContainer<ushort> column, ushort scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] > scalar);
+                    ret[i] = (span[i] > scalar);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<ushort> left, PrimitiveColumnContainer<ushort> right, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < left.Buffers.Count; bb++)
+            for (int b = 0 ; b < left.Buffers.Count; b++)
             {
-                var buffer = left.Buffers[bb];
+                var buffer = left.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                left.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                left.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                var otherSpan = right.Buffers[b].ReadOnlySpan;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < right.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] < otherSpan[i]);
                 }
             }
         }
         public void LessThan(PrimitiveColumnContainer<ushort> column, ushort scalar, PrimitiveColumnContainer<bool> ret)
         {
-            for (int bb = 0 ; bb < column.Buffers.Count; bb++)
+            for (int b = 0 ; b < column.Buffers.Count; b++)
             {
-                var buffer = column.Buffers[bb];
+                var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
-                column.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                column.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
-                    ret[i] = (buffer.ReadOnlySpan[i] < scalar);
+                    ret[i] = (span[i] < scalar);
                 }
             }
         }

--- a/src/Microsoft.Data/PrimitiveColumnArithmetic.tt
+++ b/src/Microsoft.Data/PrimitiveColumnArithmetic.tt
@@ -55,21 +55,25 @@ namespace Microsoft.Data
 <# if ((method.IsNumeric && !type.SupportsNumeric) || (method.IsBitwise && !type.SupportsBitwise) || (type.UnsupportedMethods.Contains(method.MethodName))) { #>
             throw new NotSupportedException();
 <# } else if (method.Operator != null) { #>
-            for (int bb = 0 ; bb < <#= method.Op1Name #>.Buffers.Count; bb++)
+            for (int b = 0 ; b < <#= method.Op1Name #>.Buffers.Count; b++)
             {
-                var buffer = <#= method.Op1Name #>.Buffers[bb];
+                var buffer = <#= method.Op1Name #>.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(buffer);
-                <#= method.Op1Name #>.Buffers[bb] = mutableBuffer;
-                for (int i = 0; i < buffer.Length; i++)
+                <#= method.Op1Name #>.Buffers[b] = mutableBuffer;
+                var span = mutableBuffer.Span;
+<# if (method.MethodType == MethodType.Binary || method.MethodType == MethodType.Comparison) { #>
+                var otherSpan = <#=method.Op2Name#>.Buffers[b].ReadOnlySpan;
+<# } #>
+                for (int i = 0; i < mutableBuffer.Length; i++)
                 {
 <# if (method.MethodType == MethodType.BinaryScalar || method.MethodType == MethodType.BinaryInt) { #>
-                    mutableBuffer.Span[i] = (<#=type.TypeName#>)(mutableBuffer.Span[i] <#= method.Operator #> <#= method.Op2Name #>);
+                    span[i] = (<#=type.TypeName#>)(span[i] <#= method.Operator #> <#= method.Op2Name #>);
 <# } else if (method.MethodType == MethodType.Binary) { #>
-                    mutableBuffer.Span[i] = (<#=type.TypeName#>)(mutableBuffer.Span[i] <#= method.Operator #> <#= method.Op2Name #>.Buffers[bb].ReadOnlySpan[i]);
+                    span[i] = (<#=type.TypeName#>)(span[i] <#= method.Operator #> otherSpan[i]);
 <# } else if (method.MethodType == MethodType.Comparison) { #>
-                    ret[i] = (buffer.ReadOnlySpan[i] <#= method.Operator #> <#= method.Op2Name #>.Buffers[bb].ReadOnlySpan[i]);
+                    ret[i] = (span[i] <#= method.Operator #> otherSpan[i]);
 <# } else if (method.MethodType == MethodType.ComparisonScalar) { #>
-                    ret[i] = (buffer.ReadOnlySpan[i] <#= method.Operator #> <#= method.Op2Name #>);
+                    ret[i] = (span[i] <#= method.Operator #> <#= method.Op2Name #>);
 <# } else {#>
                     throw new NotImplementedException();
 <# } #>

--- a/src/Microsoft.Data/PrimitiveColumnArithmetic.tt
+++ b/src/Microsoft.Data/PrimitiveColumnArithmetic.tt
@@ -64,7 +64,7 @@ namespace Microsoft.Data
 <# if (method.MethodType == MethodType.Binary || method.MethodType == MethodType.Comparison) { #>
                 var otherSpan = <#=method.Op2Name#>.Buffers[b].ReadOnlySpan;
 <# } #>
-                for (int i = 0; i < mutableBuffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
 <# if (method.MethodType == MethodType.BinaryScalar || method.MethodType == MethodType.BinaryInt) { #>
                     span[i] = (<#=type.TypeName#>)(span[i] <#= method.Operator #> <#= method.Op2Name #>);

--- a/src/Microsoft.Data/PrimitiveColumnComputations.cs
+++ b/src/Microsoft.Data/PrimitiveColumnComputations.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var span = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < span.Length && i < buffer.Length; i++)
                 {
                     if (span[i] == false)
                     {
@@ -135,7 +135,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var span = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < span.Length && i < buffer.Length; i++)
                 {
                     if (span[i] == true)
                     {
@@ -241,7 +241,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (byte)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -268,7 +268,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (byte)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -294,8 +294,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -309,8 +309,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (byte)Math.Max(span[(int)row], ret);
@@ -327,7 +327,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (byte)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -353,8 +353,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -368,8 +368,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (byte)Math.Min(span[(int)row], ret);
@@ -386,7 +386,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (byte)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -412,8 +412,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -427,11 +427,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (byte)((span[(int)row]) * ret);
+                ret = checked((byte)((span[(int)row]) * ret));
                 span[(int)row] = ret;
             }
         }
@@ -445,7 +445,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (byte)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -471,8 +471,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -486,11 +486,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (byte)((span[(int)row]) + ret);
+                ret = checked((byte)((span[(int)row]) + ret));
                 span[(int)row] = ret;
             }
         }
@@ -502,7 +502,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (byte)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -524,8 +524,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (byte)(Math.Max(readOnlySpan[(int)row], ret));
@@ -539,7 +539,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (byte)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -561,8 +561,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (byte)(Math.Min(readOnlySpan[(int)row], ret));
@@ -576,7 +576,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (byte)(readOnlySpan[i] * ret);
                 }
@@ -598,11 +598,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (byte)(readOnlySpan[(int)row] * ret);
+                ret = checked((byte)(readOnlySpan[(int)row] * ret));
             }
         }
 
@@ -613,7 +613,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (byte)(readOnlySpan[i] + ret);
                 }
@@ -635,11 +635,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (byte)(readOnlySpan[(int)row] + ret);
+                ret = checked((byte)(readOnlySpan[(int)row] + ret));
             }
         }
 
@@ -650,7 +650,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (byte)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -668,7 +668,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (char)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -695,7 +695,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (char)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -721,8 +721,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -736,8 +736,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (char)Math.Max(span[(int)row], ret);
@@ -754,7 +754,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (char)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -780,8 +780,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -795,8 +795,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (char)Math.Min(span[(int)row], ret);
@@ -813,7 +813,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (char)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -839,8 +839,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -854,11 +854,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (char)((span[(int)row]) * ret);
+                ret = checked((char)((span[(int)row]) * ret));
                 span[(int)row] = ret;
             }
         }
@@ -872,7 +872,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (char)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -898,8 +898,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -913,11 +913,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (char)((span[(int)row]) + ret);
+                ret = checked((char)((span[(int)row]) + ret));
                 span[(int)row] = ret;
             }
         }
@@ -929,7 +929,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (char)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -951,8 +951,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (char)(Math.Max(readOnlySpan[(int)row], ret));
@@ -966,7 +966,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (char)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -988,8 +988,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (char)(Math.Min(readOnlySpan[(int)row], ret));
@@ -1003,7 +1003,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (char)(readOnlySpan[i] * ret);
                 }
@@ -1025,11 +1025,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (char)(readOnlySpan[(int)row] * ret);
+                ret = checked((char)(readOnlySpan[(int)row] * ret));
             }
         }
 
@@ -1040,7 +1040,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (char)(readOnlySpan[i] + ret);
                 }
@@ -1062,11 +1062,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (char)(readOnlySpan[(int)row] + ret);
+                ret = checked((char)(readOnlySpan[(int)row] + ret));
             }
         }
 
@@ -1077,7 +1077,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (char)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -1095,7 +1095,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (decimal)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -1122,7 +1122,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (decimal)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -1148,8 +1148,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -1163,8 +1163,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (decimal)Math.Max(span[(int)row], ret);
@@ -1181,7 +1181,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (decimal)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -1207,8 +1207,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -1222,8 +1222,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (decimal)Math.Min(span[(int)row], ret);
@@ -1240,7 +1240,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (decimal)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -1266,8 +1266,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -1281,11 +1281,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (decimal)((span[(int)row]) * ret);
+                ret = checked((decimal)((span[(int)row]) * ret));
                 span[(int)row] = ret;
             }
         }
@@ -1299,7 +1299,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (decimal)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -1325,8 +1325,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -1340,11 +1340,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (decimal)((span[(int)row]) + ret);
+                ret = checked((decimal)((span[(int)row]) + ret));
                 span[(int)row] = ret;
             }
         }
@@ -1356,7 +1356,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (decimal)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -1378,8 +1378,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (decimal)(Math.Max(readOnlySpan[(int)row], ret));
@@ -1393,7 +1393,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (decimal)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -1415,8 +1415,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (decimal)(Math.Min(readOnlySpan[(int)row], ret));
@@ -1430,7 +1430,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (decimal)(readOnlySpan[i] * ret);
                 }
@@ -1452,11 +1452,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (decimal)(readOnlySpan[(int)row] * ret);
+                ret = checked((decimal)(readOnlySpan[(int)row] * ret));
             }
         }
 
@@ -1467,7 +1467,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (decimal)(readOnlySpan[i] + ret);
                 }
@@ -1489,11 +1489,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (decimal)(readOnlySpan[(int)row] + ret);
+                ret = checked((decimal)(readOnlySpan[(int)row] + ret));
             }
         }
 
@@ -1504,7 +1504,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (decimal)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -1522,7 +1522,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (double)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -1549,7 +1549,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (double)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -1575,8 +1575,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -1590,8 +1590,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (double)Math.Max(span[(int)row], ret);
@@ -1608,7 +1608,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (double)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -1634,8 +1634,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -1649,8 +1649,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (double)Math.Min(span[(int)row], ret);
@@ -1667,7 +1667,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (double)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -1693,8 +1693,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -1708,11 +1708,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (double)((span[(int)row]) * ret);
+                ret = checked((double)((span[(int)row]) * ret));
                 span[(int)row] = ret;
             }
         }
@@ -1726,7 +1726,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (double)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -1752,8 +1752,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -1767,11 +1767,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (double)((span[(int)row]) + ret);
+                ret = checked((double)((span[(int)row]) + ret));
                 span[(int)row] = ret;
             }
         }
@@ -1783,7 +1783,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (double)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -1805,8 +1805,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (double)(Math.Max(readOnlySpan[(int)row], ret));
@@ -1820,7 +1820,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (double)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -1842,8 +1842,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (double)(Math.Min(readOnlySpan[(int)row], ret));
@@ -1857,7 +1857,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (double)(readOnlySpan[i] * ret);
                 }
@@ -1879,11 +1879,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (double)(readOnlySpan[(int)row] * ret);
+                ret = checked((double)(readOnlySpan[(int)row] * ret));
             }
         }
 
@@ -1894,7 +1894,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (double)(readOnlySpan[i] + ret);
                 }
@@ -1916,11 +1916,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (double)(readOnlySpan[(int)row] + ret);
+                ret = checked((double)(readOnlySpan[(int)row] + ret));
             }
         }
 
@@ -1931,7 +1931,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (double)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -1949,7 +1949,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (float)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -1976,7 +1976,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (float)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -2002,8 +2002,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -2017,8 +2017,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (float)Math.Max(span[(int)row], ret);
@@ -2035,7 +2035,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (float)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -2061,8 +2061,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -2076,8 +2076,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (float)Math.Min(span[(int)row], ret);
@@ -2094,7 +2094,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (float)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -2120,8 +2120,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -2135,11 +2135,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (float)((span[(int)row]) * ret);
+                ret = checked((float)((span[(int)row]) * ret));
                 span[(int)row] = ret;
             }
         }
@@ -2153,7 +2153,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (float)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -2179,8 +2179,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -2194,11 +2194,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (float)((span[(int)row]) + ret);
+                ret = checked((float)((span[(int)row]) + ret));
                 span[(int)row] = ret;
             }
         }
@@ -2210,7 +2210,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (float)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -2232,8 +2232,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (float)(Math.Max(readOnlySpan[(int)row], ret));
@@ -2247,7 +2247,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (float)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -2269,8 +2269,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (float)(Math.Min(readOnlySpan[(int)row], ret));
@@ -2284,7 +2284,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (float)(readOnlySpan[i] * ret);
                 }
@@ -2306,11 +2306,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (float)(readOnlySpan[(int)row] * ret);
+                ret = checked((float)(readOnlySpan[(int)row] * ret));
             }
         }
 
@@ -2321,7 +2321,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (float)(readOnlySpan[i] + ret);
                 }
@@ -2343,11 +2343,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (float)(readOnlySpan[(int)row] + ret);
+                ret = checked((float)(readOnlySpan[(int)row] + ret));
             }
         }
 
@@ -2358,7 +2358,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (float)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -2376,7 +2376,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (int)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -2403,7 +2403,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (int)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -2429,8 +2429,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -2444,8 +2444,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (int)Math.Max(span[(int)row], ret);
@@ -2462,7 +2462,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (int)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -2488,8 +2488,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -2503,8 +2503,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (int)Math.Min(span[(int)row], ret);
@@ -2521,7 +2521,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (int)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -2547,8 +2547,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -2562,11 +2562,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (int)((span[(int)row]) * ret);
+                ret = checked((int)((span[(int)row]) * ret));
                 span[(int)row] = ret;
             }
         }
@@ -2580,7 +2580,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (int)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -2606,8 +2606,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -2621,11 +2621,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (int)((span[(int)row]) + ret);
+                ret = checked((int)((span[(int)row]) + ret));
                 span[(int)row] = ret;
             }
         }
@@ -2637,7 +2637,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (int)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -2659,8 +2659,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (int)(Math.Max(readOnlySpan[(int)row], ret));
@@ -2674,7 +2674,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (int)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -2696,8 +2696,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (int)(Math.Min(readOnlySpan[(int)row], ret));
@@ -2711,7 +2711,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (int)(readOnlySpan[i] * ret);
                 }
@@ -2733,11 +2733,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (int)(readOnlySpan[(int)row] * ret);
+                ret = checked((int)(readOnlySpan[(int)row] * ret));
             }
         }
 
@@ -2748,7 +2748,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (int)(readOnlySpan[i] + ret);
                 }
@@ -2770,11 +2770,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (int)(readOnlySpan[(int)row] + ret);
+                ret = checked((int)(readOnlySpan[(int)row] + ret));
             }
         }
 
@@ -2785,7 +2785,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (int)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -2803,7 +2803,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (long)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -2830,7 +2830,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (long)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -2856,8 +2856,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -2871,8 +2871,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (long)Math.Max(span[(int)row], ret);
@@ -2889,7 +2889,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (long)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -2915,8 +2915,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -2930,8 +2930,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (long)Math.Min(span[(int)row], ret);
@@ -2948,7 +2948,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (long)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -2974,8 +2974,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -2989,11 +2989,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (long)((span[(int)row]) * ret);
+                ret = checked((long)((span[(int)row]) * ret));
                 span[(int)row] = ret;
             }
         }
@@ -3007,7 +3007,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (long)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -3033,8 +3033,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -3048,11 +3048,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (long)((span[(int)row]) + ret);
+                ret = checked((long)((span[(int)row]) + ret));
                 span[(int)row] = ret;
             }
         }
@@ -3064,7 +3064,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (long)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -3086,8 +3086,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (long)(Math.Max(readOnlySpan[(int)row], ret));
@@ -3101,7 +3101,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (long)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -3123,8 +3123,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (long)(Math.Min(readOnlySpan[(int)row], ret));
@@ -3138,7 +3138,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (long)(readOnlySpan[i] * ret);
                 }
@@ -3160,11 +3160,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (long)(readOnlySpan[(int)row] * ret);
+                ret = checked((long)(readOnlySpan[(int)row] * ret));
             }
         }
 
@@ -3175,7 +3175,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (long)(readOnlySpan[i] + ret);
                 }
@@ -3197,11 +3197,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (long)(readOnlySpan[(int)row] + ret);
+                ret = checked((long)(readOnlySpan[(int)row] + ret));
             }
         }
 
@@ -3212,7 +3212,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (long)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -3230,7 +3230,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (sbyte)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -3257,7 +3257,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (sbyte)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -3283,8 +3283,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -3298,8 +3298,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (sbyte)Math.Max(span[(int)row], ret);
@@ -3316,7 +3316,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (sbyte)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -3342,8 +3342,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -3357,8 +3357,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (sbyte)Math.Min(span[(int)row], ret);
@@ -3375,7 +3375,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (sbyte)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -3401,8 +3401,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -3416,11 +3416,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (sbyte)((span[(int)row]) * ret);
+                ret = checked((sbyte)((span[(int)row]) * ret));
                 span[(int)row] = ret;
             }
         }
@@ -3434,7 +3434,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (sbyte)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -3460,8 +3460,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -3475,11 +3475,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (sbyte)((span[(int)row]) + ret);
+                ret = checked((sbyte)((span[(int)row]) + ret));
                 span[(int)row] = ret;
             }
         }
@@ -3491,7 +3491,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (sbyte)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -3513,8 +3513,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (sbyte)(Math.Max(readOnlySpan[(int)row], ret));
@@ -3528,7 +3528,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (sbyte)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -3550,8 +3550,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (sbyte)(Math.Min(readOnlySpan[(int)row], ret));
@@ -3565,7 +3565,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (sbyte)(readOnlySpan[i] * ret);
                 }
@@ -3587,11 +3587,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (sbyte)(readOnlySpan[(int)row] * ret);
+                ret = checked((sbyte)(readOnlySpan[(int)row] * ret));
             }
         }
 
@@ -3602,7 +3602,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (sbyte)(readOnlySpan[i] + ret);
                 }
@@ -3624,11 +3624,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (sbyte)(readOnlySpan[(int)row] + ret);
+                ret = checked((sbyte)(readOnlySpan[(int)row] + ret));
             }
         }
 
@@ -3639,7 +3639,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (sbyte)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -3657,7 +3657,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (short)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -3684,7 +3684,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (short)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -3710,8 +3710,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -3725,8 +3725,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (short)Math.Max(span[(int)row], ret);
@@ -3743,7 +3743,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (short)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -3769,8 +3769,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -3784,8 +3784,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (short)Math.Min(span[(int)row], ret);
@@ -3802,7 +3802,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (short)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -3828,8 +3828,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -3843,11 +3843,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (short)((span[(int)row]) * ret);
+                ret = checked((short)((span[(int)row]) * ret));
                 span[(int)row] = ret;
             }
         }
@@ -3861,7 +3861,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (short)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -3887,8 +3887,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -3902,11 +3902,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (short)((span[(int)row]) + ret);
+                ret = checked((short)((span[(int)row]) + ret));
                 span[(int)row] = ret;
             }
         }
@@ -3918,7 +3918,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (short)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -3940,8 +3940,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (short)(Math.Max(readOnlySpan[(int)row], ret));
@@ -3955,7 +3955,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (short)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -3977,8 +3977,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (short)(Math.Min(readOnlySpan[(int)row], ret));
@@ -3992,7 +3992,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (short)(readOnlySpan[i] * ret);
                 }
@@ -4014,11 +4014,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (short)(readOnlySpan[(int)row] * ret);
+                ret = checked((short)(readOnlySpan[(int)row] * ret));
             }
         }
 
@@ -4029,7 +4029,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (short)(readOnlySpan[i] + ret);
                 }
@@ -4051,11 +4051,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (short)(readOnlySpan[(int)row] + ret);
+                ret = checked((short)(readOnlySpan[(int)row] + ret));
             }
         }
 
@@ -4066,7 +4066,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (short)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -4084,7 +4084,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (uint)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -4111,7 +4111,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (uint)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -4137,8 +4137,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -4152,8 +4152,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (uint)Math.Max(span[(int)row], ret);
@@ -4170,7 +4170,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (uint)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -4196,8 +4196,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -4211,8 +4211,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (uint)Math.Min(span[(int)row], ret);
@@ -4229,7 +4229,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (uint)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -4255,8 +4255,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -4270,11 +4270,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (uint)((span[(int)row]) * ret);
+                ret = checked((uint)((span[(int)row]) * ret));
                 span[(int)row] = ret;
             }
         }
@@ -4288,7 +4288,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (uint)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -4314,8 +4314,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -4329,11 +4329,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (uint)((span[(int)row]) + ret);
+                ret = checked((uint)((span[(int)row]) + ret));
                 span[(int)row] = ret;
             }
         }
@@ -4345,7 +4345,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (uint)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -4367,8 +4367,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (uint)(Math.Max(readOnlySpan[(int)row], ret));
@@ -4382,7 +4382,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (uint)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -4404,8 +4404,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (uint)(Math.Min(readOnlySpan[(int)row], ret));
@@ -4419,7 +4419,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (uint)(readOnlySpan[i] * ret);
                 }
@@ -4441,11 +4441,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (uint)(readOnlySpan[(int)row] * ret);
+                ret = checked((uint)(readOnlySpan[(int)row] * ret));
             }
         }
 
@@ -4456,7 +4456,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (uint)(readOnlySpan[i] + ret);
                 }
@@ -4478,11 +4478,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (uint)(readOnlySpan[(int)row] + ret);
+                ret = checked((uint)(readOnlySpan[(int)row] + ret));
             }
         }
 
@@ -4493,7 +4493,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (uint)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -4511,7 +4511,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (ulong)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -4538,7 +4538,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ulong)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -4564,8 +4564,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -4579,8 +4579,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (ulong)Math.Max(span[(int)row], ret);
@@ -4597,7 +4597,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ulong)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -4623,8 +4623,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -4638,8 +4638,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (ulong)Math.Min(span[(int)row], ret);
@@ -4656,7 +4656,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ulong)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -4682,8 +4682,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -4697,11 +4697,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (ulong)((span[(int)row]) * ret);
+                ret = checked((ulong)((span[(int)row]) * ret));
                 span[(int)row] = ret;
             }
         }
@@ -4715,7 +4715,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ulong)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -4741,8 +4741,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -4756,11 +4756,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (ulong)((span[(int)row]) + ret);
+                ret = checked((ulong)((span[(int)row]) + ret));
                 span[(int)row] = ret;
             }
         }
@@ -4772,7 +4772,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ulong)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -4794,8 +4794,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (ulong)(Math.Max(readOnlySpan[(int)row], ret));
@@ -4809,7 +4809,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ulong)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -4831,8 +4831,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (ulong)(Math.Min(readOnlySpan[(int)row], ret));
@@ -4846,7 +4846,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ulong)(readOnlySpan[i] * ret);
                 }
@@ -4868,11 +4868,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (ulong)(readOnlySpan[(int)row] * ret);
+                ret = checked((ulong)(readOnlySpan[(int)row] * ret));
             }
         }
 
@@ -4883,7 +4883,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ulong)(readOnlySpan[i] + ret);
                 }
@@ -4905,11 +4905,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (ulong)(readOnlySpan[(int)row] + ret);
+                ret = checked((ulong)(readOnlySpan[(int)row] + ret));
             }
         }
 
@@ -4920,7 +4920,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (ulong)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -4938,7 +4938,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (ushort)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -4965,7 +4965,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ushort)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -4991,8 +4991,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -5006,8 +5006,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (ushort)Math.Max(span[(int)row], ret);
@@ -5024,7 +5024,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ushort)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -5050,8 +5050,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -5065,8 +5065,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (ushort)Math.Min(span[(int)row], ret);
@@ -5083,7 +5083,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ushort)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -5109,8 +5109,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -5124,11 +5124,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (ushort)((span[(int)row]) * ret);
+                ret = checked((ushort)((span[(int)row]) * ret));
                 span[(int)row] = ret;
             }
         }
@@ -5142,7 +5142,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ushort)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -5168,8 +5168,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -5183,11 +5183,11 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (ushort)((span[(int)row]) + ret);
+                ret = checked((ushort)((span[(int)row]) + ret));
                 span[(int)row] = ret;
             }
         }
@@ -5199,7 +5199,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ushort)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -5221,8 +5221,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (ushort)(Math.Max(readOnlySpan[(int)row], ret));
@@ -5236,7 +5236,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ushort)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -5258,8 +5258,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = (ushort)(Math.Min(readOnlySpan[(int)row], ret));
@@ -5273,7 +5273,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ushort)(readOnlySpan[i] * ret);
                 }
@@ -5295,11 +5295,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (ushort)(readOnlySpan[(int)row] * ret);
+                ret = checked((ushort)(readOnlySpan[(int)row] * ret));
             }
         }
 
@@ -5310,7 +5310,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
                     ret = (ushort)(readOnlySpan[i] + ret);
                 }
@@ -5332,11 +5332,11 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
-                ret = (ushort)(readOnlySpan[(int)row] + ret);
+                ret = checked((ushort)(readOnlySpan[(int)row] + ret));
             }
         }
 
@@ -5347,7 +5347,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (ushort)(Math.Round((decimal)mutableSpan[i]));
                 }

--- a/src/Microsoft.Data/PrimitiveColumnComputations.cs
+++ b/src/Microsoft.Data/PrimitiveColumnComputations.cs
@@ -296,8 +296,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -311,8 +311,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (byte)Math.Max(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -355,8 +355,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -370,8 +370,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (byte)Math.Min(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -414,8 +414,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -429,8 +429,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (byte)((span[(int)row]) * ret);
                 span[(int)row] = ret;
             }
@@ -473,8 +473,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -488,8 +488,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (byte)((span[(int)row]) + ret);
                 span[(int)row] = ret;
             }
@@ -526,8 +526,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (byte)(Math.Max(readOnlySpan[(int)row], ret));
             }
         }
@@ -563,8 +563,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (byte)(Math.Min(readOnlySpan[(int)row], ret));
             }
         }
@@ -600,8 +600,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (byte)(readOnlySpan[(int)row] * ret);
             }
         }
@@ -637,8 +637,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (byte)(readOnlySpan[(int)row] + ret);
             }
         }
@@ -723,8 +723,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -738,8 +738,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (char)Math.Max(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -782,8 +782,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -797,8 +797,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (char)Math.Min(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -841,8 +841,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -856,8 +856,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (char)((span[(int)row]) * ret);
                 span[(int)row] = ret;
             }
@@ -900,8 +900,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -915,8 +915,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (char)((span[(int)row]) + ret);
                 span[(int)row] = ret;
             }
@@ -953,8 +953,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (char)(Math.Max(readOnlySpan[(int)row], ret));
             }
         }
@@ -990,8 +990,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (char)(Math.Min(readOnlySpan[(int)row], ret));
             }
         }
@@ -1027,8 +1027,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (char)(readOnlySpan[(int)row] * ret);
             }
         }
@@ -1064,8 +1064,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (char)(readOnlySpan[(int)row] + ret);
             }
         }
@@ -1150,8 +1150,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -1165,8 +1165,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (decimal)Math.Max(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -1209,8 +1209,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -1224,8 +1224,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (decimal)Math.Min(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -1268,8 +1268,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -1283,8 +1283,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (decimal)((span[(int)row]) * ret);
                 span[(int)row] = ret;
             }
@@ -1327,8 +1327,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -1342,8 +1342,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (decimal)((span[(int)row]) + ret);
                 span[(int)row] = ret;
             }
@@ -1380,8 +1380,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (decimal)(Math.Max(readOnlySpan[(int)row], ret));
             }
         }
@@ -1417,8 +1417,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (decimal)(Math.Min(readOnlySpan[(int)row], ret));
             }
         }
@@ -1454,8 +1454,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (decimal)(readOnlySpan[(int)row] * ret);
             }
         }
@@ -1491,8 +1491,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (decimal)(readOnlySpan[(int)row] + ret);
             }
         }
@@ -1577,8 +1577,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -1592,8 +1592,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (double)Math.Max(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -1636,8 +1636,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -1651,8 +1651,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (double)Math.Min(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -1695,8 +1695,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -1710,8 +1710,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (double)((span[(int)row]) * ret);
                 span[(int)row] = ret;
             }
@@ -1754,8 +1754,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -1769,8 +1769,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (double)((span[(int)row]) + ret);
                 span[(int)row] = ret;
             }
@@ -1807,8 +1807,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (double)(Math.Max(readOnlySpan[(int)row], ret));
             }
         }
@@ -1844,8 +1844,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (double)(Math.Min(readOnlySpan[(int)row], ret));
             }
         }
@@ -1881,8 +1881,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (double)(readOnlySpan[(int)row] * ret);
             }
         }
@@ -1918,8 +1918,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (double)(readOnlySpan[(int)row] + ret);
             }
         }
@@ -2004,8 +2004,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -2019,8 +2019,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (float)Math.Max(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -2063,8 +2063,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -2078,8 +2078,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (float)Math.Min(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -2122,8 +2122,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -2137,8 +2137,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (float)((span[(int)row]) * ret);
                 span[(int)row] = ret;
             }
@@ -2181,8 +2181,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -2196,8 +2196,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (float)((span[(int)row]) + ret);
                 span[(int)row] = ret;
             }
@@ -2234,8 +2234,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (float)(Math.Max(readOnlySpan[(int)row], ret));
             }
         }
@@ -2271,8 +2271,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (float)(Math.Min(readOnlySpan[(int)row], ret));
             }
         }
@@ -2308,8 +2308,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (float)(readOnlySpan[(int)row] * ret);
             }
         }
@@ -2345,8 +2345,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (float)(readOnlySpan[(int)row] + ret);
             }
         }
@@ -2431,8 +2431,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -2446,8 +2446,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (int)Math.Max(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -2490,8 +2490,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -2505,8 +2505,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (int)Math.Min(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -2549,8 +2549,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -2564,8 +2564,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (int)((span[(int)row]) * ret);
                 span[(int)row] = ret;
             }
@@ -2608,8 +2608,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -2623,8 +2623,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (int)((span[(int)row]) + ret);
                 span[(int)row] = ret;
             }
@@ -2661,8 +2661,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (int)(Math.Max(readOnlySpan[(int)row], ret));
             }
         }
@@ -2698,8 +2698,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (int)(Math.Min(readOnlySpan[(int)row], ret));
             }
         }
@@ -2735,8 +2735,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (int)(readOnlySpan[(int)row] * ret);
             }
         }
@@ -2772,8 +2772,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (int)(readOnlySpan[(int)row] + ret);
             }
         }
@@ -2858,8 +2858,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -2873,8 +2873,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (long)Math.Max(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -2917,8 +2917,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -2932,8 +2932,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (long)Math.Min(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -2976,8 +2976,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -2991,8 +2991,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (long)((span[(int)row]) * ret);
                 span[(int)row] = ret;
             }
@@ -3035,8 +3035,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -3050,8 +3050,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (long)((span[(int)row]) + ret);
                 span[(int)row] = ret;
             }
@@ -3088,8 +3088,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (long)(Math.Max(readOnlySpan[(int)row], ret));
             }
         }
@@ -3125,8 +3125,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (long)(Math.Min(readOnlySpan[(int)row], ret));
             }
         }
@@ -3162,8 +3162,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (long)(readOnlySpan[(int)row] * ret);
             }
         }
@@ -3199,8 +3199,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (long)(readOnlySpan[(int)row] + ret);
             }
         }
@@ -3285,8 +3285,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -3300,8 +3300,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (sbyte)Math.Max(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -3344,8 +3344,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -3359,8 +3359,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (sbyte)Math.Min(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -3403,8 +3403,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -3418,8 +3418,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (sbyte)((span[(int)row]) * ret);
                 span[(int)row] = ret;
             }
@@ -3462,8 +3462,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -3477,8 +3477,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (sbyte)((span[(int)row]) + ret);
                 span[(int)row] = ret;
             }
@@ -3515,8 +3515,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (sbyte)(Math.Max(readOnlySpan[(int)row], ret));
             }
         }
@@ -3552,8 +3552,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (sbyte)(Math.Min(readOnlySpan[(int)row], ret));
             }
         }
@@ -3589,8 +3589,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (sbyte)(readOnlySpan[(int)row] * ret);
             }
         }
@@ -3626,8 +3626,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (sbyte)(readOnlySpan[(int)row] + ret);
             }
         }
@@ -3712,8 +3712,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -3727,8 +3727,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (short)Math.Max(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -3771,8 +3771,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -3786,8 +3786,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (short)Math.Min(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -3830,8 +3830,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -3845,8 +3845,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (short)((span[(int)row]) * ret);
                 span[(int)row] = ret;
             }
@@ -3889,8 +3889,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -3904,8 +3904,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (short)((span[(int)row]) + ret);
                 span[(int)row] = ret;
             }
@@ -3942,8 +3942,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (short)(Math.Max(readOnlySpan[(int)row], ret));
             }
         }
@@ -3979,8 +3979,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (short)(Math.Min(readOnlySpan[(int)row], ret));
             }
         }
@@ -4016,8 +4016,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (short)(readOnlySpan[(int)row] * ret);
             }
         }
@@ -4053,8 +4053,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (short)(readOnlySpan[(int)row] + ret);
             }
         }
@@ -4139,8 +4139,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -4154,8 +4154,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (uint)Math.Max(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -4198,8 +4198,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -4213,8 +4213,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (uint)Math.Min(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -4257,8 +4257,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -4272,8 +4272,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (uint)((span[(int)row]) * ret);
                 span[(int)row] = ret;
             }
@@ -4316,8 +4316,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -4331,8 +4331,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (uint)((span[(int)row]) + ret);
                 span[(int)row] = ret;
             }
@@ -4369,8 +4369,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (uint)(Math.Max(readOnlySpan[(int)row], ret));
             }
         }
@@ -4406,8 +4406,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (uint)(Math.Min(readOnlySpan[(int)row], ret));
             }
         }
@@ -4443,8 +4443,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (uint)(readOnlySpan[(int)row] * ret);
             }
         }
@@ -4480,8 +4480,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (uint)(readOnlySpan[(int)row] + ret);
             }
         }
@@ -4566,8 +4566,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -4581,8 +4581,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ulong)Math.Max(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -4625,8 +4625,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -4640,8 +4640,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ulong)Math.Min(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -4684,8 +4684,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -4699,8 +4699,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ulong)((span[(int)row]) * ret);
                 span[(int)row] = ret;
             }
@@ -4743,8 +4743,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -4758,8 +4758,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ulong)((span[(int)row]) + ret);
                 span[(int)row] = ret;
             }
@@ -4796,8 +4796,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ulong)(Math.Max(readOnlySpan[(int)row], ret));
             }
         }
@@ -4833,8 +4833,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ulong)(Math.Min(readOnlySpan[(int)row], ret));
             }
         }
@@ -4870,8 +4870,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ulong)(readOnlySpan[(int)row] * ret);
             }
         }
@@ -4907,8 +4907,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ulong)(readOnlySpan[(int)row] + ret);
             }
         }
@@ -4993,8 +4993,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -5008,8 +5008,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ushort)Math.Max(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -5052,8 +5052,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -5067,8 +5067,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ushort)Math.Min(span[(int)row], ret);
                 span[(int)row] = ret;
             }
@@ -5111,8 +5111,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -5126,8 +5126,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ushort)((span[(int)row]) * ret);
                 span[(int)row] = ret;
             }
@@ -5170,8 +5170,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -5185,8 +5185,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ushort)((span[(int)row]) + ret);
                 span[(int)row] = ret;
             }
@@ -5223,8 +5223,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ushort)(Math.Max(readOnlySpan[(int)row], ret));
             }
         }
@@ -5260,8 +5260,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ushort)(Math.Min(readOnlySpan[(int)row], ret));
             }
         }
@@ -5297,8 +5297,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ushort)(readOnlySpan[(int)row] * ret);
             }
         }
@@ -5334,8 +5334,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = (ushort)(readOnlySpan[(int)row] + ret);
             }
         }

--- a/src/Microsoft.Data/PrimitiveColumnComputations.cs
+++ b/src/Microsoft.Data/PrimitiveColumnComputations.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var span = buffer.ReadOnlySpan;
-                for (int i = 0; i < span.Length && i < buffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     if (span[i] == false)
                     {
@@ -135,7 +135,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var span = buffer.ReadOnlySpan;
-                for (int i = 0; i < span.Length && i < buffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     if (span[i] == true)
                     {
@@ -241,7 +241,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (byte)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -268,7 +268,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (byte)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -327,7 +327,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (byte)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -386,7 +386,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (byte)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -445,7 +445,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (byte)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -502,7 +502,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (byte)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -539,7 +539,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (byte)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -576,7 +576,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (byte)(readOnlySpan[i] * ret);
                 }
@@ -613,7 +613,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (byte)(readOnlySpan[i] + ret);
                 }
@@ -650,7 +650,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<byte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (byte)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -668,7 +668,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (char)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -695,7 +695,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (char)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -754,7 +754,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (char)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -813,7 +813,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (char)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -872,7 +872,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (char)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -929,7 +929,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (char)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -966,7 +966,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (char)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -1003,7 +1003,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (char)(readOnlySpan[i] * ret);
                 }
@@ -1040,7 +1040,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (char)(readOnlySpan[i] + ret);
                 }
@@ -1077,7 +1077,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<char>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (char)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -1095,7 +1095,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (decimal)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -1122,7 +1122,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (decimal)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -1181,7 +1181,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (decimal)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -1240,7 +1240,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (decimal)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -1299,7 +1299,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (decimal)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -1356,7 +1356,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (decimal)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -1393,7 +1393,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (decimal)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -1430,7 +1430,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (decimal)(readOnlySpan[i] * ret);
                 }
@@ -1467,7 +1467,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (decimal)(readOnlySpan[i] + ret);
                 }
@@ -1504,7 +1504,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<decimal>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (decimal)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -1522,7 +1522,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (double)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -1549,7 +1549,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (double)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -1608,7 +1608,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (double)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -1667,7 +1667,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (double)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -1726,7 +1726,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (double)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -1783,7 +1783,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (double)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -1820,7 +1820,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (double)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -1857,7 +1857,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (double)(readOnlySpan[i] * ret);
                 }
@@ -1894,7 +1894,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (double)(readOnlySpan[i] + ret);
                 }
@@ -1931,7 +1931,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<double>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (double)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -1949,7 +1949,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (float)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -1976,7 +1976,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (float)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -2035,7 +2035,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (float)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -2094,7 +2094,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (float)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -2153,7 +2153,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (float)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -2210,7 +2210,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (float)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -2247,7 +2247,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (float)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -2284,7 +2284,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (float)(readOnlySpan[i] * ret);
                 }
@@ -2321,7 +2321,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (float)(readOnlySpan[i] + ret);
                 }
@@ -2358,7 +2358,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<float>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (float)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -2376,7 +2376,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (int)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -2403,7 +2403,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (int)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -2462,7 +2462,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (int)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -2521,7 +2521,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (int)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -2580,7 +2580,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (int)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -2637,7 +2637,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (int)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -2674,7 +2674,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (int)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -2711,7 +2711,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (int)(readOnlySpan[i] * ret);
                 }
@@ -2748,7 +2748,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (int)(readOnlySpan[i] + ret);
                 }
@@ -2785,7 +2785,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<int>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (int)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -2803,7 +2803,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (long)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -2830,7 +2830,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (long)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -2889,7 +2889,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (long)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -2948,7 +2948,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (long)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -3007,7 +3007,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (long)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -3064,7 +3064,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (long)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -3101,7 +3101,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (long)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -3138,7 +3138,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (long)(readOnlySpan[i] * ret);
                 }
@@ -3175,7 +3175,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (long)(readOnlySpan[i] + ret);
                 }
@@ -3212,7 +3212,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<long>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (long)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -3230,7 +3230,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (sbyte)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -3257,7 +3257,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (sbyte)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -3316,7 +3316,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (sbyte)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -3375,7 +3375,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (sbyte)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -3434,7 +3434,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (sbyte)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -3491,7 +3491,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (sbyte)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -3528,7 +3528,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (sbyte)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -3565,7 +3565,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (sbyte)(readOnlySpan[i] * ret);
                 }
@@ -3602,7 +3602,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (sbyte)(readOnlySpan[i] + ret);
                 }
@@ -3639,7 +3639,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<sbyte>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (sbyte)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -3657,7 +3657,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (short)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -3684,7 +3684,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (short)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -3743,7 +3743,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (short)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -3802,7 +3802,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (short)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -3861,7 +3861,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (short)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -3918,7 +3918,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (short)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -3955,7 +3955,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (short)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -3992,7 +3992,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (short)(readOnlySpan[i] * ret);
                 }
@@ -4029,7 +4029,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (short)(readOnlySpan[i] + ret);
                 }
@@ -4066,7 +4066,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<short>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (short)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -4084,7 +4084,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (uint)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -4111,7 +4111,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (uint)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -4170,7 +4170,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (uint)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -4229,7 +4229,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (uint)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -4288,7 +4288,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (uint)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -4345,7 +4345,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (uint)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -4382,7 +4382,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (uint)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -4419,7 +4419,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (uint)(readOnlySpan[i] * ret);
                 }
@@ -4456,7 +4456,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (uint)(readOnlySpan[i] + ret);
                 }
@@ -4493,7 +4493,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<uint>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (uint)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -4511,7 +4511,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (ulong)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -4538,7 +4538,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ulong)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -4597,7 +4597,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ulong)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -4656,7 +4656,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ulong)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -4715,7 +4715,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ulong)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -4772,7 +4772,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ulong)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -4809,7 +4809,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ulong)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -4846,7 +4846,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ulong)(readOnlySpan[i] * ret);
                 }
@@ -4883,7 +4883,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ulong)(readOnlySpan[i] + ret);
                 }
@@ -4920,7 +4920,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ulong>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (ulong)(Math.Round((decimal)mutableSpan[i]));
                 }
@@ -4938,7 +4938,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (ushort)(Math.Abs((decimal)mutableSpan[i]));
                 }
@@ -4965,7 +4965,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ushort)(Math.Max(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -5024,7 +5024,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ushort)(Math.Min(readOnlySpan[i], ret));
                     mutableSpan[i] = ret;
@@ -5083,7 +5083,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ushort)(readOnlySpan[i] * ret);
                     mutableSpan[i] = ret;
@@ -5142,7 +5142,7 @@ namespace Microsoft.Data
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ushort)(readOnlySpan[i] + ret);
                     mutableSpan[i] = ret;
@@ -5199,7 +5199,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ushort)(Math.Max(readOnlySpan[i], ret));
                 }
@@ -5236,7 +5236,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ushort)(Math.Min(readOnlySpan[i], ret));
                 }
@@ -5273,7 +5273,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ushort)(readOnlySpan[i] * ret);
                 }
@@ -5310,7 +5310,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
                     ret = (ushort)(readOnlySpan[i] + ret);
                 }
@@ -5347,7 +5347,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<ushort>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (ushort)(Math.Round((decimal)mutableSpan[i]));
                 }

--- a/src/Microsoft.Data/PrimitiveColumnComputations.tt
+++ b/src/Microsoft.Data/PrimitiveColumnComputations.tt
@@ -96,8 +96,8 @@ namespace Microsoft.Data
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
 <# if (method.MethodName == "Max") { #>
                 ret = (<#=type.TypeName#>)(Math.Max(readOnlySpan[(int)row], ret));
 <# } #>
@@ -129,8 +129,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
                 ret = span[(int)row];
             }
 
@@ -144,8 +144,8 @@ namespace Microsoft.Data
                     span = mutableBuffer.Span;
                     minRange = bufferIndex * maxCapacity;
                     maxRange = (bufferIndex + 1) * maxCapacity;
-                    row -= minRange;
                 }
+                row -= minRange;
 <# if (method.MethodName == "CumulativeMax") { #>
                 ret = (<#=type.TypeName#>)Math.Max(span[(int)row], ret);
                 span[(int)row] = ret;

--- a/src/Microsoft.Data/PrimitiveColumnComputations.tt
+++ b/src/Microsoft.Data/PrimitiveColumnComputations.tt
@@ -182,7 +182,7 @@ namespace Microsoft.Data
                 var mutableSpan = mutableBuffer.Span;
 <# } #>
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length; i++)
                 {
 <# if (method.MethodName == "CumulativeMax") { #>
                     ret = (<#=type.TypeName#>)(Math.Max(readOnlySpan[i], ret));
@@ -223,7 +223,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length; i++)
                 {
                     mutableSpan[i] = (<#=type.TypeName#>)(<#=method.Operator#>((decimal)mutableSpan[i]));
                 }
@@ -239,7 +239,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var span = buffer.ReadOnlySpan;
-                for (int i = 0; i < span.Length && i < buffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
 <# if (method.MethodName == "All") { #>
                     if (span[i] == false)

--- a/src/Microsoft.Data/PrimitiveColumnComputations.tt
+++ b/src/Microsoft.Data/PrimitiveColumnComputations.tt
@@ -94,8 +94,8 @@ namespace Microsoft.Data
                 {
                     int bufferIndex = (int)(row / maxCapacity);
                     readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
 <# if (method.MethodName == "Max") { #>
@@ -105,10 +105,10 @@ namespace Microsoft.Data
                 ret = (<#=type.TypeName#>)(Math.Min(readOnlySpan[(int)row], ret));
 <# } #>
 <# if (method.MethodName == "Product") { #>
-                ret = (<#=type.TypeName#>)(readOnlySpan[(int)row] * ret);
+                ret = checked((<#=type.TypeName#>)(readOnlySpan[(int)row] * ret));
 <# } #>
 <# if (method.MethodName == "Sum") { #>
-                ret = (<#=type.TypeName#>)(readOnlySpan[(int)row] + ret);
+                ret = checked((<#=type.TypeName#>)(readOnlySpan[(int)row] + ret));
 <# } #>
             }
 <# } else if ((method.MethodName == "CumulativeMax" || method.MethodName == "CumulativeMin" || method.MethodName == "CumulativeProduct" || method.MethodName == "CumulativeSum") && method.SupportsRowSubsets == true) { #>
@@ -127,8 +127,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
                 ret = span[(int)row];
@@ -142,8 +142,8 @@ namespace Microsoft.Data
                     int bufferIndex = (int)(row / maxCapacity);
                     mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(column.Buffers[bufferIndex]);
                     span = mutableBuffer.Span;
-                    minRange = bufferIndex * maxCapacity;
-                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    minRange = checked(bufferIndex * maxCapacity);
+                    maxRange = checked((bufferIndex + 1) * maxCapacity);
                 }
                 row -= minRange;
 <# if (method.MethodName == "CumulativeMax") { #>
@@ -153,10 +153,10 @@ namespace Microsoft.Data
                 ret = (<#=type.TypeName#>)Math.Min(span[(int)row], ret);
                 span[(int)row] = ret;
 <# } else if (method.MethodName == "CumulativeProduct") { #>
-                ret = (<#=type.TypeName#>)((span[(int)row]) * ret);
+                ret = checked((<#=type.TypeName#>)((span[(int)row]) * ret));
                 span[(int)row] = ret;
 <# } else if (method.MethodName =="CumulativeSum") { #>
-                ret = (<#=type.TypeName#>)((span[(int)row]) + ret);
+                ret = checked((<#=type.TypeName#>)((span[(int)row]) + ret));
                 span[(int)row] = ret;
 <# } #>
             }
@@ -182,7 +182,7 @@ namespace Microsoft.Data
                 var mutableSpan = mutableBuffer.Span;
 <# } #>
                 var readOnlySpan = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < readOnlySpan.Length && i < buffer.Length; i++)
                 {
 <# if (method.MethodName == "CumulativeMax") { #>
                     ret = (<#=type.TypeName#>)(Math.Max(readOnlySpan[i], ret));
@@ -223,7 +223,7 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(buffer);
                 var mutableSpan = mutableBuffer.Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < mutableSpan.Length && i < mutableBuffer.Length; i++)
                 {
                     mutableSpan[i] = (<#=type.TypeName#>)(<#=method.Operator#>((decimal)mutableSpan[i]));
                 }
@@ -239,7 +239,7 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var span = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < span.Length && i < buffer.Length; i++)
                 {
 <# if (method.MethodName == "All") { #>
                     if (span[i] == false)

--- a/src/Microsoft.Data/PrimitiveColumnComputations.tt
+++ b/src/Microsoft.Data/PrimitiveColumnComputations.tt
@@ -82,46 +82,82 @@ namespace Microsoft.Data
 <# } else { #>
 <# if ((method.MethodName == "Max" || method.MethodName == "Min" || method.MethodName == "Product" || method.MethodName == "Sum") && method.SupportsRowSubsets == true) { #>
             ret = default;
+            var readOnlySpan = column.Buffers[0].ReadOnlySpan;
+            long minRange = 0;
+            long maxRange = ReadOnlyDataFrameBuffer<<#=type.TypeName#>>.MaxCapacity;
+            long maxCapacity = maxRange;
             IEnumerator<long> enumerator = rows.GetEnumerator();
             while (enumerator.MoveNext())
             {
                 long row = enumerator.Current;
+                if (row < minRange || row >= maxRange)
+                {
+                    int bufferIndex = (int)(row / maxCapacity);
+                    readOnlySpan = column.Buffers[bufferIndex].ReadOnlySpan;
+                    minRange = bufferIndex * maxCapacity;
+                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    row -= minRange;
+                }
 <# if (method.MethodName == "Max") { #>
-                ret = (<#=type.TypeName#>)(Math.Max(column[row] ?? default, ret));
+                ret = (<#=type.TypeName#>)(Math.Max(readOnlySpan[(int)row], ret));
 <# } #>
 <# if (method.MethodName == "Min") { #>
-                ret = (<#=type.TypeName#>)(Math.Min(column[row] ?? default, ret));
+                ret = (<#=type.TypeName#>)(Math.Min(readOnlySpan[(int)row], ret));
 <# } #>
 <# if (method.MethodName == "Product") { #>
-                ret = (<#=type.TypeName#>)((column[row] ?? default) * ret);
+                ret = (<#=type.TypeName#>)(readOnlySpan[(int)row] * ret);
 <# } #>
 <# if (method.MethodName == "Sum") { #>
-                ret = (<#=type.TypeName#>)((column[row] ?? default) + ret);
+                ret = (<#=type.TypeName#>)(readOnlySpan[(int)row] + ret);
 <# } #>
             }
 <# } else if ((method.MethodName == "CumulativeMax" || method.MethodName == "CumulativeMin" || method.MethodName == "CumulativeProduct" || method.MethodName == "CumulativeSum") && method.SupportsRowSubsets == true) { #>
             var ret = default(<#=type.TypeName#>);
+            var mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(column.Buffers[0]);
+            var span = mutableBuffer.Span;
+            long minRange = 0;
+            long maxRange = ReadOnlyDataFrameBuffer<<#=type.TypeName#>>.MaxCapacity;
+            long maxCapacity = maxRange;
             IEnumerator<long> enumerator = rows.GetEnumerator();
             if (enumerator.MoveNext())
             {
-                ret = column[enumerator.Current] ?? default;
+                long row = enumerator.Current;
+                if (row < minRange || row >= maxRange)
+                {
+                    int bufferIndex = (int)(row / maxCapacity);
+                    mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(column.Buffers[bufferIndex]);
+                    span = mutableBuffer.Span;
+                    minRange = bufferIndex * maxCapacity;
+                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    row -= minRange;
+                }
+                ret = span[(int)row];
             }
 
             while (enumerator.MoveNext())
             {
                 long row = enumerator.Current;
+                if (row < minRange || row >= maxRange)
+                {
+                    int bufferIndex = (int)(row / maxCapacity);
+                    mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(column.Buffers[bufferIndex]);
+                    span = mutableBuffer.Span;
+                    minRange = bufferIndex * maxCapacity;
+                    maxRange = (bufferIndex + 1) * maxCapacity;
+                    row -= minRange;
+                }
 <# if (method.MethodName == "CumulativeMax") { #>
-                ret = (<#=type.TypeName#>)Math.Max(column[row] ?? default, ret);
-                column[row] = ret;
+                ret = (<#=type.TypeName#>)Math.Max(span[(int)row], ret);
+                span[(int)row] = ret;
 <# } else if (method.MethodName == "CumulativeMin") { #>
-                ret = (<#=type.TypeName#>)Math.Min(column[row] ?? default, ret);
-                column[row] = ret;
+                ret = (<#=type.TypeName#>)Math.Min(span[(int)row], ret);
+                span[(int)row] = ret;
 <# } else if (method.MethodName == "CumulativeProduct") { #>
-                ret = (<#=type.TypeName#>)((column[row] ?? default) * ret);
-                column[row] = ret;
+                ret = (<#=type.TypeName#>)((span[(int)row]) * ret);
+                span[(int)row] = ret;
 <# } else if (method.MethodName =="CumulativeSum") { #>
-                ret = (<#=type.TypeName#>)((column[row] ?? default) + ret);
-                column[row] = ret;
+                ret = (<#=type.TypeName#>)((span[(int)row]) + ret);
+                span[(int)row] = ret;
 <# } #>
             }
 <# } else if (method.MethodName == "CumulativeMax" || method.MethodName == "CumulativeMin" || method.MethodName == "CumulativeProduct" || method.MethodName == "CumulativeSum" || method.MethodName == "Max" || method.MethodName == "Min" || method.MethodName == "Product" || method.MethodName == "Sum") { #>
@@ -143,36 +179,38 @@ namespace Microsoft.Data
                 var buffer = column.Buffers[b];
 <# if (method.MethodName == "CumulativeMax" || method.MethodName == "CumulativeMin" || method.MethodName == "CumulativeProduct" || method.MethodName == "CumulativeSum") { #>
                 var mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(buffer);
+                var mutableSpan = mutableBuffer.Span;
 <# } #>
+                var readOnlySpan = buffer.ReadOnlySpan;
                 for (int i = 0; i < buffer.Length; i++)
                 {
 <# if (method.MethodName == "CumulativeMax") { #>
-                    ret = (<#=type.TypeName#>)(Math.Max(buffer.ReadOnlySpan[i], ret));
-                    mutableBuffer.Span[i] = ret;
+                    ret = (<#=type.TypeName#>)(Math.Max(readOnlySpan[i], ret));
+                    mutableSpan[i] = ret;
 <# } #>
 <# if (method.MethodName == "CumulativeMin") { #>
-                    ret = (<#=type.TypeName#>)(Math.Min(buffer.ReadOnlySpan[i], ret));
-                    mutableBuffer.Span[i] = ret;
+                    ret = (<#=type.TypeName#>)(Math.Min(readOnlySpan[i], ret));
+                    mutableSpan[i] = ret;
 <# } #>
 <# if (method.MethodName == "CumulativeProduct") { #>
-                    ret = (<#=type.TypeName#>)(buffer.ReadOnlySpan[i] * ret);
-                    mutableBuffer.Span[i] = ret;
+                    ret = (<#=type.TypeName#>)(readOnlySpan[i] * ret);
+                    mutableSpan[i] = ret;
 <# } #>
 <# if (method.MethodName == "CumulativeSum") { #>
-                    ret = (<#=type.TypeName#>)(buffer.ReadOnlySpan[i] + ret);
-                    mutableBuffer.Span[i] = ret;
+                    ret = (<#=type.TypeName#>)(readOnlySpan[i] + ret);
+                    mutableSpan[i] = ret;
 <# } #>
 <# if (method.MethodName == "Max") { #>
-                    ret = (<#=type.TypeName#>)(Math.Max(buffer.ReadOnlySpan[i], ret));
+                    ret = (<#=type.TypeName#>)(Math.Max(readOnlySpan[i], ret));
 <# } #>
 <# if (method.MethodName == "Min") { #>
-                    ret = (<#=type.TypeName#>)(Math.Min(buffer.ReadOnlySpan[i], ret));
+                    ret = (<#=type.TypeName#>)(Math.Min(readOnlySpan[i], ret));
 <# } #>
 <# if (method.MethodName == "Product") { #>
-                    ret = (<#=type.TypeName#>)(buffer.ReadOnlySpan[i] * ret);
+                    ret = (<#=type.TypeName#>)(readOnlySpan[i] * ret);
 <# } #>
 <# if (method.MethodName == "Sum") { #>
-                    ret = (<#=type.TypeName#>)(buffer.ReadOnlySpan[i] + ret);
+                    ret = (<#=type.TypeName#>)(readOnlySpan[i] + ret);
 <# } #>
                 }
 <# if (method.MethodName == "CumulativeMax" || method.MethodName == "CumulativeMin" || method.MethodName == "CumulativeProduct" || method.MethodName == "CumulativeSum") { #>
@@ -184,9 +222,10 @@ namespace Microsoft.Data
             {
                 var buffer = column.Buffers[b];
                 var mutableBuffer = DataFrameBuffer<<#=type.TypeName#>>.GetMutableBuffer(buffer);
+                var mutableSpan = mutableBuffer.Span;
                 for (int i = 0; i < buffer.Length; i++)
                 {
-                    mutableBuffer.Span[i] = (<#=type.TypeName#>)(<#=method.Operator#>((decimal)mutableBuffer.Span[i]));
+                    mutableSpan[i] = (<#=type.TypeName#>)(<#=method.Operator#>((decimal)mutableSpan[i]));
                 }
                 column.Buffers[b] = mutableBuffer;
             }
@@ -199,16 +238,17 @@ namespace Microsoft.Data
             for (int b = 0; b < column.Buffers.Count; b++)
             {
                 var buffer = column.Buffers[b];
+                var span = buffer.ReadOnlySpan;
                 for (int i = 0; i < buffer.Length; i++)
                 {
 <# if (method.MethodName == "All") { #>
-                    if (buffer.ReadOnlySpan[i] == false)
+                    if (span[i] == false)
                     {
                         ret = false;
                         return;
                     }
 <# } else if (method.MethodName == "Any") { #>
-                    if (buffer.ReadOnlySpan[i] == true)
+                    if (span[i] == true)
                     {
                         ret = true;
                         return;

--- a/src/Microsoft.Data/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data/PrimitiveColumnContainer.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Data
                 DataFrameBuffer<T> mutableLastBuffer = DataFrameBuffer<T>.GetMutableBuffer(lastBuffer);
                 int allocatable = (int)Math.Min(count, ReadOnlyDataFrameBuffer<T>.MaxCapacity);
                 mutableLastBuffer.EnsureCapacity(allocatable);
-                mutableLastBuffer.Span.Slice(lastBuffer.Length, allocatable).Fill(value ?? default);
+                mutableLastBuffer.RawSpan.Slice(lastBuffer.Length, allocatable).Fill(value ?? default);
                 mutableLastBuffer.Length += allocatable;
                 Length += allocatable;
 
@@ -390,7 +390,7 @@ namespace Microsoft.Data
             {
                 DataFrameBuffer<byte> newBuffer = new DataFrameBuffer<byte>();
                 ret.Add(newBuffer);
-                ReadOnlySpan<byte> span = buffer.ReadOnlySpan;
+                ReadOnlySpan<byte> span = buffer.RawReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     newBuffer.Append(span[i]);

--- a/src/Microsoft.Data/ReadOnlyDataFrameBuffer.cs
+++ b/src/Microsoft.Data/ReadOnlyDataFrameBuffer.cs
@@ -31,6 +31,12 @@ namespace Microsoft.Data
         public ReadOnlySpan<T> ReadOnlySpan
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => (MemoryMarshal.Cast<byte, T>(ReadOnlyMemory.Span)).Slice(0, Length);
+        }
+
+        public ReadOnlySpan<T> RawReadOnlySpan
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => MemoryMarshal.Cast<byte, T>(ReadOnlyMemory.Span);
         }
 
@@ -57,7 +63,7 @@ namespace Microsoft.Data
             {
                 if (index > Length)
                     throw new ArgumentOutOfRangeException(nameof(index));
-                return ReadOnlySpan[index];
+                return RawReadOnlySpan[index];
             }
             set => throw new NotSupportedException();
         }

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ALCProxy.Proxy\ALCProxy.Proxy.csproj" />
+    <ProjectReference Include="..\..\src\Microsoft.Data\Microsoft.Data.DataFrame.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Experimental.Collections\Microsoft.Experimental.Collections.csproj" />
     <ProjectReference Include="..\..\src\System.Azure.Experimental\System.Azure.Experimental.csproj" />
     <ProjectReference Include="..\..\src\System.Binary.Base64\System.Binary.Base64.csproj" />

--- a/tests/Benchmarks/Microsoft.Data.DataFrame/DataFrameBinaryOps.cs
+++ b/tests/Benchmarks/Microsoft.Data.DataFrame/DataFrameBinaryOps.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Data;
+
+namespace Benchmarks.Microsoft.Data
+{
+    public class DataFrameBinaryOps
+    {
+        private DataFrame _dataFrame;
+        private BaseColumn _column;
+        private BaseColumn _other;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _dataFrame = new DataFrame();
+            _column = new PrimitiveColumn<int>("Int0", Enumerable.Range(0, 50000));
+            _other = _column.Clone();
+            _dataFrame.InsertColumn(0, _column);
+        }
+
+        [Benchmark]
+        public BaseColumn Add()
+        {
+            return _column.Add(_other);
+        }
+
+        [Benchmark]
+        public BaseColumn AddValue()
+        {
+            return _column.Add(10);
+        }
+
+        // The other APIs follow the exact same code as Add, except with the appropriate op. Doesn't make sense to benchmark them too
+    }
+}

--- a/tests/Benchmarks/Microsoft.Data.DataFrame/DataFrameComputations.cs
+++ b/tests/Benchmarks/Microsoft.Data.DataFrame/DataFrameComputations.cs
@@ -1,0 +1,80 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Data;
+
+namespace Benchmarks.Microsoft.Data
+{
+    public class DataFrameComputations
+    {
+        private DataFrame _dataFrame;
+        private BaseColumn _column0;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _dataFrame = new DataFrame();
+            _column0 = new PrimitiveColumn<int>("Int0", Enumerable.Range(0, 50000));
+            _dataFrame.InsertColumn(0, _column0);
+        }
+
+        [Benchmark]
+        public object Sum()
+        {
+            return _column0.Sum();
+        }
+
+        [Benchmark]
+        public object Product()
+        {
+            return _column0.Product();
+        }
+
+        [Benchmark]
+        public object Max()
+        {
+            return _column0.Max();
+        }
+
+        [Benchmark]
+        public object Min()
+        {
+            return _column0.Min();
+        }
+
+        [Benchmark]
+        public void Abs()
+        {
+            _column0.Abs();
+        }
+
+        [Benchmark]
+        public void CumulativeMax()
+        {
+            _column0.CumulativeMax();
+        }
+
+        [Benchmark]
+        public void CumulativeMin()
+        {
+            _column0.CumulativeMin();
+        }
+
+        [Benchmark]
+        public void CumulativeSum()
+        {
+            _column0.CumulativeSum();
+        }
+
+        [Benchmark]
+        public void CumulativeProduct()
+        {
+            _column0.CumulativeProduct();
+        }
+
+
+    }
+}

--- a/tests/Benchmarks/Microsoft.Data.DataFrame/DataFrameComputations.cs
+++ b/tests/Benchmarks/Microsoft.Data.DataFrame/DataFrameComputations.cs
@@ -74,7 +74,5 @@ namespace Benchmarks.Microsoft.Data
         {
             _column0.CumulativeProduct();
         }
-
-
     }
 }

--- a/tests/Benchmarks/Microsoft.Data.DataFrame/DataFrameComputations.cs
+++ b/tests/Benchmarks/Microsoft.Data.DataFrame/DataFrameComputations.cs
@@ -28,21 +28,9 @@ namespace Benchmarks.Microsoft.Data
         }
 
         [Benchmark]
-        public object Product()
-        {
-            return _column0.Product();
-        }
-
-        [Benchmark]
         public object Max()
         {
             return _column0.Max();
-        }
-
-        [Benchmark]
-        public object Min()
-        {
-            return _column0.Min();
         }
 
         [Benchmark]
@@ -58,21 +46,9 @@ namespace Benchmarks.Microsoft.Data
         }
 
         [Benchmark]
-        public void CumulativeMin()
-        {
-            _column0.CumulativeMin();
-        }
-
-        [Benchmark]
         public void CumulativeSum()
         {
             _column0.CumulativeSum();
-        }
-
-        [Benchmark]
-        public void CumulativeProduct()
-        {
-            _column0.CumulativeProduct();
         }
     }
 }

--- a/tests/Benchmarks/Microsoft.Data.DataFrame/DataFrameFunctions.cs
+++ b/tests/Benchmarks/Microsoft.Data.DataFrame/DataFrameFunctions.cs
@@ -1,0 +1,134 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using JsonBenchmarks;
+using Microsoft.Data;
+
+namespace Benchmarks.Microsoft.Data
+{
+    public class DataFrameFunctions
+    {
+        private DataFrame _dataFrame;
+        private BaseColumn _column;
+        private BaseColumn _string;
+        private BaseColumn _bool;
+
+        private DataFrame _otherDataFrame;
+        private BaseColumn _otherColumn;
+        private BaseColumn _otherString;
+        private BaseColumn _otherBool;
+
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            int length = 50000;
+            _dataFrame = new DataFrame();
+            _column = new PrimitiveColumn<int>("Int0", Enumerable.Range(0, length));
+            _string = new StringColumn("String", Enumerable.Range(0, length).Select(x => x.ToString()));
+            _bool = new PrimitiveColumn<bool>("Bool", Enumerable.Range(0, length).Select(x => x % 2 == 0 ? true : false));
+            _dataFrame.InsertColumn(0, _column);
+            _dataFrame.InsertColumn(1, _string);
+            _dataFrame.InsertColumn(2, _bool);
+
+            _otherDataFrame = new DataFrame();
+            _otherColumn = new PrimitiveColumn<int>("Int0", Enumerable.Range(0, length/2));
+            _otherString = new StringColumn("String", Enumerable.Range(0, length/2).Select(x => x.ToString()));
+            _otherBool = new PrimitiveColumn<bool>("Bool", Enumerable.Range(0, length/2).Select(x => x % 2 == 0 ? true : false));
+            _otherDataFrame.InsertColumn(0, _otherColumn);
+            _otherDataFrame.InsertColumn(1, _otherString);
+            _otherDataFrame.InsertColumn(2, _otherBool);
+            
+        }
+
+        [Benchmark]
+        public void ColumnIndexer()
+        {
+            for (long i = 0; i < _column.Length; i++)
+            {
+                _column[i] = _column[i];
+            }
+        }
+
+        [Benchmark]
+        public BaseColumn ColumnSort()
+        {
+            return _column.Sort(false);
+        }
+
+        [Benchmark]
+        public DataFrame Sort()
+        {
+            return _dataFrame.Sort("Int0", false);
+        }
+
+        [Benchmark]
+        public DataFrame Clip()
+        {
+            return _dataFrame.Clip(10000, 40000);
+        }
+
+        [Benchmark]
+        public GroupBy GroupBy()
+        {
+            return _dataFrame.GroupBy("Bool");
+        }
+
+        [Benchmark]
+        public BaseColumn ColumnFillNulls()
+        {
+            return _column.FillNulls(5);
+        }
+
+        [Benchmark]
+        public DataFrame LeftJoin()
+        {
+            return _dataFrame.Join(_otherDataFrame);
+        }
+
+        [Benchmark]
+        public DataFrame RightJoin()
+        {
+            return _dataFrame.Join(_otherDataFrame, joinAlgorithm: JoinAlgorithm.Right);
+        }
+
+        [Benchmark]
+        public DataFrame OuterJoin()
+        {
+            return _dataFrame.Join(_otherDataFrame, joinAlgorithm: JoinAlgorithm.FullOuter);
+        }
+
+        [Benchmark]
+        public DataFrame InnerJoin()
+        {
+            return _dataFrame.Join(_otherDataFrame, joinAlgorithm: JoinAlgorithm.Inner);
+        }
+
+        [Benchmark]
+        public DataFrame LeftMerge()
+        {
+            return _dataFrame.Merge<int>(_otherDataFrame, "Int0", "Int0");
+        }
+
+        [Benchmark]
+        public DataFrame RightMerge()
+        {
+            return _dataFrame.Merge<int>(_otherDataFrame, "Int0", "Int0", joinAlgorithm: JoinAlgorithm.Right);
+        }
+
+        [Benchmark]
+        public DataFrame OuterMerge()
+        {
+            return _dataFrame.Merge<int>(_otherDataFrame, "Int0", "Int0", joinAlgorithm: JoinAlgorithm.FullOuter);
+        }
+
+        [Benchmark]
+        public DataFrame InnerMerge()
+        {
+            return _dataFrame.Merge<int>(_otherDataFrame, "Int0", "Int0", joinAlgorithm: JoinAlgorithm.Inner);
+        }
+    }
+}

--- a/tests/Benchmarks/Microsoft.Data.DataFrame/DataFrameFunctions.cs
+++ b/tests/Benchmarks/Microsoft.Data.DataFrame/DataFrameFunctions.cs
@@ -4,7 +4,6 @@
 
 using System.Linq;
 using BenchmarkDotNet.Attributes;
-using JsonBenchmarks;
 using Microsoft.Data;
 
 namespace Benchmarks.Microsoft.Data

--- a/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
@@ -978,6 +978,9 @@ namespace Microsoft.Data.Tests
 
             DataFrame sum = df.GroupBy("Bool").Sum();
             Assert.Equal(2, sum.RowCount);
+
+            DataFrame mean = df.GroupBy("Bool").Mean();
+            Assert.Equal(2, mean.RowCount);
             for (int r = 0; r < 2; r++)
             {
                 for (int c = 0; c < count.ColumnCount; c++)
@@ -995,6 +998,15 @@ namespace Microsoft.Data.Tests
                     Assert.Equal("20", sumColumn[r].ToString());
                 }
             }
+
+            DataFrame columnSum = df.GroupBy("Bool").Sum("Int");
+            Assert.Equal(2, columnSum.ColumnCount);
+            DataFrame columnMax = df.GroupBy("Bool").Max("Int");
+            Assert.Equal(2, columnMax.ColumnCount);
+            DataFrame columnProduct = df.GroupBy("Bool").Product("Int");
+            Assert.Equal(2, columnProduct.ColumnCount);
+            DataFrame columnMin = df.GroupBy("Bool").Min("Int");
+            Assert.Equal(2, columnMin.ColumnCount);
         }
 
         [Fact]

--- a/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
@@ -1001,12 +1001,20 @@ namespace Microsoft.Data.Tests
 
             DataFrame columnSum = df.GroupBy("Bool").Sum("Int");
             Assert.Equal(2, columnSum.ColumnCount);
+            Assert.Equal(20, columnSum["Int"][0]);
+            Assert.Equal(20, columnSum["Int"][1]);
             DataFrame columnMax = df.GroupBy("Bool").Max("Int");
             Assert.Equal(2, columnMax.ColumnCount);
+            Assert.Equal(8, columnMax["Int"][0]);
+            Assert.Equal(9, columnMax["Int"][1]);
             DataFrame columnProduct = df.GroupBy("Bool").Product("Int");
             Assert.Equal(2, columnProduct.ColumnCount);
+            Assert.Equal(0, columnProduct["Int"][0]);
+            Assert.Equal(0, columnProduct["Int"][1]);
             DataFrame columnMin = df.GroupBy("Bool").Min("Int");
             Assert.Equal(2, columnMin.ColumnCount);
+            Assert.Equal(0, columnMin["Int"][0]);
+            Assert.Equal(0, columnMin["Int"][1]);
         }
 
         [Fact]


### PR DESCRIPTION
More work towards dotnet/corefx#26845

Added benchmarks for BinaryOps, Computations, Indexing, Sort, GroupBy, Joins and Merges
Perf improvements in GroupBy and Computations.
Minor API additions in GroupBy to enable the benchmarks

I decided to bundle the benchmarks and perf improvements together here because the perf improvement changes are straightforward. 