### PR TITLE
Perf improvements in Clone, Sort, Merge and ReadCsv

### DIFF
--- a/src/Microsoft.Data/ArrowStringColumn.cs
+++ b/src/Microsoft.Data/ArrowStringColumn.cs
@@ -322,6 +322,7 @@ namespace Microsoft.Data
             }
             return ret;
         }
+
         private ArrowStringColumn CloneImplementation<U>(PrimitiveColumn<U> mapIndices, bool invertMapIndices = false)
             where U : unmanaged
         {
@@ -359,10 +360,6 @@ namespace Microsoft.Data
 
         private ArrowStringColumn Clone(PrimitiveColumn<int> mapIndices, bool invertMapIndex = false)
         {
-            long? ConvertInt(long index)
-            {
-                return mapIndices[index];
-            }
             return CloneImplementation(mapIndices, invertMapIndex);
         }
 

--- a/src/Microsoft.Data/ArrowStringColumn.cs
+++ b/src/Microsoft.Data/ArrowStringColumn.cs
@@ -291,8 +291,6 @@ namespace Microsoft.Data
                 Type dataType = mapIndices.DataType;
                 if (dataType != typeof(long) && dataType != typeof(int) && dataType != typeof(bool))
                     throw new ArgumentException(String.Format(Strings.MultipleMismatchedValueType, typeof(long), typeof(int), typeof(bool)), nameof(mapIndices));
-                if (mapIndices.Length > Length)
-                    throw new ArgumentException(Strings.MapIndicesExceedsColumnLenth, nameof(mapIndices));
                 if (mapIndices.DataType == typeof(long))
                     clone = Clone(mapIndices as PrimitiveColumn<long>, invertMapIndices);
                 else if (dataType == typeof(int))
@@ -324,27 +322,23 @@ namespace Microsoft.Data
             }
             return ret;
         }
-
-        private ArrowStringColumn CloneImplementation(BaseColumn mapIndices, Func<long, long?> getIndex, bool invertMapIndices = false)
+        private ArrowStringColumn CloneImplementation<U>(PrimitiveColumn<U> mapIndices, bool invertMapIndices = false)
+            where U : unmanaged
         {
             ArrowStringColumn ret = new ArrowStringColumn(Name);
-            if (mapIndices.Length > Length)
-                throw new ArgumentException(Strings.MapIndicesExceedsColumnLenth, nameof(mapIndices));
-            if (invertMapIndices == false)
+            mapIndices.ApplyElementwise((U? mapIndex, long rowIndex) =>
             {
-                for (long i = 0; i < mapIndices.Length; i++)
+                if (mapIndex == null)
                 {
-                    ret.Append(GetBytes(getIndex(i).Value));
+                    ret.Append(default);
+                    return mapIndex;
                 }
-            }
-            else
-            {
-                long mapIndicesLengthIndex = mapIndices.Length - 1;
-                for (long i = 0; i < mapIndices.Length; i++)
-                {
-                    ret.Append(GetBytes(getIndex(mapIndicesLengthIndex - i).Value));
-                }
-            }
+                if (invertMapIndices)
+                    ret.Append(GetBytes(mapIndices.Length - 1 - rowIndex));
+                else
+                    ret.Append(GetBytes(rowIndex));
+                return mapIndex;
+            });
             return ret;
         }
 
@@ -360,7 +354,7 @@ namespace Microsoft.Data
                 return ret;
             }
             else
-                return CloneImplementation(mapIndices, mapIndices.GetTypedValue, invertMapIndex);
+                return CloneImplementation(mapIndices, invertMapIndex);
         }
 
         private ArrowStringColumn Clone(PrimitiveColumn<int> mapIndices, bool invertMapIndex = false)
@@ -369,7 +363,7 @@ namespace Microsoft.Data
             {
                 return mapIndices[index];
             }
-            return CloneImplementation(mapIndices, ConvertInt, invertMapIndex);
+            return CloneImplementation(mapIndices, invertMapIndex);
         }
 
         public override DataFrame ValueCounts()

