### PR TITLE
AppendRow and fix NullCount bugs

### DIFF
--- a/src/Microsoft.Data/BaseColumn.cs
+++ b/src/Microsoft.Data/BaseColumn.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Data
         /// Called internally from Merge and GroupBy. Resizes the column to the specified length to allow setting values by indexing
         /// </summary>
         /// <param name="length"></param>
-        public virtual void Resize(long length) => throw new NotImplementedException();
+        protected internal virtual void Resize(long length) => throw new NotImplementedException();
 
         /// <summary>
         /// Clone column to produce a copy potentially changing the order by supplying mapIndices and an invert flag
@@ -164,6 +164,23 @@ namespace Microsoft.Data
         public virtual double Median() => throw new NotImplementedException();
 
         /// <summary>
+        /// Returns a DataFrame with a concise summary of this column
+        /// </summary>
+        public virtual DataFrame Info()
+        {
+            DataFrame ret = new DataFrame();
+            StringColumn infoColumn = new StringColumn("Info", 0);
+            infoColumn.Append("DataType");
+            infoColumn.Append("Length");
+            StringColumn dataColumn = new StringColumn(Name, 0);
+            dataColumn.Append(DataType.ToString());
+            dataColumn.Append((Length - NullCount).ToString() + " non-null values");
+            ret.InsertColumn(0, infoColumn);
+            ret.InsertColumn(1, dataColumn);
+            return ret;
+        }
+
+        /// <summary>
         /// Used to exclude columns from the Description method
         /// </summary>
         public virtual bool HasDescription() => false;
@@ -172,6 +189,10 @@ namespace Microsoft.Data
         /// Returns a DataFrame with statistics that describe the column
         /// </summary>
         public virtual DataFrame Description() => throw new NotImplementedException();
+
+        public override bool Equals(object obj) => ReferenceEquals(this, obj);
+
+        public override int GetHashCode() => base.GetHashCode();
 
         internal virtual BaseColumn GetAscendingSortIndices() => throw new NotImplementedException();
 

--- a/src/Microsoft.Data/BaseColumn.cs
+++ b/src/Microsoft.Data/BaseColumn.cs
@@ -166,18 +166,12 @@ namespace Microsoft.Data
         /// <summary>
         /// Returns a DataFrame with a concise summary of this column
         /// </summary>
-        public virtual DataFrame Info()
+        public virtual void Info(DataFrame dataFrame)
         {
-            DataFrame ret = new DataFrame();
-            StringColumn infoColumn = new StringColumn("Info", 0);
-            infoColumn.Append("DataType");
-            infoColumn.Append("Length");
-            StringColumn dataColumn = new StringColumn(Name, 0);
-            dataColumn.Append(DataType.ToString());
-            dataColumn.Append((Length - NullCount).ToString() + " non-null values");
-            ret.InsertColumn(0, infoColumn);
-            ret.InsertColumn(1, dataColumn);
-            return ret;
+            StringColumn dataColumn = new StringColumn(Name, 2);
+            dataColumn[0] = DataType.ToString();
+            dataColumn[1] = (Length - NullCount).ToString() + " non-null values";
+            dataFrame.InsertColumn(dataFrame.ColumnCount, dataColumn);
         }
 
         /// <summary>
@@ -189,10 +183,6 @@ namespace Microsoft.Data
         /// Returns a DataFrame with statistics that describe the column
         /// </summary>
         public virtual DataFrame Description() => throw new NotImplementedException();
-
-        public override bool Equals(object obj) => ReferenceEquals(this, obj);
-
-        public override int GetHashCode() => base.GetHashCode();
 
         internal virtual BaseColumn GetAscendingSortIndices() => throw new NotImplementedException();
 

--- a/src/Microsoft.Data/DataFrame.IO.cs
+++ b/src/Microsoft.Data/DataFrame.IO.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Data
                             column[rowIndex] = null;
                             continue;
                         }
-                        throw new ArgumentException(Strings.MismatchedValueType + typeof(bool), nameof(val));
+                        throw new ArgumentException(string.Format(Strings.MismatchedValueType, typeof(bool)), nameof(val));
                     }
                 }
                 else if (dType == typeof(float))
@@ -257,7 +257,7 @@ namespace Microsoft.Data
                             column[rowIndex] = null;
                             continue;
                         }
-                        throw new ArgumentException(Strings.MismatchedValueType + typeof(float), nameof(val));
+                        throw new ArgumentException(string.Format(Strings.MismatchedValueType, typeof(float)), nameof(val));
                     }
                 }
                 else if (dType == typeof(string))

--- a/src/Microsoft.Data/DataFrame.Join.cs
+++ b/src/Microsoft.Data/DataFrame.Join.cs
@@ -244,9 +244,9 @@ namespace Microsoft.Data
                 // Hash the column with the smaller RowCount 
                 long leftRowCount = RowCount;
                 long rightRowCount = other.RowCount;
-                DataFrame longerDataFrame = leftRowCount < rightRowCount ? other : this;
+                DataFrame longerDataFrame = leftRowCount <= rightRowCount ? other : this;
                 DataFrame shorterDataFrame = ReferenceEquals(longerDataFrame, this) ? other : this;
-                BaseColumn hashColumn = (leftRowCount < rightRowCount) ? this[leftJoinColumn] : other[rightJoinColumn];
+                BaseColumn hashColumn = (leftRowCount <= rightRowCount) ? this[leftJoinColumn] : other[rightJoinColumn];
                 BaseColumn otherColumn = ReferenceEquals(hashColumn, this[leftJoinColumn]) ? other[rightJoinColumn] : this[leftJoinColumn];
                 Dictionary<TKey, ICollection<long>> multimap = hashColumn.GroupColumnValues<TKey>();
 

--- a/src/Microsoft.Data/DataFrame.cs
+++ b/src/Microsoft.Data/DataFrame.cs
@@ -568,9 +568,16 @@ namespace Microsoft.Data
         /// <summary>
         /// Appends a row inplace to the DataFrame
         /// </summary>
