### PR TITLE
Use Directory.Build.props instead of tools\common.props.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
-  <Import Project="dependencies.props" />
+  <Import Project="tools\dependencies.props" />
   <PropertyGroup>
+    <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
     <VersionSuffix Condition="$(VersionSuffix) == ''">$([System.DateTime]::Now.ToString(preview2-yyMMdd-1))</VersionSuffix>
     <Copyright>&#169; Microsoft Corporation. All rights reserved.</Copyright>
     <VersionPrefix>0.1.1</VersionPrefix>
@@ -13,11 +14,10 @@
     <SignAssembly>true</SignAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Key.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(RepoRoot)\tools\Key.snk</AssemblyOriginatorKeyFile>
     <LangVersion>latest</LangVersion>
     <!-- We are usually using a preview SDK -->
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-    <RepoRoot>$(MSBuildProjectDirectory)\..\..\</RepoRoot>
   </PropertyGroup>
 
   <ItemGroup>

--- a/archived_projects/src/System.CommandLine/System.CommandLine.csproj
+++ b/archived_projects/src/System.CommandLine/System.CommandLine.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>CLI commandline command parsing</Description>
     <TargetFrameworks>netstandard1.5</TargetFrameworks>

--- a/archived_projects/src/System.Drawing.Graphics/System.Drawing.Graphics.csproj
+++ b/archived_projects/src/System.Drawing.Graphics/System.Drawing.Graphics.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>CLI commandline command parsing</Description>
     <TargetFramework>netstandard1.5</TargetFramework>

--- a/archived_projects/tests/System.CommandLine.Tests/System.CommandLine.Tests.csproj
+++ b/archived_projects/tests/System.CommandLine.Tests/System.CommandLine.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>

--- a/archived_projects/tests/System.Drawing.Graphics.Tests/System.Drawing.Graphics.Tests.csproj
+++ b/archived_projects/tests/System.Drawing.Graphics.Tests/System.Drawing.Graphics.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>

--- a/samples/LibuvWithNonAllocatingFormatters/LibuvWithNonAllocatingFormatters.csproj
+++ b/samples/LibuvWithNonAllocatingFormatters/LibuvWithNonAllocatingFormatters.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/samples/LowAllocationWebServer/LowAllocationWebServer.csproj
+++ b/samples/LowAllocationWebServer/LowAllocationWebServer.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/samples/LowAllocationWebServer/LowAllocationWebServerCore/LowAllocationWebServerCore.csproj
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerCore/LowAllocationWebServerCore.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\tools\common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>

--- a/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/LowAllocationWebServerLibrary.csproj
+++ b/samples/LowAllocationWebServer/LowAllocationWebServerLibrary/LowAllocationWebServerLibrary.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/samples/QotdService/QotdService.csproj
+++ b/samples/QotdService/QotdService.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>

--- a/src/ALCProxy.Communication/ALCProxy.Communication.csproj
+++ b/src/ALCProxy.Communication/ALCProxy.Communication.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Communication layer of ALCProxy API, use this directly if making different versions of the Client/Server setup for ALCProxy.Proxy</Description>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/ALCProxy.Proxy/ALCProxy.Proxy.csproj
+++ b/src/ALCProxy.Proxy/ALCProxy.Proxy.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Main surface area of ALCProxy API, use this to create proxies across AssemblyLoadContexts</Description>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/Microsoft.Data/Microsoft.Data.DataFrame.csproj
+++ b/src/Microsoft.Data/Microsoft.Data.DataFrame.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Microsoft.Experimental.Collections/Microsoft.Experimental.Collections.csproj
+++ b/src/Microsoft.Experimental.Collections/Microsoft.Experimental.Collections.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>This package provides collections that are being considered for future versions of .NET Core.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/System.Azure.Experimental/System.Azure.Experimental.csproj
+++ b/src/System.Azure.Experimental/System.Azure.Experimental.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
 
     <!-- Platform detection -->
   <PropertyGroup>

--- a/src/System.Binary.Base64/System.Binary.Base64.csproj
+++ b/src/System.Binary.Base64/System.Binary.Base64.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Non-allocating Base64 encoder and decoded</Description>
     <TargetFramework>netstandard1.1</TargetFramework>

--- a/src/System.Buffers.Experimental/System.Buffers.Experimental.csproj
+++ b/src/System.Buffers.Experimental/System.Buffers.Experimental.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Pool of unmanaged Span&lt;byte&gt; values</Description>
     <TargetFramework>netstandard1.3</TargetFramework>

