### PR TITLE
Add a few types to System.Web compat assembly

### DIFF
--- a/src/System.Web.Compatibility/NotSupported.Exclude.txt
+++ b/src/System.Web.Compatibility/NotSupported.Exclude.txt
@@ -5,3 +5,7 @@ T:System.Web.HttpUtility
 P:System.Web.HttpContext.Current
 P:System.Web.Hosting.HostingEnvironment.IsHosted
 P:System.Web.Hosting.HostingEnvironment.SiteName
+T:System.Web.Routing.RequestContext
+T:System.Web.Routing.RouteData
+T:System.Web.Routing.RouteValueDictionary
+T:System.Web.Routing.StopRoutingHandler

--- a/src/System.Web.Compatibility/Strings.Designer.cs
+++ b/src/System.Web.Compatibility/Strings.Designer.cs
@@ -68,5 +68,14 @@ namespace System.Web {
                 return ResourceManager.GetString("PlatformNotSupportedSystemWeb", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The RouteData must contain an item named &apos;{0}&apos; with a non-empty string value..
+        /// </summary>
+        internal static string RouteData_RequiredValue {
+            get {
+                return ResourceManager.GetString("RouteData_RequiredValue", resourceCulture);
+            }
+        }
     }
 }

--- a/src/System.Web.Compatibility/Strings.resx
+++ b/src/System.Web.Compatibility/Strings.resx
@@ -120,4 +120,7 @@
   <data name="PlatformNotSupportedSystemWeb" xml:space="preserve">
     <value>System.Web is not supported on this platform</value>
   </data>
+  <data name="RouteData_RequiredValue" xml:space="preserve">
+    <value>The RouteData must contain an item named '{0}' with a non-empty string value.</value>
+  </data>
 </root>

--- a/src/System.Web.Compatibility/System/Web/Routing/RequestContext.cs
+++ b/src/System.Web.Compatibility/System/Web/Routing/RequestContext.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+namespace System.Web.Routing 
+{
+    [TypeForwardedFrom("System.Web.Routing, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35")]
+    public class RequestContext 
+    {
+        public RequestContext() { }
+
+        public RequestContext(HttpContextBase httpContext, RouteData routeData) 
+        {
+            HttpContext = httpContext ?? throw new ArgumentNullException(nameof(httpContext));
+            RouteData = routeData ?? throw new ArgumentNullException(nameof(routeData));
+        }
+
+        public virtual HttpContextBase HttpContext { get; set; }
+
+        public virtual RouteData RouteData { get; set; }
+    }
+}

--- a/src/System.Web.Compatibility/System/Web/Routing/RouteData.cs
+++ b/src/System.Web.Compatibility/System/Web/Routing/RouteData.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace System.Web.Routing {
+
+    [TypeForwardedFrom("System.Web.Routing, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35")]
+    public class RouteData {
+        public RouteData() { }
+
+        public RouteData(RouteBase route, IRouteHandler routeHandler) {
+            Route = route;
+            RouteHandler = routeHandler;
+        }
+
+        public RouteValueDictionary DataTokens { get; } = new RouteValueDictionary();
+
+        public RouteBase Route { get; set; }
+
+        public IRouteHandler RouteHandler { get; set; }
+
+        public RouteValueDictionary Values { get; } = new RouteValueDictionary();
+
+        public string GetRequiredString(string valueName)
+        {
+            if (Values.TryGetValue(valueName, out object value))
+            {
+                string valueString = value as string;
+                if (!string.IsNullOrEmpty(valueString)) 
+                {
+                    return valueString;
+                }
+            }
+
+            throw new InvalidOperationException(
+                string.Format(
+                    CultureInfo.CurrentUICulture,
+                    Strings.RouteData_RequiredValue,
+                    valueName));
+        }
+    }
+}