--- a/src/Microsoft.Data/DataFrame.IO.cs
+++ b/src/Microsoft.Data/DataFrame.IO.cs
@@ -127,23 +127,28 @@ namespace Microsoft.Data
             using (var st = createStream())
             {
                 string line = st.ReadLine();
-                int nbline = 0;
-                while (line != null && (numRows == -1 || rowline < numRows))
+                long nbline = 0;
+                while (line != null)
                 {
-                    var spl = line.Split(separator);
-                    if (header && nbline == 0)
+                    if ((numRows == -1) || rowline < numRows)
                     {
-                        if (columnNames == null)
-                            columnNames = spl;
-                    }
-                    else
-                    {
-                        ++rowline;
                         if (linesForGuessType.Count < guessRows)
                         {
-                            linesForGuessType.Add(spl);
-                            numberOfColumns = Math.Max(numberOfColumns, spl.Length);
+                            var spl = line.Split(separator);
+                            if (header && nbline == 0)
+                            {
+                                if (columnNames == null)
+                                    columnNames = spl;
+                            }
+                            else
+                            {
+                                ++rowline;
+                                linesForGuessType.Add(spl);
+                                numberOfColumns = Math.Max(numberOfColumns, spl.Length);
+                            }
                         }
+                        else
+                            ++rowline;
                     }
                     ++nbline;
                     line = st.ReadLine();
@@ -161,17 +166,17 @@ namespace Microsoft.Data
                 Type kind = GuessKind(i, linesForGuessType);
                 if (kind == typeof(bool))
                 {
-                    BaseColumn boolColumn = new PrimitiveColumn<bool>(columnNames[i]);
+                    BaseColumn boolColumn = new PrimitiveColumn<bool>(columnNames[i], rowline);
                     columns.Add(boolColumn);
                 }
                 else if (kind == typeof(float))
                 {
-                    BaseColumn floatColumn = new PrimitiveColumn<float>(columnNames[i]);
+                    BaseColumn floatColumn = new PrimitiveColumn<float>(columnNames[i], rowline);
                     columns.Add(floatColumn);
                 }
                 else if (kind == typeof(string))
                 {
-                    BaseColumn stringColumn = new StringColumn(columnNames[i], 0);
+                    BaseColumn stringColumn = new StringColumn(columnNames[i], rowline);
                     columns.Add(stringColumn);
                 }
                 else
@@ -218,7 +223,6 @@ namespace Microsoft.Data
             for (int i = 0; i < columns.Count; i++)
             {
                 BaseColumn column = columns[i];
-                column.Resize(rowIndex + 1);
                 string val = values[i];
                 Type dType = column.DataType;
                 if (dType == typeof(bool))

--- a/src/Microsoft.Data/DataFrame.IO.cs
+++ b/src/Microsoft.Data/DataFrame.IO.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Data
                                 bool addIndexColumn = false)
         {
             return ReadStream(() => new StreamReader(filename),
-                              separator: separator, header: header, columnNames: columnNames, dataTypes: dataTypes, numRows: numRows,
+                              separator: separator, header: header, columnNames: columnNames, dataTypes: dataTypes, numberOfRowsToRead: numRows,
                               guessRows: guessRows, addIndexColumn: addIndexColumn);
         }
 
@@ -110,47 +110,48 @@ namespace Microsoft.Data
         /// <param name="header">has a header or not</param>
         /// <param name="columnNames">column names (can be empty)</param>
         /// <param name="dataTypes">column types (can be empty)</param>
-        /// <param name="numRows">number of rows to read</param>
+        /// <param name="numberOfRowsToRead">number of rows to read not including the header(if present)</param>
         /// <param name="guessRows">number of rows used to guess types</param>
         /// <param name="addIndexColumn">add one column with the row index</param>
         /// <returns>DataFrame</returns>
         public static DataFrame ReadStream(Func<StreamReader> createStream,
                                 char separator = ',', bool header = true,
                                 string[] columnNames = null, Type[] dataTypes = null,
-                                long numRows = -1, int guessRows = 10, bool addIndexColumn = false)
+                                long numberOfRowsToRead = -1, int guessRows = 10, bool addIndexColumn = false)
         {
             var linesForGuessType = new List<string[]>();
             long rowline = 0;
             int numberOfColumns = 0;
 
+            if (header == true && numberOfRowsToRead != -1)
+                numberOfRowsToRead++;
+
             // First pass: schema and number of rows.
             using (var st = createStream())
             {
                 string line = st.ReadLine();
-                long nbline = 0;
                 while (line != null)
                 {
-                    if ((numRows == -1) || rowline < numRows)
+                    if ((numberOfRowsToRead == -1) || rowline < numberOfRowsToRead)
                     {
                         if (linesForGuessType.Count < guessRows)
                         {
                             var spl = line.Split(separator);
-                            if (header && nbline == 0)
+                            if (header && rowline == 0)
                             {
                                 if (columnNames == null)
                                     columnNames = spl;
                             }
                             else
                             {
-                                ++rowline;
                                 linesForGuessType.Add(spl);
                                 numberOfColumns = Math.Max(numberOfColumns, spl.Length);
                             }
                         }
-                        else
-                            ++rowline;
                     }
-                    ++nbline;
+                    ++rowline;
+                    if (rowline == numberOfRowsToRead)
+                        break;
                     line = st.ReadLine();
                 }
             }
@@ -166,17 +167,17 @@ namespace Microsoft.Data
                 Type kind = GuessKind(i, linesForGuessType);
                 if (kind == typeof(bool))
                 {
-                    BaseColumn boolColumn = new PrimitiveColumn<bool>(columnNames[i], rowline);
+                    BaseColumn boolColumn = new PrimitiveColumn<bool>(columnNames == null ? "Column" + i.ToString() : columnNames[i], header == true ? rowline - 1 : rowline);
                     columns.Add(boolColumn);
                 }
                 else if (kind == typeof(float))
                 {
-                    BaseColumn floatColumn = new PrimitiveColumn<float>(columnNames[i], rowline);
+                    BaseColumn floatColumn = new PrimitiveColumn<float>(columnNames == null ? "Column" + i.ToString() : columnNames[i], header == true ? rowline - 1 : rowline);
                     columns.Add(floatColumn);
                 }
                 else if (kind == typeof(string))
                 {
-                    BaseColumn stringColumn = new StringColumn(columnNames[i], rowline);
+                    BaseColumn stringColumn = new StringColumn(columnNames == null ? "Column" + i.ToString() : columnNames[i], header == true ? rowline - 1 : rowline);
                     columns.Add(stringColumn);
                 }
                 else
@@ -187,21 +188,19 @@ namespace Microsoft.Data
             using (StreamReader st = createStream())
             {
                 string line = st.ReadLine();
-                long nbline = 0;
                 rowline = 0;
-                while (line != null && (numRows == -1 || rowline < numRows))
+                while (line != null && (numberOfRowsToRead == -1 || rowline < numberOfRowsToRead))
                 {
                     var spl = line.Split(separator);
-                    if (header && nbline == 0)
+                    if (header && rowline == 0)
                     {
                         // Skips.
                     }
                     else
                     {
-                        AppendRow(columns, rowline, spl);
-                        ++rowline;
+                        AppendRow(columns, header == true ? rowline - 1 : rowline, spl);
                     }
-                    ++nbline;
+                    ++rowline;
                     line = st.ReadLine();
                 }
             }

--- a/src/Microsoft.Data/DataFrame.Join.cs
+++ b/src/Microsoft.Data/DataFrame.Join.cs
@@ -149,6 +149,8 @@ namespace Microsoft.Data
         {
             // A simple hash join 
             DataFrame ret = new DataFrame();
+            DataFrame leftDataFrame = this;
+            DataFrame rightDataFrame = other;
 
             // The final table size is not known until runtime 
             long rowNumber = 0;
@@ -197,16 +199,6 @@ namespace Microsoft.Data
                         rightRowIndices.Append(null);
                     }
                 }
-                for (int i = 0; i < ColumnCount; i++)
-                {
-                    ret.InsertColumn(i, Column(i).Clone(leftRowIndices));
-                }
-                for (int i = 0; i < other.ColumnCount; i++)
-                {
-                    BaseColumn column = other.Column(i).Clone(rightRowIndices);
-                    SetSuffixForDuplicatedColumnNames(ret, column, leftSuffix, rightSuffix);
-                    ret.InsertColumn(ret.ColumnCount, column);
-                }
             }
             else if (joinAlgorithm == JoinAlgorithm.Right)
             {
@@ -245,16 +237,6 @@ namespace Microsoft.Data
                         leftRowIndices.Append(null);
                         rightRowIndices.Append(i);
                     }
