### PR TITLE
Load DataFrame from IDataReader

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.IO;
 using System.Text;
 

--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -311,6 +311,8 @@ namespace Microsoft.Data.Analysis
         /// Reads an implementation of IDataReader into a DataFrame.
         /// </summary>
         /// <param name="reader">DataReader to be read in</param>
+        /// <param name="columnNames">column names (can be empty)</param>
+        /// <param name="dataTypes">column types (can be empty)</param>
         /// <param name="numberOfRowsToRead">number of rows to read not including the header(if present)</param>
         /// <param name="addIndexColumn">add one column with the row index</param>
         /// <returns><see cref="DataFrame"/></returns>


### PR DESCRIPTION
Not quite as straightforward as a [LoadSql() method](https://github.com/dotnet/corefxlab/issues/2880) but I think this route offers a great amount of flexibility for importing data from many sources without introducing a dependency nightmare.