-        /// <remarks>If a row value doesn't match its column's data type, a conversion will be attempted</remarks>
+        /// <remarks>If a column value doesn't match its column's data type, a conversion will be attempted</remarks>
         /// <param name="row"></param>
         public void Append(IEnumerable<object> row) => _table.Append(row);
+
+        /// <summary>
+        /// Appends a row inplace by enumerating column names and values from <paramref name="row"/>
+        /// </summary>
+        /// <remarks>If a column value doesn't match its column's data type, a conversion will be attempted</remarks>
+        /// <param name="row"></param>
+        public void Append(IEnumerable<KeyValuePair<string, object>> row) => _table.Append(row);
 
         /// <summary>
         /// Invalidates any cached data after a column has changed.

--- a/src/Microsoft.Data/DataFrame.cs
+++ b/src/Microsoft.Data/DataFrame.cs
@@ -207,19 +207,6 @@ namespace Microsoft.Data
             }
         }
 
-        public IList<string> ColumnTypes
-        {
-            get
-            {
-                var ret = new List<string>(ColumnCount);
-                for (int i = 0; i < ColumnCount; i++)
-                {
-                    ret.Add(_table.Column(i).DataType.ToString());
-                }
-                return ret;
-            }
-        }
-
         public BaseColumn Column(int index) => _table.Column(index);
 
         public void InsertColumn(int columnIndex, BaseColumn column)
@@ -345,18 +332,18 @@ namespace Microsoft.Data
         public DataFrame Info()
         {
             DataFrame ret = new DataFrame();
-            if (ColumnCount == 0)
-                return ret;
 
             for (int i = 0; i < ColumnCount; i++)
             {
                 BaseColumn column = Column(i);
-                DataFrame columnInfo = column.Info();
                 if (i == 0)
-                    ret = columnInfo;
-                else
-                    ret = ret.Merge<string>(columnInfo, "Info", "Info", "_left", "_right", joinAlgorithm: JoinAlgorithm.Inner);
-                RemoveRightAndRenameLeftColumn(ret, "Info", "_left", "_right");
+                {
+                    StringColumn strColumn = new StringColumn("Info", 2);
+                    strColumn[0] = "DataType";
+                    strColumn[1] = "Length";
+                    ret.InsertColumn(0, strColumn);
+                }
+                column.Info(ret);
             }
             return ret;
         }

--- a/src/Microsoft.Data/DataFrameBuffer.cs
+++ b/src/Microsoft.Data/DataFrameBuffer.cs
@@ -77,9 +77,10 @@ namespace Microsoft.Data
         {
             set
             {
-                if (index > Length)
+                var rawSpan = RawSpan;
+                if (index > rawSpan.Length)
                     throw new ArgumentOutOfRangeException(nameof(index));
-                RawSpan[index] = value;
+                rawSpan[index] = value;
             }
         }
 

--- a/src/Microsoft.Data/DataFrameTable.cs
+++ b/src/Microsoft.Data/DataFrameTable.cs
@@ -138,39 +138,74 @@ namespace Microsoft.Data
             }
         }
 
+        private void ResizeByOneAndAppend(BaseColumn column, object value)
+        {
+            long length = column.Length;
+            column.Resize(length + 1);
+            column[length] = value;
+        }
+
         public void Append(IEnumerable<object> row)
         {
             IEnumerator<BaseColumn> columnEnumerator = _columns.GetEnumerator();
-            IEnumerator<object> rowEnumerator = row.GetEnumerator();
             bool columnMoveNext = columnEnumerator.MoveNext();
-            bool rowMoveNext = rowEnumerator.MoveNext();
-            while (columnMoveNext && rowMoveNext)
+            if (row != null)
             {
-                BaseColumn column = columnEnumerator.Current;
-                object value = rowEnumerator.Current ?? null;
-                if (value != null)
+                IEnumerator<object> rowEnumerator = row.GetEnumerator();
+                bool rowMoveNext = rowEnumerator.MoveNext();
+                while (columnMoveNext && rowMoveNext)
                 {
-                    value = Convert.ChangeType(value, column.DataType);
-                    if (value is null)
-                        throw new ArgumentException(string.Format(Strings.MismatchedValueType, column.DataType), value.GetType().ToString());
+                    BaseColumn column = columnEnumerator.Current;
+                    object value = rowEnumerator.Current ?? null;
+                    if (value != null)
+                    {
+                        value = Convert.ChangeType(value, column.DataType);
+                        if (value is null)
+                            throw new ArgumentException(string.Format(Strings.MismatchedValueType, column.DataType), value.GetType().ToString());
+                    }
+                    ResizeByOneAndAppend(column, value);
+                    columnMoveNext = columnEnumerator.MoveNext();
+                    rowMoveNext = rowEnumerator.MoveNext();
                 }
-                long length = column.Length;
-                column.Resize(length + 1);
-                column[length] = value;
-                columnMoveNext = columnEnumerator.MoveNext();
-                rowMoveNext = rowEnumerator.MoveNext();
             }
             while (columnMoveNext)
             {
                 // Fill the remaining columns with null
                 BaseColumn column = columnEnumerator.Current;
-                long length = column.Length;
-                column.Resize(length + 1);
-                column[length] = null;
+                ResizeByOneAndAppend(column, null);
                 columnMoveNext = columnEnumerator.MoveNext();
             }
             RowCount++;
+        }
 
