### PR TITLE
Add Apply<TResult>method to PrimitiveDataFrameColumn

### DIFF
--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -487,6 +487,13 @@ namespace Microsoft.Data.Analysis
 
         public void ApplyElementwise(Func<T?, long, T?> func) => _columnContainer.ApplyElementwise(func);
 
+        public PrimitiveDataFrameColumn<TResult> Apply<TResult>(Func<T?, TResult?> func) where TResult : unmanaged
+        {
+            var resultColumn = new PrimitiveDataFrameColumn<TResult>("Result", Length);
+            _columnContainer.Apply(func, resultColumn._columnContainer);
+            return resultColumn;
+        }
+
         /// <summary>
         /// Clips values beyond the specified thresholds
         /// </summary>

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -487,6 +487,12 @@ namespace Microsoft.Data.Analysis
 
         public void ApplyElementwise(Func<T?, long, T?> func) => _columnContainer.ApplyElementwise(func);
 
+        /// <summary>
+        /// Applies a function to all the values
+        /// </summary>
+        /// <typeparam name="TResult">The new column's type</typeparam>
+        /// <param name="func">The function to apply</param>
+        /// <returns>A new PrimitiveDataFrameColumn containing the new values</returns>
         public PrimitiveDataFrameColumn<TResult> Apply<TResult>(Func<T?, TResult?> func) where TResult : unmanaged
         {
             var resultColumn = new PrimitiveDataFrameColumn<TResult>("Result", Length);

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -1946,6 +1946,7 @@ namespace Microsoft.Data.Analysis.Tests
                 }
             }
         }
+
         [Fact]
         public void TestAppendRow()
         {
@@ -2026,6 +2027,23 @@ namespace Microsoft.Data.Analysis.Tests
             df.Append(new List<object> { 1, true, null });
             Assert.Equal(13, df.Rows.Count);
             Assert.Equal(1, df.Columns[2].NullCount);
+        }
+
+        [Fact]
+        public void TestApply()
+        {
+            int[] values = { 1, 2, 3, 4, 5 };
+            var col = new PrimitiveDataFrameColumn<int>("Ints", values);
+            var df = new DataFrame(col);
+            PrimitiveDataFrameColumn<double> newCol = col.Apply(i => i + 0.5d);
+
+            Assert.Equal(values.Length, newCol.Length);
+
+            for (int i = 0; i < newCol.Length; i++)
+            {
+                Assert.Equal(col[i], values[i]); // Make sure values didn't change
+                Assert.Equal(newCol[i], values[i] + 0.5d);
+            }
         }
     }
 }

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -2034,7 +2034,6 @@ namespace Microsoft.Data.Analysis.Tests
         {
             int[] values = { 1, 2, 3, 4, 5 };
             var col = new PrimitiveDataFrameColumn<int>("Ints", values);
-            var df = new DataFrame(col);
             PrimitiveDataFrameColumn<double> newCol = col.Apply(i => i + 0.5d);
 
             Assert.Equal(values.Length, newCol.Length);


### PR DESCRIPTION
For issue #2805.

This PR adds an `Apply<TResult>` method to `PrimitiveDataFrameColumn` that takes a `Func<T?, TResult?>` and returns a new column with the new type.

Example usage (taken from the written unit test):
```csharp
int[] values = { 1, 2, 3, 4, 5 };
var col = new PrimitiveDataFrameColumn<int>("Ints", values);
PrimitiveDataFrameColumn<double> newCol = col.Apply(i => i + 0.5d);
```