### PR TITLE
Fix bug in DataFrame.OrderBy() when columns contain nulls on different rows

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -597,15 +597,45 @@ namespace Microsoft.Data.Analysis
         private DataFrame Sort(string columnName, bool isAscending)
         {
             DataFrameColumn column = Columns[columnName];
-            DataFrameColumn sortIndices = column.GetAscendingSortIndices();
+
+            List<long?> sortIndicesNonNull = column.GetAscendingSortIndices().ToList();
+            HashSet<long?> lookUp = new HashSet<long?>(sortIndicesNonNull);
+            List<long?> sortIndicesNull = new List<long?>();
+            
+            for (int i = 0; i < column.Length; i++)
+            {
+                if (!lookUp.Contains(i))
+                {
+                    sortIndicesNull.Add(i);
+                }
+            }
+            DataFrameColumn sortedCol;
+            if (isAscending)
+            {
+                // if the sort is ascending then add the null values to the end of the new column.
+                sortIndicesNonNull.AddRange(sortIndicesNull);
+                sortedCol = new PrimitiveDataFrameColumn<long>("temp", sortIndicesNonNull);
+            }
+            else
+            {
+                /* if the sort is descending then reverse the null values
+                 * and then add the nullvalues to the front the of the new column. 
+                 * This is because the final clone is inverted and will put all null values at the end.*/
+                sortIndicesNull.Reverse();
+                sortIndicesNull.AddRange(sortIndicesNonNull);
+                sortedCol = new PrimitiveDataFrameColumn<long>("temp", sortIndicesNull);
+            }
+
             List<DataFrameColumn> newColumns = new List<DataFrameColumn>(Columns.Count);
+
             for (int i = 0; i < Columns.Count; i++)
             {
                 DataFrameColumn oldColumn = Columns[i];
-                DataFrameColumn newColumn = oldColumn.Clone(sortIndices, !isAscending, oldColumn.NullCount);
+                DataFrameColumn newColumn = oldColumn.Clone(sortedCol, !isAscending);
                 Debug.Assert(newColumn.NullCount == oldColumn.NullCount);
                 newColumns.Add(newColumn);
             }
+
             return new DataFrame(newColumns);
         }
 

--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -596,15 +596,22 @@ namespace Microsoft.Data.Analysis
 
         private DataFrame Sort(string columnName, bool isAscending)
         {
+            DataFrameColumn sortIndices;
             DataFrameColumn column = Columns[columnName];
-            DataFrameColumn sortIndices = column.GetAscendingSortIndices();
+            if (isAscending)
+            {
+                sortIndices = column.GetAscendingSortIndices();
+            }
+            else
+            {
+                sortIndices = column.GetDescendingSortIndices();
+            }
             List<DataFrameColumn> newColumns = new List<DataFrameColumn>(Columns.Count);
 
             for (int i = 0; i < Columns.Count; i++)
             {
                 DataFrameColumn oldColumn = Columns[i];
-                long nullCount = oldColumn.Length - sortIndices.Length;
-                DataFrameColumn newColumn = oldColumn.Clone(sortIndices, !isAscending, nullCount);
+                DataFrameColumn newColumn = oldColumn.Clone(sortIndices);
                 Debug.Assert(newColumn.NullCount == oldColumn.NullCount);
                 newColumns.Add(newColumn);
             }

--- a/src/Microsoft.Data.Analysis/DataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumn.cs
@@ -199,8 +199,16 @@ namespace Microsoft.Data.Analysis
         /// <param name="ascending"></param>
         public virtual DataFrameColumn Sort(bool ascending = true)
         {
-            PrimitiveDataFrameColumn<long> sortIndices = GetAscendingSortIndices();
-            return Clone(sortIndices, !ascending, NullCount);
+            PrimitiveDataFrameColumn<long> sortIndices;
+            if (ascending)
+            {
+                sortIndices = GetAscendingSortIndices();
+            }
+            else
+            {
+                sortIndices = GetDescendingSortIndices();
+            }
+            return Clone(sortIndices);
         }
 
         public virtual Dictionary<TKey, ICollection<long>> GroupColumnValues<TKey>() => throw new NotImplementedException();
@@ -318,6 +326,7 @@ namespace Microsoft.Data.Analysis
         public virtual DataFrameColumn Description() => throw new NotImplementedException();
 
         internal virtual PrimitiveDataFrameColumn<long> GetAscendingSortIndices() => throw new NotImplementedException();
+        internal virtual PrimitiveDataFrameColumn<long> GetDescendingSortIndices() => throw new NotImplementedException();
 
         internal delegate long GetBufferSortIndex(int bufferIndex, int sortIndex);
         internal delegate ValueTuple<T, int> GetValueAndBufferSortIndexAtBuffer<T>(int bufferIndex, int valueIndex);

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.Sort.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.Sort.cs
@@ -28,14 +28,10 @@ namespace Microsoft.Data.Analysis
 
         internal override PrimitiveDataFrameColumn<long> GetAscendingSortIndices()
         {
-            // The return sortIndices contains only the non null indices. 
             PrimitiveDataFrameColumn<long> sortIndices = GetSortIndices(Comparer<T>.Default, out PrimitiveDataFrameColumn<long> columnNullIndices);
-            if(columnNullIndices.Length > 0)
+            for (int i = 0; i < columnNullIndices.Length; i++)
             {
-                for(int i = 0; i < columnNullIndices.Length; i++)
-                {
-                    sortIndices.Append(columnNullIndices[i]);
-                }
+                sortIndices.Append(columnNullIndices[i]);
             }
             return sortIndices;
         }
@@ -47,7 +43,6 @@ namespace Microsoft.Data.Analysis
                 return Comparer<T>.Default.Compare(b, a);
             });
             Comparer<T> descending = Comparer<T>.Create(descendingComparison);
