### PR TITLE
DataFrame.LoadCsv throws an exception on projects targeting < netcore3.0

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -5,12 +5,14 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace Microsoft.Data.Analysis
 {
-
     public partial class DataFrame
     {
+        private const int DefaultStreamReaderBufferSize = 1024;
+
         private static Type GuessKind(int col, List<string[]> read)
         {
             Type res = typeof(string);
@@ -205,7 +207,7 @@ namespace Microsoft.Data.Analysis
             List<DataFrameColumn> columns;
             long streamStart = csvStream.Position;
             // First pass: schema and number of rows.
-            using (var streamReader = new StreamReader(csvStream, encoding: null, detectEncodingFromByteOrderMarks: true, bufferSize: -1, leaveOpen: true))
+            using (var streamReader = new StreamReader(csvStream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, DefaultStreamReaderBufferSize, leaveOpen: true))
             {
                 string line = null;
                 if (dataTypes == null)

--- a/tests/Microsoft.Data.Analysis.Tests/BufferTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/BufferTests.cs
@@ -188,6 +188,7 @@ namespace Microsoft.Data.Analysis.Tests
                 Assert.Null(clone[i]);
         }
 
+#if !NETFRAMEWORK // https://github.com/dotnet/corefxlab/issues/2796
         [Fact]
         public void TestPrimitiveColumnGetReadOnlyBuffers()
         {
@@ -275,5 +276,6 @@ namespace Microsoft.Data.Analysis.Tests
                 }
             }
         }
+#endif //!NETFRAMEWORK
     }
 }

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.IDataView.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.IDataView.cs
@@ -66,8 +66,8 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal((ushort)1, preview.ColumnView[10].Values[1]);
 
             Assert.Equal("String", preview.ColumnView[11].Column.Name);
-            Assert.Equal("0".AsMemory(), preview.ColumnView[11].Values[0]);
-            Assert.Equal("1".AsMemory(), preview.ColumnView[11].Values[1]);
+            Assert.Equal("0".ToString(), preview.ColumnView[11].Values[0].ToString());
+            Assert.Equal("1".ToString(), preview.ColumnView[11].Values[1].ToString());
 
             Assert.Equal("Char", preview.ColumnView[12].Column.Name);
             Assert.Equal((ushort)65, preview.ColumnView[12].Values[0]);

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Data.Analysis.Tests
         {
             IEnumerable<int> randomIndices = Enumerable.Range(0, (int)input.RowCount);
             IEnumerable<int> trainIndices = randomIndices.Take((int)(input.RowCount * testRatio));
-            IEnumerable<int> testIndices = randomIndices.TakeLast((int)(input.RowCount * (1 - testRatio)));
+            IEnumerable<int> testIndices = randomIndices.Skip((int)(input.RowCount * testRatio));
             Test = input[testIndices];
             return input[trainIndices];
         }
@@ -1540,11 +1540,11 @@ namespace Microsoft.Data.Analysis.Tests
 
             DataFrame prefix = df.AddPrefix("Prefix_");
             IEnumerable<DataViewSchema.Column> prefixNames = ((IDataView)prefix).Schema;
-            foreach ((DataViewSchema.Column First, DataViewSchema.Column Second) in columnNames.Zip(((IDataView)df).Schema))
+            foreach ((DataViewSchema.Column First, DataViewSchema.Column Second) in columnNames.Zip(((IDataView)df).Schema, (e1, e2) => (e1, e2)))
             {
                 Assert.Equal(First.Name, Second.Name);
             }
-            foreach ((DataViewSchema.Column First, DataViewSchema.Column Second) in prefixNames.Zip(columnNames))
+            foreach ((DataViewSchema.Column First, DataViewSchema.Column Second) in prefixNames.Zip(columnNames, (e1, e2) => (e1, e2)))
             {
                 Assert.Equal(First.Name, "Prefix_" + Second.Name);
             }
@@ -1552,18 +1552,18 @@ namespace Microsoft.Data.Analysis.Tests
             // Inplace
             df.AddPrefix("Prefix_", true);
             prefixNames = ((IDataView)df).Schema;