-                }
-                for (int i = 0; i < ColumnCount; i++)
-                {
-                    ret.InsertColumn(i, Column(i).Clone(leftRowIndices));
-                }
-                for (int i = 0; i < other.ColumnCount; i++)
-                {
-                    BaseColumn column = other.Column(i).Clone(rightRowIndices);
-                    SetSuffixForDuplicatedColumnNames(ret, column, leftSuffix, rightSuffix);
-                    ret.InsertColumn(ret.ColumnCount, column);
                 }
             }
             else if (joinAlgorithm == JoinAlgorithm.Inner)
@@ -295,16 +277,8 @@ namespace Microsoft.Data
                         }
                     }
                 }
-                for (int i = 0; i < shorterDataFrame.ColumnCount; i++)
-                {
-                    ret.InsertColumn(i, shorterDataFrame.Column(i).Clone(leftRowIndices));
-                }
-                for (int i = 0; i < longerDataFrame.ColumnCount; i++)
-                {
-                    BaseColumn column = longerDataFrame.Column(i).Clone(rightRowIndices);
-                    SetSuffixForDuplicatedColumnNames(ret, column, leftSuffix, rightSuffix);
-                    ret.InsertColumn(ret.ColumnCount, column);
-                }
+                leftDataFrame = shorterDataFrame;
+                rightDataFrame = longerDataFrame;
             }
             else if (joinAlgorithm == JoinAlgorithm.FullOuter)
             {
@@ -366,16 +340,19 @@ namespace Microsoft.Data
                         rightRowIndices.Append(i);
                     }
                 }
