### PR TITLE
Implement FillNulls() for ArrowStringDataFrameColumn with inPlace: false

### DIFF
--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -1771,6 +1771,8 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(3, arrowColumnFilled.Length);
             Assert.Equal(0, arrowColumnFilled.NullCount);
             Assert.Equal("foo", arrowColumnFilled[1]);
+            Assert.Equal(arrowColumn[0], arrowColumnFilled[0]);
+            Assert.Equal(arrowColumn[2], arrowColumnFilled[2]);
         }
 
         [Fact]

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -1759,6 +1759,18 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(0, strColumn.NullCount);
             Assert.Equal("foo", strColumn[0]);
             Assert.Equal("foo", strColumn[1]);
+
+            // ArrowStringColumn (not inplace)
+            ArrowStringDataFrameColumn arrowColumn = CreateArrowStringColumn(3);
+            Assert.Equal(3, arrowColumn.Length);
+            Assert.Equal(1, arrowColumn.NullCount);
+            Assert.Equal(null, arrowColumn[1]);
+            ArrowStringDataFrameColumn arrowColumnFilled = arrowColumn.FillNulls("foo");
+            Assert.Equal(3, arrowColumn.Length);
+            Assert.Equal(1, arrowColumn.NullCount);
+            Assert.Equal(3, arrowColumnFilled.Length);
+            Assert.Equal(0, arrowColumnFilled.NullCount);
+            Assert.Equal("foo", arrowColumnFilled[1]);
         }
 
         [Fact]


### PR DESCRIPTION
**Issue**
FillNulls is not implemented for the ArrowStringDataFrameColumn Class.

**Solution**
I have followed guidance from @pgovind and implemented the FillNulls method when inPlace is false. This method does not yet work for inPlace: true. In the event that inPlace is true the method will throw a NotSupportedException.
A test case has been included.

Kind Regards,
Ramon
Fixes: #2756 