### PR TITLE
Bump the package version so the builds are sorted right

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
     <VersionSuffix Condition="$(VersionSuffix) == ''">$([System.DateTime]::Now.ToString(preview2-yyMMdd-1))</VersionSuffix>
     <Copyright>&#169; Microsoft Corporation. All rights reserved.</Copyright>
-    <VersionPrefix>0.1.1</VersionPrefix>
+    <VersionPrefix>0.1.2</VersionPrefix>
     <Authors>Microsoft</Authors>
     <PackageReleaseNotes>Pre-release package, for testing only</PackageReleaseNotes>
     <PackageIcon>Icon.png</PackageIcon>


### PR DESCRIPTION
A change about a year ago (acc1d8fcc07e48e971170897e683ab202e491afe) changed the preview version identifier from `-preview2-<date>-#` to `-e<date>-#`, which means packages that haven't bumped their version have been producing newer packages with "lower" versions than the build on 2019-01-17.

This change bumps the default package version from 0.1.1 to 0.1.2, which will put all newer builds on top.  Packages that don't use the default version are unaffected.