### PR TITLE
APIs to get at the underlying buffers

### DIFF
--- a/src/Microsoft.Data/ArrowStringColumn.cs
+++ b/src/Microsoft.Data/ArrowStringColumn.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Data
         /// <summary>
         /// Returns an enumerable of immutable ReadOnlyMemory<byte> buffers representing null values in the Apache Arrow format
         /// </summary>
-        /// <remarks>Each ReadOnlyMemory<byte> encodes the null values for its corresponding Data buffer</remarks>
+        /// <remarks>Each ReadOnlyMemory<byte> encodes the indices of null values in its corresponding Data buffer</remarks>
         /// <returns>IEnumerable<ReadOnlyMemory<byte>></returns>
         public IEnumerable<ReadOnlyMemory<byte>> GetReadOnlyNullBitMapBuffers()
         {
@@ -153,7 +153,7 @@ namespace Microsoft.Data
 
         /// <summary>
         /// Returns an enumerable of immutable ReadOnlyMemory<int> representing offsets into its corresponding Data buffer.
-        /// The Apache Arrow format specifies how the offset buffer encodes the length of each string in the Data buffer
+        /// The Apache Arrow format specifies how the offset buffer encodes the length of each value in the Data buffer
         /// </summary>
         /// <returns>IEnumerable<ReadOnlyMemory<int>></returns>
         public IEnumerable<ReadOnlyMemory<int>> GetReadOnlyOffsetsBuffers()

--- a/src/Microsoft.Data/ArrowStringColumn.cs
+++ b/src/Microsoft.Data/ArrowStringColumn.cs
@@ -214,12 +214,12 @@ namespace Microsoft.Data
             return ret;
         }
 
-        protected override void SetValue(long rowIndex, object value) => throw new NotSupportedException(Strings.ImmutableStringColumn);
+        protected override void SetValue(long rowIndex, object value) => throw new NotSupportedException(Strings.ImmutableColumn);
 
         public new string this[long rowIndex]
         {
             get => GetValueImplementation(rowIndex);
-            set => throw new NotSupportedException(Strings.ImmutableStringColumn);
+            set => throw new NotSupportedException(Strings.ImmutableColumn);
         }
 
         public new List<string> this[long startIndex, int length]

--- a/src/Microsoft.Data/ArrowStringColumn.cs
+++ b/src/Microsoft.Data/ArrowStringColumn.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Apache.Arrow;
@@ -129,9 +128,7 @@ namespace Microsoft.Data
             for (int i = 0; i < _dataBuffers.Count; i++)
             {
                 ReadOnlyDataFrameBuffer<byte> buffer = _dataBuffers[i];
-                ReadOnlyMemory<byte> data = buffer.ReadOnlyMemory;
-
-                yield return data;
+                yield return buffer.RawReadOnlyMemory;
             }
         }
 
@@ -145,9 +142,7 @@ namespace Microsoft.Data
             for (int i = 0; i < _nullBitMapBuffers.Count; i++)
             {
                 ReadOnlyDataFrameBuffer<byte> buffer = _nullBitMapBuffers[i];
-                ReadOnlyMemory<byte> nullBitMap = buffer.ReadOnlyMemory;
-
-                yield return nullBitMap;
+                yield return buffer.RawReadOnlyMemory;
             }
         }
 
@@ -161,9 +156,7 @@ namespace Microsoft.Data
             for (int i = 0; i < _offsetsBuffers.Count; i++)
             {
                 ReadOnlyDataFrameBuffer<int> buffer = _offsetsBuffers[i];
-                ReadOnlyMemory<byte> offsetBuffer = buffer.ReadOnlyMemory;
-
-                yield return Unsafe.As<ReadOnlyMemory<byte>, ReadOnlyMemory<int>>(ref offsetBuffer).Slice(0, buffer.Length);
+                yield return buffer.ReadOnlyMemory;
             }
         }
 
@@ -324,9 +317,9 @@ namespace Microsoft.Data
             {
                 throw new ArgumentException(Strings.SpansMultipleBuffers, nameof(numberOfRows));
             }