-            // The return sortIndices contains only the non null indices. 
             PrimitiveDataFrameColumn<long> sortIndices = GetSortIndices(descending, out PrimitiveDataFrameColumn<long> nullIndices);
             for (long i = 0; i < nullIndices.Length; i++)
             {

--- a/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/PrimitiveDataFrameColumn.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Data.Analysis
             if (Length == 0)
                 return 0;
             PrimitiveDataFrameColumn<long> sortIndices = GetAscendingSortIndices();
-            long middle = sortIndices.Length / 2;
+            long middle = (sortIndices.Length - NullCount) / 2;
             double middleValue = (double)Convert.ChangeType(this[sortIndices[middle].Value].Value, typeof(double));
             if (Length % 2 == 0)
             {

--- a/src/Microsoft.Data.Analysis/StringDataFrameColumn.cs
+++ b/src/Microsoft.Data.Analysis/StringDataFrameColumn.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Data.Analysis
                 // TODO: Refactor the sort routine to also work with IList?
                 string[] array = buffer.ToArray();
                 IntrospectiveSort(array, array.Length, sortIndices, comparer);
-                // do a for loop here and get the nonnulls together
+
                 List<int> nonNullSortIndices = new List<int>();
                 for(int i=0; i<sortIndices.Length; i++)
                 {
@@ -241,7 +241,7 @@ namespace Microsoft.Data.Analysis
                         nonNullSortIndices.Add(sortIndices[i]);
                     }
                 }
-                
+
                 bufferSortIndices.Add(nonNullSortIndices);
             }
             // Simple merge sort to build the full column's sort indices

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -802,7 +802,6 @@ namespace Microsoft.Data.Analysis.Tests
             df.Columns["Int"][0] = 100;
             df.Columns["Int"][19] = -1;
             df.Columns["Int"][5] = 2000;
-
             // Sort by "Int" in ascending order
             var sortedDf = df.OrderBy("Int");
             Assert.Null(sortedDf.Columns["Int"][19]);
@@ -874,6 +873,7 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(14, sortedDf.Columns["Int"][13]);
             Assert.Equal(-1, sortedDf.Columns["Int"][8]);
             Assert.Equal(2000, sortedDf.Columns["Int"][4]);
+            Assert.Null(sortedDf.Columns["Int"][2]);
             Assert.Equal(9, sortedDf.Columns["Int"][0]);
         }
 

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -802,32 +802,42 @@ namespace Microsoft.Data.Analysis.Tests
             df.Columns["Int"][0] = 100;
             df.Columns["Int"][19] = -1;
             df.Columns["Int"][5] = 2000;
+            df.Columns["Int"][6] = null;
+            df.Columns["Int"][7] = null;
 
             // Sort by "Int" in ascending order
             var sortedDf = df.OrderBy("Int");
-            Assert.Null(sortedDf.Columns["Int"][19]);
             Assert.Equal(-1, sortedDf.Columns["Int"][0]);
-            Assert.Equal(100, sortedDf.Columns["Int"][17]);
-            Assert.Equal(2000, sortedDf.Columns["Int"][18]);
+            Assert.Equal(12, sortedDf.Columns["Int"][8]);
+            Assert.Equal(14, sortedDf.Columns["Int"][10]);
+            Assert.Equal(2000, sortedDf.Columns["Int"][16]);
+            Assert.Null(sortedDf.Columns["Int"][17]);
+            Assert.Null(sortedDf.Columns["Int"][19]);
 
             // Sort by "Int" in descending order
             sortedDf = df.OrderByDescending("Int");
             Assert.Null(sortedDf.Columns["Int"][19]);
-            Assert.Equal(-1, sortedDf.Columns["Int"][18]);
+            Assert.Null(sortedDf.Columns["Int"][17]);
+            Assert.Equal(-1, sortedDf.Columns["Int"][16]);
+            Assert.Equal(11, sortedDf.Columns["Int"][9]);
             Assert.Equal(100, sortedDf.Columns["Int"][1]);
             Assert.Equal(2000, sortedDf.Columns["Int"][0]);
 
             // Sort by "String" in ascending order
             sortedDf = df.OrderBy("String");
