### PR TITLE
Revert "Create a 0.4.0 package (#2918)"

### DIFF
--- a/src/Microsoft.Data.Analysis/Microsoft.Data.Analysis.csproj
+++ b/src/Microsoft.Data.Analysis/Microsoft.Data.Analysis.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <SuppressFinalPackageVersion>false</SuppressFinalPackageVersion>
     <VersionPrefix>0.4.0</VersionPrefix>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>This package contains easy-to-use and high-performance libraries for data analysis and transformation.</Description>


### PR DESCRIPTION
Sets the property back to false. The property should be left untouched. The right way to make a stable package is to set the DotNetFinalVersionKind property.