--- a/src/System.Buffers.Primitives/System.Buffers.Primitives.csproj
+++ b/src/System.Buffers.Primitives/System.Buffers.Primitives.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Slices of arrays and buffers</Description>
     <TargetFramework>netstandard1.1</TargetFramework>

--- a/src/System.Buffers.ReaderWriter/System.Buffers.ReaderWriter.csproj
+++ b/src/System.Buffers.ReaderWriter/System.Buffers.ReaderWriter.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Buffer Readers, Writers, and Transformations</Description>
     <TargetFramework>netstandard1.1</TargetFramework>

--- a/src/System.Collections.Sequences/System.Collections.Sequences.csproj
+++ b/src/System.Collections.Sequences/System.Collections.Sequences.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Non-allocating collections</Description>
     <TargetFramework>netstandard1.1</TargetFramework>

--- a/src/System.IO.FileSystem.Watcher.Polling/System.IO.FileSystem.Watcher.Polling.csproj
+++ b/src/System.IO.FileSystem.Watcher.Polling/System.IO.FileSystem.Watcher.Polling.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Polling file system watcher</Description>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/src/System.Memory.Polyfill/System.Memory.Polyfill.csproj
+++ b/src/System.Memory.Polyfill/System.Memory.Polyfill.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Adapters for Span APIs</Description>
     <TargetFrameworks>netstandard1.3;netcoreapp2.1</TargetFrameworks>

--- a/src/System.Numerics.Experimental/System.Numerics.Experimental.csproj
+++ b/src/System.Numerics.Experimental/System.Numerics.Experimental.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>Experimental numeric types.</Description>

--- a/src/System.Reflection.Metadata.Cil/System.Reflection.Metadata.Cil.csproj
+++ b/src/System.Reflection.Metadata.Cil/System.Reflection.Metadata.Cil.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>.NET Core Metadata Reader</Description>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/System.Reflection.TypeLoader/System.Reflection.TypeLoader.csproj
+++ b/src/System.Reflection.TypeLoader/System.Reflection.TypeLoader.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>.NET Core Type Loader</Description>
     <!-- System.Reflection.TypeLoader.dll has two build configurations: NetCore and NetStandard. The functional difference is that the NetCore

--- a/src/System.Security.Cryptography.Asn1.Experimental/System.Security.Cryptography.Asn1.Experimental.csproj
+++ b/src/System.Security.Cryptography.Asn1.Experimental/System.Security.Cryptography.Asn1.Experimental.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>ASN.1 BER/CER/DER Reader/Writer</Description>
     <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>

--- a/src/System.Text.CaseFolding/System.Text.CaseFolding.csproj
+++ b/src/System.Text.CaseFolding/System.Text.CaseFolding.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Unicode Case Folding.</Description>
     <Copyright>Microsoft Corporation, All rights reserved.</Copyright>

--- a/src/System.Text.Encodings.Web.Utf8/System.Text.Encodings.Web.Utf8.csproj
+++ b/src/System.Text.Encodings.Web.Utf8/System.Text.Encodings.Web.Utf8.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Provides types for encoding and escaping strings for use in JavaScript, HyperText Markup Language (HTML), and uniform resource locators (URL).</Description>
     <TargetFramework>netstandard1.1</TargetFramework>

--- a/src/System.Text.Formatting.Globalization/System.Text.Formatting.Globalization.csproj
+++ b/src/System.Text.Formatting.Globalization/System.Text.Formatting.Globalization.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>A formatting library for pl-PL</Description>
     <TargetFramework>netstandard1.3</TargetFramework>

--- a/src/System.Text.Formatting/System.Text.Formatting.csproj
+++ b/src/System.Text.Formatting/System.Text.Formatting.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Non-allocating formatting library</Description>
     <TargetFramework>netstandard1.3</TargetFramework>

--- a/src/System.Text.Http/System.Text.Http.csproj
+++ b/src/System.Text.Http/System.Text.Http.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Non-allocating HTTP parser</Description>
     <TargetFramework>netstandard1.3</TargetFramework>

--- a/src/System.Text.JsonLab.Dynamic/System.Text.JsonLab.Dynamic.csproj
+++ b/src/System.Text.JsonLab.Dynamic/System.Text.JsonLab.Dynamic.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>JSON dynamic object</Description>
     <TargetFramework>netstandard1.1</TargetFramework>