-                for (int i = 0; i < ColumnCount; i++)
-                {
-                    ret.InsertColumn(i, Column(i).Clone(leftRowIndices));
-                }
-                for (int i = 0; i < other.ColumnCount; i++)
-                {
-                    BaseColumn column = other.Column(i).Clone(rightRowIndices);
-                    SetSuffixForDuplicatedColumnNames(ret, column, leftSuffix, rightSuffix);
-                    ret.InsertColumn(ret.ColumnCount, column);
-                }
+            }
+            else
+                throw new NotImplementedException(nameof(joinAlgorithm));
+
+            for (int i = 0; i < leftDataFrame.ColumnCount; i++)
+            {
+                ret.InsertColumn(i, leftDataFrame.Column(i).Clone(leftRowIndices));
+            }
+            for (int i = 0; i < rightDataFrame.ColumnCount; i++)
+            {
+                BaseColumn column = rightDataFrame.Column(i).Clone(rightRowIndices);
+                SetSuffixForDuplicatedColumnNames(ret, column, leftSuffix, rightSuffix);
+                ret.InsertColumn(ret.ColumnCount, column);
             }
             return ret;
         }

--- a/src/Microsoft.Data/PrimitiveColumn.Sort.cs
+++ b/src/Microsoft.Data/PrimitiveColumn.Sort.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Data
                 List<int> nonNullSortIndices = new List<int>();
                 for (int i = 0; i < sortIndices.Length; i++)
                 {
-                    if (_columnContainer.IsValid(ref nullBitMapSpan, sortIndices[i]))
+                    if (_columnContainer.IsValid(nullBitMapSpan, sortIndices[i]))
                         nonNullSortIndices.Add(sortIndices[i]);
 
                 }
@@ -57,10 +57,10 @@ namespace Microsoft.Data
                 ReadOnlyMemory<T> typedBuffer = Unsafe.As<ReadOnlyMemory<byte>, ReadOnlyMemory<T>>(ref buffer);
                 if (!typedBuffer.IsEmpty)
                 {
-                    bool isArray = MemoryMarshal.TryGetArray(typedBuffer, out ArraySegment<T> array);
+                    bool isArray = MemoryMarshal.TryGetArray(typedBuffer, out ArraySegment<T> arraySegment);
                     if (isArray)
                     {
-                        value = array.Array[index];
+                        value = arraySegment.Array[index + arraySegment.Offset];
                     }
                     else
                         value = _columnContainer.Buffers[bufferIndex][index];

--- a/src/Microsoft.Data/PrimitiveColumn.Sort.cs
+++ b/src/Microsoft.Data/PrimitiveColumn.Sort.cs
@@ -64,7 +64,6 @@ namespace Microsoft.Data
                     }
                     else
                         value = _columnContainer.Buffers[bufferIndex][index];
-
                 }
                 else
                 {

--- a/src/Microsoft.Data/PrimitiveColumn.cs
+++ b/src/Microsoft.Data/PrimitiveColumn.cs
@@ -324,7 +324,8 @@ namespace Microsoft.Data
             return ret;
         }
 