-            Assert.Null(sortedDf.Columns["Int"][19]);
             Assert.Equal(1, sortedDf.Columns["Int"][1]);
-            Assert.Equal(8, sortedDf.Columns["Int"][17]);
+            Assert.Equal(14, sortedDf.Columns["Int"][5]);
+            Assert.Equal(2000, sortedDf.Columns["Int"][14]);
+            Assert.Null(sortedDf.Columns["Int"][15]);
             Assert.Equal(9, sortedDf.Columns["Int"][18]);
+            Assert.Null(sortedDf.Columns["Int"][19]);
 
             // Sort by "String" in descending order
             sortedDf = df.OrderByDescending("String");
             Assert.Null(sortedDf.Columns["Int"][19]);
-            Assert.Equal(8, sortedDf.Columns["Int"][1]);
+            Assert.Equal(14, sortedDf.Columns["Int"][13]);
+            Assert.Equal(-1, sortedDf.Columns["Int"][8]);
+            Assert.Equal(2000, sortedDf.Columns["Int"][4]);
             Assert.Equal(9, sortedDf.Columns["Int"][0]);
         }
 

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -802,6 +802,42 @@ namespace Microsoft.Data.Analysis.Tests
             df.Columns["Int"][0] = 100;
             df.Columns["Int"][19] = -1;
             df.Columns["Int"][5] = 2000;
+
+            // Sort by "Int" in ascending order
+            var sortedDf = df.OrderBy("Int");
+            Assert.Null(sortedDf.Columns["Int"][19]);
+            Assert.Equal(-1, sortedDf.Columns["Int"][0]);
+            Assert.Equal(100, sortedDf.Columns["Int"][17]);
+            Assert.Equal(2000, sortedDf.Columns["Int"][18]);
+
+            // Sort by "Int" in descending order
+            sortedDf = df.OrderByDescending("Int");
+            Assert.Null(sortedDf.Columns["Int"][19]);
+            Assert.Equal(-1, sortedDf.Columns["Int"][18]);
+            Assert.Equal(100, sortedDf.Columns["Int"][1]);
+            Assert.Equal(2000, sortedDf.Columns["Int"][0]);
+
+            // Sort by "String" in ascending order
+            sortedDf = df.OrderBy("String");
+            Assert.Null(sortedDf.Columns["Int"][19]);
+            Assert.Equal(1, sortedDf.Columns["Int"][1]);
+            Assert.Equal(8, sortedDf.Columns["Int"][17]);
+            Assert.Equal(9, sortedDf.Columns["Int"][18]);
+
+            // Sort by "String" in descending order
+            sortedDf = df.OrderByDescending("String");
+            Assert.Null(sortedDf.Columns["Int"][19]);
+            Assert.Equal(8, sortedDf.Columns["Int"][1]);
+            Assert.Equal(9, sortedDf.Columns["Int"][0]);
+        }
+
+        [Fact]
+        public void TestOrderByWithNulls()
+        {
+            DataFrame df = MakeDataFrameWithAllMutableColumnTypes(20);
+            df.Columns["Int"][0] = 100;
+            df.Columns["Int"][19] = -1;
+            df.Columns["Int"][5] = 2000;
             df.Columns["Int"][6] = null;
             df.Columns["Int"][7] = null;
 

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -1465,6 +1465,16 @@ namespace Microsoft.Data.Analysis.Tests
         }
 
         [Fact]
+        public void TestMeanAndMedian()
+        {
+            Int32DataFrameColumn ints = new Int32DataFrameColumn("Ints", new int?[] { 1, 3, 3, 2, null, 9, 10 });
+            double mean = ints.Mean();
+            double median = ints.Median();
+            Assert.Equal(4, mean);
+            Assert.Equal(3, median);
+        }
+
+        [Fact]
         public void TestDataFrameClamp()
         {
             DataFrame df = MakeDataFrameWithAllColumnTypes(10);


### PR DESCRIPTION
**Issue**
A user found a bug in the OrderBy code but in fact the test case they raised also raises another bug. To summarise: 

1. If the column we want to sort contains nulls then the `.GetAscendingSortIndices()` method will ignore any index that has a null value and the code will break when this mismatched column is added to the final dataframe.
 
2. The code will also break if the column we want to sort doesn't contain nulls but the other columns do contain nulls. This is because the  nullCount parameter  in the following Clone method `DataFrameColumn newColumn = oldColumn.Clone(sortIndices, !isAscending, oldColumn.NullCount);` will append additional nulls to the end of the column which will cause the columns to be mismatched

This passed the previous test cases because the null values are all on the same row for the dataframe used in the test. So any nulls that are removed from point 1 will be offset by the nulls added in point 2( if ALL values in the row are null).


**Solution**
I have made adjustments to the original Sort column and updated/extended the tests to capture the issue raised. I have created a variable sortIndicesNull to capture all the indexes that get omitted by `GetAscendingSortIndices()` i then add these to the end or beginning of a new sorted column and the code continues as it did before.

Kind Regards,
Ramon
Fixes #2903 