### PR TITLE
resolution for #2746

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrameColumnCollection.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumnCollection.cs
@@ -66,6 +66,12 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
             }
+
+            if (Count >= 1 && RowCount == 0 && column.Length != RowCount)
+            {
+                throw new ArgumentException(Strings.MismatchedColumnLengths, nameof(column));
+            }
+
             if (_columnNameToIndexDictionary.ContainsKey(column.Name))
             {
                 throw new ArgumentException(string.Format(Strings.DuplicateColumnName, column.Name), nameof(column));

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -1716,6 +1716,18 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
+        public void TestInsertMismatchedColumnToEmptyDataFrame()
+        {
+            DataFrame df = new DataFrame();
+            DataFrameColumn dataFrameColumn1 = new Int32DataFrameColumn("Int1");
+            df.Columns.Insert(0, dataFrameColumn1);
+
+            // should throw exception as column sizes are mismatched.
+
+            Assert.Throws<ArgumentException>(() => df.Columns.Insert(1, new Int32DataFrameColumn("Int2", Enumerable.Range(0, 5).Select(x => x))));
+        }
+
+        [Fact]
         public void TestFillNulls()
         {
             DataFrame df = MakeDataFrameWithTwoColumns(20);


### PR DESCRIPTION
**Issue**
> If a DataFrame has 1 column of Length 0, and I insert a new column of Length > 0, InsertColumn should throw. It doesn't at the moment.

**Solution**
I have included an IF statement that will throw an exception if a new column of a length > 0 is inserted into a DataFrame that already has a column(s) that are of length 0. I have also included a test for this scenario.