### PR TITLE
Fix the Description method to not throw

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -204,7 +204,6 @@ namespace Microsoft.Data.Analysis
             return new DataFrame(newColumns);
         }
 
-
         /// <summary>
         /// Generates a concise summary of each column in the DataFrame
         /// </summary>

--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -204,37 +204,54 @@ namespace Microsoft.Data.Analysis
             return new DataFrame(newColumns);
         }
 
+
+        /// <summary>
+        /// Generates a concise summary of each column in the DataFrame
+        /// </summary>
+        public DataFrame Info()
+        {
+            DataFrame ret = new DataFrame();
+
+            for (int i = 0; i < Columns.Count; i++)
+            {
+                DataFrameColumn column = Columns[i];
+                if (i == 0)
+                {
+                    StringDataFrameColumn strColumn = new StringDataFrameColumn("Info", 2);
+                    strColumn[0] = "DataType";
+                    strColumn[1] = Strings.DescriptionMethodLength;
+                    ret.Columns.Add(strColumn);
+                }
+                column.Info(ret);
+            }
+            return ret;
+        }
+
         /// <summary>
         /// Generates descriptive statistics that summarize each numeric column
         /// </summary>
         public DataFrame Description()
         {
             DataFrame ret = new DataFrame();
-            if (Columns.Count == 0)
-                return ret;
-            int i = 0;
-            while (!Columns[i].HasDescription())
+
+            bool firstDescriptionColumn = true;
+            foreach (DataFrameColumn column in Columns)
             {
-                i++;
-            }
-            ret = Columns[i].Description();
-            i++;
-            for (; i < Columns.Count; i++)
-            {
-                DataFrameColumn column = Columns[i];
                 if (!column.HasDescription())
                 {
                     continue;
                 }
-                DataFrame columnDescription = column.Description();
-                ret = ret.Merge<string>(columnDescription, "Description", "Description", "_left", "_right", JoinAlgorithm.Inner);
-                int leftMergeColumn = ret._columnCollection.IndexOf("Description" + "_left");
-                int rightMergeColumn = ret._columnCollection.IndexOf("Description" + "_right");
-                if (leftMergeColumn != -1 && rightMergeColumn != -1)
+                if (firstDescriptionColumn)
                 {
-                    ret.Columns.Remove("Description" + "_right");
-                    ret._columnCollection.SetColumnName(ret["Description_left"], "Description");
+                    firstDescriptionColumn = false;
+                    StringDataFrameColumn stringColumn = new StringDataFrameColumn("Description", 0);
+                    stringColumn.Append(Strings.DescriptionMethodLength);
+                    stringColumn.Append("Max");
+                    stringColumn.Append("Min");
+                    stringColumn.Append("Mean");
+                    ret.Columns.Add(stringColumn);
                 }
+                column.Description(ret);
             }
             return ret;
         }

--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -211,17 +211,18 @@ namespace Microsoft.Data.Analysis
         {
             DataFrame ret = new DataFrame();
 
-            for (int i = 0; i < Columns.Count; i++)
+            bool firstColumn = true;
+            foreach (DataFrameColumn column in Columns)
             {
-                DataFrameColumn column = Columns[i];
-                if (i == 0)
+                if (firstColumn)
                 {
+                    firstColumn = false;
                     StringDataFrameColumn strColumn = new StringDataFrameColumn("Info", 2);
                     strColumn[0] = "DataType";
                     strColumn[1] = Strings.DescriptionMethodLength;
                     ret.Columns.Add(strColumn);
                 }
-                column.Info(ret);
+                ret.Columns.Add(column.Info());
             }
             return ret;
         }
@@ -250,11 +251,10 @@ namespace Microsoft.Data.Analysis
                     stringColumn.Append("Mean");
                     ret.Columns.Add(stringColumn);
                 }
-                column.Description(ret);
+                ret.Columns.Add(column.Description());
             }
             return ret;
         }
-
 
         public DataFrame Sort(string columnName, bool ascending = true)
         {

--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Data.Analysis
                 {
                     firstColumn = false;
                     StringDataFrameColumn strColumn = new StringDataFrameColumn("Info", 2);
-                    strColumn[0] = "DataType";
+                    strColumn[0] = Strings.DataType;
                     strColumn[1] = Strings.DescriptionMethodLength;
                     ret.Columns.Add(strColumn);
                 }

--- a/src/Microsoft.Data.Analysis/DataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumn.cs
@@ -196,9 +196,9 @@ namespace Microsoft.Data.Analysis
         }
 
         /// <summary>