-        private PrimitiveColumn<T> CloneImplementation(BaseColumn mapIndices, Func<long, long?> getIndex, bool invertMapIndices = false)
+        private PrimitiveColumn<T> CloneImplementation<U>(PrimitiveColumn<U> mapIndices, Func<long, long?> getIndex, bool invertMapIndices = false)
+            where U : unmanaged
         {
             if (!mapIndices.IsNumericColumn())
                 throw new ArgumentException(String.Format(Strings.MismatchedValueType, Strings.NumericColumnType), nameof(mapIndices));
@@ -332,29 +333,82 @@ namespace Microsoft.Data
             if (mapIndices.Length > Length)
                 throw new ArgumentException(Strings.MapIndicesExceedsColumnLenth, nameof(mapIndices));
 
+            ReadOnlySpan<T> thisSpan = _columnContainer.Buffers[0].ReadOnlySpan;
+            long minRange = 0;
+            long maxRange = DataFrameBuffer<T>.MaxCapacity;
+            long maxCapacity = maxRange;
             PrimitiveColumn<T> ret = new PrimitiveColumn<T>(Name, mapIndices.Length);
             ret._columnContainer._modifyNullCountWhileIndexing = false;
-            if (invertMapIndices == false)
+            for (int b = 0; b < mapIndices._columnContainer.Buffers.Count; b++)
             {
-                for (long i = 0; i < mapIndices.Length; i++)
+                int index = b;
+                if (invertMapIndices)
+                    index = mapIndices._columnContainer.Buffers.Count - 1 - b;
+
+                ReadOnlyDataFrameBuffer<U> buffer = mapIndices._columnContainer.Buffers[index];
+                ReadOnlySpan<U> mapIndicesSpan = buffer.ReadOnlySpan;
+                ReadOnlySpan<long> mapIndicesLongSpan = default;
+                ReadOnlySpan<int> mapIndicesIntSpan = default;
+                Span<T> retSpan = DataFrameBuffer<T>.GetMutableBuffer(ret._columnContainer.Buffers[index]).Span;
+                if (mapIndices.DataType == typeof(long))
                 {
-                    T? value = _columnContainer[getIndex(i).Value];
-                    ret[i] = value;
-                    if (!value.HasValue)
+                    mapIndicesLongSpan = MemoryMarshal.Cast<U, long>(mapIndicesSpan);
+                }
+                if (mapIndices.DataType == typeof(int))
+                {
+                    mapIndicesIntSpan = MemoryMarshal.Cast<U, int>(mapIndicesSpan);
+                }
+                for (int i = 0; i < buffer.Length; i++)
+                {
+                    int spanIndex = i;
+                    if (invertMapIndices)
+                        spanIndex = buffer.Length - 1 - i;
+
+                    long rowIndex = mapIndicesIntSpan.IsEmpty ? mapIndicesLongSpan[spanIndex] : mapIndicesIntSpan[spanIndex];
+                    if (rowIndex < minRange || rowIndex >= maxRange)
+                    {
+                        int bufferIndex = (int)(rowIndex / maxCapacity);
+                        thisSpan = _columnContainer.Buffers[bufferIndex].ReadOnlySpan;
+                        minRange = bufferIndex * maxCapacity;
+                        maxRange = (bufferIndex + 1) * maxCapacity;
+                    }
+                    rowIndex -= minRange;
+                    T value = thisSpan[(int)rowIndex];
+                    bool isValid = IsValid(rowIndex);
+                    retSpan[i] = isValid ? value : default;
+                    if (!isValid)
+                    {
                         ret._columnContainer.NullCount++;
+                        ret._columnContainer.SetValidityBit(rowIndex, false);
+                    }
+                    else
+                    {
+                        ret._columnContainer.SetValidityBit(rowIndex, true);
+                    }
                 }
             }
-            else
-            {
-                long mapIndicesIndex = mapIndices.Length - 1;
-                for (long i = 0; i < mapIndices.Length; i++)
-                {
-                    T? value = _columnContainer[getIndex(mapIndicesIndex - i).Value];
-                    ret[i] = value;
-                    if (!value.HasValue)
-                        ret._columnContainer.NullCount++;
-                }
-            }
+            //if (invertMapIndices == false)
+            //{
+            //    for (long i = 0; i < mapIndices.Length; i++)
+            //    {
+            //        T? value = _columnContainer[getIndex(i).Value];
+            //        ret[i] = value;
+            //        if (!value.HasValue)
+            //            ret._columnContainer.NullCount++;
+            //    }
+
+            //}
+            //else
+            //{
+            //    long mapIndicesIndex = mapIndices.Length - 1;
+            //    for (long i = 0; i < mapIndices.Length; i++)
+            //    {
+            //        T? value = _columnContainer[getIndex(mapIndicesIndex - i).Value];
+            //        ret[i] = value;
+            //        if (!value.HasValue)
+            //            ret._columnContainer.NullCount++;
+            //    }
+            //}
             ret._columnContainer._modifyNullCountWhileIndexing = true;
             return ret;
         }

