### PR TITLE
Fix https://github.com/dotnet/corefxlab/issues/2735

### DIFF
--- a/src/Microsoft.Data/BaseColumn.BinaryOperations.cs
+++ b/src/Microsoft.Data/BaseColumn.BinaryOperations.cs
@@ -110,67 +110,67 @@ namespace Microsoft.Data
             throw new NotImplementedException();
         }
 
-        public virtual BaseColumn Equals(BaseColumn column)
+        public virtual PrimitiveColumn<bool> Equals(BaseColumn column)
         {
             throw new NotImplementedException();
         }
 
-        public virtual BaseColumn Equals<T>(T value)
+        public virtual PrimitiveColumn<bool> Equals<T>(T value)
             where T : unmanaged
         {
             throw new NotImplementedException();
         }
 
-        public virtual BaseColumn NotEquals(BaseColumn column)
+        public virtual PrimitiveColumn<bool> NotEquals(BaseColumn column)
         {
             throw new NotImplementedException();
         }
 
-        public virtual BaseColumn NotEquals<T>(T value)
+        public virtual PrimitiveColumn<bool> NotEquals<T>(T value)
             where T : unmanaged
         {
             throw new NotImplementedException();
         }
 
-        public virtual BaseColumn GreaterThanOrEqual(BaseColumn column)
+        public virtual PrimitiveColumn<bool> GreaterThanOrEqual(BaseColumn column)
         {
             throw new NotImplementedException();
         }
 
-        public virtual BaseColumn GreaterThanOrEqual<T>(T value)
+        public virtual PrimitiveColumn<bool> GreaterThanOrEqual<T>(T value)
             where T : unmanaged
         {
             throw new NotImplementedException();
         }
 
-        public virtual BaseColumn LessThanOrEqual(BaseColumn column)
+        public virtual PrimitiveColumn<bool> LessThanOrEqual(BaseColumn column)
         {
             throw new NotImplementedException();
         }
 
-        public virtual BaseColumn LessThanOrEqual<T>(T value)
+        public virtual PrimitiveColumn<bool> LessThanOrEqual<T>(T value)
             where T : unmanaged
         {
             throw new NotImplementedException();
         }
 
-        public virtual BaseColumn GreaterThan(BaseColumn column)
+        public virtual PrimitiveColumn<bool> GreaterThan(BaseColumn column)
         {
             throw new NotImplementedException();
         }
 
-        public virtual BaseColumn GreaterThan<T>(T value)
+        public virtual PrimitiveColumn<bool> GreaterThan<T>(T value)
             where T : unmanaged
         {
             throw new NotImplementedException();
         }
 
-        public virtual BaseColumn LessThan(BaseColumn column)
+        public virtual PrimitiveColumn<bool> LessThan(BaseColumn column)
         {
             throw new NotImplementedException();
         }
 
-        public virtual BaseColumn LessThan<T>(T value)
+        public virtual PrimitiveColumn<bool> LessThan<T>(T value)
             where T : unmanaged
         {
             throw new NotImplementedException();

--- a/src/Microsoft.Data/BaseColumn.BinaryOperations.tt
+++ b/src/Microsoft.Data/BaseColumn.BinaryOperations.tt
@@ -24,14 +24,14 @@ namespace Microsoft.Data
             where T : unmanaged
 <# } #>
 <# if (method.MethodType == MethodType.ComparisonScalar) { #>
-        public virtual BaseColumn <#=method.MethodName#><T>(T value)
+        public virtual PrimitiveColumn<bool> <#=method.MethodName#><T>(T value)
             where T : unmanaged
 <# } #>
 <# if (method.MethodType == MethodType.Binary) {#>
         public virtual BaseColumn <#=method.MethodName#>(BaseColumn column, bool inPlace = false)
 <# } #>
 <# if (method.MethodType == MethodType.Comparison) {#>
-        public virtual BaseColumn <#=method.MethodName#>(BaseColumn column)
+        public virtual PrimitiveColumn<bool> <#=method.MethodName#>(BaseColumn column)
 <# } #>
 <# if (method.MethodType == MethodType.BinaryInt ) {#>
         public virtual BaseColumn <#=method.MethodName#>(int value, bool inPlace = false)

--- a/src/Microsoft.Data/BaseColumn.BinaryOperators.cs
+++ b/src/Microsoft.Data/BaseColumn.BinaryOperators.cs
@@ -582,422 +582,422 @@ namespace Microsoft.Data
             return column.RightShift(value);
         }
 
-        public static BaseColumn operator ==(BaseColumn left, BaseColumn right)
+        public static PrimitiveColumn<bool> operator ==(BaseColumn left, BaseColumn right)
         {
             return left.Equals(right);
         }
 
-        public static BaseColumn operator ==(BaseColumn column, bool value)
+        public static PrimitiveColumn<bool> operator ==(BaseColumn column, bool value)
         {
             return column.Equals(value);
         }
 
