### PR TITLE
Empty ArrowStringColumn->Arrow column

### DIFF
--- a/src/Microsoft.Data/ArrowStringColumn.cs
+++ b/src/Microsoft.Data/ArrowStringColumn.cs
@@ -312,14 +312,16 @@ namespace Microsoft.Data
 
         protected internal override Apache.Arrow.Array AsArrowArray(long startIndex, int numberOfRows)
         {
+            if (numberOfRows == 0)
+                return new StringArray.Builder().Build();
             int offsetsBufferIndex = GetBufferIndexContainingRowIndex(startIndex, out int indexInBuffer);
             if (numberOfRows != 0 && numberOfRows > _offsetsBuffers[offsetsBufferIndex].Length - 1 - indexInBuffer)
             {
                 throw new ArgumentException(Strings.SpansMultipleBuffers, nameof(numberOfRows));
             }
-            ArrowBuffer dataBuffer = numberOfRows == 0 ? ArrowBuffer.Empty : new ArrowBuffer(_dataBuffers[offsetsBufferIndex].ReadOnlyBuffer);
-            ArrowBuffer offsetsBuffer = numberOfRows == 0 ? ArrowBuffer.Empty : new ArrowBuffer(_offsetsBuffers[offsetsBufferIndex].ReadOnlyBuffer);
-            ArrowBuffer nullBuffer = numberOfRows == 0 ? ArrowBuffer.Empty : new ArrowBuffer(_nullBitMapBuffers[offsetsBufferIndex].ReadOnlyBuffer);
+            ArrowBuffer dataBuffer = new ArrowBuffer(_dataBuffers[offsetsBufferIndex].ReadOnlyBuffer);
+            ArrowBuffer offsetsBuffer = new ArrowBuffer(_offsetsBuffers[offsetsBufferIndex].ReadOnlyBuffer);
+            ArrowBuffer nullBuffer = new ArrowBuffer(_nullBitMapBuffers[offsetsBufferIndex].ReadOnlyBuffer);
             int nullCount = GetNullCount(indexInBuffer, numberOfRows);
             return new StringArray(numberOfRows, offsetsBuffer, dataBuffer, nullBuffer, nullCount, indexInBuffer);
         }

--- a/src/Microsoft.Data/ArrowStringColumn.cs
+++ b/src/Microsoft.Data/ArrowStringColumn.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Data
         protected internal override Apache.Arrow.Array AsArrowArray(long startIndex, int numberOfRows)
         {
             if (numberOfRows == 0)
-                return new StringArray.Builder().Build();
+                return new StringArray(numberOfRows, ArrowBuffer.Empty, ArrowBuffer.Empty, ArrowBuffer.Empty);
             int offsetsBufferIndex = GetBufferIndexContainingRowIndex(startIndex, out int indexInBuffer);
             if (numberOfRows != 0 && numberOfRows > _offsetsBuffers[offsetsBufferIndex].Length - 1 - indexInBuffer)
             {

--- a/tests/Microsoft.Data.DataFrame.Tests/ArrowIntegrationTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/ArrowIntegrationTests.cs
@@ -64,7 +64,8 @@ namespace Microsoft.Data.Tests
         {
             PrimitiveColumn<int> ageColumn = new PrimitiveColumn<int>("Age");
             PrimitiveColumn<int> lengthColumn = new PrimitiveColumn<int>("CharCount");
-            DataFrame df = new DataFrame(new List<BaseColumn>() { ageColumn, lengthColumn });
+            ArrowStringColumn stringColumn = new ArrowStringColumn("Empty");
+            DataFrame df = new DataFrame(new List<BaseColumn>() { ageColumn, lengthColumn, stringColumn });
 
             IEnumerable<RecordBatch> recordBatches = df.AsArrowRecordBatches();
             bool foundARecordBatch = false;


### PR DESCRIPTION
Fix a bug in `ArrowStringColumn.AsArrowArray`.
Required for the Spark work.