--- a/src/Microsoft.Data/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data/PrimitiveColumnContainer.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Data
                 for (int i = 0; i < span.Length; i++)
                 {
                     long curIndex = i + prevLength;
-                    bool isValid = IsValid(ref nullBitMapSpan, i);
+                    bool isValid = IsValid(nullBitMapSpan, i);
                     T? value = func(isValid ? span[i] : default(T?), curIndex);
                     span[i] = value.GetValueOrDefault();
                     SetValidityBit(nullBitMapSpan, i, value != null);
@@ -204,15 +204,7 @@ namespace Microsoft.Data
         }
 
         // Faster to use when we already have a span since it avoids indexing
-        public bool IsValid(ref Span<byte> bitMapBufferSpan, int index)
-        {
-            int nullBitMapSpanIndex = index / 8;
-            byte thisBitMap = bitMapBufferSpan[nullBitMapSpanIndex];
-            return IsBitSet(thisBitMap, index);
-        }
-
-        // Faster to use when we already have a span since it avoids indexing
-        public bool IsValid(ref ReadOnlySpan<byte> bitMapBufferSpan, int index)
+        public bool IsValid(ReadOnlySpan<byte> bitMapBufferSpan, int index)
         {
             int nullBitMapSpanIndex = index / 8;
             byte thisBitMap = bitMapBufferSpan[nullBitMapSpanIndex];
@@ -477,7 +469,7 @@ namespace Microsoft.Data
                         spanIndex = buffer.Length - 1 - i;
 
                     long mapRowIndex = mapIndicesIntSpan.IsEmpty ? mapIndicesLongSpan[spanIndex] : mapIndicesIntSpan[spanIndex];
-                    bool mapRowIndexIsValid = mapIndices.IsValid(ref mapIndicesNullBitMapSpan, spanIndex);
+                    bool mapRowIndexIsValid = mapIndices.IsValid(mapIndicesNullBitMapSpan, spanIndex);
                     if (mapRowIndexIsValid && (mapRowIndex < minRange || mapRowIndex >= maxRange))
                     {
                         int bufferIndex = (int)(mapRowIndex / maxCapacity);
@@ -492,7 +484,7 @@ namespace Microsoft.Data
                     {
                         mapRowIndex -= minRange;
                         value = thisSpan[(int)mapRowIndex];
-                        isValid = IsValid(ref thisNullBitMapSpan, (int)mapRowIndex);
+                        isValid = IsValid(thisNullBitMapSpan, (int)mapRowIndex);
                     }
 
                     retSpan[i] = isValid ? value : default;

--- a/src/Microsoft.Data/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data/PrimitiveColumnContainer.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Data
         /// </summary>
         /// <param name="index"></param>
         /// <param name="value"></param>
-        private void SetValidityBit(long index, bool value)
+        internal void SetValidityBit(long index, bool value)
         {
             if ((ulong)index > (ulong)Length)
             {

--- a/src/Microsoft.Data/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data/PrimitiveColumnContainer.cs
@@ -191,7 +191,7 @@ namespace Microsoft.Data
                 long prevLength = checked(Buffers[0].Length * b);
                 DataFrameBuffer<T> mutableBuffer = DataFrameBuffer<T>.GetMutableBuffer(buffer);
                 Span<T> span = mutableBuffer.Span;
-                Span<byte> nullBitMapSpan = DataFrameBuffer<byte>.GetMutableBuffer(NullBitMapBuffers[b]).Span;
+                Span<byte> nullBitMapSpan = DataFrameBuffer<byte>.GetMutableBuffer(NullBitMapBuffers[b]).RawSpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     long curIndex = i + prevLength;
@@ -283,7 +283,7 @@ namespace Microsoft.Data
             Debug.Assert(bitMapBuffer.Length >= bitMapBufferIndex);
             if (bitMapBuffer.Length == bitMapBufferIndex)
                 bitMapBuffer.Append(0);
-            SetValidityBit(bitMapBuffer.Span, (int)index, value);
+            SetValidityBit(bitMapBuffer.RawSpan, (int)index, value);
         }
 
         private bool IsBitSet(byte curBitMap, int index)
@@ -443,7 +443,7 @@ namespace Microsoft.Data
             where U : unmanaged
         {
             ReadOnlySpan<T> thisSpan = Buffers[0].ReadOnlySpan;
-            ReadOnlySpan<byte> thisNullBitMapSpan = NullBitMapBuffers[0].ReadOnlySpan;
+            ReadOnlySpan<byte> thisNullBitMapSpan = NullBitMapBuffers[0].RawReadOnlySpan;
             long minRange = 0;
             long maxRange = DataFrameBuffer<T>.MaxCapacity;
             long maxCapacity = maxRange;
@@ -456,12 +456,12 @@ namespace Microsoft.Data
                     index = mapIndices.Buffers.Count - 1 - b;
 
                 ReadOnlyDataFrameBuffer<U> buffer = mapIndices.Buffers[index];
-                ReadOnlySpan<byte> mapIndicesNullBitMapSpan = mapIndices.NullBitMapBuffers[index].ReadOnlySpan;
+                ReadOnlySpan<byte> mapIndicesNullBitMapSpan = mapIndices.NullBitMapBuffers[index].RawReadOnlySpan;
                 ReadOnlySpan<U> mapIndicesSpan = buffer.ReadOnlySpan;
                 ReadOnlySpan<long> mapIndicesLongSpan = default;
                 ReadOnlySpan<int> mapIndicesIntSpan = default;
                 Span<T> retSpan = DataFrameBuffer<T>.GetMutableBuffer(ret.Buffers[index]).Span;
-                Span<byte> retNullBitMapSpan = DataFrameBuffer<byte>.GetMutableBuffer(ret.NullBitMapBuffers[index]).Span;
+                Span<byte> retNullBitMapSpan = DataFrameBuffer<byte>.GetMutableBuffer(ret.NullBitMapBuffers[index]).RawSpan;
                 if (type == typeof(long))
                 {
                     mapIndicesLongSpan = MemoryMarshal.Cast<U, long>(mapIndicesSpan);

--- a/src/Microsoft.Data/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data/PrimitiveColumnContainer.cs
@@ -192,10 +192,9 @@ namespace Microsoft.Data
                 DataFrameBuffer<T> mutableBuffer = DataFrameBuffer<T>.GetMutableBuffer(buffer);
                 Span<T> span = mutableBuffer.Span;
                 Span<byte> nullBitMapSpan = DataFrameBuffer<byte>.GetMutableBuffer(NullBitMapBuffers[b]).Span;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     long curIndex = i + prevLength;
-                    //this[curIndex] = func(IsValid(curIndex) ? span[i] : default(T?), curIndex);
                     bool isValid = IsValid(ref nullBitMapSpan, i);
                     T? value = func(isValid ? span[i] : default(T?), curIndex);
                     span[i] = value.GetValueOrDefault();
@@ -515,7 +514,7 @@ namespace Microsoft.Data
                 ret.Buffers.Add(newBuffer);
                 ReadOnlySpan<T> span = buffer.ReadOnlySpan;
                 ret.Length += buffer.Length;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     newBuffer.Append(span[i]);
                 }
@@ -552,7 +551,7 @@ namespace Microsoft.Data
                 ret.Buffers.Add(newBuffer);
                 newBuffer.EnsureCapacity(buffer.Length);
                 ReadOnlySpan<T> span = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     newBuffer.Append(DoubleConverter<T>.Instance.GetDouble(span[i]));
                 }
@@ -572,7 +571,7 @@ namespace Microsoft.Data
                 ret.Buffers.Add(newBuffer);
                 newBuffer.EnsureCapacity(buffer.Length);
                 ReadOnlySpan<T> span = buffer.ReadOnlySpan;
-                for (int i = 0; i < buffer.Length; i++)
+                for (int i = 0; i < span.Length; i++)
                 {
                     newBuffer.Append(DecimalConverter<T>.Instance.GetDecimal(span[i]));
                 }

--- a/src/Microsoft.Data/StringColumn.cs
+++ b/src/Microsoft.Data/StringColumn.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.ML;
 using Microsoft.ML.Data;
 
@@ -339,7 +340,9 @@ namespace Microsoft.Data
                 });
             }
             else