-            ArrowBuffer dataBuffer = numberOfRows == 0 ? ArrowBuffer.Empty : new ArrowBuffer(_dataBuffers[offsetsBufferIndex].ReadOnlyMemory);
-            ArrowBuffer offsetsBuffer = numberOfRows == 0 ? ArrowBuffer.Empty : new ArrowBuffer(_offsetsBuffers[offsetsBufferIndex].ReadOnlyMemory);
-            ArrowBuffer nullBuffer = numberOfRows == 0 ? ArrowBuffer.Empty : new ArrowBuffer(_nullBitMapBuffers[offsetsBufferIndex].ReadOnlyMemory);
+            ArrowBuffer dataBuffer = numberOfRows == 0 ? ArrowBuffer.Empty : new ArrowBuffer(_dataBuffers[offsetsBufferIndex].ReadOnlyBuffer);
+            ArrowBuffer offsetsBuffer = numberOfRows == 0 ? ArrowBuffer.Empty : new ArrowBuffer(_offsetsBuffers[offsetsBufferIndex].ReadOnlyBuffer);
+            ArrowBuffer nullBuffer = numberOfRows == 0 ? ArrowBuffer.Empty : new ArrowBuffer(_nullBitMapBuffers[offsetsBufferIndex].ReadOnlyBuffer);
             int nullCount = GetNullCount(indexInBuffer, numberOfRows);
             return new StringArray(numberOfRows, offsetsBuffer, dataBuffer, nullBuffer, nullCount, indexInBuffer);
         }

--- a/src/Microsoft.Data/DataFrameBuffer.cs
+++ b/src/Microsoft.Data/DataFrameBuffer.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Data
     {
         private Memory<byte> _memory;
 
-        public override ReadOnlyMemory<byte> ReadOnlyMemory => _memory;
+        public override ReadOnlyMemory<byte> ReadOnlyBuffer => _memory;
 
-        public Memory<byte> Memory
+        public Memory<byte> Buffer
         {
             get => _memory;
         }
@@ -27,13 +27,13 @@ namespace Microsoft.Data
         public Span<T> Span
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => (MemoryMarshal.Cast<byte, T>(Memory.Span)).Slice(0, Length);
+            get => (MemoryMarshal.Cast<byte, T>(Buffer.Span)).Slice(0, Length);
         }
 
         public Span<T> RawSpan
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => MemoryMarshal.Cast<byte, T>(Memory.Span);
+            get => MemoryMarshal.Cast<byte, T>(Buffer.Span);
         }
 
         public DataFrameBuffer(int numberOfValues = 8) : base(numberOfValues) { }
@@ -66,7 +66,7 @@ namespace Microsoft.Data
 
             if (newLength > Capacity)
             {
-                var newCapacity = Math.Max(newLength * Size, ReadOnlyMemory.Length * 2);
+                var newCapacity = Math.Max(newLength * Size, ReadOnlyBuffer.Length * 2);
                 var memory = new Memory<byte>(new byte[newCapacity]);
                 _memory.CopyTo(memory);
                 _memory = memory;
@@ -88,7 +88,7 @@ namespace Microsoft.Data
             DataFrameBuffer<T> mutableBuffer = buffer as DataFrameBuffer<T>;
             if (mutableBuffer == null)
             {
-                mutableBuffer = new DataFrameBuffer<T>(buffer.ReadOnlyMemory, buffer.Length);
+                mutableBuffer = new DataFrameBuffer<T>(buffer.ReadOnlyBuffer, buffer.Length);
                 mutableBuffer.Length = buffer.Length;
             }
             return mutableBuffer;

--- a/src/Microsoft.Data/PrimitiveColumn.Sort.cs
+++ b/src/Microsoft.Data/PrimitiveColumn.Sort.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Data
             {
                 int index = bufferSortIndices[bufferIndex][startIndex];
                 T value;
-                ReadOnlyMemory<byte> buffer = _columnContainer.Buffers[bufferIndex].ReadOnlyMemory;
+                ReadOnlyMemory<byte> buffer = _columnContainer.Buffers[bufferIndex].ReadOnlyBuffer;
                 ReadOnlyMemory<T> typedBuffer = Unsafe.As<ReadOnlyMemory<byte>, ReadOnlyMemory<T>>(ref buffer);
                 if (!typedBuffer.IsEmpty)
                 {

--- a/src/Microsoft.Data/PrimitiveColumn.cs
+++ b/src/Microsoft.Data/PrimitiveColumn.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Data
         }
 
         /// <summary>
-        /// Returns a mutable memory buffer representing the underlying values
+        /// Returns an enumerable of mutable memory buffers representing the underlying values
         /// </summary>
         /// <remarks>Null values are represented as default(T)</remarks>
         /// <returns>IEnumerable<Memory<typeparamref name="T"/>></returns>
@@ -60,7 +60,7 @@ namespace Microsoft.Data
         }
 
         /// <summary>
-        /// Returns an immutable memory buffer representing the underlying values
+        /// Returns an enumerable of immutable memory buffers representing the underlying values
         /// </summary>
         /// <remarks>Null values are represented as default(T)</remarks>
         /// <returns>IEnumerable<ReadOnlyMemory<typeparamref name="T"/>></returns>

--- a/src/Microsoft.Data/PrimitiveColumn.cs
+++ b/src/Microsoft.Data/PrimitiveColumn.cs
@@ -53,9 +53,12 @@ namespace Microsoft.Data
         {
             for (int i = 0; i < _columnContainer.Buffers.Count; i++)
             {
-                DataFrameBuffer<T> buffer = DataFrameBuffer<T>.GetMutableBuffer(_columnContainer.Buffers[i]);
-                Memory<byte> memory = buffer.Memory;
-                yield return Unsafe.As<Memory<byte>, Memory<T>>(ref memory).Slice(0, buffer.Length);
+                ReadOnlyDataFrameBuffer<T> buffer = _columnContainer.Buffers[i];
+                DataFrameBuffer<T> mutableBuffer = buffer as DataFrameBuffer<T>;
+                if (mutableBuffer is null)
+                    throw new ArgumentException(Strings.ImmutableColumn);
+                Memory<byte> memory = mutableBuffer.Memory;
+                yield return Unsafe.As<Memory<byte>, Memory<T>>(ref memory).Slice(0, mutableBuffer.Length);
             }
         }
 

--- a/src/Microsoft.Data/PrimitiveColumn.cs
+++ b/src/Microsoft.Data/PrimitiveColumn.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Apache.Arrow;
 using Apache.Arrow.Types;
 using Microsoft.ML;
@@ -54,9 +53,7 @@ namespace Microsoft.Data
             for (int i = 0; i < _columnContainer.Buffers.Count; i++)
             {
                 ReadOnlyDataFrameBuffer<T> buffer = _columnContainer.Buffers[i];
-                ReadOnlyMemory<byte> readOnlyMemory = buffer.ReadOnlyMemory;
-
-                yield return Unsafe.As<ReadOnlyMemory<byte>, ReadOnlyMemory<T>>(ref readOnlyMemory).Slice(0, buffer.Length);
+                yield return buffer.ReadOnlyMemory;
             }
         }
 
