### PR TITLE
Add constructor for MultiDictionary that takes IEnumerable of KeyValuePair

### DIFF
--- a/src/Microsoft.Experimental.Collections/Microsoft/Collections/Extensions/MultiValueDictionary.cs
+++ b/src/Microsoft.Experimental.Collections/Microsoft/Collections/Extensions/MultiValueDictionary.cs
@@ -118,7 +118,21 @@ namespace Microsoft.Collections.Extensions
         public MultiValueDictionary(IEnumerable<KeyValuePair<TKey, IReadOnlyCollection<TValue>>> enumerable)
             : this(enumerable, null)
         { }
-
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> class that contains 
+        /// elements copied from the specified IEnumerable&lt;KeyValuePair&lt;TKey, Value&gt;&gt; and uses the 
+        /// default <see cref="IEqualityComparer{TKey}" /> for the <typeparamref name="TKey"/> type.
+        /// </summary>
+        /// <param name="enumerable">IEnumerable to copy elements into this from</param>
+        /// <exception cref="ArgumentNullException">enumerable must be non-null</exception>
+        public MultiValueDictionary(IEnumerable<KeyValuePair<TKey, TValue>> enumerable)
+            : this()
+        { 
+            for (var item in enumerable)
+                this.Add(item.Key,item.Value);
+        }
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="MultiValueDictionary{TKey, TValue}" /> class that contains 
         /// elements copied from the specified IEnumerable&lt;KeyValuePair&lt;TKey, IReadOnlyCollection&lt;TValue&gt;&gt;&gt; and uses the 

--- a/src/Microsoft.Experimental.Collections/Microsoft/Collections/Extensions/MultiValueDictionary.cs
+++ b/src/Microsoft.Experimental.Collections/Microsoft/Collections/Extensions/MultiValueDictionary.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Collections.Extensions
         public MultiValueDictionary(IEnumerable<KeyValuePair<TKey, TValue>> enumerable)
             : this()
         { 
-            for (var item in enumerable)
+            foreach (var item in enumerable)
                 this.Add(item.Key,item.Value);
         }
         


### PR DESCRIPTION
This fixes the missing foreach in #2976
 for sugguestion #2975 

This would allow users to add an IEnumerable that is unsorted without presorting it.

There would be a performance hit, but would make for simpler code on the part of the user.