-        public static BaseColumn operator ==(BaseColumn column, byte value)
+        public static PrimitiveColumn<bool> operator ==(BaseColumn column, byte value)
         {
             return column.Equals(value);
         }
 
-        public static BaseColumn operator ==(BaseColumn column, char value)
+        public static PrimitiveColumn<bool> operator ==(BaseColumn column, char value)
         {
             return column.Equals(value);
         }
 
-        public static BaseColumn operator ==(BaseColumn column, decimal value)
+        public static PrimitiveColumn<bool> operator ==(BaseColumn column, decimal value)
         {
             return column.Equals(value);
         }
 
-        public static BaseColumn operator ==(BaseColumn column, double value)
+        public static PrimitiveColumn<bool> operator ==(BaseColumn column, double value)
         {
             return column.Equals(value);
         }
 
-        public static BaseColumn operator ==(BaseColumn column, float value)
+        public static PrimitiveColumn<bool> operator ==(BaseColumn column, float value)
         {
             return column.Equals(value);
         }
 
-        public static BaseColumn operator ==(BaseColumn column, int value)
+        public static PrimitiveColumn<bool> operator ==(BaseColumn column, int value)
         {
             return column.Equals(value);
         }
 
-        public static BaseColumn operator ==(BaseColumn column, long value)
+        public static PrimitiveColumn<bool> operator ==(BaseColumn column, long value)
         {
             return column.Equals(value);
         }
 
-        public static BaseColumn operator ==(BaseColumn column, sbyte value)
+        public static PrimitiveColumn<bool> operator ==(BaseColumn column, sbyte value)
         {
             return column.Equals(value);
         }
 
-        public static BaseColumn operator ==(BaseColumn column, short value)
+        public static PrimitiveColumn<bool> operator ==(BaseColumn column, short value)
         {
             return column.Equals(value);
         }
 
-        public static BaseColumn operator ==(BaseColumn column, uint value)
+        public static PrimitiveColumn<bool> operator ==(BaseColumn column, uint value)
         {
             return column.Equals(value);
         }
 
-        public static BaseColumn operator ==(BaseColumn column, ulong value)
+        public static PrimitiveColumn<bool> operator ==(BaseColumn column, ulong value)
         {
             return column.Equals(value);
         }
 
-        public static BaseColumn operator ==(BaseColumn column, ushort value)
+        public static PrimitiveColumn<bool> operator ==(BaseColumn column, ushort value)
         {
             return column.Equals(value);
         }
 
-        public static BaseColumn operator !=(BaseColumn left, BaseColumn right)
+        public static PrimitiveColumn<bool> operator !=(BaseColumn left, BaseColumn right)
         {
             return left.NotEquals(right);
         }
 
-        public static BaseColumn operator !=(BaseColumn column, bool value)
+        public static PrimitiveColumn<bool> operator !=(BaseColumn column, bool value)
         {
             return column.NotEquals(value);
         }
 
-        public static BaseColumn operator !=(BaseColumn column, byte value)
+        public static PrimitiveColumn<bool> operator !=(BaseColumn column, byte value)
         {
             return column.NotEquals(value);
         }
 
-        public static BaseColumn operator !=(BaseColumn column, char value)
+        public static PrimitiveColumn<bool> operator !=(BaseColumn column, char value)
         {
             return column.NotEquals(value);
         }
 
-        public static BaseColumn operator !=(BaseColumn column, decimal value)
+        public static PrimitiveColumn<bool> operator !=(BaseColumn column, decimal value)
         {
             return column.NotEquals(value);
         }
 
-        public static BaseColumn operator !=(BaseColumn column, double value)
+        public static PrimitiveColumn<bool> operator !=(BaseColumn column, double value)
         {
             return column.NotEquals(value);
         }
 
-        public static BaseColumn operator !=(BaseColumn column, float value)
+        public static PrimitiveColumn<bool> operator !=(BaseColumn column, float value)
         {
             return column.NotEquals(value);
         }
 
-        public static BaseColumn operator !=(BaseColumn column, int value)
+        public static PrimitiveColumn<bool> operator !=(BaseColumn column, int value)
         {
             return column.NotEquals(value);
         }
 
-        public static BaseColumn operator !=(BaseColumn column, long value)
+        public static PrimitiveColumn<bool> operator !=(BaseColumn column, long value)
         {
             return column.NotEquals(value);
         }
 
-        public static BaseColumn operator !=(BaseColumn column, sbyte value)
+        public static PrimitiveColumn<bool> operator !=(BaseColumn column, sbyte value)
         {
             return column.NotEquals(value);
         }
 
-        public static BaseColumn operator !=(BaseColumn column, short value)
+        public static PrimitiveColumn<bool> operator !=(BaseColumn column, short value)
         {
             return column.NotEquals(value);
         }
 
