### PR TITLE
The ToSpan<T> dependency on ResizableArray has been removed.  Resizab…

### DIFF
--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/SequenceExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/SequenceExtensions.cs
@@ -16,6 +16,7 @@ namespace System.Buffers
             while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> buffer))
                 capacity += buffer.Length;
 
+            position = sequence.Start;
             var count = 0;
             byte[] array = new byte[capacity];
             while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> buffer))
@@ -33,6 +34,7 @@ namespace System.Buffers
             while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> buffer))
                 capacity += buffer.Length;
 
+            position = sequence.Start;
             var count = 0;
             byte[] array = new byte[capacity];
             while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> buffer))

--- a/src/System.Buffers.Experimental/System/Buffers/Sequences/SequenceExtensions.cs
+++ b/src/System.Buffers.Experimental/System/Buffers/Sequences/SequenceExtensions.cs
@@ -12,24 +12,36 @@ namespace System.Buffers
         public static ReadOnlySpan<byte> ToSpan(this ReadOnlySequence<byte> sequence)
         {
             SequencePosition position = sequence.Start;
-            ResizableArray<byte> array = new ResizableArray<byte>(1024);
+            int capacity = 0;
+            while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> buffer))
+                capacity += buffer.Length;
+
+            var count = 0;
+            byte[] array = new byte[capacity];
             while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> buffer))
             {
-                array.AddAll(buffer.Span);
+                buffer.Span.CopyTo(array.AsSpan(count));
+                count += buffer.Length;
             }
-            return array.Span;
+            return array.AsSpan();
         }
 
         public static ReadOnlySpan<byte> ToSpan<T>(this T sequence) where T : ISequence<ReadOnlyMemory<byte>>
         {
             SequencePosition position = sequence.Start;
-            ResizableArray<byte> array = new ResizableArray<byte>(1024);
+            int capacity = 0;
+            while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> buffer))
+                capacity += buffer.Length;
+
+            var count = 0;
+            byte[] array = new byte[capacity];
             while (sequence.TryGet(ref position, out ReadOnlyMemory<byte> buffer))
             {
-                array.AddAll(buffer.Span);
+                buffer.Span.CopyTo(array.AsSpan(count));
+                count += buffer.Length;
             }
-            array.Resize(array.Count);
-            return array.Span.Slice(0, array.Count);
+
+            return array.AsSpan();
         }
 
         // TODO: this cannot be an extension method (as I would like it to be).

--- a/tests/Benchmarks/System.Buffers/ToSpan.cs
+++ b/tests/Benchmarks/System.Buffers/ToSpan.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Buffers;
+using System.Buffers.Tests;
+using System.Collections.Generic;
+using System.Collections.Sequences;
+using System.Linq;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+
+namespace Benchmarks.System.Buffers
+{
+    public class ToSpan
+    {
+        public static ReadOnlySequence<byte> Sequence = BufferFactory.Create(Enumerable.Repeat(0, 10000000)
+            .Select(x => new Memory<byte>(new byte[] { 0 })));
+
+        [Benchmark]
+        public void NewToSpan()
+        {
+            var Result = Sequence.ToSpan();
+        }
+
+        [Benchmark]
+        public void OldToSpan()
+        {
+            SequencePosition position = Sequence.Start;
+            ResizableArray<byte> array = new ResizableArray<byte>(1024);
+            while (Sequence.TryGet(ref position, out ReadOnlyMemory<byte> buffer))
+            {
+                array.AddAll(buffer.Span);
+            }
+            var Result = array.Span;
+        }
+    }
+}


### PR DESCRIPTION
…leArray is not necessary and in most cases slower than precalculating the exact capacity of an array when it is possible.