+        public void Append(IEnumerable<KeyValuePair<string, object>> row)
+        {
+            if (row != null)
+            {
+                foreach (KeyValuePair<string, object> columnAndValue in row)
+                {
+                    string columnName = columnAndValue.Key;
+                    bool valid = _columnNameToIndexDictionary.TryGetValue(columnName, out int columnIndex);
+                    if (!valid)
+                        throw new ArgumentException(Strings.InvalidColumnName, nameof(columnName));
+
+                    BaseColumn column = Column(columnIndex);
+                    object value = columnAndValue.Value;
+                    if (value != null)
+                    {
+                        value = Convert.ChangeType(value, column.DataType);
+                        if (value is null)
+                            throw new ArgumentException(string.Format(Strings.MismatchedValueType, column.DataType), value.GetType().ToString());
+                    }
+                    ResizeByOneAndAppend(column, value);
+                }
+            }
+            foreach (BaseColumn column in _columns)
+            {
+                if (column.Length == RowCount)
+                    ResizeByOneAndAppend(column, null);
+            }
+            RowCount++;
         }
 
         public int GetColumnIndex(string columnName)

--- a/src/Microsoft.Data/DataFrameTable.cs
+++ b/src/Microsoft.Data/DataFrameTable.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Data
                 while (columnMoveNext && rowMoveNext)
                 {
                     BaseColumn column = columnEnumerator.Current;
-                    object value = rowEnumerator.Current ?? null;
+                    object value = rowEnumerator.Current;
                     if (value != null)
                     {
                         value = Convert.ChangeType(value, column.DataType);

--- a/src/Microsoft.Data/PrimitiveColumn.cs
+++ b/src/Microsoft.Data/PrimitiveColumn.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Data
             }
             else
             {
-                throw new ArgumentException(Strings.MismatchedValueType + $" {DataType.ToString()}", nameof(value));
+                throw new ArgumentException(string.Format(Strings.MismatchedValueType, DataType), nameof(value));
             }
         }
 
@@ -200,7 +200,7 @@ namespace Microsoft.Data
                 }
                 else
                 {
-                    throw new ArgumentException(Strings.MismatchedValueType + $" {DataType.ToString()}", nameof(value));
+                    throw new ArgumentException(string.Format(Strings.MismatchedValueType, DataType), nameof(value));
                 }
             }
         }
@@ -231,7 +231,7 @@ namespace Microsoft.Data
             return (double)Convert.ChangeType((T)Sum(), typeof(double)) / Length;
         }
 
-        public override void Resize(long length)
+        protected internal override void Resize(long length)
         {
             _columnContainer.Resize(length);
             Length = _columnContainer.Length;
@@ -383,25 +383,6 @@ namespace Microsoft.Data
             return CloneImplementation(mapIndices, invertMapIndices);
         }
 
-        public PrimitiveColumn<T> Clone(IEnumerable<long> mapIndices)
-        {
-            IEnumerator<long> rows = mapIndices.GetEnumerator();
-            PrimitiveColumn<T> ret = new PrimitiveColumn<T>(Name);
-            ret._columnContainer._modifyNullCountWhileIndexing = false;
-            long numberOfRows = 0;
-            while (rows.MoveNext() && numberOfRows < Length)
-            {
-                numberOfRows++;
-                long curRow = rows.Current;
-                T? value = _columnContainer[curRow];
-                ret[curRow] = value;
-                if (!value.HasValue)
-                    ret._columnContainer.NullCount++;
-            }
-            ret._columnContainer._modifyNullCountWhileIndexing = true;
-            return ret;
-        }
-
         internal PrimitiveColumn<bool> CloneAsBoolColumn()
         {
             PrimitiveColumnContainer<bool> newColumnContainer = _columnContainer.CloneAsBoolContainer();
@@ -468,7 +449,7 @@ namespace Microsoft.Data
                 return _Clip((T)convertedLower, (T)Convert.ChangeType(upper, typeof(T)));
             }
             else
-                throw new ArgumentException(Strings.MismatchedValueType + typeof(T).ToString(), nameof(U));
+                throw new ArgumentException(string.Format(Strings.MismatchedValueType, typeof(T)), typeof(U).ToString());
         }
 
         public override BaseColumn Filter<U>(U lower, U upper)
@@ -479,14 +460,14 @@ namespace Microsoft.Data
                 return _Filter((T)convertedLower, (T)Convert.ChangeType(upper, typeof(T)));
             }
             else
-                throw new ArgumentException(Strings.MismatchedValueType + typeof(T).ToString(), nameof(U));
+                throw new ArgumentException(string.Format(Strings.MismatchedValueType, typeof(T)), typeof(U).ToString());
         }
 
         public override DataFrame Description()
         {
             DataFrame ret = new DataFrame();
             StringColumn stringColumn = new StringColumn("Description", 0);
-            stringColumn.Append("Length");
+            stringColumn.Append("Length(non null values)");
             stringColumn.Append("Max");
             stringColumn.Append("Min");
             stringColumn.Append("Mean");

--- a/src/Microsoft.Data/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data/PrimitiveColumnContainer.cs
@@ -90,24 +90,24 @@ namespace Microsoft.Data
                 dataBuffer = mutableBuffer;
             }
             else
