### PR TITLE
Prevent DataFrame.Sample() method from returning duplicated rows

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -316,14 +316,29 @@ namespace Microsoft.Data.Analysis
         /// <param name="numberOfRows">Number of rows in the returned DataFrame</param>
         public DataFrame Sample(int numberOfRows)
         {
-            Random rand = new Random();
-            PrimitiveDataFrameColumn<long> indices = new PrimitiveDataFrameColumn<long>("Indices", numberOfRows);
-            int randMaxValue = (int)Math.Min(Int32.MaxValue, Rows.Count);
-            for (long i = 0; i < numberOfRows; i++)
+            if (numberOfRows > Rows.Count)
             {
-                indices[i] = rand.Next(randMaxValue);
+                throw new ArgumentException(string.Format(Strings.ExceedsNumberOfRows, Rows.Count), nameof(numberOfRows));
+            }
+            
+            int shuffleSize = (int)Math.Min(Int32.MaxValue, Rows.Count);
+            int[] shuffleArray = Enumerable.Range(0, shuffleSize).ToArray();
+            Random rand = new Random();
+            while (shuffleSize > 1)
+            {
+                int randomIndex = rand.Next(shuffleSize--);
+                int temp = shuffleArray[shuffleSize];
+                shuffleArray[shuffleSize] = shuffleArray[randomIndex];
+                shuffleArray[randomIndex] = temp;
             }
 
+            PrimitiveDataFrameColumn<long> indices = new PrimitiveDataFrameColumn<long>("Indices", numberOfRows);
+            
+            for(long i = 0; i < numberOfRows; i++)
+            {
+                indices[i] = shuffleArray[i];
+            }
+            
             return Clone(indices);
         }
 

--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -320,18 +320,21 @@ namespace Microsoft.Data.Analysis
             {
                 throw new ArgumentException(string.Format(Strings.ExceedsNumberOfRows, Rows.Count), nameof(numberOfRows));
             }
+
+            int shuffleLowerLimit = 0;
+            int shuffleUpperLimit = (int)Math.Min(Int32.MaxValue, Rows.Count);
             
-            int shuffleSize = (int)Math.Min(Int32.MaxValue, Rows.Count);
-            int[] shuffleArray = Enumerable.Range(0, shuffleSize).ToArray();
+            int[] shuffleArray = Enumerable.Range(0, shuffleUpperLimit).ToArray();
             Random rand = new Random();
-            while (shuffleSize > 1)
+            while (shuffleLowerLimit < numberOfRows)
             {
-                int randomIndex = rand.Next(shuffleSize--);
-                int temp = shuffleArray[shuffleSize];
-                shuffleArray[shuffleSize] = shuffleArray[randomIndex];
+                int randomIndex = rand.Next(shuffleLowerLimit, shuffleUpperLimit);
+                int temp = shuffleArray[shuffleLowerLimit];
+                shuffleArray[shuffleLowerLimit] = shuffleArray[randomIndex];
                 shuffleArray[randomIndex] = temp;
+                shuffleLowerLimit++;
             }
-            ArraySegment<int> segment = new ArraySegment<int>(shuffleArray, 0, numberOfRows);
+            ArraySegment<int> segment = new ArraySegment<int>(shuffleArray, 0, shuffleLowerLimit);
 
             PrimitiveDataFrameColumn<int> indices = new PrimitiveDataFrameColumn<int>("indices", segment);
             

--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -331,13 +331,9 @@ namespace Microsoft.Data.Analysis
                 shuffleArray[shuffleSize] = shuffleArray[randomIndex];
                 shuffleArray[randomIndex] = temp;
             }
+            ArraySegment<int> segment = new ArraySegment<int>(shuffleArray, 0, numberOfRows);
 
-            PrimitiveDataFrameColumn<long> indices = new PrimitiveDataFrameColumn<long>("Indices", numberOfRows);
-            
-            for(long i = 0; i < numberOfRows; i++)
-            {
-                indices[i] = shuffleArray[i];
-            }
+            PrimitiveDataFrameColumn<int> indices = new PrimitiveDataFrameColumn<int>("indices", segment);
             
             return Clone(indices);
         }

--- a/src/Microsoft.Data.Analysis/strings.Designer.cs
+++ b/src/Microsoft.Data.Analysis/strings.Designer.cs
@@ -133,6 +133,15 @@ namespace Microsoft.Data {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Parameter.Count exceeds the number of rows({0}) in the DataFrame .
+        /// </summary>
+        internal static string ExceedsNumberOfRows {
+            get {
+                return ResourceManager.GetString("ExceedsNumberOfRows", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Expected either {0} or {1} to be provided.
         /// </summary>
         internal static string ExpectedEitherGuessRowsOrDataTypes {

--- a/src/Microsoft.Data.Analysis/strings.resx
+++ b/src/Microsoft.Data.Analysis/strings.resx
@@ -141,6 +141,9 @@
   <data name="ExceedsNumberOfColumns" xml:space="preserve">
     <value>Parameter.Count exceeds the number of columns({0}) in the DataFrame </value>
   </data>
+  <data name="ExceedsNumberOfRows" xml:space="preserve">
+    <value>Parameter.Count exceeds the number of rows({0}) in the DataFrame </value>
+  </data>
   <data name="ExpectedEitherGuessRowsOrDataTypes" xml:space="preserve">
     <value>Expected either {0} or {1} to be provided</value>
   </data>

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -1560,9 +1560,20 @@ namespace Microsoft.Data.Analysis.Tests
         public void TestSample()
         {
             DataFrame df = MakeDataFrameWithAllColumnTypes(10);
-            DataFrame sampled = df.Sample(3);
-            Assert.Equal(3, sampled.Rows.Count);
+            DataFrame sampled = df.Sample(7);
+            Assert.Equal(7, sampled.Rows.Count);
             Assert.Equal(df.Columns.Count, sampled.Columns.Count);
+
+            // all sampled rows should be unique.
+            HashSet<int?> uniqueRowValues = new HashSet<int?>();
+            foreach(int? value in sampled.Columns["Int"])
+            {
+                uniqueRowValues.Add(value);
+            }
+            Assert.Equal(uniqueRowValues.Count, sampled.Rows.Count);
+
+            // should throw exception as sample size is greater than dataframe rows
+            Assert.Throws<ArgumentException>(()=> df.Sample(13));
         }
 
         [Fact]


### PR DESCRIPTION
**Issue**

> The Sample method in DataFrame (code here) does not check if an index was already generated by rand. Most of the time I get duplicate rows because of it.

**Solution**
I have amended the Sample method to implement the Fisher-Yates shuffle so that the sample returned is unique and still random. Additions also include a new string resource so that an exception is throw if the sample size requested is greater than the number of rows. Tests for row uniqueness and the exception being thrown have been included also.

Kind Regards,
Ramon
Fixes: #2806