### PR TITLE
Fix NullCount bugs

### DIFF
--- a/src/Microsoft.Data/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data/PrimitiveColumnContainer.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Data
                 }
                 if (!buffer.IsEmpty)
                 {
-                    // Create a new bitMap with all the bits set
+                    // Create a new bitMap with all the bits upto length set
                     var bitMap = new byte[bitMapBufferLength];
                     bitMap.AsSpan().Slice(0, bitMapBufferLength - 1).Fill(255);
                     int lastByte = 1 << (length - (bitMapBufferLength - 1) * 8); 

--- a/src/Microsoft.Data/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data/PrimitiveColumnContainer.cs
@@ -75,8 +75,47 @@ namespace Microsoft.Data
 
         public PrimitiveColumnContainer(ReadOnlyMemory<byte> buffer, ReadOnlyMemory<byte> nullBitMap, int length, int nullCount)
         {
-            Buffers.Add(new ReadOnlyDataFrameBuffer<T>(buffer, length));
-            NullBitMapBuffers.Add(new ReadOnlyDataFrameBuffer<byte>(nullBitMap, length));
+            ReadOnlyDataFrameBuffer<T> dataBuffer;
+            if (buffer.IsEmpty)
+            {
+                DataFrameBuffer<T> mutableBuffer = new DataFrameBuffer<T>();
+                mutableBuffer.EnsureCapacity(length);
+                mutableBuffer.Length = length;
+                mutableBuffer.RawSpan.Fill(default(T));
+                dataBuffer = mutableBuffer;
+            }
+            else
+            {
+                dataBuffer = new ReadOnlyDataFrameBuffer<T>(buffer, length);
+            }
+            Buffers.Add(dataBuffer);
+            int bitMapBufferLength = (length + 7) / 8;
+            ReadOnlyDataFrameBuffer<byte> nullDataFrameBuffer;
+            if (nullBitMap.IsEmpty)
+            {
+                if (nullCount != 0)
+                {
+                    throw new ArgumentNullException(Strings.InconsistentNullBitMapAndNullCount, nameof(nullBitMap));
+                }
+                if (!buffer.IsEmpty)
+                {
+                    // Create a new bitMap with all the bits set
+                    var bitMap = new byte[bitMapBufferLength];
+                    bitMap.AsSpan().Slice(0, bitMapBufferLength - 1).Fill(255);
+                    int lastByte = 1 << (length - (bitMapBufferLength - 1) * 8); 
+                    bitMap[bitMapBufferLength - 1] = (byte)(lastByte - 1);
+                    nullDataFrameBuffer = new DataFrameBuffer<byte>(bitMap, bitMapBufferLength);
+                }
+                else
+                {
+                    nullDataFrameBuffer = new DataFrameBuffer<byte>();
+                }
+            }
+            else
+            {
+                nullDataFrameBuffer = new ReadOnlyDataFrameBuffer<byte>(nullBitMap, bitMapBufferLength);
+            }
+            NullBitMapBuffers.Add(nullDataFrameBuffer);
             Length = length;
             NullCount = nullCount;
         }
@@ -100,11 +139,13 @@ namespace Microsoft.Data
                 int allocatable = (int)Math.Min(length, ReadOnlyDataFrameBuffer<T>.MaxCapacity);
                 lastBuffer.EnsureCapacity(allocatable);
                 DataFrameBuffer<byte> lastNullBitMapBuffer = (DataFrameBuffer<byte>)(NullBitMapBuffers[NullBitMapBuffers.Count - 1]);
-                lastNullBitMapBuffer.EnsureCapacity((int)Math.Ceiling(allocatable / 8.0));
+                int nullBufferAllocatable = (allocatable + 7) / 8;
+                lastNullBitMapBuffer.EnsureCapacity(nullBufferAllocatable);
                 lastBuffer.Length = allocatable;
-                lastNullBitMapBuffer.Length = allocatable;
+                lastNullBitMapBuffer.Length = nullBufferAllocatable;
                 length -= allocatable;
                 Length += lastBuffer.Length;
+                NullCount += lastBuffer.Length;
             }
         }
 
@@ -122,7 +163,8 @@ namespace Microsoft.Data
                 Buffers.Add(new DataFrameBuffer<T>());
                 NullBitMapBuffers.Add(new DataFrameBuffer<byte>());
             }