+            {
                 dataBuffer = new ReadOnlyDataFrameBuffer<T>(buffer, length);
+            }
             Buffers.Add(dataBuffer);
             int bitMapBufferLength = (int)Math.Ceiling(length / 8.0);
             ReadOnlyDataFrameBuffer<byte> nullDataFrameBuffer;
             if (nullBitMap.IsEmpty)
             {
                 if (nullCount != 0)
-                    throw new ArgumentNullException(nameof(nullBitMap));
+                    throw new ArgumentNullException(Strings.InconsistentNullBitMapAndNullCount, nameof(nullBitMap));
                 if (!buffer.IsEmpty)
                 {
                     // Create a new bitMap with all the bits set
                     var bitMap = new byte[bitMapBufferLength];
-                    for (int i = 0; i < bitMapBufferLength - 1; i++)
-                        bitMap[i] = 255;
-                    for (int i = 0; i < length - (bitMapBufferLength - 1) * 8; i++)
-                    {
-                        bitMap[bitMapBufferLength - 1] = SetBit(bitMap[bitMapBufferLength - 1], i, true);
-                    }
+                    bitMap.AsSpan().Slice(0, bitMapBufferLength - 1).Fill(255);
+                    int lastByte = 1 << (length - (bitMapBufferLength - 1) * 8);
+                    bitMap[bitMapBufferLength - 1] = (byte)(lastByte - 1);
+
                     nullDataFrameBuffer = new ReadOnlyDataFrameBuffer<byte>(bitMap, bitMapBufferLength);
                 }
                 else

--- a/src/Microsoft.Data/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data/PrimitiveColumnContainer.cs
@@ -81,8 +81,44 @@ namespace Microsoft.Data
 
         public PrimitiveColumnContainer(ReadOnlyMemory<byte> buffer, ReadOnlyMemory<byte> nullBitMap, int length, int nullCount)
         {
-            Buffers.Add(new ReadOnlyDataFrameBuffer<T>(buffer, length));
-            NullBitMapBuffers.Add(new ReadOnlyDataFrameBuffer<byte>(nullBitMap, length));
+            ReadOnlyDataFrameBuffer<T> dataBuffer;
+            if (buffer.IsEmpty)
+            {
+                DataFrameBuffer<T> mutableBuffer = new DataFrameBuffer<T>();
+                mutableBuffer.EnsureCapacity(length);
+                mutableBuffer.RawSpan.Fill(default(T));
+                dataBuffer = mutableBuffer;
+            }
+            else
+                dataBuffer = new ReadOnlyDataFrameBuffer<T>(buffer, length);
+            Buffers.Add(dataBuffer);
+            int bitMapBufferLength = (int)Math.Ceiling(length / 8.0);
+            ReadOnlyDataFrameBuffer<byte> nullDataFrameBuffer;
+            if (nullBitMap.IsEmpty)
+            {
+                if (nullCount != 0)
+                    throw new ArgumentNullException(nameof(nullBitMap));
+                if (!buffer.IsEmpty)
+                {
+                    // Create a new bitMap with all the bits set
+                    var bitMap = new byte[bitMapBufferLength];
+                    for (int i = 0; i < bitMapBufferLength - 1; i++)
+                        bitMap[i] = 255;
+                    byte lastBitMap = bitMap[bitMapBufferLength - 1];
+                    for (int i = 0; i < length - (bitMapBufferLength - 1) * 8; i++)
+                    {
+                        bitMap[bitMapBufferLength - 1] = SetBit(bitMap[bitMapBufferLength - 1], i, true);
+                    }
+                    nullDataFrameBuffer = new ReadOnlyDataFrameBuffer<byte>(bitMap, bitMapBufferLength);
+                }
+                else
+                    nullDataFrameBuffer = new ReadOnlyDataFrameBuffer<byte>();
+            }
+            else
+            {
+                nullDataFrameBuffer = new ReadOnlyDataFrameBuffer<byte>(nullBitMap, bitMapBufferLength);
+            }
+            NullBitMapBuffers.Add(nullDataFrameBuffer);
             Length = length;
             NullCount = nullCount;
         }
@@ -106,11 +142,13 @@ namespace Microsoft.Data
                 int allocatable = (int)Math.Min(length, ReadOnlyDataFrameBuffer<T>.MaxCapacity);
                 lastBuffer.EnsureCapacity(allocatable);
                 DataFrameBuffer<byte> lastNullBitMapBuffer = (DataFrameBuffer<byte>)(NullBitMapBuffers[NullBitMapBuffers.Count - 1]);
-                lastNullBitMapBuffer.EnsureCapacity((int)Math.Ceiling(allocatable / 8.0));
+                int nullBufferAllocatable = (int)Math.Ceiling(allocatable / 8.0);
+                lastNullBitMapBuffer.EnsureCapacity(nullBufferAllocatable);
                 lastBuffer.Length = allocatable;
-                lastNullBitMapBuffer.Length = allocatable;
+                lastNullBitMapBuffer.Length = nullBufferAllocatable;
                 length -= allocatable;
                 Length += lastBuffer.Length;
+                NullCount += lastBuffer.Length;
             }
         }
 
@@ -128,7 +166,8 @@ namespace Microsoft.Data
                 Buffers.Add(new DataFrameBuffer<T>());
                 NullBitMapBuffers.Add(new DataFrameBuffer<byte>());
             }
-            ReadOnlyDataFrameBuffer<T> lastBuffer = Buffers[Buffers.Count - 1];
+            int bufferIndex = Buffers.Count - 1;
+            ReadOnlyDataFrameBuffer<T> lastBuffer = Buffers[bufferIndex];
             if (lastBuffer.Length == ReadOnlyDataFrameBuffer<T>.MaxCapacity)
             {
                 lastBuffer = new DataFrameBuffer<T>();
@@ -136,6 +175,7 @@ namespace Microsoft.Data
                 NullBitMapBuffers.Add(new DataFrameBuffer<byte>());
             }
             DataFrameBuffer<T> mutableLastBuffer = DataFrameBuffer<T>.GetMutableBuffer(lastBuffer);
+            Buffers[bufferIndex] = mutableLastBuffer;
             mutableLastBuffer.Append(value ?? default);
             SetValidityBit(Length, value.HasValue ? true : false);
             Length++;
@@ -155,7 +195,8 @@ namespace Microsoft.Data
                     Buffers.Add(new DataFrameBuffer<T>());
                     NullBitMapBuffers.Add(new DataFrameBuffer<byte>());
                 }
-                ReadOnlyDataFrameBuffer<T> lastBuffer = Buffers[Buffers.Count - 1];
+                int bufferIndex = Buffers.Count - 1;
+                ReadOnlyDataFrameBuffer<T> lastBuffer = Buffers[bufferIndex];
                 if (lastBuffer.Length == ReadOnlyDataFrameBuffer<T>.MaxCapacity)
                 {
                     lastBuffer = new DataFrameBuffer<T>();
@@ -163,14 +204,17 @@ namespace Microsoft.Data
                     NullBitMapBuffers.Add(new DataFrameBuffer<byte>());
                 }
                 DataFrameBuffer<T> mutableLastBuffer = DataFrameBuffer<T>.GetMutableBuffer(lastBuffer);
