### PR TITLE
ColumnName indexer on DataFrame

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.cs
@@ -148,6 +148,18 @@ namespace Microsoft.Data.Analysis
         }
 
         /// <summary>
+        /// An indexer based on <see cref="DataFrameColumn.Name"/>
+        /// </summary>
+        /// <param name="columnName">The name of a <see cref="DataFrameColumn"/></param>
+        /// <returns>A <see cref="DataFrameColumn"/> if it exists.</returns>
+        /// <exception cref="ArgumentException">Throws if <paramref name="columnName"/> is not present in this <see cref="DataFrame"/></exception>
+        public DataFrameColumn this[string columnName]
+        {
+            get => Columns[columnName];
+            set => Columns[columnName] = value;
+        }
+
+        /// <summary>
         /// Returns the first <paramref name="numberOfRows"/> rows
         /// </summary>
         /// <param name="numberOfRows"></param>

--- a/src/Microsoft.Data.Analysis/DataFrameColumnCollection.cs
+++ b/src/Microsoft.Data.Analysis/DataFrameColumnCollection.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Data.Analysis
         /// <param name="columnName"></param>
         public int IndexOf(string columnName)
         {
-            if (_columnNameToIndexDictionary.TryGetValue(columnName, out int columnIndex))
+            if (columnName != null && _columnNameToIndexDictionary.TryGetValue(columnName, out int columnIndex))
             {
                 return columnIndex;
             }

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -204,6 +204,7 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(1000, (int)column[2]);
 
             Assert.Throws<ArgumentException>(() => dataFrame["Int5"]);
+            Assert.Throws<ArgumentException>(() => dataFrame[(string)null]);
         }
 
         [Fact]

--- a/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/DataFrameTests.cs
@@ -200,10 +200,10 @@ namespace Microsoft.Data.Analysis.Tests
             var row = dataFrame.Rows[4];
             Assert.Equal(14, (int)row[1]);
 
-            var column = dataFrame.Columns["Int2"] as Int32DataFrameColumn;
+            var column = dataFrame["Int2"] as Int32DataFrameColumn;
             Assert.Equal(1000, (int)column[2]);
 
-            Assert.Throws<ArgumentException>(() => dataFrame.Columns["Int5"]);
+            Assert.Throws<ArgumentException>(() => dataFrame["Int5"]);
         }
 
         [Fact]
@@ -645,7 +645,7 @@ namespace Microsoft.Data.Analysis.Tests
         {
             DataFrame df = MakeDataFrameWithTwoColumns(10);
 
-            df.Columns["Int3"] = df.Columns["Int1"] * 2 + df.Columns["Int2"];
+            df["Int3"] = df.Columns["Int1"] * 2 + df.Columns["Int2"];
             Assert.Equal(16, df.Columns["Int3"][2]);
         }
 
@@ -653,7 +653,7 @@ namespace Microsoft.Data.Analysis.Tests
         public void TestComputations()
         {
             DataFrame df = MakeDataFrameWithAllMutableColumnTypes(10);
-            df.Columns["Int"][0] = -10;
+            df["Int"][0] = -10;
             Assert.Equal(-10, df.Columns["Int"][0]);
 
             DataFrameColumn absColumn = df.Columns["Int"].Abs();


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefxlab/issues/2934

This change brings back the column name indexer on `DataFrame`. I modified a couple test cases to test the new getter and setter.

cc @Hamaze