-        public static BaseColumn operator !=(BaseColumn column, uint value)
+        public static PrimitiveColumn<bool> operator !=(BaseColumn column, uint value)
         {
             return column.NotEquals(value);
         }
 
-        public static BaseColumn operator !=(BaseColumn column, ulong value)
+        public static PrimitiveColumn<bool> operator !=(BaseColumn column, ulong value)
         {
             return column.NotEquals(value);
         }
 
-        public static BaseColumn operator !=(BaseColumn column, ushort value)
+        public static PrimitiveColumn<bool> operator !=(BaseColumn column, ushort value)
         {
             return column.NotEquals(value);
         }
 
-        public static BaseColumn operator >=(BaseColumn left, BaseColumn right)
+        public static PrimitiveColumn<bool> operator >=(BaseColumn left, BaseColumn right)
         {
             return left.GreaterThanOrEqual(right);
         }
 
-        public static BaseColumn operator >=(BaseColumn column, bool value)
+        public static PrimitiveColumn<bool> operator >=(BaseColumn column, bool value)
         {
             return column.GreaterThanOrEqual(value);
         }
 
-        public static BaseColumn operator >=(BaseColumn column, byte value)
+        public static PrimitiveColumn<bool> operator >=(BaseColumn column, byte value)
         {
             return column.GreaterThanOrEqual(value);
         }
 
-        public static BaseColumn operator >=(BaseColumn column, char value)
+        public static PrimitiveColumn<bool> operator >=(BaseColumn column, char value)
         {
             return column.GreaterThanOrEqual(value);
         }
 
-        public static BaseColumn operator >=(BaseColumn column, decimal value)
+        public static PrimitiveColumn<bool> operator >=(BaseColumn column, decimal value)
         {
             return column.GreaterThanOrEqual(value);
         }
 
-        public static BaseColumn operator >=(BaseColumn column, double value)
+        public static PrimitiveColumn<bool> operator >=(BaseColumn column, double value)
         {
             return column.GreaterThanOrEqual(value);
         }
 
-        public static BaseColumn operator >=(BaseColumn column, float value)
+        public static PrimitiveColumn<bool> operator >=(BaseColumn column, float value)
         {
             return column.GreaterThanOrEqual(value);
         }
 
-        public static BaseColumn operator >=(BaseColumn column, int value)
+        public static PrimitiveColumn<bool> operator >=(BaseColumn column, int value)
         {
             return column.GreaterThanOrEqual(value);
         }
 
-        public static BaseColumn operator >=(BaseColumn column, long value)
+        public static PrimitiveColumn<bool> operator >=(BaseColumn column, long value)
         {
             return column.GreaterThanOrEqual(value);
         }
 
-        public static BaseColumn operator >=(BaseColumn column, sbyte value)
+        public static PrimitiveColumn<bool> operator >=(BaseColumn column, sbyte value)
         {
             return column.GreaterThanOrEqual(value);
         }
 
-        public static BaseColumn operator >=(BaseColumn column, short value)
+        public static PrimitiveColumn<bool> operator >=(BaseColumn column, short value)
         {
             return column.GreaterThanOrEqual(value);
         }
 
-        public static BaseColumn operator >=(BaseColumn column, uint value)
+        public static PrimitiveColumn<bool> operator >=(BaseColumn column, uint value)
         {
             return column.GreaterThanOrEqual(value);
         }
 
-        public static BaseColumn operator >=(BaseColumn column, ulong value)
+        public static PrimitiveColumn<bool> operator >=(BaseColumn column, ulong value)
         {
             return column.GreaterThanOrEqual(value);
         }
 
-        public static BaseColumn operator >=(BaseColumn column, ushort value)
+        public static PrimitiveColumn<bool> operator >=(BaseColumn column, ushort value)
         {
             return column.GreaterThanOrEqual(value);
         }
 
-        public static BaseColumn operator <=(BaseColumn left, BaseColumn right)
+        public static PrimitiveColumn<bool> operator <=(BaseColumn left, BaseColumn right)
         {
             return left.LessThanOrEqual(right);
         }
 
-        public static BaseColumn operator <=(BaseColumn column, bool value)
+        public static PrimitiveColumn<bool> operator <=(BaseColumn column, bool value)
         {
             return column.LessThanOrEqual(value);
         }
 
-        public static BaseColumn operator <=(BaseColumn column, byte value)
+        public static PrimitiveColumn<bool> operator <=(BaseColumn column, byte value)
         {
             return column.LessThanOrEqual(value);
         }
 
-        public static BaseColumn operator <=(BaseColumn column, char value)
+        public static PrimitiveColumn<bool> operator <=(BaseColumn column, char value)
         {
             return column.LessThanOrEqual(value);
         }
 
