### PR TITLE
Added static factory methods to DataFrameColumn 

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumn.cs
@@ -24,8 +24,6 @@ namespace Microsoft.Data.Analysis
             DataType = type;
         }
 
-        #region Static Factory Methods
-
         /// <summary>
         /// A static factory method to create a <see cref="PrimitiveDataFrameColumn{T}"/>. 
         /// It allows you to take advantage of type inference based on the type of the values supplied.
@@ -64,8 +62,6 @@ namespace Microsoft.Data.Analysis
         {
             return new StringDataFrameColumn(name, values);
         }
-
-        #endregion
 
         private long _length;
         public long Length

--- a/src/Microsoft.Data.Analysis/DataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumn.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Analysis
         }
 
         /// <summary>
-        /// A static factory method to create a <see cref="StringDataFrameColumn{T}"/>. 
+        /// A static factory method to create a <see cref="StringDataFrameColumn"/>. 
         /// It allows you to take advantage of type inference based on the type of the values supplied.
         /// </summary>
         /// <typeparam name="T">The type of the column to create.</typeparam>

--- a/src/Microsoft.Data.Analysis/DataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumn.cs
@@ -24,6 +24,49 @@ namespace Microsoft.Data.Analysis
             DataType = type;
         }
 
+        #region Static Factory Methods
+
+        /// <summary>
+        /// A static factory method to create a <see cref="PrimitiveDataFrameColumn{T}"/>. 
+        /// It allows you to take advantage of type inference based on the type of the values supplied.
+        /// </summary>
+        /// <typeparam name="T">The type of the column to create.</typeparam>
+        /// <param name="name">The name of the column.</param>
+        /// <param name="values">The initial values to populate in the column.</param>
+        /// <returns>A <see cref="PrimitiveDataFrameColumn{T}"/> populated with the provided data.</returns>
+        public static PrimitiveDataFrameColumn<T> Create<T>(string name, IEnumerable<T?> values) where T : unmanaged
+        {
+            return new PrimitiveDataFrameColumn<T>(name, values);
+        }
+
+        /// <summary>
+        /// A static factory method to create a <see cref="PrimitiveDataFrameColumn{T}"/>. 
+        /// It allows you to take advantage of type inference based on the type of the values supplied.
+        /// </summary>
+        /// <typeparam name="T">The type of the column to create.</typeparam>
+        /// <param name="name">The name of the column.</param>
+        /// <param name="values">The initial values to populate in the column.</param>
+        /// <returns>A <see cref="PrimitiveDataFrameColumn{T}"/> populated with the provided data.</returns>
+        public static PrimitiveDataFrameColumn<T> Create<T>(string name, IEnumerable<T> values) where T : unmanaged
+        {
+            return new PrimitiveDataFrameColumn<T>(name, values);
+        }
+
+        /// <summary>
+        /// A static factory method to create a <see cref="StringDataFrameColumn{T}"/>. 
+        /// It allows you to take advantage of type inference based on the type of the values supplied.
+        /// </summary>
+        /// <typeparam name="T">The type of the column to create.</typeparam>
+        /// <param name="name">The name of the column.</param>
+        /// <param name="values">The initial values to populate in the column.</param>
+        /// <returns>A <see cref="StringDataFrameColumn{T}"/> populated with the provided data.</returns>
+        public static StringDataFrameColumn Create(string name, IEnumerable<string> values)
+        {
+            return new StringDataFrameColumn(name, values);
+        }
+
+        #endregion
+
         private long _length;
         public long Length
         {

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -104,14 +104,14 @@ namespace Microsoft.Data.Analysis.Tests
         public static DataFrame MakeDataFrameWithNumericAndStringColumns(int length, bool withNulls = true)
         {
             DataFrame df = MakeDataFrameWithNumericColumns(length, withNulls);
-            DataFrameColumn stringColumn = new StringDataFrameColumn("String", Enumerable.Range(0, length).Select(x => x.ToString()));
+            DataFrameColumn stringColumn = DataFrameColumn.Create("String", Enumerable.Range(0, length).Select(x => x.ToString()));
             df.Columns.Insert(df.Columns.Count, stringColumn);
             if (withNulls)
             {
                 stringColumn[length / 2] = null;
             }
 
-            DataFrameColumn charColumn = new PrimitiveDataFrameColumn<char>("Char", Enumerable.Range(0, length).Select(x => (char)(x + 65)));
+            DataFrameColumn charColumn = DataFrameColumn.Create("Char", Enumerable.Range(0, length).Select(x => (char)(x + 65)));
             df.Columns.Insert(df.Columns.Count, charColumn);
             if (withNulls)
             {
@@ -122,17 +122,17 @@ namespace Microsoft.Data.Analysis.Tests
 
         public static DataFrame MakeDataFrameWithNumericColumns(int length, bool withNulls = true)
         {
-            DataFrameColumn byteColumn = new PrimitiveDataFrameColumn<byte>("Byte", Enumerable.Range(0, length).Select(x => (byte)x));
-            DataFrameColumn decimalColumn = new PrimitiveDataFrameColumn<decimal>("Decimal", Enumerable.Range(0, length).Select(x => (decimal)x));
-            DataFrameColumn doubleColumn = new PrimitiveDataFrameColumn<double>("Double", Enumerable.Range(0, length).Select(x => (double)x));
-            DataFrameColumn floatColumn = new PrimitiveDataFrameColumn<float>("Float", Enumerable.Range(0, length).Select(x => (float)x));
-            DataFrameColumn intColumn = new PrimitiveDataFrameColumn<int>("Int", Enumerable.Range(0, length).Select(x => x));
-            DataFrameColumn longColumn = new PrimitiveDataFrameColumn<long>("Long", Enumerable.Range(0, length).Select(x => (long)x));
-            DataFrameColumn sbyteColumn = new PrimitiveDataFrameColumn<sbyte>("Sbyte", Enumerable.Range(0, length).Select(x => (sbyte)x));
-            DataFrameColumn shortColumn = new PrimitiveDataFrameColumn<short>("Short", Enumerable.Range(0, length).Select(x => (short)x));
-            DataFrameColumn uintColumn = new PrimitiveDataFrameColumn<uint>("Uint", Enumerable.Range(0, length).Select(x => (uint)x));
-            DataFrameColumn ulongColumn = new PrimitiveDataFrameColumn<ulong>("Ulong", Enumerable.Range(0, length).Select(x => (ulong)x));
-            DataFrameColumn ushortColumn = new PrimitiveDataFrameColumn<ushort>("Ushort", Enumerable.Range(0, length).Select(x => (ushort)x));
+            DataFrameColumn byteColumn = DataFrameColumn.Create("Byte", Enumerable.Range(0, length).Select(x => (byte)x));
+            DataFrameColumn decimalColumn = DataFrameColumn.Create("Decimal", Enumerable.Range(0, length).Select(x => (decimal)x));
+            DataFrameColumn doubleColumn = DataFrameColumn.Create("Double", Enumerable.Range(0, length).Select(x => (double)x));
+            DataFrameColumn floatColumn = DataFrameColumn.Create("Float", Enumerable.Range(0, length).Select(x => (float)x));
+            DataFrameColumn intColumn = DataFrameColumn.Create("Int", Enumerable.Range(0, length).Select(x => x));
+            DataFrameColumn longColumn = DataFrameColumn.Create("Long", Enumerable.Range(0, length).Select(x => (long)x));
+            DataFrameColumn sbyteColumn = DataFrameColumn.Create("Sbyte", Enumerable.Range(0, length).Select(x => (sbyte)x));
+            DataFrameColumn shortColumn = DataFrameColumn.Create("Short", Enumerable.Range(0, length).Select(x => (short)x));
+            DataFrameColumn uintColumn = DataFrameColumn.Create("Uint", Enumerable.Range(0, length).Select(x => (uint)x));
+            DataFrameColumn ulongColumn = DataFrameColumn.Create("Ulong", Enumerable.Range(0, length).Select(x => (ulong)x));
+            DataFrameColumn ushortColumn = DataFrameColumn.Create("Ushort", Enumerable.Range(0, length).Select(x => (ushort)x));
 
             DataFrame dataFrame = new DataFrame(new List<DataFrameColumn> { byteColumn, decimalColumn, doubleColumn, floatColumn, intColumn, longColumn, sbyteColumn, shortColumn, uintColumn, ulongColumn, ushortColumn });
 
@@ -150,8 +150,8 @@ namespace Microsoft.Data.Analysis.Tests
             where T1 : unmanaged
             where T2 : unmanaged
         {
-            DataFrameColumn baseColumn1 = new PrimitiveDataFrameColumn<T1>("Column1", Enumerable.Range(0, length).Select(x => (T1)Convert.ChangeType(x % 2 == 0 ? 0 : 1, typeof(T1))));
-            DataFrameColumn baseColumn2 = new PrimitiveDataFrameColumn<T2>("Column2", Enumerable.Range(0, length).Select(x => (T2)Convert.ChangeType(x % 2 == 0 ? 0 : 1, typeof(T2))));
+            DataFrameColumn baseColumn1 = DataFrameColumn.Create("Column1", Enumerable.Range(0, length).Select(x => (T1)Convert.ChangeType(x % 2 == 0 ? 0 : 1, typeof(T1))));
+            DataFrameColumn baseColumn2 = DataFrameColumn.Create("Column2", Enumerable.Range(0, length).Select(x => (T2)Convert.ChangeType(x % 2 == 0 ? 0 : 1, typeof(T2))));
             DataFrame dataFrame = new DataFrame(new List<DataFrameColumn> { baseColumn1, baseColumn2 });
 
             if (withNulls)


### PR DESCRIPTION
I added static factory methods only for the constructor overloads where type inference is possible. 

I experimented with adding overloads for all constructors, but for the overloads where `values` are not provided it didn't feel helpful. It seemed weird to do `DataFrameColumn.Create("foo")` and get back `StringDataFrameColumn`. (Also seemed like a bad idea because it would preclude adding any other "special" DataFrameColumn types in the future).

I also thought it would be inconsistent to allow `DataFrameColumn.Create<int>("Foo")` but not have any counterpart for `String`. Please let me know if you disagree, if so I can add the other overloads back in.