-            foreach ((DataViewSchema.Column First, DataViewSchema.Column Second) in columnNames.Zip(prefixNames))
+            foreach ((DataViewSchema.Column First, DataViewSchema.Column Second) in columnNames.Zip(prefixNames, (e1, e2) => (e1, e2)))
             {
                 Assert.Equal("Prefix_" + First.Name, Second.Name);
             }
 
             DataFrame suffix = df.AddSuffix("_Suffix");
             IEnumerable<DataViewSchema.Column> suffixNames = ((IDataView)suffix).Schema;
-            foreach ((DataViewSchema.Column First, DataViewSchema.Column Second) in ((IDataView)df).Schema.Zip(columnNames))
+            foreach ((DataViewSchema.Column First, DataViewSchema.Column Second) in ((IDataView)df).Schema.Zip(columnNames, (e1, e2) => (e1, e2)))
             {
                 Assert.Equal(First.Name, "Prefix_" + Second.Name);
             }
-            foreach ((DataViewSchema.Column First, DataViewSchema.Column Second) in columnNames.Zip(suffixNames))
+            foreach ((DataViewSchema.Column First, DataViewSchema.Column Second) in columnNames.Zip(suffixNames, (e1, e2) => (e1, e2)))
             {
                 Assert.Equal("Prefix_" + First.Name + "_Suffix", Second.Name);
             }
@@ -1571,7 +1571,7 @@ namespace Microsoft.Data.Analysis.Tests
             // InPlace
             df.AddSuffix("_Suffix", true);
             suffixNames = ((IDataView)df).Schema;
-            foreach ((DataViewSchema.Column First, DataViewSchema.Column Second) in columnNames.Zip(suffixNames))
+            foreach ((DataViewSchema.Column First, DataViewSchema.Column Second) in columnNames.Zip(suffixNames, (e1, e2) => (e1, e2)))
             {
                 Assert.Equal("Prefix_" + First.Name + "_Suffix", Second.Name);
             }
@@ -1888,19 +1888,19 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(2, df.Columns[0].NullCount);
             Assert.Equal(3, df.Columns[1].NullCount);
 
-            df.Append(new List<KeyValuePair<string, object>> { KeyValuePair.Create("Column1", (object)5), KeyValuePair.Create("Column2", (object)false) });
+            df.Append(new Dictionary<string, object> { { "Column1", (object)5 } ,  { "Column2", false } });
             Assert.Equal(14, df.RowCount);
             Assert.Equal(2, df.Columns[0].NullCount);
             Assert.Equal(3, df.Columns[1].NullCount);
 
-            df.Append(new List<KeyValuePair<string, object>> { KeyValuePair.Create("Column1", (object)5) });
+            df.Append(new Dictionary<string, object> { { "Column1", 5 } });
             Assert.Equal(15, df.RowCount);
             Assert.Equal(15, df["Column1"].Length);
             Assert.Equal(15, df["Column2"].Length);
             Assert.Equal(2, df.Columns[0].NullCount);
             Assert.Equal(4, df.Columns[1].NullCount);
 
-            df.Append(new List<KeyValuePair<string, object>> { KeyValuePair.Create("Column2", (object)false) });
+            df.Append(new Dictionary<string, object> { { "Column2", false } });
             Assert.Equal(16, df.RowCount);
             Assert.Equal(16, df["Column1"].Length);
             Assert.Equal(16, df["Column2"].Length);
@@ -1916,7 +1916,7 @@ namespace Microsoft.Data.Analysis.Tests
 
             // DataFrame must remain usable even if Append throws
             Assert.Throws<FormatException>(() => df.Append(new List<object> { 5, "str" }));
-            Assert.Throws<FormatException>(() => df.Append(new List<KeyValuePair<string, object>> { KeyValuePair.Create("Column2", (object)"str") }));
+            Assert.Throws<FormatException>(() => df.Append(new Dictionary<string, object> { { "Column2", "str" } }));
             Assert.Throws<ArgumentException>(() => df.Append(new List<object> { 5, true, true }));
 
             df.Append();

--- a/tests/Microsoft.Data.Analysis.Tests/Microsoft.Data.Analysis.Tests.csproj
+++ b/tests/Microsoft.Data.Analysis.Tests/Microsoft.Data.Analysis.Tests.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixing by passing in an encoding and a default buffer size.

Also, get our tests running on .NET Framework.

Fix #2783