-        public static BaseColumn operator <=(BaseColumn column, decimal value)
+        public static PrimitiveColumn<bool> operator <=(BaseColumn column, decimal value)
         {
             return column.LessThanOrEqual(value);
         }
 
-        public static BaseColumn operator <=(BaseColumn column, double value)
+        public static PrimitiveColumn<bool> operator <=(BaseColumn column, double value)
         {
             return column.LessThanOrEqual(value);
         }
 
-        public static BaseColumn operator <=(BaseColumn column, float value)
+        public static PrimitiveColumn<bool> operator <=(BaseColumn column, float value)
         {
             return column.LessThanOrEqual(value);
         }
 
-        public static BaseColumn operator <=(BaseColumn column, int value)
+        public static PrimitiveColumn<bool> operator <=(BaseColumn column, int value)
         {
             return column.LessThanOrEqual(value);
         }
 
-        public static BaseColumn operator <=(BaseColumn column, long value)
+        public static PrimitiveColumn<bool> operator <=(BaseColumn column, long value)
         {
             return column.LessThanOrEqual(value);
         }
 
-        public static BaseColumn operator <=(BaseColumn column, sbyte value)
+        public static PrimitiveColumn<bool> operator <=(BaseColumn column, sbyte value)
         {
             return column.LessThanOrEqual(value);
         }
 
-        public static BaseColumn operator <=(BaseColumn column, short value)
+        public static PrimitiveColumn<bool> operator <=(BaseColumn column, short value)
         {
             return column.LessThanOrEqual(value);
         }
 
-        public static BaseColumn operator <=(BaseColumn column, uint value)
+        public static PrimitiveColumn<bool> operator <=(BaseColumn column, uint value)
         {
             return column.LessThanOrEqual(value);
         }
 
-        public static BaseColumn operator <=(BaseColumn column, ulong value)
+        public static PrimitiveColumn<bool> operator <=(BaseColumn column, ulong value)
         {
             return column.LessThanOrEqual(value);
         }
 
-        public static BaseColumn operator <=(BaseColumn column, ushort value)
+        public static PrimitiveColumn<bool> operator <=(BaseColumn column, ushort value)
         {
             return column.LessThanOrEqual(value);
         }
 
-        public static BaseColumn operator >(BaseColumn left, BaseColumn right)
+        public static PrimitiveColumn<bool> operator >(BaseColumn left, BaseColumn right)
         {
             return left.GreaterThan(right);
         }
 
-        public static BaseColumn operator >(BaseColumn column, bool value)
+        public static PrimitiveColumn<bool> operator >(BaseColumn column, bool value)
         {
             return column.GreaterThan(value);
         }
 
-        public static BaseColumn operator >(BaseColumn column, byte value)
+        public static PrimitiveColumn<bool> operator >(BaseColumn column, byte value)
         {
             return column.GreaterThan(value);
         }
 
-        public static BaseColumn operator >(BaseColumn column, char value)
+        public static PrimitiveColumn<bool> operator >(BaseColumn column, char value)
         {
             return column.GreaterThan(value);
         }
 
-        public static BaseColumn operator >(BaseColumn column, decimal value)
+        public static PrimitiveColumn<bool> operator >(BaseColumn column, decimal value)
         {
             return column.GreaterThan(value);
         }
 
-        public static BaseColumn operator >(BaseColumn column, double value)
+        public static PrimitiveColumn<bool> operator >(BaseColumn column, double value)
         {
             return column.GreaterThan(value);
         }
 
-        public static BaseColumn operator >(BaseColumn column, float value)
+        public static PrimitiveColumn<bool> operator >(BaseColumn column, float value)
         {
             return column.GreaterThan(value);
         }
 
-        public static BaseColumn operator >(BaseColumn column, int value)
+        public static PrimitiveColumn<bool> operator >(BaseColumn column, int value)
         {
             return column.GreaterThan(value);
         }
 
-        public static BaseColumn operator >(BaseColumn column, long value)
+        public static PrimitiveColumn<bool> operator >(BaseColumn column, long value)
         {
             return column.GreaterThan(value);
         }
 
-        public static BaseColumn operator >(BaseColumn column, sbyte value)
+        public static PrimitiveColumn<bool> operator >(BaseColumn column, sbyte value)
         {
             return column.GreaterThan(value);
         }
 
-        public static BaseColumn operator >(BaseColumn column, short value)
+        public static PrimitiveColumn<bool> operator >(BaseColumn column, short value)
         {
             return column.GreaterThan(value);
         }
 
-        public static BaseColumn operator >(BaseColumn column, uint value)
+        public static PrimitiveColumn<bool> operator >(BaseColumn column, uint value)
         {
             return column.GreaterThan(value);
         }
 
-        public static BaseColumn operator >(BaseColumn column, ulong value)
+        public static PrimitiveColumn<bool> operator >(BaseColumn column, ulong value)
         {
             return column.GreaterThan(value);
         }
 