--- a/src/System.Web.Compatibility/System/Web/Routing/RouteValueDictionary.cs
+++ b/src/System.Web.Compatibility/System/Web/Routing/RouteValueDictionary.cs
@@ -1,0 +1,182 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace System.Web.Routing
+{
+    [TypeForwardedFrom("System.Web.Routing, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35")]
+    public class RouteValueDictionary : IDictionary<string, object>
+    {
+        private Dictionary<string, object> _dictionary;
+
+        public RouteValueDictionary()
+        {
+            _dictionary = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public RouteValueDictionary(object values)
+        {
+            _dictionary = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+            AddValues(values);
+        }
+
+        public RouteValueDictionary(IDictionary<string, object> dictionary)
+        {
+            _dictionary = new Dictionary<string, object>(dictionary, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public int Count
+        {
+            get
+            {
+                return _dictionary.Count;
+            }
+        }
+
+        public Dictionary<string, object>.KeyCollection Keys
+        {
+            get
+            {
+                return _dictionary.Keys;
+            }
+        }
+
+        public Dictionary<string, object>.ValueCollection Values
+        {
+            get
+            {
+                return _dictionary.Values;
+            }
+        }
+
+        public object this[string key]
+        {
+            get
+            {
+                object value;
+                TryGetValue(key, out value);
+                return value;
+            }
+            set
+            {
+                _dictionary[key] = value;
+            }
+        }
+
+        public void Add(string key, object value)
+        {
+            _dictionary.Add(key, value);
+        }
+
+        private void AddValues(object values)
+        {
+            if (values != null)
+            {
+                PropertyDescriptorCollection props = TypeDescriptor.GetProperties(values);
+                foreach (PropertyDescriptor prop in props)
+                {
+                    object val = prop.GetValue(values);
+                    Add(prop.Name, val);
+                }
+            }
+        }
+
+        public void Clear()
+        {
+            _dictionary.Clear();
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return _dictionary.ContainsKey(key);
+        }
+
+        public bool ContainsValue(object value)
+        {
+            return _dictionary.ContainsValue(value);
+        }
+
+        public Dictionary<string, object>.Enumerator GetEnumerator()
+        {
+            return _dictionary.GetEnumerator();
+        }
+
+        public bool Remove(string key)
+        {
+            return _dictionary.Remove(key);
+        }
+
+        public bool TryGetValue(string key, out object value)
+        {
+            return _dictionary.TryGetValue(key, out value);
+        }
+
+        #region IDictionary<string,object> Members
+        ICollection<string> IDictionary<string, object>.Keys
+        {
+            get
+            {
+                return _dictionary.Keys;
+            }
+        }
+
+        ICollection<object> IDictionary<string, object>.Values
+        {
+            get
+            {
+                return _dictionary.Values;
+            }
+        }
+        #endregion
+
+        #region ICollection<KeyValuePair<string,object>> Members
+        void ICollection<KeyValuePair<string, object>>.Add(KeyValuePair<string, object> item)
+        {
+            ((ICollection<KeyValuePair<string, object>>)_dictionary).Add(item);
+        }
+
+        bool ICollection<KeyValuePair<string, object>>.Contains(KeyValuePair<string, object> item)
+        {
+            return ((ICollection<KeyValuePair<string, object>>)_dictionary).Contains(item);
+        }
+
+        void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
+        {
+            ((ICollection<KeyValuePair<string, object>>)_dictionary).CopyTo(array, arrayIndex);
+        }
+
+        bool ICollection<KeyValuePair<string, object>>.IsReadOnly
+        {
+            get
+            {
+                return ((ICollection<KeyValuePair<string, object>>)_dictionary).IsReadOnly;
+            }
+        }
+
+        bool ICollection<KeyValuePair<string, object>>.Remove(KeyValuePair<string, object> item)
+        {
+            return ((ICollection<KeyValuePair<string, object>>)_dictionary).Remove(item);
+        }
+        #endregion
+
+        #region IEnumerable<KeyValuePair<string,object>> Members
+        IEnumerator<KeyValuePair<string, object>> IEnumerable<KeyValuePair<string, object>>.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+        #endregion
+
+        #region IEnumerable Members
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+        #endregion
+    }
+}

--- a/src/System.Web.Compatibility/System/Web/Routing/StopRoutingHandler.cs
+++ b/src/System.Web.Compatibility/System/Web/Routing/StopRoutingHandler.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace System.Web.Routing
+{
+    [TypeForwardedFrom("System.Web.Routing, Version=3.5.0.0, Culture=Neutral, PublicKeyToken=31bf3856ad364e35")]
+    public class StopRoutingHandler : IRouteHandler
+    {
+        protected virtual IHttpHandler GetHttpHandler(RequestContext requestContext)
+        {
+            throw new NotSupportedException();
+        }
+
+        #region IRouteHandler Members
+        IHttpHandler IRouteHandler.GetHttpHandler(RequestContext requestContext)
+        {
+            return GetHttpHandler(requestContext);
+        }
+        #endregion
+
+    }
+}

--- a/tests/System.Web.Compatibility.Tests/RequestContextTests.cs
+++ b/tests/System.Web.Compatibility.Tests/RequestContextTests.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Web.Routing;
+using Xunit;
+
+namespace System.Web.Compatibility.Tests
+{
+    public class RequestContextTests
+    {
+        [Fact]
+        public void RequestContextDefaultCtor()
+        {
+            RequestContext rc = new RequestContext();
+            Assert.Null(rc.HttpContext);
+            Assert.Null(rc.RouteData);
+        }
+
+        [Fact]
+        public void RequestContextCtor()
+        {
+            Assert.Throws<ArgumentNullException>("httpContext", () => new RequestContext(null, null));
+            Assert.Throws<ArgumentNullException>("httpContext", () => new RequestContext(null, new RouteData()));
+
+            // can't construct a HttpContextBase as it will throw PNSE
+        }
+    }
+}

--- a/tests/System.Web.Compatibility.Tests/RouteDataTests.cs
+++ b/tests/System.Web.Compatibility.Tests/RouteDataTests.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Web.Routing;
+using Xunit;
+
+namespace System.Web.Compatibility.Tests
+{
+    public class RouteDataTests
+    {
+        [Fact]
+        public void RouteDataDefaultCtor()
+        {
+            RouteData rd = new RouteData();
+            Assert.Null(rd.Route);
+            Assert.Null(rd.RouteHandler);
+
+            Assert.NotNull(rd.Values);
+            Assert.NotNull(rd.DataTokens);
+        }
+
+        class NoopHandler : IRouteHandler
+        {
+            public IHttpHandler GetHttpHandler(RequestContext requestContext)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Fact]
+        public void RouteDataRouteHandlerCtor()
+        {
+            RouteData rd = new RouteData(null, null);
+            Assert.Null(rd.Route);
+            Assert.Null(rd.RouteHandler);
+
+            Assert.NotNull(rd.Values);
+            Assert.NotNull(rd.DataTokens);
+
+            // can't construct a RouteBase as it will throw PNSE
+            RouteBase rb = null;
+            IRouteHandler rh = new NoopHandler();
+            rd = new RouteData(rb, rh);
+            Assert.Same(rh, rd.RouteHandler);
+
+            Assert.NotNull(rd.Values);
+            Assert.NotNull(rd.DataTokens);
+        }
+
+        [Fact]
+        public void RouteDataValuesString()
+        {
+            RouteData rd = new RouteData();
+            string key = nameof(key);
+            string value = nameof(value);
+            rd.Values.Add(key, value);
+
+            string actual = rd.GetRequiredString(key);
+            Assert.Equal(value, actual);
+        }
+
+        [Theory]
+        [InlineData(typeof(RouteData))]
+        [InlineData(null)]
+        [InlineData(42)]
+        [InlineData(new [] { 1 })]
+        public void RouteDataValuesThrow(object value)
+        {
+            RouteData rd = new RouteData();
+            string key = nameof(key);
+            rd.Values.Add(key, value);
+
+            Assert.Throws<InvalidOperationException>(() => rd.GetRequiredString(key));
+        }
+
+        [Fact]
+        public void RouteDataValuesNoExist()
+        {
+            RouteData rd = new RouteData();
+            string key = nameof(key);
+
+            Assert.Throws<InvalidOperationException>(() => rd.GetRequiredString(key));
+        }
+    }
+}

--- a/tests/System.Web.Compatibility.Tests/StopRoutingHandlerTests.cs
+++ b/tests/System.Web.Compatibility.Tests/StopRoutingHandlerTests.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Web.Routing;
+using Xunit;
+
+namespace System.Web.Compatibility.Tests
+{
+    public class StopRoutingHandlerTests
+    {
+        [Fact]
+        public void StopRoutingHandlerDefault()
+        {
+            StopRoutingHandler srh = new StopRoutingHandler();
+
+            IRouteHandler rh = srh as IRouteHandler;
+
+            Assert.NotNull(rh);
+            Assert.Throws<NotSupportedException>(() => rh.GetHttpHandler(null));
+        }
+    }
+}


### PR DESCRIPTION
The source was ported from desktop / reference-source.  Made minor cleanups.

Tests illustrate what was enabled.  Note the couple places where we can't exercise API's because we can't actually construct the types that they accept as parameters. cc @mjsabby 