--- a/src/System.Text.JsonLab/System.Text.JsonLab.csproj
+++ b/src/System.Text.JsonLab/System.Text.JsonLab.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Non-allocating JSON reader and writer</Description>
     <TargetFramework>netstandard1.1</TargetFramework>

--- a/src/System.Text.Primitives/System.Text.Primitives.csproj
+++ b/src/System.Text.Primitives/System.Text.Primitives.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Efficient parsing, formatting, and encoding APIs</Description>
     <Copyright>Microsoft Corporation, All rights reserved.</Copyright>

--- a/src/System.Text.Utf8String/System.Text.Utf8String.csproj
+++ b/src/System.Text.Utf8String/System.Text.Utf8String.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Efficient UTF-8 String Manipulation and Storage.</Description>
     <Copyright>Microsoft Corporation, All rights reserved.</Copyright>

--- a/src/System.Time/System.Time.csproj
+++ b/src/System.Time/System.Time.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <Description>Date and Time helper classes</Description>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>

--- a/tests/ALCProxy.TestAssembly/ALCProxy.TestAssembly.csproj
+++ b/tests/ALCProxy.TestAssembly/ALCProxy.TestAssembly.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/tests/ALCProxy.TestInterface/ALCProxy.TestInterface.csproj
+++ b/tests/ALCProxy.TestInterface/ALCProxy.TestInterface.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/tests/ALCProxy.TestInterfaceUpdated/ALCProxy.TestInterfaceUpdated.csproj
+++ b/tests/ALCProxy.TestInterfaceUpdated/ALCProxy.TestInterfaceUpdated.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/tests/ALCProxy.Tests/ALCProxy.Tests.csproj
+++ b/tests/ALCProxy.Tests/ALCProxy.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>8.0</LangVersion>

--- a/tests/Benchmarks/Benchmarks.csproj
+++ b/tests/Benchmarks/Benchmarks.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>

--- a/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
@@ -74,9 +74,9 @@ namespace Microsoft.Data.Tests
             intColumn.Append(3);
             Assert.Equal(0, intColumn[0]);
             Assert.Equal(1, intColumn[1]);
-            Assert.Equal(null, intColumn[2]);
+            Assert.Null(intColumn[2]);
             Assert.Equal(2, intColumn[3]);
-            Assert.Equal(null, intColumn[4]);
+            Assert.Null(intColumn[4]);
             Assert.Equal(3, intColumn[5]);
 
         }

--- a/tests/Microsoft.Data.DataFrame.Tests/DataFrame.IOTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/DataFrame.IOTests.cs
@@ -21,9 +21,9 @@ CMT,1,1,474,1.5,CRD,8
 CMT,1,1,637,1.4,CRD,8.5
 CMT,1,1,181,0.6,CSH,4.5";
 
-            Stream GetStream(string data)
+            Stream GetStream(string streamData)
             {
-                return new MemoryStream(Encoding.Default.GetBytes(data));
+                return new MemoryStream(Encoding.Default.GetBytes(streamData));
             }
             DataFrame df = DataFrame.ReadStream(() => new StreamReader(GetStream(data)));
             Assert.Equal(4, df.RowCount);
@@ -44,9 +44,9 @@ CMT,1,1,474,1.5,CRD,8
 CMT,1,1,637,1.4,CRD,8.5
 CMT,1,1,181,0.6,CSH,4.5";
 
-            Stream GetStream(string data)
+            Stream GetStream(string streamData)
             {
-                return new MemoryStream(Encoding.Default.GetBytes(data));
+                return new MemoryStream(Encoding.Default.GetBytes(streamData));
             }
             DataFrame df = DataFrame.ReadStream(() => new StreamReader(GetStream(data)), header: false);
             Assert.Equal(4, df.RowCount);