-                throw new NotImplementedException(nameof(mapIndices.DataType));
+            {
+                Debug.Assert(false, nameof(mapIndices.DataType));
+            }
 
             return ret;
         }

--- a/tests/Microsoft.Data.DataFrame.Tests/DataFrame.IOTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/DataFrame.IOTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.Tests
     public partial class DataFrameTests
     {
         [Fact]
-        public void TestReadCsv()
+        public void TestReadCsvWithHeader()
         {
             string data = @"vendor_id,rate_code,passenger_count,trip_time_in_secs,trip_distance,payment_type,fare_amount
 CMT,1,1,1271,3.8,CRD,17.5
@@ -29,6 +29,34 @@ CMT,1,1,181,0.6,CSH,4.5";
             Assert.Equal(4, df.RowCount);
             Assert.Equal(7, df.ColumnCount);
             Assert.Equal("CMT", df["vendor_id"][3]);
+
+            DataFrame reducedRows = DataFrame.ReadStream(() => new StreamReader(GetStream(data)), numberOfRowsToRead: 3);
+            Assert.Equal(3, reducedRows.RowCount);
+            Assert.Equal(7, reducedRows.ColumnCount);
+            Assert.Equal("CMT", reducedRows["vendor_id"][2]);
+        }
+
+        [Fact]
+        public void TestReadCsvNoHeader()
+        {
+            string data = @"CMT,1,1,1271,3.8,CRD,17.5
+CMT,1,1,474,1.5,CRD,8
+CMT,1,1,637,1.4,CRD,8.5
+CMT,1,1,181,0.6,CSH,4.5";
+
+            Stream GetStream(string data)
+            {
+                return new MemoryStream(Encoding.Default.GetBytes(data));
+            }
+            DataFrame df = DataFrame.ReadStream(() => new StreamReader(GetStream(data)), header: false);
+            Assert.Equal(4, df.RowCount);
+            Assert.Equal(7, df.ColumnCount);
+            Assert.Equal("CMT", df["Column0"][3]);
+
+            DataFrame reducedRows = DataFrame.ReadStream(() => new StreamReader(GetStream(data)), header: false, numberOfRowsToRead: 3);
+            Assert.Equal(3, reducedRows.RowCount);
+            Assert.Equal(7, reducedRows.ColumnCount);
+            Assert.Equal("CMT", reducedRows["Column0"][2]);
         }
     }
 }