-        public static BaseColumn operator >(BaseColumn column, ushort value)
+        public static PrimitiveColumn<bool> operator >(BaseColumn column, ushort value)
         {
             return column.GreaterThan(value);
         }
 
-        public static BaseColumn operator <(BaseColumn left, BaseColumn right)
+        public static PrimitiveColumn<bool> operator <(BaseColumn left, BaseColumn right)
         {
             return left.LessThan(right);
         }
 
-        public static BaseColumn operator <(BaseColumn column, bool value)
+        public static PrimitiveColumn<bool> operator <(BaseColumn column, bool value)
         {
             return column.LessThan(value);
         }
 
-        public static BaseColumn operator <(BaseColumn column, byte value)
+        public static PrimitiveColumn<bool> operator <(BaseColumn column, byte value)
         {
             return column.LessThan(value);
         }
 
-        public static BaseColumn operator <(BaseColumn column, char value)
+        public static PrimitiveColumn<bool> operator <(BaseColumn column, char value)
         {
             return column.LessThan(value);
         }
 
-        public static BaseColumn operator <(BaseColumn column, decimal value)
+        public static PrimitiveColumn<bool> operator <(BaseColumn column, decimal value)
         {
             return column.LessThan(value);
         }
 
-        public static BaseColumn operator <(BaseColumn column, double value)
+        public static PrimitiveColumn<bool> operator <(BaseColumn column, double value)
         {
             return column.LessThan(value);
         }
 
-        public static BaseColumn operator <(BaseColumn column, float value)
+        public static PrimitiveColumn<bool> operator <(BaseColumn column, float value)
         {
             return column.LessThan(value);
         }
 
-        public static BaseColumn operator <(BaseColumn column, int value)
+        public static PrimitiveColumn<bool> operator <(BaseColumn column, int value)
         {
             return column.LessThan(value);
         }
 
-        public static BaseColumn operator <(BaseColumn column, long value)
+        public static PrimitiveColumn<bool> operator <(BaseColumn column, long value)
         {
             return column.LessThan(value);
         }
 
-        public static BaseColumn operator <(BaseColumn column, sbyte value)
+        public static PrimitiveColumn<bool> operator <(BaseColumn column, sbyte value)
         {
             return column.LessThan(value);
         }
 
-        public static BaseColumn operator <(BaseColumn column, short value)
+        public static PrimitiveColumn<bool> operator <(BaseColumn column, short value)
         {
             return column.LessThan(value);
         }
 
-        public static BaseColumn operator <(BaseColumn column, uint value)
+        public static PrimitiveColumn<bool> operator <(BaseColumn column, uint value)
         {
             return column.LessThan(value);
         }
 
-        public static BaseColumn operator <(BaseColumn column, ulong value)
+        public static PrimitiveColumn<bool> operator <(BaseColumn column, ulong value)
         {
             return column.LessThan(value);
         }
 
-        public static BaseColumn operator <(BaseColumn column, ushort value)
+        public static PrimitiveColumn<bool> operator <(BaseColumn column, ushort value)
         {
             return column.LessThan(value);
         }