--- a/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
@@ -1020,9 +1020,9 @@ namespace Microsoft.Data.Tests
         [Fact]
         public void TestGoupByDifferentColumnTypes()
         {
-            void GroupCountAndAssert(DataFrame df)
+            void GroupCountAndAssert(DataFrame frame)
             {
-                DataFrame grouped = df.GroupBy("Column1").Count();
+                DataFrame grouped = frame.GroupBy("Column1").Count();
                 Assert.Equal(2, grouped.RowCount);
             }
 

--- a/tests/Microsoft.Experimental.Collections.Tests/Microsoft.Experimental.Collections.Tests.csproj
+++ b/tests/Microsoft.Experimental.Collections.Tests/Microsoft.Experimental.Collections.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyOriginatorKeyFile>../../tools/test_key.snk</AssemblyOriginatorKeyFile>

--- a/tests/System.Azure.Experimental.Tests/System.Azure.Experimental.Tests.csproj
+++ b/tests/System.Azure.Experimental.Tests/System.Azure.Experimental.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Binary.Base64.Tests/System.Binary.Base64.Tests.csproj
+++ b/tests/System.Binary.Base64.Tests/System.Binary.Base64.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Buffers.Experimental.Tests/System.Buffers.Experimental.Tests.csproj
+++ b/tests/System.Buffers.Experimental.Tests/System.Buffers.Experimental.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Buffers.Primitives.Tests/System.Buffers.Primitives.Tests.csproj
+++ b/tests/System.Buffers.Primitives.Tests/System.Buffers.Primitives.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Buffers.ReaderWriter.Tests/System.Buffers.ReaderWriter.Tests.csproj
+++ b/tests/System.Buffers.ReaderWriter.Tests/System.Buffers.ReaderWriter.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Collections.Sequences.Tests/System.Collections.Sequences.Tests.csproj
+++ b/tests/System.Collections.Sequences.Tests/System.Collections.Sequences.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>

--- a/tests/System.IO.FileSystem.Watcher.Polling.Tests/System.IO.FileSystem.Watcher.Polling.Tests.csproj
+++ b/tests/System.IO.FileSystem.Watcher.Polling.Tests/System.IO.FileSystem.Watcher.Polling.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>

--- a/tests/System.Memory.Polyfill.Tests/System.Memory.Polyfill.Tests.csproj
+++ b/tests/System.Memory.Polyfill.Tests/System.Memory.Polyfill.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>

--- a/tests/System.Numerics.Experimental.Tests/System.Numerics.Experimental.Tests.csproj
+++ b/tests/System.Numerics.Experimental.Tests/System.Numerics.Experimental.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Reflection.Metadata.Cil.Tests/System.Reflection.Metadata.Cil.Tests.csproj
+++ b/tests/System.Reflection.Metadata.Cil.Tests/System.Reflection.Metadata.Cil.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>

--- a/tests/System.Reflection.TypeLoader.Tests/System.Reflection.TypeLoader.Tests.csproj
+++ b/tests/System.Reflection.TypeLoader.Tests/System.Reflection.TypeLoader.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Security.Cryptography.Asn1.Experimental.Tests/System.Security.Cryptography.Asn1.Experimental.Tests.csproj
+++ b/tests/System.Security.Cryptography.Asn1.Experimental.Tests/System.Security.Cryptography.Asn1.Experimental.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Text.CaseFolding.Tests/System.Text.CaseFolding.Tests.csproj
+++ b/tests/System.Text.CaseFolding.Tests/System.Text.CaseFolding.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Text.Encodings.Web.Utf8.Tests/System.Text.Encodings.Web.Utf8.Tests.csproj
+++ b/tests/System.Text.Encodings.Web.Utf8.Tests/System.Text.Encodings.Web.Utf8.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>

--- a/tests/System.Text.Formatting.Globalization.Tests/System.Text.Formatting.Globalization.Tests.csproj
+++ b/tests/System.Text.Formatting.Globalization.Tests/System.Text.Formatting.Globalization.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>

--- a/tests/System.Text.Formatting.Tests/System.Text.Formatting.Tests.csproj
+++ b/tests/System.Text.Formatting.Tests/System.Text.Formatting.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Text.Http.Tests/System.Text.Http.Tests.csproj
+++ b/tests/System.Text.Http.Tests/System.Text.Http.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Text.JsonLab.Dynamic.Tests/System.Text.JsonLab.Dynamic.Tests.csproj
+++ b/tests/System.Text.JsonLab.Dynamic.Tests/System.Text.JsonLab.Dynamic.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Text.JsonLab.Tests/System.Text.JsonLab.Tests.csproj
+++ b/tests/System.Text.JsonLab.Tests/System.Text.JsonLab.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Text.Primitives.Tests/System.Text.Primitives.Tests.csproj
+++ b/tests/System.Text.Primitives.Tests/System.Text.Primitives.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Text.Utf8String.Tests/System.Text.Utf8String.Tests.csproj
+++ b/tests/System.Text.Utf8String.Tests/System.Text.Utf8String.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/tests/System.Time.Tests/System.Time.Tests.csproj
+++ b/tests/System.Time.Tests/System.Time.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\tools\common.props" />
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>


### PR DESCRIPTION
This ensures new projects get the global settings by default.