-            ReadOnlyDataFrameBuffer<T> lastBuffer = Buffers[Buffers.Count - 1];
+            int bufferIndex = Buffers.Count - 1;
+            ReadOnlyDataFrameBuffer<T> lastBuffer = Buffers[bufferIndex];
             if (lastBuffer.Length == ReadOnlyDataFrameBuffer<T>.MaxCapacity)
             {
                 lastBuffer = new DataFrameBuffer<T>();
@@ -130,6 +172,7 @@ namespace Microsoft.Data
                 NullBitMapBuffers.Add(new DataFrameBuffer<byte>());
             }
             DataFrameBuffer<T> mutableLastBuffer = DataFrameBuffer<T>.GetMutableBuffer(lastBuffer);
+            Buffers[bufferIndex] = mutableLastBuffer;
             mutableLastBuffer.Append(value ?? default);
             SetValidityBit(Length, value.HasValue);
             Length++;
@@ -149,7 +192,8 @@ namespace Microsoft.Data
                     Buffers.Add(new DataFrameBuffer<T>());
                     NullBitMapBuffers.Add(new DataFrameBuffer<byte>());
                 }
-                ReadOnlyDataFrameBuffer<T> lastBuffer = Buffers[Buffers.Count - 1];
+                int bufferIndex = Buffers.Count - 1;
+                ReadOnlyDataFrameBuffer<T> lastBuffer = Buffers[bufferIndex];
                 if (lastBuffer.Length == ReadOnlyDataFrameBuffer<T>.MaxCapacity)
                 {
                     lastBuffer = new DataFrameBuffer<T>();
@@ -157,14 +201,17 @@ namespace Microsoft.Data
                     NullBitMapBuffers.Add(new DataFrameBuffer<byte>());
                 }
                 DataFrameBuffer<T> mutableLastBuffer = DataFrameBuffer<T>.GetMutableBuffer(lastBuffer);
+                Buffers[bufferIndex] = mutableLastBuffer;
                 int allocatable = (int)Math.Min(count, ReadOnlyDataFrameBuffer<T>.MaxCapacity);
                 mutableLastBuffer.EnsureCapacity(allocatable);
                 mutableLastBuffer.RawSpan.Slice(lastBuffer.Length, allocatable).Fill(value ?? default);
                 mutableLastBuffer.Length += allocatable;
                 Length += allocatable;
 
-                ReadOnlyDataFrameBuffer<byte> lastNullBitMapBuffer = NullBitMapBuffers[NullBitMapBuffers.Count - 1];
+                int nullBitMapBufferIndex = NullBitMapBuffers.Count - 1;
+                ReadOnlyDataFrameBuffer<byte> lastNullBitMapBuffer = NullBitMapBuffers[nullBitMapBufferIndex];
                 DataFrameBuffer<byte> mutableLastNullBitMapBuffer = DataFrameBuffer<byte>.GetMutableBuffer(lastNullBitMapBuffer);
+                NullBitMapBuffers[nullBitMapBufferIndex] = mutableLastNullBitMapBuffer;
                 int nullBitMapAllocatable = (int)(((uint)allocatable) / 8) + 1;
                 mutableLastNullBitMapBuffer.EnsureCapacity(nullBitMapAllocatable);
                 _modifyNullCountWhileIndexing = false;
@@ -184,8 +231,11 @@ namespace Microsoft.Data
                 ReadOnlyDataFrameBuffer<T> buffer = Buffers[b];
                 long prevLength = checked(Buffers[0].Length * b);
                 DataFrameBuffer<T> mutableBuffer = DataFrameBuffer<T>.GetMutableBuffer(buffer);
+                Buffers[b] = mutableBuffer;
                 Span<T> span = mutableBuffer.Span;