-        /// Returns a <see cref="PrimitiveDataFrameColumn{T}"/> with statistics that describe the column
+        /// Returns a <see cref= "DataFrameColumn"/> with statistics that describe the column
         /// </summary>
-        public virtual PrimitiveDataFrameColumn<float> Description() => throw new NotImplementedException();
+        public virtual DataFrameColumn Description() => throw new NotImplementedException();
 
         internal virtual PrimitiveDataFrameColumn<long> GetAscendingSortIndices() => throw new NotImplementedException();
 

--- a/src/Microsoft.Data.Analysis/DataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumn.cs
@@ -185,23 +185,20 @@ namespace Microsoft.Data.Analysis
         public virtual bool HasDescription() => false;
 
         /// <summary>
-        /// Generates a concise summary of this column.
+        /// Returns a <seealso cref="StringDataFrameColumn"/> containing the DataType and Length of this column
         /// </summary>
-        /// <param name="dataFrame"></param>
-        /// <remarks>The <seealso cref="DataFrame.Info"/> method expects this method to append values in a particular order </remarks>
-        public virtual void Info(DataFrame dataFrame)
+        public virtual StringDataFrameColumn Info()
         {
             StringDataFrameColumn dataColumn = new StringDataFrameColumn(Name, 2);
             dataColumn[0] = DataType.ToString();
             dataColumn[1] = (Length - NullCount).ToString();
-            dataFrame.Columns.Add(dataColumn);
+            return dataColumn;
         }
 
         /// <summary>
-        /// Populates <paramref name="dataFrame"/> with statistics that describe the column
+        /// Returns a <see cref="PrimitiveDataFrameColumn{T}"/> with statistics that describe the column
         /// </summary>
-        /// <remarks>The <seealso cref="DataFrame.Description"/> method expects this method to append values in a particular order </remarks>
-        public virtual void Description(DataFrame dataFrame) => throw new NotImplementedException();
+        public virtual PrimitiveDataFrameColumn<float> Description() => throw new NotImplementedException();
 
         internal virtual PrimitiveDataFrameColumn<long> GetAscendingSortIndices() => throw new NotImplementedException();
 

--- a/src/Microsoft.Data.Analysis/DataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumn.cs
@@ -185,9 +185,23 @@ namespace Microsoft.Data.Analysis
         public virtual bool HasDescription() => false;
 
         /// <summary>
-        /// Returns a DataFrame with statistics that describe the column
+        /// Generates a concise summary of this column.
         /// </summary>
-        public virtual DataFrame Description() => throw new NotImplementedException();
+        /// <param name="dataFrame"></param>
+        /// <remarks>The <seealso cref="DataFrame.Info"/> method expects this method to append values in a particular order </remarks>
+        public virtual void Info(DataFrame dataFrame)
+        {
+            StringDataFrameColumn dataColumn = new StringDataFrameColumn(Name, 2);
+            dataColumn[0] = DataType.ToString();
+            dataColumn[1] = (Length - NullCount).ToString();
+            dataFrame.Columns.Add(dataColumn);
+        }
+
+        /// <summary>
+        /// Populates <paramref name="dataFrame"/> with statistics that describe the column
+        /// </summary>
+        /// <remarks>The <seealso cref="DataFrame.Description"/> method expects this method to append values in a particular order </remarks>
+        public virtual void Description(DataFrame dataFrame) => throw new NotImplementedException();
 
         internal virtual PrimitiveDataFrameColumn<long> GetAscendingSortIndices() => throw new NotImplementedException();
 

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -551,7 +551,7 @@ namespace Microsoft.Data.Analysis
                 throw new ArgumentException(string.Format(Strings.MismatchedValueType, typeof(T)), nameof(U));
         }
 
-        public override PrimitiveDataFrameColumn<float> Description()
+        public override DataFrameColumn Description()
         {
             float? max;
             float? min;

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -551,7 +551,7 @@ namespace Microsoft.Data.Analysis
                 throw new ArgumentException(string.Format(Strings.MismatchedValueType, typeof(T)), nameof(U));
         }
 
-        public override void Description(DataFrame dataFrame)
+        public override PrimitiveDataFrameColumn<float> Description()
         {
             float? max;
             float? min;
@@ -585,7 +585,7 @@ namespace Microsoft.Data.Analysis
             column.Append(max);
             column.Append(min);
             column.Append(mean);
-            dataFrame.Columns.Add(column);
+            return column;
         }
 
         protected internal override void AddDataViewColumn(DataViewSchema.Builder builder)

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -551,25 +551,41 @@ namespace Microsoft.Data.Analysis
                 throw new ArgumentException(string.Format(Strings.MismatchedValueType, typeof(T)), nameof(U));
         }
 
