### PR TITLE
Enable Strong Naming in DataFrame library

### DIFF
--- a/src/Microsoft.Data/Microsoft.Data.DataFrame.csproj
+++ b/src/Microsoft.Data/Microsoft.Data.DataFrame.csproj
@@ -1,9 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="..\..\tools\common.props" />
+  
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- TODO: Remove this https://github.com/dotnet/corefxlab/issues/2724 -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is necessary so other strong named libraries can consume the DataFrame library.