### PR TITLE
Use dataTypes if it passed in to LoadCsv

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -286,59 +286,5 @@ namespace Microsoft.Data.Analysis
             }
             return ret;
         }
-
-        private static void AppendRow(List<DataFrameColumn> columns, long rowIndex, string[] values)
-        {
-            for (int i = 0; i < columns.Count; i++)
-            {
-                DataFrameColumn column = columns[i];
-                string val = values[i];
-                Type dType = column.DataType;
-                if (dType == typeof(bool))
-                {
-                    bool boolParse = bool.TryParse(val, out bool boolResult);
-                    if (boolParse)
-                    {
-                        column[rowIndex] = boolResult;
-                        continue;
-                    }
-                    else
-                    {
-                        if (string.IsNullOrEmpty(val))
-                        {
-                            column[rowIndex] = null;
-                            continue;
-                        }
-                        throw new ArgumentException(string.Format(Strings.MismatchedValueType, typeof(bool)), nameof(val));
-                    }
-                }
-                else if (dType == typeof(float))
-                {
-                    bool floatParse = float.TryParse(val, out float floatResult);
-                    if (floatParse)
-                    {
-                        column[rowIndex] = floatResult;
-                        continue;
-                    }
-                    else
-                    {
-                        if (string.IsNullOrEmpty(val))
-                        {
-                            column[rowIndex] = null;
-                            continue;
-                        }
-                        throw new ArgumentException(string.Format(Strings.MismatchedValueType, typeof(float)), nameof(val));
-                    }
-                }
-                else if (dType == typeof(string))
-                {
-                    column[rowIndex] = values[i];
-                }
-                else
-                {
-                    throw new NotImplementedException();
-                }
-            }
-        }
     }
 }

--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -197,12 +197,11 @@ namespace Microsoft.Data.Analysis
 
             var linesForGuessType = new List<string[]>();
             long rowline = 0;
-            int numberOfColumns = dataTypes != null ? dataTypes.Length : 0;
+            int numberOfColumns = dataTypes?.Length ?? 0;
 
             if (header == true && numberOfRowsToRead != -1)
                 numberOfRowsToRead++;
 
-            DataFrame ret;
             List<DataFrameColumn> columns;
             long streamStart = csvStream.Position;
             // First pass: schema and number of rows.
@@ -244,7 +243,7 @@ namespace Microsoft.Data.Analysis
                         throw new FormatException(Strings.EmptyFile);
                     }
                 }
-                
+
                 columns = new List<DataFrameColumn>(numberOfColumns);
                 // Guesses types or looks up dataTypes and adds columns.
                 for (int i = 0; i < numberOfColumns; ++i)
@@ -253,7 +252,7 @@ namespace Microsoft.Data.Analysis
                     columns.Add(CreateColumn(kind, columnNames, i));
                 }
 
-                ret = new DataFrame(columns);
+                DataFrame ret = new DataFrame(columns);
                 line = null;
                 streamReader.DiscardBufferedData();
                 streamReader.BaseStream.Seek(streamStart, SeekOrigin.Begin);
@@ -285,8 +284,8 @@ namespace Microsoft.Data.Analysis
                     }
                     columns.Insert(0, indexColumn);
                 }
+                return ret;
             }
-            return ret;
         }
     }
 }

--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -202,9 +202,9 @@ namespace Microsoft.Data.Analysis
             if (header == true && numberOfRowsToRead != -1)
                 numberOfRowsToRead++;
 
+            DataFrame ret;
             List<DataFrameColumn> columns;
             long streamStart = csvStream.Position;
-            DataFrame ret;
             // First pass: schema and number of rows.
             using (var streamReader = new StreamReader(csvStream, encoding: null, detectEncodingFromByteOrderMarks: true, bufferSize: -1, leaveOpen: true))
             {
@@ -232,17 +232,19 @@ namespace Microsoft.Data.Analysis
                             }
                         }
                         ++rowline;
-                        if (rowline == numberOfRowsToRead)
+                        if (rowline == guessRows)
+                        {
                             break;
+                        }
                         line = streamReader.ReadLine();
                     }
 
                     if (linesForGuessType.Count == 0)
                     {
                         throw new FormatException(Strings.EmptyFile);
-
                     }
                 }
+                
                 columns = new List<DataFrameColumn>(numberOfColumns);
                 // Guesses types or looks up dataTypes and adds columns.
                 for (int i = 0; i < numberOfColumns; ++i)