-                Span<byte> nullBitMapSpan = DataFrameBuffer<byte>.GetMutableBuffer(NullBitMapBuffers[b]).RawSpan;
+                DataFrameBuffer<byte> mutableNullBitMapBuffer = DataFrameBuffer<byte>.GetMutableBuffer(NullBitMapBuffers[b]);
+                NullBitMapBuffers[b] = mutableNullBitMapBuffer;
+                Span<byte> nullBitMapSpan = mutableNullBitMapBuffer.Span;
                 for (int i = 0; i < span.Length; i++)
                 {
                     long curIndex = i + prevLength;
@@ -269,7 +319,7 @@ namespace Microsoft.Data
             Debug.Assert(bitMapBuffer.Length >= bitMapBufferIndex);
             if (bitMapBuffer.Length == bitMapBufferIndex)
                 bitMapBuffer.Append(0);
-            SetValidityBit(bitMapBuffer.RawSpan, (int)index, value);
+            SetValidityBit(bitMapBuffer.Span, (int)index, value);
         }
 
         private bool IsBitSet(byte curBitMap, int index)
@@ -362,6 +412,8 @@ namespace Microsoft.Data
                 ReadOnlyDataFrameBuffer<T> buffer = Buffers[arrayIndex];
                 DataFrameBuffer<T> mutableBuffer = DataFrameBuffer<T>.GetMutableBuffer(buffer);
                 Buffers[arrayIndex] = mutableBuffer;