+                Buffers[bufferIndex] = mutableLastBuffer;
                 int allocatable = (int)Math.Min(count, ReadOnlyDataFrameBuffer<T>.MaxCapacity);
                 mutableLastBuffer.EnsureCapacity(allocatable);
                 mutableLastBuffer.RawSpan.Slice(lastBuffer.Length, allocatable).Fill(value ?? default);
                 mutableLastBuffer.Length += allocatable;
                 Length += allocatable;
 
-                ReadOnlyDataFrameBuffer<byte> lastNullBitMapBuffer = NullBitMapBuffers[NullBitMapBuffers.Count - 1];
+                int nullBitMapBufferIndex = NullBitMapBuffers.Count - 1;
+                ReadOnlyDataFrameBuffer<byte> lastNullBitMapBuffer = NullBitMapBuffers[nullBitMapBufferIndex];
                 DataFrameBuffer<byte> mutableLastNullBitMapBuffer = DataFrameBuffer<byte>.GetMutableBuffer(lastNullBitMapBuffer);
+                NullBitMapBuffers[nullBitMapBufferIndex] = mutableLastNullBitMapBuffer;
                 int nullBitMapAllocatable = (int)(((uint)allocatable) / 8) + 1;
                 mutableLastNullBitMapBuffer.EnsureCapacity(nullBitMapAllocatable);
                 _modifyNullCountWhileIndexing = false;
@@ -190,8 +234,11 @@ namespace Microsoft.Data
                 ReadOnlyDataFrameBuffer<T> buffer = Buffers[b];
                 long prevLength = checked(Buffers[0].Length * b);
                 DataFrameBuffer<T> mutableBuffer = DataFrameBuffer<T>.GetMutableBuffer(buffer);
+                Buffers[b] = mutableBuffer;
                 Span<T> span = mutableBuffer.Span;
-                Span<byte> nullBitMapSpan = DataFrameBuffer<byte>.GetMutableBuffer(NullBitMapBuffers[b]).RawSpan;
+                DataFrameBuffer<byte> mutableNullBitMapBuffer = DataFrameBuffer<byte>.GetMutableBuffer(NullBitMapBuffers[b]);
+                NullBitMapBuffers[b] = mutableNullBitMapBuffer;
+                Span<byte> nullBitMapSpan = mutableNullBitMapBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
                     long curIndex = i + prevLength;
@@ -275,7 +322,7 @@ namespace Microsoft.Data
             Debug.Assert(bitMapBuffer.Length >= bitMapBufferIndex);
             if (bitMapBuffer.Length == bitMapBufferIndex)
                 bitMapBuffer.Append(0);
-            SetValidityBit(bitMapBuffer.RawSpan, (int)index, value);
+            SetValidityBit(bitMapBuffer.Span, (int)index, value);
         }
 
         private bool IsBitSet(byte curBitMap, int index)
@@ -368,6 +415,8 @@ namespace Microsoft.Data
                 ReadOnlyDataFrameBuffer<T> buffer = Buffers[arrayIndex];
                 DataFrameBuffer<T> mutableBuffer = DataFrameBuffer<T>.GetMutableBuffer(buffer);
                 Buffers[arrayIndex] = mutableBuffer;