--- a/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
@@ -1383,6 +1383,45 @@ namespace Microsoft.Data.Tests
         }
 
         [Fact]
+        public void TestApplyElementwiseNullCount()
+        {
+            DataFrame df = MakeDataFrameWithTwoColumns(10);
+            PrimitiveColumn<int> column = df["Int1"] as PrimitiveColumn<int>;
+            Assert.Equal(1, column.NullCount);
+
+            // Change all existing values to null
+            column.ApplyElementwise((int? value, long rowIndex) =>
+            {
+                if (!(value is null))
+                    return null;
+                return value;
+            });
+            Assert.Equal(column.Length, column.NullCount);
+
+            // Don't change null values
+            column.ApplyElementwise((int? value, long rowIndex) =>
+            {
+                return value;
+            });
+            Assert.Equal(column.Length, column.NullCount);
+
+            // Change all null values to real values
+            column.ApplyElementwise((int? value, long rowIndex) =>
+            {
+                return 5;
+            });
+            Assert.Equal(0, column.NullCount);
+
+            // Don't change real values
+            column.ApplyElementwise((int? value, long rowIndex) =>
+            {
+                return value;
+            });
+            Assert.Equal(0, column.NullCount);
+
+        }
+
+        [Fact]
         public void TestClone()
         {
             DataFrame df = MakeDataFrameWithAllColumnTypes(10, withNulls: false);


### PR DESCRIPTION
Perf work towards dotnet/corefx#26845. 

Most of the changes are related to caching the Span<T> instead of randomly accessing Memory<T> every iteration. Some algorithms(for ex: Merge) need random access, so there's not much we can do there.