+                DataFrameBuffer<byte> mutableNullBuffer = DataFrameBuffer<byte>.GetMutableBuffer(NullBitMapBuffers[arrayIndex]);
+                NullBitMapBuffers[arrayIndex] = mutableNullBuffer;
                 if (value.HasValue)
                 {
                     Buffers[arrayIndex][(int)rowIndex] = value.Value;
@@ -416,7 +468,7 @@ namespace Microsoft.Data
             {
                 DataFrameBuffer<byte> newBuffer = new DataFrameBuffer<byte>();
                 ret.Add(newBuffer);
-                ReadOnlySpan<byte> span = buffer.RawReadOnlySpan;
+                ReadOnlySpan<byte> span = buffer.ReadOnlySpan;
                 for (int i = 0; i < span.Length; i++)
                 {
                     newBuffer.Append(span[i]);
@@ -429,12 +481,11 @@ namespace Microsoft.Data
             where U : unmanaged
         {
             ReadOnlySpan<T> thisSpan = Buffers[0].ReadOnlySpan;
-            ReadOnlySpan<byte> thisNullBitMapSpan = NullBitMapBuffers[0].RawReadOnlySpan;
+            ReadOnlySpan<byte> thisNullBitMapSpan = NullBitMapBuffers[0].ReadOnlySpan;
             long minRange = 0;
             long maxRange = DataFrameBuffer<T>.MaxCapacity;
             long maxCapacity = maxRange;
             PrimitiveColumnContainer<T> ret = new PrimitiveColumnContainer<T>(mapIndices.Length);
-            ret._modifyNullCountWhileIndexing = false;
             for (int b = 0; b < mapIndices.Buffers.Count; b++)
             {
                 int index = b;
@@ -442,12 +493,16 @@ namespace Microsoft.Data
                     index = mapIndices.Buffers.Count - 1 - b;
 
                 ReadOnlyDataFrameBuffer<U> buffer = mapIndices.Buffers[index];
-                ReadOnlySpan<byte> mapIndicesNullBitMapSpan = mapIndices.NullBitMapBuffers[index].RawReadOnlySpan;
+                ReadOnlySpan<byte> mapIndicesNullBitMapSpan = mapIndices.NullBitMapBuffers[index].ReadOnlySpan;
                 ReadOnlySpan<U> mapIndicesSpan = buffer.ReadOnlySpan;
                 ReadOnlySpan<long> mapIndicesLongSpan = default;
                 ReadOnlySpan<int> mapIndicesIntSpan = default;
-                Span<T> retSpan = DataFrameBuffer<T>.GetMutableBuffer(ret.Buffers[index]).Span;
-                Span<byte> retNullBitMapSpan = DataFrameBuffer<byte>.GetMutableBuffer(ret.NullBitMapBuffers[index]).RawSpan;
+                DataFrameBuffer<T> mutableBuffer = DataFrameBuffer<T>.GetMutableBuffer(ret.Buffers[index]);
+                ret.Buffers[index] = mutableBuffer;
+                Span<T> retSpan = mutableBuffer.Span;
+                DataFrameBuffer<byte> mutableNullBuffer = DataFrameBuffer<byte>.GetMutableBuffer(ret.NullBitMapBuffers[index]);
+                ret.NullBitMapBuffers[index] = mutableNullBuffer;
+                Span<byte> retNullBitMapSpan = mutableNullBuffer.Span;
                 if (type == typeof(long))
                 {
                     mapIndicesLongSpan = MemoryMarshal.Cast<U, long>(mapIndicesSpan);
@@ -468,7 +523,7 @@ namespace Microsoft.Data
                     {
                         int bufferIndex = (int)(mapRowIndex / maxCapacity);
                         thisSpan = Buffers[bufferIndex].ReadOnlySpan;
-                        thisNullBitMapSpan = DataFrameBuffer<byte>.GetMutableBuffer(NullBitMapBuffers[bufferIndex]).Span;
+                        thisNullBitMapSpan = NullBitMapBuffers[bufferIndex].ReadOnlySpan;
                         minRange = bufferIndex * maxCapacity;
                         maxRange = (bufferIndex + 1) * maxCapacity;
                     }
@@ -483,11 +538,8 @@ namespace Microsoft.Data
 
                     retSpan[i] = isValid ? value : default;
                     ret.SetValidityBit(retNullBitMapSpan, i, isValid);
-                    if (!isValid)
-                        ret.NullCount++;
                 }
             }
-            ret._modifyNullCountWhileIndexing = true;
             return ret;
         }
 

--- a/src/Microsoft.Data/PrimitiveColumnContainer.cs
+++ b/src/Microsoft.Data/PrimitiveColumnContainer.cs
@@ -99,9 +99,9 @@ namespace Microsoft.Data
                 }
                 if (!buffer.IsEmpty)
                 {
-                    // Create a new bitMap with all the bits upto length set
+                    // Create a new bitMap with all the bits up to length set
                     var bitMap = new byte[bitMapBufferLength];
-                    bitMap.AsSpan().Slice(0, bitMapBufferLength - 1).Fill(255);
+                    bitMap.AsSpan().Fill(255);
                     int lastByte = 1 << (length - (bitMapBufferLength - 1) * 8); 
                     bitMap[bitMapBufferLength - 1] = (byte)(lastByte - 1);
                     nullDataFrameBuffer = new DataFrameBuffer<byte>(bitMap, bitMapBufferLength);
@@ -113,6 +113,10 @@ namespace Microsoft.Data
             }
             else
             {
+                if (nullBitMap.Length < bitMapBufferLength)
+                {
+                    throw new ArgumentException(Strings.InconsistentNullBitMapAndLength, nameof(nullBitMap));
+                }
                 nullDataFrameBuffer = new ReadOnlyDataFrameBuffer<byte>(nullBitMap, bitMapBufferLength);
             }
             NullBitMapBuffers.Add(nullDataFrameBuffer);

--- a/src/Microsoft.Data/PrimitiveDataFrameColumn.Sort.cs
+++ b/src/Microsoft.Data/PrimitiveDataFrameColumn.Sort.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Data
             for (int b = 0; b < _columnContainer.Buffers.Count; b++)
             {
                 ReadOnlyDataFrameBuffer<T> buffer = _columnContainer.Buffers[b];
-                ReadOnlySpan<byte> nullBitMapSpan = _columnContainer.NullBitMapBuffers[b].RawReadOnlySpan;
+                ReadOnlySpan<byte> nullBitMapSpan = _columnContainer.NullBitMapBuffers[b].ReadOnlySpan;
                 int[] sortIndices = new int[buffer.Length];
                 for (int i = 0; i < buffer.Length; i++)
                     sortIndices[i] = i;

--- a/src/Microsoft.Data/ReadOnlyDataFrameBuffer.cs
+++ b/src/Microsoft.Data/ReadOnlyDataFrameBuffer.cs
@@ -45,11 +45,11 @@ namespace Microsoft.Data
             get => (MemoryMarshal.Cast<byte, T>(ReadOnlyBuffer.Span)).Slice(0, Length);
         }
 
-        public ReadOnlySpan<T> RawReadOnlySpan
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => MemoryMarshal.Cast<byte, T>(ReadOnlyBuffer.Span);
-        }
+        //public ReadOnlySpan<T> RawReadOnlySpan
+        //{
+        //    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        //    get => MemoryMarshal.Cast<byte, T>(ReadOnlyBuffer.Span);
+        //}
 
         public int Length { get; internal set; }
 
@@ -74,7 +74,7 @@ namespace Microsoft.Data
             {
                 if (index > Length)
                     throw new ArgumentOutOfRangeException(nameof(index));
-                return RawReadOnlySpan[index];
+                return ReadOnlySpan[index];
             }
             set => throw new NotSupportedException();
         }