+                DataFrameBuffer<byte> mutableNullBuffer = DataFrameBuffer<byte>.GetMutableBuffer(NullBitMapBuffers[arrayIndex]);
+                NullBitMapBuffers[arrayIndex] = mutableNullBuffer;
                 if (value.HasValue)
                 {
                     Buffers[arrayIndex][(int)rowIndex] = value.Value;
@@ -422,7 +471,7 @@ namespace Microsoft.Data
             {
                 DataFrameBuffer<byte> newBuffer = new DataFrameBuffer<byte>();
                 ret.Add(newBuffer);
-                ReadOnlySpan<byte> span = buffer.RawReadOnlySpan;
+                ReadOnlySpan<byte> span = buffer.ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     newBuffer.Append(span[i]);
@@ -435,12 +484,11 @@ namespace Microsoft.Data
             where U : unmanaged
         {
             ReadOnlySpan<T> thisSpan = Buffers[0].ReadOnlySpan;
-            ReadOnlySpan<byte> thisNullBitMapSpan = NullBitMapBuffers[0].RawReadOnlySpan;
+            ReadOnlySpan<byte> thisNullBitMapSpan = NullBitMapBuffers[0].ReadOnlySpan;
             long minRange = 0;
             long maxRange = DataFrameBuffer<T>.MaxCapacity;
             long maxCapacity = maxRange;
             PrimitiveColumnContainer<T> ret = new PrimitiveColumnContainer<T>(mapIndices.Length);
-            ret._modifyNullCountWhileIndexing = false;
             for (int b = 0; b < mapIndices.Buffers.Count; b++)
             {
                 int index = b;
@@ -448,12 +496,16 @@ namespace Microsoft.Data
                     index = mapIndices.Buffers.Count - 1 - b;
 
                 ReadOnlyDataFrameBuffer<U> buffer = mapIndices.Buffers[index];
-                ReadOnlySpan<byte> mapIndicesNullBitMapSpan = mapIndices.NullBitMapBuffers[index].RawReadOnlySpan;
+                ReadOnlySpan<byte> mapIndicesNullBitMapSpan = mapIndices.NullBitMapBuffers[index].ReadOnlySpan;
                 ReadOnlySpan<U> mapIndicesSpan = buffer.ReadOnlySpan;
                 ReadOnlySpan<long> mapIndicesLongSpan = default;
                 ReadOnlySpan<int> mapIndicesIntSpan = default;
-                Span<T> retSpan = DataFrameBuffer<T>.GetMutableBuffer(ret.Buffers[index]).Span;
-                Span<byte> retNullBitMapSpan = DataFrameBuffer<byte>.GetMutableBuffer(ret.NullBitMapBuffers[index]).RawSpan;
+                DataFrameBuffer<T> mutableBuffer = DataFrameBuffer<T>.GetMutableBuffer(ret.Buffers[index]);
+                ret.Buffers[index] = mutableBuffer;
+                Span<T> retSpan = mutableBuffer.Span;
+                DataFrameBuffer<byte> mutableNullBuffer = DataFrameBuffer<byte>.GetMutableBuffer(ret.NullBitMapBuffers[index]);
+                ret.NullBitMapBuffers[index] = mutableNullBuffer;
+                Span<byte> retNullBitMapSpan = mutableNullBuffer.Span;
                 if (type == typeof(long))
                 {
                     mapIndicesLongSpan = MemoryMarshal.Cast<U, long>(mapIndicesSpan);
@@ -474,7 +526,7 @@ namespace Microsoft.Data
                     {
                         int bufferIndex = (int)(mapRowIndex / maxCapacity);
                         thisSpan = Buffers[bufferIndex].ReadOnlySpan;
-                        thisNullBitMapSpan = DataFrameBuffer<byte>.GetMutableBuffer(NullBitMapBuffers[bufferIndex]).Span;
+                        thisNullBitMapSpan = NullBitMapBuffers[bufferIndex].ReadOnlySpan;
                         minRange = bufferIndex * maxCapacity;
                         maxRange = (bufferIndex + 1) * maxCapacity;
                     }
@@ -489,11 +541,8 @@ namespace Microsoft.Data
 
                     retSpan[i] = isValid ? value : default;
                     ret.SetValidityBit(retNullBitMapSpan, i, isValid);
-                    if (!isValid)
-                        ret.NullCount++;
                 }
             }
-            ret._modifyNullCountWhileIndexing = true;
             return ret;
         }
 

--- a/src/Microsoft.Data/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data/PrimitiveColumnContainer.cs
@@ -104,7 +104,6 @@ namespace Microsoft.Data
                     var bitMap = new byte[bitMapBufferLength];
                     for (int i = 0; i < bitMapBufferLength - 1; i++)
                         bitMap[i] = 255;
-                    byte lastBitMap = bitMap[bitMapBufferLength - 1];
                     for (int i = 0; i < length - (bitMapBufferLength - 1) * 8; i++)
                     {
                         bitMap[bitMapBufferLength - 1] = SetBit(bitMap[bitMapBufferLength - 1], i, true);

--- a/src/Microsoft.Data/ReadOnlyDataFrameBuffer.cs
+++ b/src/Microsoft.Data/ReadOnlyDataFrameBuffer.cs
@@ -45,12 +45,6 @@ namespace Microsoft.Data
             get => (MemoryMarshal.Cast<byte, T>(ReadOnlyBuffer.Span)).Slice(0, Length);
         }
 
-        public ReadOnlySpan<T> RawReadOnlySpan
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => MemoryMarshal.Cast<byte, T>(ReadOnlyBuffer.Span);
-        }
-
         public int Length { get; internal set; }
 
         public ReadOnlyDataFrameBuffer(int numberOfValues = 8)
@@ -74,7 +68,7 @@ namespace Microsoft.Data
             {
                 if (index > Length)
                     throw new ArgumentOutOfRangeException(nameof(index));
-                return RawReadOnlySpan[index];
+                return ReadOnlySpan[index];
             }
             set => throw new NotSupportedException();
         }

--- a/src/Microsoft.Data/StringColumn.cs
+++ b/src/Microsoft.Data/StringColumn.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Data
         private long _nullCount;
         public override long NullCount => _nullCount;
 
-        public override void Resize(long length)
+        protected internal override void Resize(long length)
         {
             if (length < Length)
                 throw new ArgumentException(Strings.CannotResizeDown, nameof(length));
@@ -123,7 +123,7 @@ namespace Microsoft.Data
             }
             else
             {
-                throw new ArgumentException(Strings.MismatchedValueType + " string", nameof(value));
+                throw new ArgumentException(string.Format(Strings.MismatchedValueType, typeof(string)), nameof(value));
             }
         }
 
@@ -366,10 +366,6 @@ namespace Microsoft.Data
 
         private StringColumn Clone(PrimitiveColumn<int> mapIndices, bool invertMapIndex = false)
         {
-            long? ConvertInt(long index)
-            {
-                return mapIndices[index];
-            }
             return CloneImplementation(mapIndices, invertMapIndex);
         }
 