@@ -70,9 +67,7 @@ namespace Microsoft.Data
             for (int i = 0; i < _columnContainer.NullBitMapBuffers.Count; i++)
             {
                 ReadOnlyDataFrameBuffer<byte> buffer = _columnContainer.NullBitMapBuffers[i];
-                ReadOnlyMemory<byte> nullBitMap = buffer.ReadOnlyMemory;
-
-                yield return nullBitMap;
+                yield return buffer.RawReadOnlyMemory;
             }
         }
 
@@ -389,10 +384,6 @@ namespace Microsoft.Data
 
         public PrimitiveColumn<T> Clone(PrimitiveColumn<int> mapIndices, bool invertMapIndices = false)
         {
-            long? ConvertInt(long index)
-            {
-                return mapIndices[index];
-            }
             return CloneImplementation(mapIndices, invertMapIndices);
         }
 

--- a/src/Microsoft.Data/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data/PrimitiveColumnContainer.cs
@@ -326,13 +326,13 @@ namespace Microsoft.Data
         internal ReadOnlyMemory<byte> GetValueBuffer(long startIndex)
         {
             int arrayIndex = GetArrayContainingRowIndex(startIndex);
-            return Buffers[arrayIndex].ReadOnlyMemory;
+            return Buffers[arrayIndex].ReadOnlyBuffer;
         }
 
         internal ReadOnlyMemory<byte> GetNullBuffer(long startIndex)
         {
             int arrayIndex = GetArrayContainingRowIndex(startIndex);
-            return NullBitMapBuffers[arrayIndex].ReadOnlyMemory;
+            return NullBitMapBuffers[arrayIndex].ReadOnlyBuffer;
         }
 
         public IList<T?> this[long startIndex, int length]

--- a/src/Microsoft.Data/StringColumn.cs
+++ b/src/Microsoft.Data/StringColumn.cs
@@ -47,6 +47,16 @@ namespace Microsoft.Data
             }
         }
 
+        public IEnumerable<IReadOnlyList<string>> GetReadOnlyBuffers()
+        {
+            foreach (List<string> buffer in _stringBuffers)
+            {
+                yield return buffer;
+            }
+        }
+
+        // Not providing a mutable GetBuffers(), since that would mean strings can be deleted from the middle of a buffer and would break internal book-keeping. 
+
         private long _nullCount;
         public override long NullCount => _nullCount;
 