--- a/src/Microsoft.Data/BaseColumn.BinaryOperators.tt
+++ b/src/Microsoft.Data/BaseColumn.BinaryOperators.tt
@@ -19,7 +19,7 @@ namespace Microsoft.Data
     public abstract partial class BaseColumn
     {
 <# foreach (MethodConfiguration method in methodConfiguration) { #>
-<# if (method.MethodType == MethodType.BinaryScalar || method.MethodType == MethodType.ComparisonScalar) { #>
+<# if (method.MethodType == MethodType.BinaryScalar) { #>
 <# foreach (TypeConfiguration type in typeConfiguration) { #>
         public static BaseColumn operator <#=method.Operator#>(BaseColumn column, <#=type.TypeName#> value)
         {
@@ -27,6 +27,20 @@ namespace Microsoft.Data
         }
 
 <# } #>
+<# } else if (method.MethodType == MethodType.ComparisonScalar) { #>
+<# foreach (TypeConfiguration type in typeConfiguration) { #>
+        public static PrimitiveColumn<bool> operator <#=method.Operator#>(BaseColumn column, <#=type.TypeName#> value)
+        {
+            return column.<#=method.MethodName#>(value);
+        }
+
+<# } #>
+<# } else if (method.MethodType == MethodType.Comparison) { #>
+        public static PrimitiveColumn<bool> operator <#=method.Operator#>(BaseColumn left, BaseColumn right)
+        {
+            return left.<#=method.MethodName#>(right);
+        }
+
 <# } else if (method.MethodType == MethodType.BinaryInt) {#>
         public static BaseColumn operator <#=method.Operator#>(BaseColumn column, int value)
         {

--- a/src/Microsoft.Data/PrimitiveColumn.BinaryOperations.cs
+++ b/src/Microsoft.Data/PrimitiveColumn.BinaryOperations.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Data
         {
             return RightShiftImplementation(value, inPlace);
         }
-        public override BaseColumn Equals(BaseColumn column)
+        public override PrimitiveColumn<bool> Equals(BaseColumn column)
         {
             switch (column)
             {
@@ -359,11 +359,11 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        public override BaseColumn Equals<U>(U value)
+        public override PrimitiveColumn<bool> Equals<U>(U value)
         {
             return EqualsImplementation(value);
         }
-        public override BaseColumn NotEquals(BaseColumn column)
+        public override PrimitiveColumn<bool> NotEquals(BaseColumn column)
         {
             switch (column)
             {
@@ -397,11 +397,11 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        public override BaseColumn NotEquals<U>(U value)
+        public override PrimitiveColumn<bool> NotEquals<U>(U value)
         {
             return NotEqualsImplementation(value);
         }
-        public override BaseColumn GreaterThanOrEqual(BaseColumn column)
+        public override PrimitiveColumn<bool> GreaterThanOrEqual(BaseColumn column)
         {
             switch (column)
             {
@@ -435,11 +435,11 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        public override BaseColumn GreaterThanOrEqual<U>(U value)
+        public override PrimitiveColumn<bool> GreaterThanOrEqual<U>(U value)
         {
             return GreaterThanOrEqualImplementation(value);
         }
-        public override BaseColumn LessThanOrEqual(BaseColumn column)
+        public override PrimitiveColumn<bool> LessThanOrEqual(BaseColumn column)
         {
             switch (column)
             {
@@ -473,11 +473,11 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        public override BaseColumn LessThanOrEqual<U>(U value)
+        public override PrimitiveColumn<bool> LessThanOrEqual<U>(U value)
         {
             return LessThanOrEqualImplementation(value);
         }
-        public override BaseColumn GreaterThan(BaseColumn column)
+        public override PrimitiveColumn<bool> GreaterThan(BaseColumn column)
         {
             switch (column)
             {
@@ -511,11 +511,11 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        public override BaseColumn GreaterThan<U>(U value)
+        public override PrimitiveColumn<bool> GreaterThan<U>(U value)
         {
             return GreaterThanImplementation(value);
         }
-        public override BaseColumn LessThan(BaseColumn column)
+        public override PrimitiveColumn<bool> LessThan(BaseColumn column)
         {
             switch (column)
             {
@@ -549,7 +549,7 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        public override BaseColumn LessThan<U>(U value)
+        public override PrimitiveColumn<bool> LessThan<U>(U value)
         {
             return LessThanImplementation(value);
         }
@@ -1568,7 +1568,7 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        internal BaseColumn EqualsImplementation<U>(PrimitiveColumn<U> column)
+        internal PrimitiveColumn<bool> EqualsImplementation<U>(PrimitiveColumn<U> column)
             where U : unmanaged
         {
             if (column.Length != Length)
@@ -1649,7 +1649,7 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        internal BaseColumn EqualsImplementation<U>(U value)
+        internal PrimitiveColumn<bool> EqualsImplementation<U>(U value)
             where U : unmanaged
         {
             switch (typeof(T))
@@ -1726,7 +1726,7 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        internal BaseColumn NotEqualsImplementation<U>(PrimitiveColumn<U> column)
+        internal PrimitiveColumn<bool> NotEqualsImplementation<U>(PrimitiveColumn<U> column)
             where U : unmanaged
         {
             if (column.Length != Length)
@@ -1807,7 +1807,7 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        internal BaseColumn NotEqualsImplementation<U>(U value)
+        internal PrimitiveColumn<bool> NotEqualsImplementation<U>(U value)
             where U : unmanaged
         {
             switch (typeof(T))
@@ -1884,7 +1884,7 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        internal BaseColumn GreaterThanOrEqualImplementation<U>(PrimitiveColumn<U> column)
+        internal PrimitiveColumn<bool> GreaterThanOrEqualImplementation<U>(PrimitiveColumn<U> column)
             where U : unmanaged
         {
             if (column.Length != Length)
@@ -1959,7 +1959,7 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        internal BaseColumn GreaterThanOrEqualImplementation<U>(U value)
+        internal PrimitiveColumn<bool> GreaterThanOrEqualImplementation<U>(U value)
             where U : unmanaged
         {
             switch (typeof(T))
@@ -2030,7 +2030,7 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        internal BaseColumn LessThanOrEqualImplementation<U>(PrimitiveColumn<U> column)
+        internal PrimitiveColumn<bool> LessThanOrEqualImplementation<U>(PrimitiveColumn<U> column)
             where U : unmanaged
         {
             if (column.Length != Length)
@@ -2105,7 +2105,7 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        internal BaseColumn LessThanOrEqualImplementation<U>(U value)
+        internal PrimitiveColumn<bool> LessThanOrEqualImplementation<U>(U value)
             where U : unmanaged
         {
             switch (typeof(T))
@@ -2176,7 +2176,7 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        internal BaseColumn GreaterThanImplementation<U>(PrimitiveColumn<U> column)
+        internal PrimitiveColumn<bool> GreaterThanImplementation<U>(PrimitiveColumn<U> column)
             where U : unmanaged
         {
             if (column.Length != Length)
@@ -2251,7 +2251,7 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        internal BaseColumn GreaterThanImplementation<U>(U value)
+        internal PrimitiveColumn<bool> GreaterThanImplementation<U>(U value)
             where U : unmanaged
         {
             switch (typeof(T))
@@ -2322,7 +2322,7 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        internal BaseColumn LessThanImplementation<U>(PrimitiveColumn<U> column)
+        internal PrimitiveColumn<bool> LessThanImplementation<U>(PrimitiveColumn<U> column)
             where U : unmanaged
         {
             if (column.Length != Length)
@@ -2397,7 +2397,7 @@ namespace Microsoft.Data
                     throw new NotSupportedException();
             }
         }
-        internal BaseColumn LessThanImplementation<U>(U value)
+        internal PrimitiveColumn<bool> LessThanImplementation<U>(U value)
             where U : unmanaged
         {
             switch (typeof(T))

--- a/src/Microsoft.Data/PrimitiveColumn.BinaryOperations.tt
+++ b/src/Microsoft.Data/PrimitiveColumn.BinaryOperations.tt
@@ -24,7 +24,7 @@ namespace Microsoft.Data
 <# if (method.MethodType == MethodType.Binary) {#>
         public override BaseColumn <#=method.MethodName#>(BaseColumn column, bool inPlace = false)
 <# } else { #>
-        public override BaseColumn <#=method.MethodName#>(BaseColumn column)
+        public override PrimitiveColumn<bool> <#=method.MethodName#>(BaseColumn column)
 <# } #>
         {
             switch (column)
@@ -46,7 +46,7 @@ namespace Microsoft.Data
 <# if (method.MethodType == MethodType.BinaryScalar) {#>
         public override BaseColumn <#=method.MethodName#><U>(U value, bool inPlace = false)
 <# } else {#>
-        public override BaseColumn <#=method.MethodName#><U>(U value)
+        public override PrimitiveColumn<bool> <#=method.MethodName#><U>(U value)
 <# } #>
         {
 <# if (method.MethodType == MethodType.BinaryScalar) {#>
@@ -69,7 +69,7 @@ namespace Microsoft.Data
 <# if (method.MethodType == MethodType.BinaryScalar) {#>
         internal BaseColumn <#=method.MethodName#>Implementation<U>(U value, bool inPlace)
 <# } else {#>
-        internal BaseColumn <#=method.MethodName#>Implementation<U>(U value)
+        internal PrimitiveColumn<bool> <#=method.MethodName#>Implementation<U>(U value)
 <# } #>
             where U : unmanaged
 <# } #>
@@ -77,7 +77,7 @@ namespace Microsoft.Data
 <# if (method.MethodType == MethodType.Binary) {#>
         internal BaseColumn <#=method.MethodName#>Implementation<U>(PrimitiveColumn<U> column, bool inPlace)
 <# } else { #>
-        internal BaseColumn <#=method.MethodName#>Implementation<U>(PrimitiveColumn<U> column)
+        internal PrimitiveColumn<bool> <#=method.MethodName#>Implementation<U>(PrimitiveColumn<U> column)
 <# } #>
             where U : unmanaged
 <# } #>

--- a/src/Microsoft.Data/PrimitiveColumn.cs
+++ b/src/Microsoft.Data/PrimitiveColumn.cs
@@ -27,6 +27,12 @@ namespace Microsoft.Data
             _columnContainer = column;
         }
 
+        public PrimitiveColumn(string name, IEnumerable<T?> values) : base(name, 0, typeof(T))
+        {
+            _columnContainer = new PrimitiveColumnContainer<T>(values);
+            Length = _columnContainer.Length;
+        }
+
         public PrimitiveColumn(string name, IEnumerable<T> values) : base(name, 0, typeof(T))
         {
             _columnContainer = new PrimitiveColumnContainer<T>(values);

--- a/src/Microsoft.Data/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data/PrimitiveColumnContainer.cs
@@ -59,23 +59,17 @@ namespace Microsoft.Data
         public PrimitiveColumnContainer(IEnumerable<T> values)
         {
             values = values ?? throw new ArgumentNullException(nameof(values));
-            if (Buffers.Count == 0)
-            {
-                Buffers.Add(new DataFrameBuffer<T>());
-                NullBitMapBuffers.Add(new DataFrameBuffer<byte>());
-            }
-            DataFrameBuffer<T> curBuffer = (DataFrameBuffer<T>)Buffers[Buffers.Count - 1];
             foreach (T value in values)
             {
-                if (curBuffer.Length == ReadOnlyDataFrameBuffer<T>.MaxCapacity)
-                {
-                    curBuffer = new DataFrameBuffer<T>();
-                    Buffers.Add(curBuffer);
-                    NullBitMapBuffers.Add(new DataFrameBuffer<byte>());
-                }
-                curBuffer.Append(value);
-                SetValidityBit(Length, true);
-                Length++;
+                Append(value);
+            }
+        }
+        public PrimitiveColumnContainer(IEnumerable<T?> values)
+        {
+            values = values ?? throw new ArgumentNullException(nameof(values));
+            foreach (T? value in values)
+            {
+                Append(value);
             }
         }
 
@@ -137,7 +131,7 @@ namespace Microsoft.Data
             }
             DataFrameBuffer<T> mutableLastBuffer = DataFrameBuffer<T>.GetMutableBuffer(lastBuffer);
             mutableLastBuffer.Append(value ?? default);
-            SetValidityBit(Length, value.HasValue ? true : false);
+            SetValidityBit(Length, value.HasValue);
             Length++;
         }
 

--- a/src/Microsoft.Data/StringColumn.BinaryOperations.cs
+++ b/src/Microsoft.Data/StringColumn.BinaryOperations.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Data
             return ret;
         }
 
-        public override BaseColumn Equals(BaseColumn column)
+        public override PrimitiveColumn<bool> Equals(BaseColumn column)
         {
             // TODO: Using indexing is VERY inefficient here. Each indexer call will find the "right" buffer and then return the value
             if (Length != column.Length)
@@ -57,7 +57,7 @@ namespace Microsoft.Data
             return ret;
         }
 
-        public override BaseColumn Equals<T>(T value)
+        public override PrimitiveColumn<bool> Equals<T>(T value)
         {
             PrimitiveColumn<bool> ret = new PrimitiveColumn<bool>(Name, Length);
             string valString = value.ToString();
@@ -68,7 +68,7 @@ namespace Microsoft.Data
             return ret;
         }
 
-        public override BaseColumn NotEquals(BaseColumn column)
+        public override PrimitiveColumn<bool> NotEquals(BaseColumn column)
         {
             // TODO: Using indexing is VERY inefficient here. Each indexer call will find the "right" buffer and then return the value
             if (Length != column.Length)
@@ -83,7 +83,7 @@ namespace Microsoft.Data
             return ret;
         }
 
-        public override BaseColumn NotEquals<T>(T value)
+        public override PrimitiveColumn<bool> NotEquals<T>(T value)
         {
             PrimitiveColumn<bool> ret = new PrimitiveColumn<bool>(Name, Length);
             string valString = value.ToString();

--- a/src/Microsoft.Data/StringColumn.cs
+++ b/src/Microsoft.Data/StringColumn.cs
@@ -366,10 +366,6 @@ namespace Microsoft.Data
 
         private StringColumn Clone(PrimitiveColumn<int> mapIndices, bool invertMapIndex = false)
         {
-            long? ConvertInt(long index)
-            {
-                return mapIndices[index];
-            }
             return CloneImplementation(mapIndices, invertMapIndex);
         }
 

--- a/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
@@ -1512,5 +1512,19 @@ namespace Microsoft.Data.Tests
             }
         }
 
+        [Fact]
+        public void TestColumnCreationFromExisitingColumn()
+        {
+            DataFrame df = MakeDataFrameWithAllColumnTypes(10);
+            PrimitiveColumn<bool> bigInts = new PrimitiveColumn<bool>("BugInts", df["Int"] > 5);
+            for (int i = 0; i < 10; i++)
+            {
+                if (i <= 5)
+                    Assert.False(bigInts[i]);
+                else
+                    Assert.True(bigInts[i]);
+            }
+        }
+
     }
 }

--- a/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/DataFrameTests.cs
@@ -1516,7 +1516,7 @@ namespace Microsoft.Data.Tests
         public void TestColumnCreationFromExisitingColumn()
         {
             DataFrame df = MakeDataFrameWithAllColumnTypes(10);
-            PrimitiveColumn<bool> bigInts = new PrimitiveColumn<bool>("BugInts", df["Int"] > 5);
+            PrimitiveColumn<bool> bigInts = new PrimitiveColumn<bool>("BigInts", df["Int"] > 5);
             for (int i = 0; i < 10; i++)
             {
                 if (i <= 5)


### PR DESCRIPTION
Binary comparisons always return a PrimitiveColumn<bool>
PrimitiveColumn constructor with IEnumerable<T?>

Should be an easy review 