--- a/src/Microsoft.Data/strings.Designer.cs
+++ b/src/Microsoft.Data/strings.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Data {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Table already contains a column called {0}.
+        /// </summary>
+        public static string DuplicateColumnName {
+            get {
+                return ResourceManager.GetString("DuplicateColumnName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Empty file.
         /// </summary>
         public static string EmptyFile {
@@ -142,7 +151,7 @@ namespace Microsoft.Data {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Expected value to be of type .
+        ///   Looks up a localized string similar to Expected value to be of type {0}.
         /// </summary>
         public static string MismatchedValueType {
             get {

--- a/src/Microsoft.Data/strings.Designer.cs
+++ b/src/Microsoft.Data/strings.Designer.cs
@@ -106,6 +106,15 @@ namespace Microsoft.Data {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Inconsistent Null bitmaps and NullCounts.
+        /// </summary>
+        public static string InconsistentNullBitMapAndNullCount {
+            get {
+                return ResourceManager.GetString("InconsistentNullBitMapAndNullCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Column does not exist.
         /// </summary>
         public static string InvalidColumnName {

--- a/src/Microsoft.Data/strings.resx
+++ b/src/Microsoft.Data/strings.resx
@@ -123,6 +123,9 @@
   <data name="ColumnIndexOutOfRange" xml:space="preserve">
     <value>Index cannot be greater than the Column's Length</value>
   </data>
+  <data name="DuplicateColumnName" xml:space="preserve">
+    <value>Table already contains a column called {0}</value>
+  </data>
   <data name="EmptyFile" xml:space="preserve">
     <value>Empty file</value>
   </data>
@@ -145,7 +148,7 @@
     <value>rowCount differs from Column length for Column </value>
   </data>
   <data name="MismatchedValueType" xml:space="preserve">
-    <value>Expected value to be of type </value>
+    <value>Expected value to be of type {0}</value>
   </data>
   <data name="MultipleMismatchedValueType" xml:space="preserve">
     <value>Expected value to be of type {0}, {1} or {2}</value>

--- a/src/Microsoft.Data/strings.resx
+++ b/src/Microsoft.Data/strings.resx
@@ -132,6 +132,9 @@
   <data name="ImmutableColumn" xml:space="preserve">
     <value>Column is immutable</value>
   </data>
+  <data name="InconsistentNullBitMapAndNullCount" xml:space="preserve">
+    <value>Inconsistent Null bitmaps and NullCounts</value>
+  </data>
   <data name="InvalidColumnName" xml:space="preserve">
     <value>Column does not exist</value>
   </data>

--- a/tests/Microsoft.Data.DataFrame.Tests/ArrayComparer.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/ArrayComparer.cs
@@ -64,7 +64,18 @@ namespace Microsoft.Data.Tests
             Assert.Equal(expectedArray.NullCount, actualArray.NullCount);
             Assert.Equal(expectedArray.Offset, actualArray.Offset);
 
-            Assert.True(expectedArray.NullBitmapBuffer.Span.SequenceEqual(actualArray.NullBitmapBuffer.Span));
+            if (expectedArray.NullCount > 0)
+                Assert.True(expectedArray.NullBitmapBuffer.Span.SequenceEqual(actualArray.NullBitmapBuffer.Span));
+            else
+            {
+                // expectedArray may have passed in a null bitmap. DataFrame might have populated it with Length set bits
+                Assert.Equal(0, expectedArray.NullCount);
+                Assert.Equal(0, actualArray.NullCount);
+                for (int i = 0; i < actualArray.Length; i++)
+                {
+                    Assert.True(actualArray.IsValid(i));
+                }
+            }
             Assert.True(expectedArray.Values.Slice(0, expectedArray.Length).SequenceEqual(actualArray.Values.Slice(0, actualArray.Length)));
         }
 

--- a/tests/Microsoft.Data.DataFrame.Tests/ArrowIntegrationTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/ArrowIntegrationTests.cs
@@ -86,5 +86,55 @@ namespace Microsoft.Data.Tests
             }
             Assert.True(foundARecordBatch);
         }
+
+        [Fact]
+        public void TestMutationOnArrowColumn()
+        {
+            RecordBatch originalBatch = new RecordBatch.Builder()
+                .Append("Column1", false, col => col.Int32(array => array.AppendRange(Enumerable.Range(0, 10)))).Build();
+            DataFrame df = new DataFrame(originalBatch);
+            Assert.Equal(1, df["Column1"][1]);
+            df["Column1"][1] = 100;
+            Assert.Equal(100, df["Column1"][1]);
+        }
+
+        [Fact]
+        public void TestEmptyArrowColumns()
+        {
+            // Tests to ensure that we don't crash and the internal NullCounts stay consistent on encountering:
+            // 1. Data + Empty null bitmaps
+            // 2. Empty Data + Null bitmaps
+            // 3. Empty Data + Empty null bitmaps
+            RecordBatch originalBatch = new RecordBatch.Builder()
+                .Append("EmptyNullBitMapColumn", false, col => col.Int32(array => array.AppendRange(Enumerable.Range(0, 10))))
+                .Append("EmptyDataColumn", true, new Int32Array(
+                    valueBuffer: ArrowBuffer.Empty,
+                    nullBitmapBuffer: new ArrowBuffer.Builder<byte>().Append(0x00).Append(0x00).Build(),
+                    length: 10,
+                    nullCount: 10,
+                    offset: 0)).Build();
+            DataFrame df = new DataFrame(originalBatch);
+            Assert.Equal(0, df["EmptyNullBitMapColumn"].NullCount);
+            Assert.Equal(10, df["EmptyNullBitMapColumn"].Length);
+            df["EmptyNullBitMapColumn"][9] = null;
+            Assert.Equal(1, df["EmptyNullBitMapColumn"].NullCount);
+            Assert.Equal(10, df["EmptyDataColumn"].NullCount);
+            Assert.Equal(10, df["EmptyDataColumn"].Length);
+            df["EmptyDataColumn"][9] = 9;
+            Assert.Equal(9, df["EmptyDataColumn"].NullCount);
+            Assert.Equal(10, df["EmptyDataColumn"].Length);
+            for (int i = 0; i < 9; i++)
+            {
+                Assert.Equal(i, (int)df["EmptyNullBitMapColumn"][i]);
+                Assert.Null(df["EmptyDataColumn"][i]);
+            }
+
+            RecordBatch batch1 = new RecordBatch.Builder()
+                .Append("EmptyDataAndNullColumns", false, col => col.Int32(array => array.Clear())).Build();
+            DataFrame emptyDataFrame = new DataFrame(batch1);
+            Assert.Equal(0, emptyDataFrame.RowCount);
+            Assert.Equal(0, emptyDataFrame["EmptyDataAndNullColumns"].Length);
+            Assert.Equal(0, emptyDataFrame["EmptyDataAndNullColumns"].NullCount);
+        }
     }
 }

--- a/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
@@ -20,24 +20,24 @@ namespace Microsoft.Data.Tests
             dataFrameColumn1.Append(null);
             Assert.Equal(1, dataFrameColumn1.NullCount);
 
-            PrimitiveColumn<int> df2 = new PrimitiveColumn<int>("Int2");
-            Assert.Equal(0, df2.NullCount);
+            PrimitiveColumn<int> column2 = new PrimitiveColumn<int>("Int2");
+            Assert.Equal(0, column2.NullCount);
 
-            PrimitiveColumn<int> df3 = new PrimitiveColumn<int>("Int3", 10);
-            Assert.Equal(0, df3.NullCount);
+            PrimitiveColumn<int> column3 = new PrimitiveColumn<int>("Int3", 10);
+            Assert.Equal(10, column3.NullCount);
 
             // Test null counts with assignments on Primitive Columns
-            df2.Append(null);
-            df2.Append(1);
-            Assert.Equal(1, df2.NullCount);
-            df2[1] = 10;
-            Assert.Equal(1, df2.NullCount);
-            df2[1] = null;
-            Assert.Equal(2, df2.NullCount);
-            df2[1] = 5;
-            Assert.Equal(1, df2.NullCount);
-            df2[0] = null;
-            Assert.Equal(1, df2.NullCount);
+            column2.Append(null);
+            column2.Append(1);
+            Assert.Equal(1, column2.NullCount);
+            column2[1] = 10;
+            Assert.Equal(1, column2.NullCount);
+            column2[1] = null;
+            Assert.Equal(2, column2.NullCount);
+            column2[1] = 5;
+            Assert.Equal(1, column2.NullCount);
+            column2[0] = null;
+            Assert.Equal(1, column2.NullCount);
 
             // Test null counts with assignments on String Columns
             StringColumn strCol = new StringColumn("String", 0);
@@ -212,6 +212,8 @@ namespace Microsoft.Data.Tests
                 {
                     for (int k = 0; k < 8; k++)
                     {
+                        if (j * 8 + k == column.Length)
+                            break;
                         Assert.True(GetBit(bitMapSpan[j], k));
                     }
                 }

--- a/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
@@ -1505,5 +1505,26 @@ namespace Microsoft.Data.Tests
             }
         }
 
+        [Fact]
+        public void TestAppendRow()
+        {
+            DataFrame df = MakeDataFrame<int, bool>(10);
+            df.Append(new List<object> { 5, true });
+            Assert.Equal(11, df.RowCount);
+            Assert.Equal(1, df.Column(0).NullCount);
+            Assert.Equal(1, df.Column(1).NullCount);
+
+            df.Append(new List<object> { 100 });
+            Assert.Equal(12, df.RowCount);
+            Assert.Equal(1, df.Column(0).NullCount);
+            Assert.Equal(2, df.Column(1).NullCount);
+
+            df.Append(new List<object> { null, null });
+            Assert.Equal(13, df.RowCount);
+            Assert.Equal(2, df.Column(0).NullCount);
+            Assert.Equal(3, df.Column(1).NullCount);
+
+        }
+
     }
 }

--- a/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
@@ -1524,6 +1524,38 @@ namespace Microsoft.Data.Tests
             Assert.Equal(2, df.Column(0).NullCount);
             Assert.Equal(3, df.Column(1).NullCount);
 
+            df.Append(new List<KeyValuePair<string, object>> { KeyValuePair.Create("Column1", (object)5), KeyValuePair.Create("Column2", (object)false) });
+            Assert.Equal(14, df.RowCount);
+            Assert.Equal(2, df.Column(0).NullCount);
+            Assert.Equal(3, df.Column(1).NullCount);
+
+            df.Append(new List<KeyValuePair<string, object>> { KeyValuePair.Create("Column1", (object)5)});
+            Assert.Equal(15, df.RowCount);
+            Assert.Equal(15, df["Column1"].Length);
+            Assert.Equal(15, df["Column2"].Length);
+            Assert.Equal(2, df.Column(0).NullCount);
+            Assert.Equal(4, df.Column(1).NullCount);
+
+            df.Append(new List<KeyValuePair<string, object>> { KeyValuePair.Create("Column2", (object)false) });
+            Assert.Equal(16, df.RowCount);
+            Assert.Equal(16, df["Column1"].Length);
+            Assert.Equal(16, df["Column2"].Length);
+            Assert.Equal(3, df.Column(0).NullCount);
+            Assert.Equal(4, df.Column(1).NullCount);
+
+            df.Append((IEnumerable<object>)null);
+            Assert.Equal(17, df.RowCount);
+            Assert.Equal(17, df["Column1"].Length);
+            Assert.Equal(17, df["Column2"].Length);
+            Assert.Equal(4, df.Column(0).NullCount);
+            Assert.Equal(5, df.Column(1).NullCount);
+
+            df.Append((IEnumerable<KeyValuePair<string, object>>)null);
+            Assert.Equal(18, df.RowCount);
+            Assert.Equal(18, df["Column1"].Length);
+            Assert.Equal(18, df["Column2"].Length);
+            Assert.Equal(5, df.Column(0).NullCount);
+            Assert.Equal(6, df.Column(1).NullCount);
         }
 
     }

--- a/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
@@ -1397,6 +1397,7 @@ namespace Microsoft.Data.Tests
             for (int i = 1; i < description.ColumnCount; i++)
             {
                 BaseColumn column = description.Column(i);
+                Assert.Equal(df.Column(i - 1).Name, column.Name);
                 Assert.Equal(4, column.Length);
                 Assert.Equal((float)9, column[0]);
                 Assert.Equal((float)9, column[1]);


### PR DESCRIPTION
Implements one part of [2719](https://github.com/dotnet/corefxlab/issues/2719). I've added some discussions about adding an `AppendRow` API to BaseColumn. 
This patch also fixes some bugs around `NullCount`.  Because C# Arrow is essentially immutable, it doesn't have to deal with keeping `NullCount` in sync on mutation. Arrow can pass in empty data and/or null buffers. DataFrame prefers to always populate both the data and null buffers, so this patch ensures that when empty data/null buffers are encounterd, they are initialized with the right default values. 
Note: This is still zero copy. We only allocate and initialize when empty buffers are present. 