--- a/src/Microsoft.Data/StringColumn.cs
+++ b/src/Microsoft.Data/StringColumn.cs
@@ -47,16 +47,6 @@ namespace Microsoft.Data
             }
         }
 
-        public IEnumerable<IReadOnlyList<string>> GetReadOnlyBuffers()
-        {
-            foreach (List<string> buffer in _stringBuffers)
-            {
-                yield return buffer;
-            }
-        }
-
-        // Not providing a mutable GetBuffers(), since that would mean strings can be deleted from the middle of a buffer and would break internal book-keeping. 
-
         private long _nullCount;
         public override long NullCount => _nullCount;
 

--- a/src/Microsoft.Data/strings.Designer.cs
+++ b/src/Microsoft.Data/strings.Designer.cs
@@ -90,9 +90,9 @@ namespace Microsoft.Data {
         /// <summary>
         ///   Looks up a localized string similar to Column is immutable.
         /// </summary>
-        public static string ImmutableStringColumn {
+        public static string ImmutableColumn {
             get {
-                return ResourceManager.GetString("ImmutableStringColumn", resourceCulture);
+                return ResourceManager.GetString("ImmutableColumn", resourceCulture);
             }
         }
         

--- a/src/Microsoft.Data/strings.resx
+++ b/src/Microsoft.Data/strings.resx
@@ -126,7 +126,7 @@
   <data name="EmptyFile" xml:space="preserve">
     <value>Empty file</value>
   </data>
-  <data name="ImmutableStringColumn" xml:space="preserve">
+  <data name="ImmutableColumn" xml:space="preserve">
     <value>Column is immutable</value>
   </data>
   <data name="InvalidColumnName" xml:space="preserve">

--- a/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
@@ -224,7 +224,6 @@ namespace Microsoft.Data.Tests
         [Fact]
         public void TestArrowStringColumnGetReadOnlyBuffers()
         {
-
             // Test ArrowStringColumn.
             StringArray strArray = new StringArray.Builder().Append("foo").Append("bar").Build();
             Memory<byte> dataMemory = new byte[] { 102, 111, 111, 98, 97, 114 };

--- a/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
@@ -175,5 +175,39 @@ namespace Microsoft.Data.Tests
             Assert.Equal(stringColumn[1], clone[1]);
         }
 
+        [Fact]
+        public void TestGetBuffers()
+        {
+            PrimitiveColumn<int> intColumn = new PrimitiveColumn<int>("Int1", Enumerable.Range(0, 10).Select(x => x));
+            intColumn[9] = null;
+            Assert.Equal(1, intColumn.NullCount);
+            IEnumerable<Memory<int>> intBuffers = intColumn.GetBuffers();
+            foreach (var buffer in intBuffers)
+            {
+                Span<int> ints = buffer.Span;
+                ints.Fill(5);
+            }
+            Assert.Equal(1, intColumn.NullCount);
+            for (int i = 0; i < intColumn.Length - 1; i++)
+            {
+                int value = intColumn[i].Value;
+                Assert.Equal(5, value);
+            }
+            Assert.Null(intColumn[9]);
+
+            StringColumn strCol = new StringColumn("String", Enumerable.Range(0, 10).Select(x => x.ToString()));
+            strCol[9] = null;
+            Assert.Equal(1, strCol.NullCount);
+            IEnumerable<IReadOnlyList<string>> buffers = strCol.GetReadOnlyBuffers();
+            foreach (var buffer in buffers)
+            {
+                for (int i = 0; i < buffer.Count - 1; i++)
+                {
+                    var str = buffer[i];
+                    Assert.Equal(str, strCol[i]);
+                }
+                Assert.Null(buffer[buffer.Count - 1]);
+            }
+        }
     }
 }

--- a/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
@@ -181,10 +181,10 @@ namespace Microsoft.Data.Tests
             PrimitiveColumn<int> intColumn = new PrimitiveColumn<int>("Int1", Enumerable.Range(0, 10).Select(x => x));
             intColumn[9] = null;
             Assert.Equal(1, intColumn.NullCount);