--- a/src/Microsoft.Data/ReadOnlyDataFrameBuffer.cs
+++ b/src/Microsoft.Data/ReadOnlyDataFrameBuffer.cs
@@ -45,12 +45,6 @@ namespace Microsoft.Data
             get => (MemoryMarshal.Cast<byte, T>(ReadOnlyBuffer.Span)).Slice(0, Length);
         }
 
-        //public ReadOnlySpan<T> RawReadOnlySpan
-        //{
-        //    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        //    get => MemoryMarshal.Cast<byte, T>(ReadOnlyBuffer.Span);
-        //}
-
         public int Length { get; internal set; }
 
         public ReadOnlyDataFrameBuffer(int numberOfValues = 8)

--- a/src/Microsoft.Data/strings.Designer.cs
+++ b/src/Microsoft.Data/strings.Designer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Data {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Inconsisten Null bitmaps and NullCounts.
+        ///   Looks up a localized string similar to Inconsistent Null bitmaps and NullCounts.
         /// </summary>
         public static string InconsistentNullBitMapAndNullCount {
             get {

--- a/src/Microsoft.Data/strings.Designer.cs
+++ b/src/Microsoft.Data/strings.Designer.cs
@@ -106,7 +106,16 @@ namespace Microsoft.Data {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Inconsistent Null bitmaps and NullCounts.
+        ///   Looks up a localized string similar to Inconsistent null bitmap and data buffer lengths.
+        /// </summary>
+        public static string InconsistentNullBitMapAndLength {
+            get {
+                return ResourceManager.GetString("InconsistentNullBitMapAndLength", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inconsistent null bitmaps and NullCounts.
         /// </summary>
         public static string InconsistentNullBitMapAndNullCount {
             get {

--- a/src/Microsoft.Data/strings.Designer.cs
+++ b/src/Microsoft.Data/strings.Designer.cs
@@ -106,6 +106,15 @@ namespace Microsoft.Data {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Inconsisten Null bitmaps and NullCounts.
+        /// </summary>
+        public static string InconsistentNullBitMapAndNullCount {
+            get {
+                return ResourceManager.GetString("InconsistentNullBitMapAndNullCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Column does not exist.
         /// </summary>
         public static string InvalidColumnName {

--- a/src/Microsoft.Data/strings.resx
+++ b/src/Microsoft.Data/strings.resx
@@ -133,7 +133,7 @@
     <value>Column is immutable</value>
   </data>
   <data name="InconsistentNullBitMapAndNullCount" xml:space="preserve">
-    <value>Inconsisten Null bitmaps and NullCounts</value>
+    <value>Inconsistent Null bitmaps and NullCounts</value>
   </data>
   <data name="InvalidColumnName" xml:space="preserve">
     <value>Column does not exist</value>

--- a/src/Microsoft.Data/strings.resx
+++ b/src/Microsoft.Data/strings.resx
@@ -132,6 +132,9 @@
   <data name="ImmutableColumn" xml:space="preserve">
     <value>Column is immutable</value>
   </data>
+  <data name="InconsistentNullBitMapAndNullCount" xml:space="preserve">
+    <value>Inconsisten Null bitmaps and NullCounts</value>
+  </data>
   <data name="InvalidColumnName" xml:space="preserve">
     <value>Column does not exist</value>
   </data>

--- a/src/Microsoft.Data/strings.resx
+++ b/src/Microsoft.Data/strings.resx
@@ -132,8 +132,11 @@
   <data name="ImmutableColumn" xml:space="preserve">
     <value>Column is immutable</value>
   </data>
+  <data name="InconsistentNullBitMapAndLength" xml:space="preserve">
+    <value>Inconsistent null bitmap and data buffer lengths</value>
+  </data>
   <data name="InconsistentNullBitMapAndNullCount" xml:space="preserve">
-    <value>Inconsistent Null bitmaps and NullCounts</value>
+    <value>Inconsistent null bitmaps and NullCounts</value>
   </data>
   <data name="InvalidColumnName" xml:space="preserve">
     <value>Column does not exist</value>

--- a/tests/Microsoft.Data.DataFrame.Tests/ArrayComparer.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/ArrayComparer.cs
@@ -64,7 +64,20 @@ namespace Microsoft.Data.Tests
             Assert.Equal(expectedArray.NullCount, actualArray.NullCount);
             Assert.Equal(expectedArray.Offset, actualArray.Offset);
 
-            Assert.True(expectedArray.NullBitmapBuffer.Span.SequenceEqual(actualArray.NullBitmapBuffer.Span));
+            if (expectedArray.NullCount > 0)
+            {
+                Assert.True(expectedArray.NullBitmapBuffer.Span.SequenceEqual(actualArray.NullBitmapBuffer.Span));
+            }
+            else 
+            { 
+                // expectedArray may have passed in a null bitmap. DataFrame might have populated it with Length set bits 
+                Assert.Equal(0, expectedArray.NullCount); 
+                Assert.Equal(0, actualArray.NullCount); 
+                for (int i = 0; i < actualArray.Length; i++) 
+                { 
+                    Assert.True(actualArray.IsValid(i)); 
+                } 
+            }
             Assert.True(expectedArray.Values.Slice(0, expectedArray.Length).SequenceEqual(actualArray.Values.Slice(0, actualArray.Length)));
         }
 

--- a/tests/Microsoft.Data.DataFrame.Tests/ArrowIntegrationTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/ArrowIntegrationTests.cs
@@ -87,5 +87,56 @@ namespace Microsoft.Data.Tests
             }
             Assert.True(foundARecordBatch);
         }
+
+        [Fact]
+        public void TestMutationOnArrowColumn()
+        {
+            RecordBatch originalBatch = new RecordBatch.Builder()
+                .Append("Column1", false, col => col.Int32(array => array.AppendRange(Enumerable.Range(0, 10)))).Build();
+            DataFrame df = DataFrame.FromArrowRecordBatch(originalBatch);
+            Assert.Equal(1, df["Column1"][1]);
+            df["Column1"][1] = 100;
+            Assert.Equal(100, df["Column1"][1]);
+            Assert.Equal(0, df["Column1"].NullCount);
+        }
+
+        [Fact]
+        public void TestEmptyArrowColumns()
+        {
+            // Tests to ensure that we don't crash and the internal NullCounts stay consistent on encountering:
+            // 1. Data + Empty null bitmaps
+            // 2. Empty Data + Null bitmaps
+            // 3. Empty Data + Empty null bitmaps
+            RecordBatch originalBatch = new RecordBatch.Builder()
+                .Append("EmptyNullBitMapColumn", false, col => col.Int32(array => array.AppendRange(Enumerable.Range(0, 10))))
+                .Append("EmptyDataColumn", true, new Int32Array(
+                    valueBuffer: ArrowBuffer.Empty,
+                    nullBitmapBuffer: new ArrowBuffer.Builder<byte>().Append(0x00).Append(0x00).Build(),
+                    length: 10,
+                    nullCount: 10,
+                    offset: 0)).Build();
+            DataFrame df = DataFrame.FromArrowRecordBatch(originalBatch);
+            Assert.Equal(0, df["EmptyNullBitMapColumn"].NullCount);
+            Assert.Equal(10, df["EmptyNullBitMapColumn"].Length);
+            df["EmptyNullBitMapColumn"][9] = null;
+            Assert.Equal(1, df["EmptyNullBitMapColumn"].NullCount);
+            Assert.Equal(10, df["EmptyDataColumn"].NullCount);
+            Assert.Equal(10, df["EmptyDataColumn"].Length);
+            df["EmptyDataColumn"][9] = 9;
+            Assert.Equal(9, df["EmptyDataColumn"].NullCount);
+            Assert.Equal(10, df["EmptyDataColumn"].Length);
+            for (int i = 0; i < 9; i++)
+            {
+                Assert.Equal(i, (int)df["EmptyNullBitMapColumn"][i]);
+                Assert.Null(df["EmptyDataColumn"][i]);
+            }
+
+            RecordBatch batch1 = new RecordBatch.Builder()
+                .Append("EmptyDataAndNullColumns", false, col => col.Int32(array => array.Clear())).Build();
+            DataFrame emptyDataFrame = DataFrame.FromArrowRecordBatch(batch1);
+            Assert.Equal(0, emptyDataFrame.RowCount);
+            Assert.Equal(0, emptyDataFrame["EmptyDataAndNullColumns"].Length);
+            Assert.Equal(0, emptyDataFrame["EmptyDataAndNullColumns"].NullCount);
+        }
     }
 }

--- a/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
@@ -20,24 +20,24 @@ namespace Microsoft.Data.Tests
             dataFrameColumn1.Append(null);
             Assert.Equal(1, dataFrameColumn1.NullCount);
 
-            PrimitiveDataFrameColumn<int> df2 = new PrimitiveDataFrameColumn<int>("Int2");
-            Assert.Equal(0, df2.NullCount);
+            PrimitiveDataFrameColumn<int> column2 = new PrimitiveDataFrameColumn<int>("Int2");
+            Assert.Equal(0, column2.NullCount);
 
-            PrimitiveDataFrameColumn<int> df3 = new PrimitiveDataFrameColumn<int>("Int3", 10);
-            Assert.Equal(0, df3.NullCount);
+            PrimitiveDataFrameColumn<int> column3 = new PrimitiveDataFrameColumn<int>("Int3", 10);
+            Assert.Equal(10, column3.NullCount);
 
             // Test null counts with assignments on Primitive Columns
-            df2.Append(null);
-            df2.Append(1);
-            Assert.Equal(1, df2.NullCount);
-            df2[1] = 10;
-            Assert.Equal(1, df2.NullCount);
-            df2[1] = null;
-            Assert.Equal(2, df2.NullCount);
-            df2[1] = 5;
-            Assert.Equal(1, df2.NullCount);
-            df2[0] = null;
-            Assert.Equal(1, df2.NullCount);
+            column2.Append(null);
+            column2.Append(1);
+            Assert.Equal(1, column2.NullCount);
+            column2[1] = 10;
+            Assert.Equal(1, column2.NullCount);
+            column2[1] = null;
+            Assert.Equal(2, column2.NullCount);
+            column2[1] = 5;
+            Assert.Equal(1, column2.NullCount);
+            column2[0] = null;
+            Assert.Equal(1, column2.NullCount);
 
             // Test null counts with assignments on String Columns
             StringDataFrameColumn strCol = new StringDataFrameColumn("String", 0);
@@ -214,6 +214,8 @@ namespace Microsoft.Data.Tests
                 {
                     for (int k = 0; k < 8; k++)
                     {
+                        if (j * 8 + k == column.Length) 
+                            break;
                         Assert.True(GetBit(bitMapSpan[j], k));
                     }
                 }

--- a/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
+++ b/tests/Microsoft.Data.DataFrame.Tests/BufferTests.cs
@@ -82,6 +82,17 @@ namespace Microsoft.Data.Tests
         }
 
         [Fact]
+        public void TestNullCountWithIndexers()
+        {
+            PrimitiveDataFrameColumn<int> intColumn = new PrimitiveDataFrameColumn<int>("Int", 5);
+            Assert.Equal(5, intColumn.NullCount);
+            intColumn[2] = null;
+            Assert.Equal(5, intColumn.NullCount);
+            intColumn[2] = 5;
+            Assert.Equal(4, intColumn.NullCount);
+        }
+
+        [Fact]
         public void TestValidity()
         {
             PrimitiveDataFrameColumn<int> dataFrameColumn1 = new PrimitiveDataFrameColumn<int>("Int1", Enumerable.Range(0, 10).Select(x => x));
@@ -214,7 +225,7 @@ namespace Microsoft.Data.Tests
                 {
                     for (int k = 0; k < 8; k++)
                     {
-                        if (j * 8 + k == column.Length) 
+                        if (j * 8 + k == column.Length)
                             break;
                         Assert.True(GetBit(bitMapSpan[j], k));
                     }


### PR DESCRIPTION
Fixes issues around NullCount when we encounter Arrow data(C# Arrow doesn't populate it's NullBitMapBuffer if NullCount is 0)

This patch contains half the changes from https://github.com/dotnet/corefxlab/pull/2730/. 