-        public override DataFrame Description()
+        public override void Description(DataFrame dataFrame)
         {
-            DataFrame ret = new DataFrame();
-            StringDataFrameColumn stringColumn = new StringDataFrameColumn("Description", 0);
-            stringColumn.Append("Length");
-            stringColumn.Append("Max");
-            stringColumn.Append("Min");
-            stringColumn.Append("Mean");
-            float max = (float)Convert.ChangeType(Max(), typeof(float));
-            float min = (float)Convert.ChangeType(Min(), typeof(float));
-            float mean = (float)Convert.ChangeType(Sum(), typeof(float)) / Length;
+            float? max;
+            float? min;
+            float? mean;
+            try
+            {
+                max = (float)Convert.ChangeType(Max(), typeof(float));
+            }
+            catch (Exception)
+            {
+                max = null;
+            }
+            try
+            {
+                min = (float)Convert.ChangeType(Min(), typeof(float));
+            }
+            catch (Exception)
+            {
+                min = null;
+            }
+            try
+            {
+                mean = (float)Convert.ChangeType(Sum(), typeof(float)) / Length;
+            }
+            catch (Exception)
+            {
+                mean = null;
+            }
             PrimitiveDataFrameColumn<float> column = new PrimitiveDataFrameColumn<float>(Name);
             column.Append(Length - NullCount);
             column.Append(max);
             column.Append(min);
             column.Append(mean);
-            ret.Columns.Insert(0, stringColumn);
-            ret.Columns.Insert(1, column);
-            return ret;
+            dataFrame.Columns.Add(column);
         }
 
         protected internal override void AddDataViewColumn(DataViewSchema.Builder builder)