-            IEnumerable<Memory<int>> intBuffers = intColumn.GetBuffers();
-            foreach (var buffer in intBuffers)
+            IEnumerable<Tuple<Memory<int>, ReadOnlyMemory<byte>>> intBuffers = intColumn.GetBuffers();
+            foreach (Tuple<Memory<int>, ReadOnlyMemory<byte>> buffers in intBuffers)
             {
-                Span<int> ints = buffer.Span;
+                Span<int> ints = buffers.Item1.Span;
                 ints.Fill(5);
             }
             Assert.Equal(1, intColumn.NullCount);
@@ -198,8 +198,8 @@ namespace Microsoft.Data.Tests
             StringColumn strCol = new StringColumn("String", Enumerable.Range(0, 10).Select(x => x.ToString()));
             strCol[9] = null;
             Assert.Equal(1, strCol.NullCount);
-            IEnumerable<IReadOnlyList<string>> buffers = strCol.GetReadOnlyBuffers();
-            foreach (var buffer in buffers)
+            IEnumerable<IReadOnlyList<string>> stringBuffers = strCol.GetReadOnlyBuffers();
+            foreach (var buffer in stringBuffers)
             {
                 for (int i = 0; i < buffer.Count - 1; i++)
                 {
@@ -221,11 +221,11 @@ namespace Microsoft.Data.Tests
 
             Assert.Throws<ArgumentException>(() => column.GetBuffers().First());
 
-            IEnumerable<ReadOnlyMemory<int>> buffers = column.GetReadOnlyBuffers();
+            IEnumerable<Tuple<ReadOnlyMemory<int>, ReadOnlyMemory<byte>>> buffers = column.GetReadOnlyBuffers();
             long i = 0;
-            foreach (ReadOnlyMemory<int> buffer in buffers)
+            foreach (Tuple<ReadOnlyMemory<int>, ReadOnlyMemory<byte>> buffer in buffers)
             {
-                ReadOnlySpan<int> span = buffer.Span;
+                ReadOnlySpan<int> span = buffer.Item1.Span;
                 for (int j = 0; j < span.Length; j++)
                 {
                     // Each buffer has a max length of int.MaxValue

--- a/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
@@ -176,41 +176,6 @@ namespace Microsoft.Data.Tests
         }
 
         [Fact]
-        public void TestGetBuffers()
-        {
-            PrimitiveColumn<int> intColumn = new PrimitiveColumn<int>("Int1", Enumerable.Range(0, 10).Select(x => x));
-            intColumn[9] = null;
-            Assert.Equal(1, intColumn.NullCount);
-            IEnumerable<Tuple<Memory<int>, ReadOnlyMemory<byte>>> intBuffers = intColumn.GetBuffers();
-            foreach (Tuple<Memory<int>, ReadOnlyMemory<byte>> buffers in intBuffers)
-            {
-                Span<int> ints = buffers.Item1.Span;
-                ints.Fill(5);
-            }
-            Assert.Equal(1, intColumn.NullCount);
-            for (int i = 0; i < intColumn.Length - 1; i++)
-            {
-                int value = intColumn[i].Value;
-                Assert.Equal(5, value);
-            }
-            Assert.Null(intColumn[9]);
-
-            StringColumn strCol = new StringColumn("String", Enumerable.Range(0, 10).Select(x => x.ToString()));
-            strCol[9] = null;
-            Assert.Equal(1, strCol.NullCount);
-            IEnumerable<IReadOnlyList<string>> stringBuffers = strCol.GetReadOnlyBuffers();
-            foreach (var buffer in stringBuffers)
-            {
-                for (int i = 0; i < buffer.Count - 1; i++)
-                {
-                    var str = buffer[i];
-                    Assert.Equal(str, strCol[i]);
-                }
-                Assert.Null(buffer[buffer.Count - 1]);
-            }
-        }
-
-        [Fact]
         public void TestGetReadOnlyBuffers()
         {
             RecordBatch recordBatch = new RecordBatch.Builder()
@@ -218,8 +183,6 @@ namespace Microsoft.Data.Tests
             DataFrame df = new DataFrame(recordBatch);
 
             PrimitiveColumn<int> column = df["Column1"] as PrimitiveColumn<int>;
-
-            Assert.Throws<ArgumentException>(() => column.GetBuffers().First());
 
             IEnumerable<Tuple<ReadOnlyMemory<int>, ReadOnlyMemory<byte>>> buffers = column.GetReadOnlyBuffers();
             long i = 0;


### PR DESCRIPTION
Simple PR: 
GetBuffers and GetReadOnlyBuffers APIs on PrimitiveColumn and StringColumn to get at the underlying buffers.
There's no equivalent on ArrowStringColumn, since it stores data across 3 buffers. 