### PR TITLE
Improve LoadCsv to handle null values when deducing the column types

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Analysis
 
                 string val = line[col];
 
-                if (val == "null" || val == "Null")
+                if (val.Equals("null", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }

--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Analysis
 
                 string val = line[col];
 
-                if (val.Equals("null", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(val, "null", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }

--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -23,6 +23,12 @@ namespace Microsoft.Data.Analysis
                     throw new FormatException(string.Format(Strings.LessColumnsThatExpected, nbline + 1));
 
                 string val = line[col];
+
+                if (val == "null" || val == "Null")
+                {
+                    continue;
+                }
+
                 bool boolParse = bool.TryParse(val, out bool boolResult);
                 if (boolParse)
                 {

--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -463,35 +463,42 @@ namespace Microsoft.Data.Analysis
             bool columnMoveNext = columnEnumerator.MoveNext();
             if (row != null)
             {
-                    // Go through row first to make sure there are no data type incompatibilities
-                    IEnumerator<object> rowEnumerator = row.GetEnumerator();
-                    bool rowMoveNext = rowEnumerator.MoveNext();
-                    List<object> cachedObjectConversions = new List<object>();
-                    while (columnMoveNext && rowMoveNext)
+                // Go through row first to make sure there are no data type incompatibilities
+                IEnumerator<object> rowEnumerator = row.GetEnumerator();
+                bool rowMoveNext = rowEnumerator.MoveNext();
+                List<object> cachedObjectConversions = new List<object>();
+                while (columnMoveNext && rowMoveNext)
+                {
+                    DataFrameColumn column = columnEnumerator.Current;
+                    object value = rowEnumerator.Current;
+                    // StringDataFrameColumn can accept empty strings. The other columns interpret empty values as nulls
+                    if (value is string stringValue)
                     {
-                        DataFrameColumn column = columnEnumerator.Current;
-                        object value = rowEnumerator.Current;
-                        // StringDataFrameColumn can accept empty strings. The other columns interpret empty values as nulls
-                        if (value is string stringValue && string.IsNullOrEmpty(stringValue) && column.DataType != typeof(string))
+                        if (string.IsNullOrEmpty(stringValue) && column.DataType != typeof(string))
                         {
                             value = null;
                         }
-                        if (value != null)
+                        if (stringValue == "null" || stringValue == "Null")
                         {
-                            value = Convert.ChangeType(value, column.DataType);
-                            if (value is null)
-                            {
-                                throw new ArgumentException(string.Format(Strings.MismatchedValueType, column.DataType), value.GetType().ToString());
-                            }
+                            value = null;
                         }
-                        cachedObjectConversions.Add(value);
-                        columnMoveNext = columnEnumerator.MoveNext();
-                        rowMoveNext = rowEnumerator.MoveNext();
                     }
-                    if (rowMoveNext)
+                    if (value != null)
                     {
-                        throw new ArgumentException(string.Format(Strings.ExceedsNumberOfColumns, Columns.Count), nameof(row));
+                        value = Convert.ChangeType(value, column.DataType);
+                        if (value is null)
+                        {
+                            throw new ArgumentException(string.Format(Strings.MismatchedValueType, column.DataType), value.GetType().ToString());
+                        }
                     }
+                    cachedObjectConversions.Add(value);
+                    columnMoveNext = columnEnumerator.MoveNext();
+                    rowMoveNext = rowEnumerator.MoveNext();
+                }
+                if (rowMoveNext)
+                {
+                    throw new ArgumentException(string.Format(Strings.ExceedsNumberOfColumns, Columns.Count), nameof(row));
+                }
                 // Reset the enumerators
                 columnEnumerator = ret.Columns.GetEnumerator();
                 columnMoveNext = columnEnumerator.MoveNext();

--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -478,7 +478,7 @@ namespace Microsoft.Data.Analysis
                         {
                             value = null;
                         }
-                        if (stringValue == "null" || stringValue == "Null")
+                        if (stringValue.Equals("null", StringComparison.OrdinalIgnoreCase))
                         {
                             value = null;
                         }

--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -474,11 +474,11 @@ namespace Microsoft.Data.Analysis
                     // StringDataFrameColumn can accept empty strings. The other columns interpret empty values as nulls
                     if (value is string stringValue)
                     {
-                        if (string.IsNullOrEmpty(stringValue) && column.DataType != typeof(string))
+                        if (stringValue.Length == 0 && column.DataType != typeof(string))
                         {
                             value = null;
                         }
-                        if (stringValue.Equals("null", StringComparison.OrdinalIgnoreCase))
+                        else if (stringValue.Equals("null", StringComparison.OrdinalIgnoreCase))
                         {
                             value = null;
                         }

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrame.IOTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrame.IOTests.cs
@@ -445,5 +445,12 @@ CMT,1,1,181,0.6,CSH";
             VerifyColumnTypes(df);
 
         }
+
+        [Fact]
+        public void Test()
+        {
+            DataFrame df = DataFrame.LoadCsv(@"C:\Users\prgovi\Downloads\Test.csv");
+            Console.WriteLine("bh");
+        }
     }
 }

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrame.IOTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrame.IOTests.cs
@@ -447,10 +447,161 @@ CMT,1,1,181,0.6,CSH";
         }
 
         [Fact]
-        public void Test()
+        public void TestReadCsvWithAllNulls()
         {
-            DataFrame df = DataFrame.LoadCsv(@"C:\Users\prgovi\Downloads\Test.csv");
-            Console.WriteLine("bh");
+            string data = @"vendor_id,rate_code,passenger_count,trip_time_in_secs
+null,null,null,null
+Null,Null,Null,Null
+null,null,null,null
+Null,Null,Null,Null
+null,null,null,null
+null,null,null,null";
+
+            Stream GetStream(string streamData)
+            {
+                return new MemoryStream(Encoding.Default.GetBytes(streamData));
+            }
+            DataFrame df = DataFrame.LoadCsv(GetStream(data));
+            Assert.Equal(6, df.Rows.Count);
+            Assert.Equal(4, df.Columns.Count);
+
+            Assert.True(typeof(string) == df.Columns[0].DataType);
+            Assert.True(typeof(string) == df.Columns[1].DataType);
+            Assert.True(typeof(string) == df.Columns[2].DataType);
+            Assert.True(typeof(string) == df.Columns[3].DataType);
+
+            Assert.Equal("vendor_id", df.Columns[0].Name);
+            Assert.Equal("rate_code", df.Columns[1].Name);
+            Assert.Equal("passenger_count", df.Columns[2].Name);
+            Assert.Equal("trip_time_in_secs", df.Columns[3].Name);
+            VerifyColumnTypes(df);
+
+            foreach (var column in df.Columns)
+            {
+                Assert.Equal(6, column.NullCount);
+                foreach (var value in column)
+                {
+                    Assert.Null(value);
+                }
+            }
+        }
+
+        [Fact]
+        public void TestReadCsvWithNullsAndDataTypes()
+        {
+            string data = @"vendor_id,rate_code,passenger_count,trip_time_in_secs
+null,1,1,1271
+CMT,Null,1,474
+CMT,1,null,637
+Null,,,
+,,,
+CMT,1,1,null";
+
+            Stream GetStream(string streamData)
+            {
+                return new MemoryStream(Encoding.Default.GetBytes(streamData));
+            }
+            DataFrame df = DataFrame.LoadCsv(GetStream(data), dataTypes: new Type[] { typeof(string), typeof(short), typeof(int), typeof(long) });
+            Assert.Equal(6, df.Rows.Count);
+            Assert.Equal(4, df.Columns.Count);
+
+            Assert.True(typeof(string) == df.Columns[0].DataType);
+            Assert.True(typeof(short) == df.Columns[1].DataType);
+            Assert.True(typeof(int) == df.Columns[2].DataType);
+            Assert.True(typeof(long) == df.Columns[3].DataType);
+
+            Assert.Equal("vendor_id", df.Columns[0].Name);
+            Assert.Equal("rate_code", df.Columns[1].Name);
+            Assert.Equal("passenger_count", df.Columns[2].Name);
+            Assert.Equal("trip_time_in_secs", df.Columns[3].Name);
+            VerifyColumnTypes(df);
+
+            foreach (var column in df.Columns)
+            {
+                if (column.DataType != typeof(string))
+                {
+                    Assert.Equal(3, column.NullCount);
+                }
+                else
+                {
+                    Assert.Equal(2, column.NullCount);
+                }
+            }
+            var nullRow = df.Rows[3];
+            Assert.Null(nullRow[0]);
+            Assert.Null(nullRow[1]);
+            Assert.Null(nullRow[2]);
+            Assert.Null(nullRow[3]);
+
+            nullRow = df.Rows[4];
+            Assert.Equal("", nullRow[0]);
+            Assert.Null(nullRow[1]);
+            Assert.Null(nullRow[2]);
+            Assert.Null(nullRow[3]);
+
+            Assert.Null(df[0, 0]);
+            Assert.Null(df[1, 1]);
+            Assert.Null(df[2, 2]);
+            Assert.Null(df[5, 3]);
+        }
+
+        [Fact]
+        public void TestReadCsvWithNulls()
+        {
+            string data = @"vendor_id,rate_code,passenger_count,trip_time_in_secs
+null,1,1,1271
+CMT,Null,1,474
+CMT,1,null,637
+Null,,,
+,,,
+CMT,1,1,null";
+
+            Stream GetStream(string streamData)
+            {
+                return new MemoryStream(Encoding.Default.GetBytes(streamData));
+            }
+            DataFrame df = DataFrame.LoadCsv(GetStream(data));
+            Assert.Equal(6, df.Rows.Count);
+            Assert.Equal(4, df.Columns.Count);
+
+            Assert.True(typeof(string) == df.Columns[0].DataType);
+            Assert.True(typeof(float) == df.Columns[1].DataType);
+            Assert.True(typeof(float) == df.Columns[2].DataType);
+            Assert.True(typeof(float) == df.Columns[3].DataType);
+
+            Assert.Equal("vendor_id", df.Columns[0].Name);
+            Assert.Equal("rate_code", df.Columns[1].Name);
+            Assert.Equal("passenger_count", df.Columns[2].Name);
+            Assert.Equal("trip_time_in_secs", df.Columns[3].Name);
+            VerifyColumnTypes(df);
+
+            foreach (var column in df.Columns)
+            {
+                if (column.DataType != typeof(string))
+                {
+                    Assert.Equal(3, column.NullCount);
+                }
+                else
+                {
+                    Assert.Equal(2, column.NullCount);
+                }
+            }
+            var nullRow = df.Rows[3];
+            Assert.Null(nullRow[0]);
+            Assert.Null(nullRow[1]);
+            Assert.Null(nullRow[2]);
+            Assert.Null(nullRow[3]);
+
+            nullRow = df.Rows[4];
+            Assert.Equal("", nullRow[0]);
+            Assert.Null(nullRow[1]);
+            Assert.Null(nullRow[2]);
+            Assert.Null(nullRow[3]);
+
+            Assert.Null(df[0, 0]);
+            Assert.Null(df[1, 1]);
+            Assert.Null(df[2, 2]);
+            Assert.Null(df[5, 3]);
         }
     }
 }


### PR DESCRIPTION
Fixes #2915 

Instead of falling back to a `StringDataFrameColumn`, we now deduce the column type correctly and append a `null` value to whatever the column type becomes.  