--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -429,7 +429,7 @@ namespace Microsoft.Data.Analysis
                 {
                     DataFrameColumn column = columnEnumerator.Current;
                     object value = rowEnumerator.Current;
-                    if (value is string stringValue && string.IsNullOrEmpty(stringValue))
+                    if (value is string stringValue && string.IsNullOrEmpty(stringValue) && column.DataType != typeof(string))
                     {
                         value = null;
                     }

--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -429,6 +429,7 @@ namespace Microsoft.Data.Analysis
                 {
                     DataFrameColumn column = columnEnumerator.Current;
                     object value = rowEnumerator.Current;
+                    // StringDataFrameColumn can accept empty strings. The other columns interpret empty values as nulls
                     if (value is string stringValue && string.IsNullOrEmpty(stringValue) && column.DataType != typeof(string))
                     {
                         value = null;

--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -429,6 +429,10 @@ namespace Microsoft.Data.Analysis
                 {
                     DataFrameColumn column = columnEnumerator.Current;
                     object value = rowEnumerator.Current;
+                    if (value is string stringValue && string.IsNullOrEmpty(stringValue))
+                    {
+                        value = null;
+                    }
                     if (value != null)
                     {
                         value = Convert.ChangeType(value, column.DataType);

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrame.IOTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrame.IOTests.cs
@@ -96,10 +96,12 @@ CMT,1,1,181,0.6,CSH,4.5";
                 }
             }
             var nullRow = df[3];
+            Assert.Equal("", nullRow[0]);
             Assert.Null(nullRow[1]);
             Assert.Null(nullRow[2]);
             Assert.Null(nullRow[3]);
             Assert.Null(nullRow[4]);
+            Assert.Equal("", nullRow[5]);
             Assert.Null(nullRow[6]);
         }
     }

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrame.IOTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrame.IOTests.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Text;
 using Xunit;
 
@@ -57,6 +56,43 @@ CMT,1,1,181,0.6,CSH,4.5";
             Assert.Equal(3, reducedRows.RowCount);
             Assert.Equal(7, reducedRows.Columns.Count);
             Assert.Equal("CMT", reducedRows["Column0"][2]);
+        }
+
+        [Fact]
+        public void TestReadCsvWithTypes()
+        {
+            string data = @"vendor_id,rate_code,passenger_count,trip_time_in_secs,trip_distance,payment_type,fare_amount
+CMT,1,1,1271,3.8,CRD,17.5
+CMT,1,1,474,1.5,CRD,8
+CMT,1,1,637,1.4,CRD,8.5
+,,,,,,
+CMT,1,1,181,0.6,CSH,4.5";
+
+            Stream GetStream(string streamData)
+            {
+                return new MemoryStream(Encoding.Default.GetBytes(streamData));
+            }
+            DataFrame df = DataFrame.LoadCsv(GetStream(data), dataTypes: new Type[] { typeof(string), typeof(short), typeof(int), typeof(long), typeof(float), typeof(string), typeof(double) });
+            Assert.Equal(5, df.RowCount);
+            Assert.Equal(7, df.Columns.Count);
+
+            Assert.True(typeof(string) == df.Columns[0].DataType);
+            Assert.True(typeof(short) == df.Columns[1].DataType);
+            Assert.True(typeof(int) == df.Columns[2].DataType);
+            Assert.True(typeof(long) == df.Columns[3].DataType);
+            Assert.True(typeof(float) == df.Columns[4].DataType);
+            Assert.True(typeof(string) == df.Columns[5].DataType);
+            Assert.True(typeof(double) == df.Columns[6].DataType);
+
+            foreach (var column in df.Columns)
+            {
+                Assert.Equal(1, column.NullCount);
+            }
+            var nullRow = df[3];
+            foreach (var value in nullRow)
+            {
+                Assert.Null(value);
+            }
         }
     }
 }

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrame.IOTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrame.IOTests.cs
@@ -86,13 +86,21 @@ CMT,1,1,181,0.6,CSH,4.5";
 
             foreach (var column in df.Columns)
             {
-                Assert.Equal(1, column.NullCount);
+                if (column.DataType != typeof(string))
+                {
+                    Assert.Equal(1, column.NullCount);
+                }
+                else
+                {
+                    Assert.Equal(0, column.NullCount);
+                }
             }
             var nullRow = df[3];
-            foreach (var value in nullRow)
-            {
-                Assert.Null(value);
-            }
+            Assert.Null(nullRow[1]);
+            Assert.Null(nullRow[2]);
+            Assert.Null(nullRow[3]);
+            Assert.Null(nullRow[4]);
+            Assert.Null(nullRow[6]);
         }
     }
 }

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -1881,5 +1881,15 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(5, df.Columns[0].NullCount);
             Assert.Equal(6, df.Columns[1].NullCount);
         }
+
+        [Fact]
+        public void TestAppendEmptyValue()
+        {
+            DataFrame df = MakeDataFrame<int, bool>(10);
+            df.Append(new List<object> { "", true });
+            Assert.Equal(11, df.RowCount);
+            Assert.Equal(2, df.Columns[0].NullCount);
+            Assert.Equal(1, df.Columns[1].NullCount);
+        }
     }
 }

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -1890,6 +1890,19 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(11, df.RowCount);
             Assert.Equal(2, df.Columns[0].NullCount);
             Assert.Equal(1, df.Columns[1].NullCount);
+
+            StringDataFrameColumn column = new StringDataFrameColumn("Strings", Enumerable.Range(0, 11).Select(x => x.ToString()));
+            df.Columns.Add(column);
+
+            df.Append(new List<object> { 1, true, "" });
+            Assert.Equal(12, df.RowCount);
+            Assert.Equal(2, df.Columns[0].NullCount);
+            Assert.Equal(1, df.Columns[1].NullCount);
+            Assert.Equal(0, df.Columns[2].NullCount);
+
+            df.Append(new List<object> { 1, true, null });
+            Assert.Equal(13, df.RowCount);
+            Assert.Equal(1, df.Columns[2].NullCount);
         }
     }
 }


### PR DESCRIPTION
At the moment, we ignore dataTypes if it passed in to `LoadCsv`. This patch lets us use `dataTypes` and also read in the input file just once when the data types are known. If dataTypes is `null`, we don't read the full file twice now. Instead, we rely on the `DataFrame.Append` method to append values as we read them. 

`dataTypes` can still have structs or user defined types. We just throw in such cases. 