--- a/src/Microsoft.Data.Analysis/strings.Designer.cs
+++ b/src/Microsoft.Data.Analysis/strings.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Data {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to DataType.
+        /// </summary>
+        internal static string DataType {
+            get {
+                return ResourceManager.GetString("DataType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Length (excluding null values).
         /// </summary>
         internal static string DescriptionMethodLength {

--- a/src/Microsoft.Data.Analysis/strings.Designer.cs
+++ b/src/Microsoft.Data.Analysis/strings.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Data {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Length (excluding null values).
+        /// </summary>
+        internal static string DescriptionMethodLength {
+            get {
+                return ResourceManager.GetString("DescriptionMethodLength", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to DataFrame already contains a column called {0}.
         /// </summary>
         internal static string DuplicateColumnName {

--- a/src/Microsoft.Data.Analysis/strings.resx
+++ b/src/Microsoft.Data.Analysis/strings.resx
@@ -123,6 +123,9 @@
   <data name="ColumnIndexOutOfRange" xml:space="preserve">
     <value>Index cannot be greater than the Column's Length</value>
   </data>
+  <data name="DataType" xml:space="preserve">
+    <value>DataType</value>
+  </data>
   <data name="DescriptionMethodLength" xml:space="preserve">
     <value>Length (excluding null values)</value>
   </data>

--- a/src/Microsoft.Data.Analysis/strings.resx
+++ b/src/Microsoft.Data.Analysis/strings.resx
@@ -123,6 +123,9 @@
   <data name="ColumnIndexOutOfRange" xml:space="preserve">
     <value>Index cannot be greater than the Column's Length</value>
   </data>
+  <data name="DescriptionMethodLength" xml:space="preserve">
+    <value>Length (excluding null values)</value>
+  </data>
   <data name="DuplicateColumnName" xml:space="preserve">
     <value>DataFrame already contains a column called {0}</value>
   </data>

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -5,12 +5,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
-using System.Runtime.Serialization.Formatters;
 using System.Text;
 using Apache.Arrow;
 using Microsoft.ML;
-using Microsoft.VisualBasic;
 using Xunit;
 
 namespace Microsoft.Data.Analysis.Tests
@@ -1666,7 +1663,7 @@ namespace Microsoft.Data.Analysis.Tests
             DataFrame df = MakeDataFrameWithAllMutableColumnTypes(10);
 
             // Add a column manually here until we fix https://github.com/dotnet/corefxlab/issues/2784
-            PrimitiveDataFrameColumn<DateTime> dateTimes = new PrimitiveDataFrameColumn<DateTime>("DateTimes"); // Default length is 0.
+            PrimitiveDataFrameColumn<DateTime> dateTimes = new PrimitiveDataFrameColumn<DateTime>("DateTimes");
             for (int i = 0; i < 10; i++)
             {
                 dateTimes.Append(DateTime.Parse("2019/01/01"));
@@ -1707,7 +1704,7 @@ namespace Microsoft.Data.Analysis.Tests
             DataFrame df = MakeDataFrameWithAllMutableColumnTypes(10);
 
             // Add a column manually here until we fix https://github.com/dotnet/corefxlab/issues/2784
-            PrimitiveDataFrameColumn<DateTime> dateTimes = new PrimitiveDataFrameColumn<DateTime>("DateTimes"); // Default length is 0.
+            PrimitiveDataFrameColumn<DateTime> dateTimes = new PrimitiveDataFrameColumn<DateTime>("DateTimes");
             for (int i = 0; i < 10; i++)
             {
                 dateTimes.Append(DateTime.Parse("2019/01/01"));

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -5,9 +5,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
+using System.Runtime.Serialization.Formatters;
 using System.Text;
 using Apache.Arrow;
 using Microsoft.ML;
+using Microsoft.VisualBasic;
 using Xunit;
 
 namespace Microsoft.Data.Analysis.Tests
@@ -1661,14 +1664,23 @@ namespace Microsoft.Data.Analysis.Tests
         public void TestDescription()
         {
             DataFrame df = MakeDataFrameWithAllMutableColumnTypes(10);
+
+            // Add a column manually here until we fix https://github.com/dotnet/corefxlab/issues/2784
+            PrimitiveDataFrameColumn<DateTime> dateTimes = new PrimitiveDataFrameColumn<DateTime>("DateTimes"); // Default length is 0.
+            for (int i = 0; i < 10; i++)
+            {
+                dateTimes.Append(DateTime.Parse("2019/01/01"));
+            }
+            df.Columns.Add(dateTimes);
+
             DataFrame description = df.Description();
             DataFrameColumn descriptionColumn = description.Columns[0];
             Assert.Equal("Description", descriptionColumn.Name);
-            Assert.Equal("Length", descriptionColumn[0]);
+            Assert.Equal("Length (excluding null values)", descriptionColumn[0]);
             Assert.Equal("Max", descriptionColumn[1]);
             Assert.Equal("Min", descriptionColumn[2]);
             Assert.Equal("Mean", descriptionColumn[3]);
-            for (int i = 1; i < description.Columns.Count; i++)
+            for (int i = 1; i < description.Columns.Count - 1; i++)
             {
                 DataFrameColumn column = description.Columns[i];
                 Assert.Equal(df.Columns[i - 1].Name, column.Name);
@@ -1677,6 +1689,42 @@ namespace Microsoft.Data.Analysis.Tests
                 Assert.Equal((float)9, column[1]);
                 Assert.Equal((float)0, column[2]);
                 Assert.Equal((float)4, column[3]);
+            }
+
+            // Explicitly check the dateTimes column
+            DataFrameColumn dateTimeColumn = description.Columns[description.Columns.Count - 1];
+            Assert.Equal(dateTimeColumn.Name, dateTimes.Name);
+            Assert.Equal(4, dateTimeColumn.Length);
+            Assert.Equal((float)10, dateTimeColumn[0]);
+            Assert.Null(dateTimeColumn[1]);
+            Assert.Null(dateTimeColumn[2]);
+            Assert.Null(dateTimeColumn[3]);
+        }
+
+        [Fact]
+        public void TestInfo()
+        {
+            DataFrame df = MakeDataFrameWithAllMutableColumnTypes(10);
+
+            // Add a column manually here until we fix https://github.com/dotnet/corefxlab/issues/2784
+            PrimitiveDataFrameColumn<DateTime> dateTimes = new PrimitiveDataFrameColumn<DateTime>("DateTimes"); // Default length is 0.
+            for (int i = 0; i < 10; i++)
+            {
+                dateTimes.Append(DateTime.Parse("2019/01/01"));
+            }
+            df.Columns.Add(dateTimes);
+
+            DataFrame Info = df.Info();
+            DataFrameColumn infoColumn = Info.Columns[0];
+            Assert.Equal("Info", infoColumn.Name);
+            Assert.Equal("Length (excluding null values)", infoColumn[1]);
+            Assert.Equal("DataType", infoColumn[0]);
+
+            for (int i = 1; i < Info.Columns.Count; i++)
+            {
+                DataFrameColumn column = Info.Columns[i];
+                Assert.Equal(df.Columns[i - 1].DataType.ToString(), column[0].ToString());
+                Assert.Equal(2, column.Length);
             }
         }
 


### PR DESCRIPTION
Adds an Info method

The Description method was always calling `Max` on `PrimitiveDataFrameColumn<T>`. If `T` was a struct (such as `DateTime` where `Max` may not be well defined), we return `null` instead of throwing. 