### PR TITLE
Update FromArrowRecordBatches for dotnet-spark

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.Arrow.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.Arrow.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Data.Analysis
                     StructArray structArray = (StructArray)arrowArray;
                     StructType structType = (StructType)field.DataType;
                     IEnumerator<Field> fieldsEnumerator = structType.Fields.GetEnumerator();
-                    IEnumerator<Apache.Arrow.Array> structArrayEnumerator = structArray.Fields.GetEnumerator();
+                    IEnumerator<IArrowArray> structArrayEnumerator = structArray.Fields.GetEnumerator();
                     while (fieldsEnumerator.MoveNext() && structArrayEnumerator.MoveNext())
                     {
                         AppendDataFrameColumnFromArrowArray(fieldsEnumerator.Current, structArrayEnumerator.Current, ret);

--- a/src/Microsoft.Data.Analysis/DataFrame.Arrow.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.Arrow.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Data.Analysis
 {
     public partial class DataFrame
     {
-        private static void AppendDataFrameColumnFromArrowArray(Field field, IArrowArray arrowArray, DataFrame ret, string structName = "")
+        private static void AppendDataFrameColumnFromArrowArray(Field field, IArrowArray arrowArray, DataFrame ret, string fieldNamePrefix = "")
         {
             IArrowType fieldType = field.DataType;
             DataFrameColumn dataFrameColumn = null;
-            string fieldName = structName + field.Name;
+            string fieldName = fieldNamePrefix + field.Name;
             switch (fieldType.TypeId)
             {
                 case ArrowTypeId.Boolean:
@@ -98,7 +98,7 @@ namespace Microsoft.Data.Analysis
                     IEnumerator<IArrowArray> structArrayEnumerator = structArray.Fields.GetEnumerator();
                     while (fieldsEnumerator.MoveNext() && structArrayEnumerator.MoveNext())
                     {
-                        AppendDataFrameColumnFromArrowArray(fieldsEnumerator.Current, structArrayEnumerator.Current, ret, field.Name + ".");
+                        AppendDataFrameColumnFromArrowArray(fieldsEnumerator.Current, structArrayEnumerator.Current, ret, field.Name + "_");
                     }
                     break;
                 case ArrowTypeId.Decimal:

--- a/src/Microsoft.Data.Analysis/DataFrame.Arrow.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.Arrow.cs
@@ -3,11 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text;
-using System.Threading.Tasks;
 using Apache.Arrow;
 using Apache.Arrow.Types;
 
@@ -15,6 +11,118 @@ namespace Microsoft.Data.Analysis
 {
     public partial class DataFrame
     {
+        private static void AppendDataFrameColumnFromArrowArray(Field field, IArrowArray arrowArray, DataFrame ret)
+        {
+            IArrowType fieldType = field.DataType;
+            DataFrameColumn dataFrameColumn = null;
+            switch (fieldType.TypeId)
+            {
+                case ArrowTypeId.Boolean:
+                    BooleanArray arrowBooleanArray = (BooleanArray)arrowArray;
+                    ReadOnlyMemory<byte> valueBuffer = arrowBooleanArray.ValueBuffer.Memory;
+                    ReadOnlyMemory<byte> nullBitMapBuffer = arrowBooleanArray.NullBitmapBuffer.Memory;
+                    dataFrameColumn = new BooleanDataFrameColumn(field.Name, valueBuffer, nullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    break;
+                case ArrowTypeId.Double:
+                    PrimitiveArray<double> arrowDoubleArray = (PrimitiveArray<double>)arrowArray;
+                    ReadOnlyMemory<byte> doubleValueBuffer = arrowDoubleArray.ValueBuffer.Memory;
+                    ReadOnlyMemory<byte> doubleNullBitMapBuffer = arrowDoubleArray.NullBitmapBuffer.Memory;
+                    dataFrameColumn = new DoubleDataFrameColumn(field.Name, doubleValueBuffer, doubleNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    break;
+                case ArrowTypeId.Float:
+                    PrimitiveArray<float> arrowFloatArray = (PrimitiveArray<float>)arrowArray;
+                    ReadOnlyMemory<byte> floatValueBuffer = arrowFloatArray.ValueBuffer.Memory;
+                    ReadOnlyMemory<byte> floatNullBitMapBuffer = arrowFloatArray.NullBitmapBuffer.Memory;
+                    dataFrameColumn = new SingleDataFrameColumn(field.Name, floatValueBuffer, floatNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    break;
+                case ArrowTypeId.Int8:
+                    PrimitiveArray<sbyte> arrowsbyteArray = (PrimitiveArray<sbyte>)arrowArray;
+                    ReadOnlyMemory<byte> sbyteValueBuffer = arrowsbyteArray.ValueBuffer.Memory;
+                    ReadOnlyMemory<byte> sbyteNullBitMapBuffer = arrowsbyteArray.NullBitmapBuffer.Memory;
+                    dataFrameColumn = new SByteDataFrameColumn(field.Name, sbyteValueBuffer, sbyteNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    break;
+                case ArrowTypeId.Int16:
+                    PrimitiveArray<short> arrowshortArray = (PrimitiveArray<short>)arrowArray;
+                    ReadOnlyMemory<byte> shortValueBuffer = arrowshortArray.ValueBuffer.Memory;
+                    ReadOnlyMemory<byte> shortNullBitMapBuffer = arrowshortArray.NullBitmapBuffer.Memory;
+                    dataFrameColumn = new Int16DataFrameColumn(field.Name, shortValueBuffer, shortNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    break;
+                case ArrowTypeId.Int32:
+                    PrimitiveArray<int> arrowIntArray = (PrimitiveArray<int>)arrowArray;
+                    ReadOnlyMemory<byte> intValueBuffer = arrowIntArray.ValueBuffer.Memory;
+                    ReadOnlyMemory<byte> intNullBitMapBuffer = arrowIntArray.NullBitmapBuffer.Memory;
+                    dataFrameColumn = new Int32DataFrameColumn(field.Name, intValueBuffer, intNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    break;
+                case ArrowTypeId.Int64:
+                    PrimitiveArray<long> arrowLongArray = (PrimitiveArray<long>)arrowArray;
+                    ReadOnlyMemory<byte> longValueBuffer = arrowLongArray.ValueBuffer.Memory;
+                    ReadOnlyMemory<byte> longNullBitMapBuffer = arrowLongArray.NullBitmapBuffer.Memory;
+                    dataFrameColumn = new Int64DataFrameColumn(field.Name, longValueBuffer, longNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    break;
+                case ArrowTypeId.String:
+                    StringArray stringArray = (StringArray)arrowArray;
+                    ReadOnlyMemory<byte> dataMemory = stringArray.ValueBuffer.Memory;
+                    ReadOnlyMemory<byte> offsetsMemory = stringArray.ValueOffsetsBuffer.Memory;
+                    ReadOnlyMemory<byte> nullMemory = stringArray.NullBitmapBuffer.Memory;
+                    dataFrameColumn = new ArrowStringDataFrameColumn(field.Name, dataMemory, offsetsMemory, nullMemory, stringArray.Length, stringArray.NullCount);
+                    break;
+                case ArrowTypeId.UInt8:
+                    PrimitiveArray<byte> arrowbyteArray = (PrimitiveArray<byte>)arrowArray;
+                    ReadOnlyMemory<byte> byteValueBuffer = arrowbyteArray.ValueBuffer.Memory;
+                    ReadOnlyMemory<byte> byteNullBitMapBuffer = arrowbyteArray.NullBitmapBuffer.Memory;
+                    dataFrameColumn = new ByteDataFrameColumn(field.Name, byteValueBuffer, byteNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    break;
+                case ArrowTypeId.UInt16:
+                    PrimitiveArray<ushort> arrowUshortArray = (PrimitiveArray<ushort>)arrowArray;
+                    ReadOnlyMemory<byte> ushortValueBuffer = arrowUshortArray.ValueBuffer.Memory;
+                    ReadOnlyMemory<byte> ushortNullBitMapBuffer = arrowUshortArray.NullBitmapBuffer.Memory;
+                    dataFrameColumn = new UInt16DataFrameColumn(field.Name, ushortValueBuffer, ushortNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    break;
+                case ArrowTypeId.UInt32:
+                    PrimitiveArray<uint> arrowUintArray = (PrimitiveArray<uint>)arrowArray;
+                    ReadOnlyMemory<byte> uintValueBuffer = arrowUintArray.ValueBuffer.Memory;
+                    ReadOnlyMemory<byte> uintNullBitMapBuffer = arrowUintArray.NullBitmapBuffer.Memory;
+                    dataFrameColumn = new UInt32DataFrameColumn(field.Name, uintValueBuffer, uintNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    break;
+                case ArrowTypeId.UInt64:
+                    PrimitiveArray<ulong> arrowUlongArray = (PrimitiveArray<ulong>)arrowArray;
+                    ReadOnlyMemory<byte> ulongValueBuffer = arrowUlongArray.ValueBuffer.Memory;
+                    ReadOnlyMemory<byte> ulongNullBitMapBuffer = arrowUlongArray.NullBitmapBuffer.Memory;
+                    dataFrameColumn = new UInt64DataFrameColumn(field.Name, ulongValueBuffer, ulongNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    break;
+                case ArrowTypeId.Struct:
+                    StructArray structArray = (StructArray)arrowArray;
+                    StructType structType = (StructType)field.DataType;
+                    IEnumerator<Field> fieldsEnumerator = structType.Fields.GetEnumerator();
+                    IEnumerator<Apache.Arrow.Array> structArrayEnumerator = structArray.Fields.GetEnumerator();
+                    while (fieldsEnumerator.MoveNext() && structArrayEnumerator.MoveNext())
+                    {
+                        AppendDataFrameColumnFromArrowArray(fieldsEnumerator.Current, structArrayEnumerator.Current, ret);
+                    }
+                    break;
+                case ArrowTypeId.Decimal:
+                case ArrowTypeId.Binary:
+                case ArrowTypeId.Date32:
+                case ArrowTypeId.Date64:
+                case ArrowTypeId.Dictionary:
+                case ArrowTypeId.FixedSizedBinary:
+                case ArrowTypeId.HalfFloat:
+                case ArrowTypeId.Interval:
+                case ArrowTypeId.List:
+                case ArrowTypeId.Map:
+                case ArrowTypeId.Null:
+                case ArrowTypeId.Time32:
+                case ArrowTypeId.Time64:
+                default:
+                    throw new NotImplementedException(nameof(fieldType.Name));
+            }
+
+            if (dataFrameColumn != null)
+            {
+                ret.Columns.Insert(ret.Columns.Count, dataFrameColumn);
+            }
+        }
+
         /// <summary>
         /// Wraps a <see cref="DataFrame"/> around an Arrow <see cref="RecordBatch"/> without copying data
         /// </summary>
@@ -29,101 +137,7 @@ namespace Microsoft.Data.Analysis
             foreach (IArrowArray arrowArray in arrowArrays)
             {
                 Field field = arrowSchema.GetFieldByIndex(fieldIndex);
-                IArrowType fieldType = field.DataType;
-                DataFrameColumn dataFrameColumn = null;
-                switch (fieldType.TypeId)
-                {
-                    case ArrowTypeId.Boolean:
-                        BooleanArray arrowBooleanArray = (BooleanArray)arrowArray;
-                        ReadOnlyMemory<byte> valueBuffer = arrowBooleanArray.ValueBuffer.Memory;
-                        ReadOnlyMemory<byte> nullBitMapBuffer = arrowBooleanArray.NullBitmapBuffer.Memory;
-                        dataFrameColumn = new BooleanDataFrameColumn(field.Name, valueBuffer, nullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
-                        break;
-                    case ArrowTypeId.Double:
-                        PrimitiveArray<double> arrowDoubleArray = (PrimitiveArray<double>)arrowArray;
-                        ReadOnlyMemory<byte> doubleValueBuffer = arrowDoubleArray.ValueBuffer.Memory;
-                        ReadOnlyMemory<byte> doubleNullBitMapBuffer = arrowDoubleArray.NullBitmapBuffer.Memory;
-                        dataFrameColumn = new DoubleDataFrameColumn(field.Name, doubleValueBuffer, doubleNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
-                        break;
-                    case ArrowTypeId.Float:
-                        PrimitiveArray<float> arrowFloatArray = (PrimitiveArray<float>)arrowArray;
-                        ReadOnlyMemory<byte> floatValueBuffer = arrowFloatArray.ValueBuffer.Memory;
-                        ReadOnlyMemory<byte> floatNullBitMapBuffer = arrowFloatArray.NullBitmapBuffer.Memory;
-                        dataFrameColumn = new SingleDataFrameColumn(field.Name, floatValueBuffer, floatNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
-                        break;
-                    case ArrowTypeId.Int8:
-                        PrimitiveArray<sbyte> arrowsbyteArray = (PrimitiveArray<sbyte>)arrowArray;
-                        ReadOnlyMemory<byte> sbyteValueBuffer = arrowsbyteArray.ValueBuffer.Memory;
-                        ReadOnlyMemory<byte> sbyteNullBitMapBuffer = arrowsbyteArray.NullBitmapBuffer.Memory;
-                        dataFrameColumn = new SByteDataFrameColumn(field.Name, sbyteValueBuffer, sbyteNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
-                        break;
-                    case ArrowTypeId.Int16:
-                        PrimitiveArray<short> arrowshortArray = (PrimitiveArray<short>)arrowArray;
-                        ReadOnlyMemory<byte> shortValueBuffer = arrowshortArray.ValueBuffer.Memory;
-                        ReadOnlyMemory<byte> shortNullBitMapBuffer = arrowshortArray.NullBitmapBuffer.Memory;
-                        dataFrameColumn = new Int16DataFrameColumn(field.Name, shortValueBuffer, shortNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
-                        break;
-                    case ArrowTypeId.Int32:
-                        PrimitiveArray<int> arrowIntArray = (PrimitiveArray<int>)arrowArray;
-                        ReadOnlyMemory<byte> intValueBuffer = arrowIntArray.ValueBuffer.Memory;
-                        ReadOnlyMemory<byte> intNullBitMapBuffer = arrowIntArray.NullBitmapBuffer.Memory;
-                        dataFrameColumn = new Int32DataFrameColumn(field.Name, intValueBuffer, intNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
-                        break;
-                    case ArrowTypeId.Int64:
-                        PrimitiveArray<long> arrowLongArray = (PrimitiveArray<long>)arrowArray;
-                        ReadOnlyMemory<byte> longValueBuffer = arrowLongArray.ValueBuffer.Memory;
-                        ReadOnlyMemory<byte> longNullBitMapBuffer = arrowLongArray.NullBitmapBuffer.Memory;
-                        dataFrameColumn = new Int64DataFrameColumn(field.Name, longValueBuffer, longNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
-                        break;
-                    case ArrowTypeId.String:
-                        StringArray stringArray = (StringArray)arrowArray;
-                        ReadOnlyMemory<byte> dataMemory = stringArray.ValueBuffer.Memory;
-                        ReadOnlyMemory<byte> offsetsMemory = stringArray.ValueOffsetsBuffer.Memory;
-                        ReadOnlyMemory<byte> nullMemory = stringArray.NullBitmapBuffer.Memory;
-                        dataFrameColumn = new ArrowStringDataFrameColumn(field.Name, dataMemory, offsetsMemory, nullMemory, stringArray.Length, stringArray.NullCount);
-                        break;
-                    case ArrowTypeId.UInt8:
-                        PrimitiveArray<byte> arrowbyteArray = (PrimitiveArray<byte>)arrowArray;
-                        ReadOnlyMemory<byte> byteValueBuffer = arrowbyteArray.ValueBuffer.Memory;
-                        ReadOnlyMemory<byte> byteNullBitMapBuffer = arrowbyteArray.NullBitmapBuffer.Memory;
-                        dataFrameColumn = new ByteDataFrameColumn(field.Name, byteValueBuffer, byteNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
-                        break;
-                    case ArrowTypeId.UInt16:
-                        PrimitiveArray<ushort> arrowUshortArray = (PrimitiveArray<ushort>)arrowArray;
-                        ReadOnlyMemory<byte> ushortValueBuffer = arrowUshortArray.ValueBuffer.Memory;
-                        ReadOnlyMemory<byte> ushortNullBitMapBuffer = arrowUshortArray.NullBitmapBuffer.Memory;
-                        dataFrameColumn = new UInt16DataFrameColumn(field.Name, ushortValueBuffer, ushortNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
-                        break;
-                    case ArrowTypeId.UInt32:
-                        PrimitiveArray<uint> arrowUintArray = (PrimitiveArray<uint>)arrowArray;
-                        ReadOnlyMemory<byte> uintValueBuffer = arrowUintArray.ValueBuffer.Memory;
-                        ReadOnlyMemory<byte> uintNullBitMapBuffer = arrowUintArray.NullBitmapBuffer.Memory;
-                        dataFrameColumn = new UInt32DataFrameColumn(field.Name, uintValueBuffer, uintNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
-                        break;
-                    case ArrowTypeId.UInt64:
-                        PrimitiveArray<ulong> arrowUlongArray = (PrimitiveArray<ulong>)arrowArray;
-                        ReadOnlyMemory<byte> ulongValueBuffer = arrowUlongArray.ValueBuffer.Memory;
-                        ReadOnlyMemory<byte> ulongNullBitMapBuffer = arrowUlongArray.NullBitmapBuffer.Memory;
-                        dataFrameColumn = new UInt64DataFrameColumn(field.Name, ulongValueBuffer, ulongNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
-                        break;
-                    case ArrowTypeId.Decimal:
-                    case ArrowTypeId.Binary:
-                    case ArrowTypeId.Date32:
-                    case ArrowTypeId.Date64:
-                    case ArrowTypeId.Dictionary:
-                    case ArrowTypeId.FixedSizedBinary:
-                    case ArrowTypeId.HalfFloat:
-                    case ArrowTypeId.Interval:
-                    case ArrowTypeId.List:
-                    case ArrowTypeId.Map:
-                    case ArrowTypeId.Null:
-                    case ArrowTypeId.Struct:
-                    case ArrowTypeId.Time32:
-                    case ArrowTypeId.Time64:
-                    default:
-                        throw new NotImplementedException(nameof(fieldType.Name));
-                }
-                ret.Columns.Insert(ret.Columns.Count, dataFrameColumn);
+                AppendDataFrameColumnFromArrowArray(field, arrowArray, ret);
                 fieldIndex++;
             }
             return ret;

--- a/src/Microsoft.Data.Analysis/DataFrame.Arrow.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.Arrow.cs
@@ -11,84 +11,85 @@ namespace Microsoft.Data.Analysis
 {
     public partial class DataFrame
     {
-        private static void AppendDataFrameColumnFromArrowArray(Field field, IArrowArray arrowArray, DataFrame ret)
+        private static void AppendDataFrameColumnFromArrowArray(Field field, IArrowArray arrowArray, DataFrame ret, string structName = "")
         {
             IArrowType fieldType = field.DataType;
             DataFrameColumn dataFrameColumn = null;
+            string fieldName = structName + field.Name;
             switch (fieldType.TypeId)
             {
                 case ArrowTypeId.Boolean:
                     BooleanArray arrowBooleanArray = (BooleanArray)arrowArray;
                     ReadOnlyMemory<byte> valueBuffer = arrowBooleanArray.ValueBuffer.Memory;
                     ReadOnlyMemory<byte> nullBitMapBuffer = arrowBooleanArray.NullBitmapBuffer.Memory;
-                    dataFrameColumn = new BooleanDataFrameColumn(field.Name, valueBuffer, nullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    dataFrameColumn = new BooleanDataFrameColumn(fieldName, valueBuffer, nullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
                     break;
                 case ArrowTypeId.Double:
                     PrimitiveArray<double> arrowDoubleArray = (PrimitiveArray<double>)arrowArray;
                     ReadOnlyMemory<byte> doubleValueBuffer = arrowDoubleArray.ValueBuffer.Memory;
                     ReadOnlyMemory<byte> doubleNullBitMapBuffer = arrowDoubleArray.NullBitmapBuffer.Memory;
-                    dataFrameColumn = new DoubleDataFrameColumn(field.Name, doubleValueBuffer, doubleNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    dataFrameColumn = new DoubleDataFrameColumn(fieldName, doubleValueBuffer, doubleNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
                     break;
                 case ArrowTypeId.Float:
                     PrimitiveArray<float> arrowFloatArray = (PrimitiveArray<float>)arrowArray;
                     ReadOnlyMemory<byte> floatValueBuffer = arrowFloatArray.ValueBuffer.Memory;
                     ReadOnlyMemory<byte> floatNullBitMapBuffer = arrowFloatArray.NullBitmapBuffer.Memory;
-                    dataFrameColumn = new SingleDataFrameColumn(field.Name, floatValueBuffer, floatNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    dataFrameColumn = new SingleDataFrameColumn(fieldName, floatValueBuffer, floatNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
                     break;
                 case ArrowTypeId.Int8:
                     PrimitiveArray<sbyte> arrowsbyteArray = (PrimitiveArray<sbyte>)arrowArray;
                     ReadOnlyMemory<byte> sbyteValueBuffer = arrowsbyteArray.ValueBuffer.Memory;
                     ReadOnlyMemory<byte> sbyteNullBitMapBuffer = arrowsbyteArray.NullBitmapBuffer.Memory;
-                    dataFrameColumn = new SByteDataFrameColumn(field.Name, sbyteValueBuffer, sbyteNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    dataFrameColumn = new SByteDataFrameColumn(fieldName, sbyteValueBuffer, sbyteNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
                     break;
                 case ArrowTypeId.Int16:
                     PrimitiveArray<short> arrowshortArray = (PrimitiveArray<short>)arrowArray;
                     ReadOnlyMemory<byte> shortValueBuffer = arrowshortArray.ValueBuffer.Memory;
                     ReadOnlyMemory<byte> shortNullBitMapBuffer = arrowshortArray.NullBitmapBuffer.Memory;
-                    dataFrameColumn = new Int16DataFrameColumn(field.Name, shortValueBuffer, shortNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    dataFrameColumn = new Int16DataFrameColumn(fieldName, shortValueBuffer, shortNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
                     break;
                 case ArrowTypeId.Int32:
                     PrimitiveArray<int> arrowIntArray = (PrimitiveArray<int>)arrowArray;
                     ReadOnlyMemory<byte> intValueBuffer = arrowIntArray.ValueBuffer.Memory;
                     ReadOnlyMemory<byte> intNullBitMapBuffer = arrowIntArray.NullBitmapBuffer.Memory;
-                    dataFrameColumn = new Int32DataFrameColumn(field.Name, intValueBuffer, intNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    dataFrameColumn = new Int32DataFrameColumn(fieldName, intValueBuffer, intNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
                     break;
                 case ArrowTypeId.Int64:
                     PrimitiveArray<long> arrowLongArray = (PrimitiveArray<long>)arrowArray;
                     ReadOnlyMemory<byte> longValueBuffer = arrowLongArray.ValueBuffer.Memory;
                     ReadOnlyMemory<byte> longNullBitMapBuffer = arrowLongArray.NullBitmapBuffer.Memory;
-                    dataFrameColumn = new Int64DataFrameColumn(field.Name, longValueBuffer, longNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    dataFrameColumn = new Int64DataFrameColumn(fieldName, longValueBuffer, longNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
                     break;
                 case ArrowTypeId.String:
                     StringArray stringArray = (StringArray)arrowArray;
                     ReadOnlyMemory<byte> dataMemory = stringArray.ValueBuffer.Memory;
                     ReadOnlyMemory<byte> offsetsMemory = stringArray.ValueOffsetsBuffer.Memory;
                     ReadOnlyMemory<byte> nullMemory = stringArray.NullBitmapBuffer.Memory;
-                    dataFrameColumn = new ArrowStringDataFrameColumn(field.Name, dataMemory, offsetsMemory, nullMemory, stringArray.Length, stringArray.NullCount);
+                    dataFrameColumn = new ArrowStringDataFrameColumn(fieldName, dataMemory, offsetsMemory, nullMemory, stringArray.Length, stringArray.NullCount);
                     break;
                 case ArrowTypeId.UInt8:
                     PrimitiveArray<byte> arrowbyteArray = (PrimitiveArray<byte>)arrowArray;
                     ReadOnlyMemory<byte> byteValueBuffer = arrowbyteArray.ValueBuffer.Memory;
                     ReadOnlyMemory<byte> byteNullBitMapBuffer = arrowbyteArray.NullBitmapBuffer.Memory;
-                    dataFrameColumn = new ByteDataFrameColumn(field.Name, byteValueBuffer, byteNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    dataFrameColumn = new ByteDataFrameColumn(fieldName, byteValueBuffer, byteNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
                     break;
                 case ArrowTypeId.UInt16:
                     PrimitiveArray<ushort> arrowUshortArray = (PrimitiveArray<ushort>)arrowArray;
                     ReadOnlyMemory<byte> ushortValueBuffer = arrowUshortArray.ValueBuffer.Memory;
                     ReadOnlyMemory<byte> ushortNullBitMapBuffer = arrowUshortArray.NullBitmapBuffer.Memory;
-                    dataFrameColumn = new UInt16DataFrameColumn(field.Name, ushortValueBuffer, ushortNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    dataFrameColumn = new UInt16DataFrameColumn(fieldName, ushortValueBuffer, ushortNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
                     break;
                 case ArrowTypeId.UInt32:
                     PrimitiveArray<uint> arrowUintArray = (PrimitiveArray<uint>)arrowArray;
                     ReadOnlyMemory<byte> uintValueBuffer = arrowUintArray.ValueBuffer.Memory;
                     ReadOnlyMemory<byte> uintNullBitMapBuffer = arrowUintArray.NullBitmapBuffer.Memory;
-                    dataFrameColumn = new UInt32DataFrameColumn(field.Name, uintValueBuffer, uintNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    dataFrameColumn = new UInt32DataFrameColumn(fieldName, uintValueBuffer, uintNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
                     break;
                 case ArrowTypeId.UInt64:
                     PrimitiveArray<ulong> arrowUlongArray = (PrimitiveArray<ulong>)arrowArray;
                     ReadOnlyMemory<byte> ulongValueBuffer = arrowUlongArray.ValueBuffer.Memory;
                     ReadOnlyMemory<byte> ulongNullBitMapBuffer = arrowUlongArray.NullBitmapBuffer.Memory;
-                    dataFrameColumn = new UInt64DataFrameColumn(field.Name, ulongValueBuffer, ulongNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
+                    dataFrameColumn = new UInt64DataFrameColumn(fieldName, ulongValueBuffer, ulongNullBitMapBuffer, arrowArray.Length, arrowArray.NullCount);
                     break;
                 case ArrowTypeId.Struct:
                     StructArray structArray = (StructArray)arrowArray;
@@ -97,7 +98,7 @@ namespace Microsoft.Data.Analysis
                     IEnumerator<IArrowArray> structArrayEnumerator = structArray.Fields.GetEnumerator();
                     while (fieldsEnumerator.MoveNext() && structArrayEnumerator.MoveNext())
                     {
-                        AppendDataFrameColumnFromArrowArray(fieldsEnumerator.Current, structArrayEnumerator.Current, ret);
+                        AppendDataFrameColumnFromArrowArray(fieldsEnumerator.Current, structArrayEnumerator.Current, ret, field.Name + ".");
                     }
                     break;
                 case ArrowTypeId.Decimal:

--- a/src/Microsoft.Data.Analysis/Microsoft.Data.Analysis.csproj
+++ b/src/Microsoft.Data.Analysis/Microsoft.Data.Analysis.csproj
@@ -47,7 +47,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Apache.Arrow" Version="0.14.1" />
+    <PackageReference Include="Apache.Arrow" Version="2.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />

--- a/tests/Microsoft.Data.Analysis.Tests/ArrayComparer.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/ArrayComparer.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Data.Analysis.Tests
         IArrowArrayVisitor<Date64Array>,
         IArrowArrayVisitor<ListArray>,
         IArrowArrayVisitor<StringArray>,
-        IArrowArrayVisitor<BinaryArray>
+        IArrowArrayVisitor<BinaryArray>,
+        IArrowArrayVisitor<StructArray>
     {
         private readonly IArrowArray _expectedArray;
 
@@ -54,6 +55,24 @@ namespace Microsoft.Data.Analysis.Tests
         public void Visit(BinaryArray array) => throw new NotImplementedException();
         public void Visit(IArrowArray array) => throw new NotImplementedException();
 
+        public void Visit(StructArray array)
+        {
+            Assert.IsAssignableFrom<StructArray>(_expectedArray);
+            StructArray expectedArray = (StructArray)_expectedArray;
+
+            Assert.Equal(expectedArray.Length, array.Length);
+            Assert.Equal(expectedArray.NullCount, array.NullCount);
+            Assert.Equal(expectedArray.Offset, array.Offset);
+            Assert.Equal(expectedArray.Data.Children.Length, array.Data.Children.Length);
+
+            var arrayFieldsEnumerator = array.Fields.GetEnumerator();
+            var expectedArrayFieldsEnumerator = expectedArray.Fields.GetEnumerator();
+            while (arrayFieldsEnumerator.MoveNext() && expectedArrayFieldsEnumerator.MoveNext())
+            {
+                arrayFieldsEnumerator.Current.Accept(new ArrayComparer(expectedArrayFieldsEnumerator.Current));
+            }
+        }
+
         private void CompareArrays<T>(PrimitiveArray<T> actualArray)
             where T : struct, IEquatable<T>
         {
@@ -68,15 +87,15 @@ namespace Microsoft.Data.Analysis.Tests
             {
                 Assert.True(expectedArray.NullBitmapBuffer.Span.SequenceEqual(actualArray.NullBitmapBuffer.Span));
             }
-            else 
-            { 
+            else
+            {
                 // expectedArray may have passed in a null bitmap. DataFrame might have populated it with Length set bits 
-                Assert.Equal(0, expectedArray.NullCount); 
-                Assert.Equal(0, actualArray.NullCount); 
-                for (int i = 0; i < actualArray.Length; i++) 
-                { 
-                    Assert.True(actualArray.IsValid(i)); 
-                } 
+                Assert.Equal(0, expectedArray.NullCount);
+                Assert.Equal(0, actualArray.NullCount);
+                for (int i = 0; i < actualArray.Length; i++)
+                {
+                    Assert.True(actualArray.IsValid(i));
+                }
             }
             Assert.True(expectedArray.Values.Slice(0, expectedArray.Length).SequenceEqual(actualArray.Values.Slice(0, actualArray.Length)));
         }

--- a/tests/Microsoft.Data.Analysis.Tests/ArrayComparer.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/ArrayComparer.cs
@@ -64,12 +64,11 @@ namespace Microsoft.Data.Analysis.Tests
             Assert.Equal(expectedArray.NullCount, array.NullCount);
             Assert.Equal(expectedArray.Offset, array.Offset);
             Assert.Equal(expectedArray.Data.Children.Length, array.Data.Children.Length);
+            Assert.Equal(expectedArray.Fields.Count, array.Fields.Count);
 
-            var arrayFieldsEnumerator = array.Fields.GetEnumerator();
-            var expectedArrayFieldsEnumerator = expectedArray.Fields.GetEnumerator();
-            while (arrayFieldsEnumerator.MoveNext() && expectedArrayFieldsEnumerator.MoveNext())
+            for (int i = 0; i < array.Fields.Count; i++)
             {
-                arrayFieldsEnumerator.Current.Accept(new ArrayComparer(expectedArrayFieldsEnumerator.Current));
+                array.Fields[i].Accept(new ArrayComparer(expectedArray.Fields[i]));
             }
         }
 

--- a/tests/Microsoft.Data.Analysis.Tests/ArrowIntegrationTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/ArrowIntegrationTests.cs
@@ -102,15 +102,15 @@ namespace Microsoft.Data.Analysis.Tests
             }
 
             RecordBatch originalBatch = CreateRecordBatch();
-            ArrowBuffer.BitmapBuilder nullBitmapBufferBuilder = new ArrowBuffer.BitmapBuilder();
+            ArrowBuffer.BitmapBuilder validityBitmapBuilder = new ArrowBuffer.BitmapBuilder();
             for (int i = 0; i < originalBatch.Length; i++)
             {
-                nullBitmapBufferBuilder.Append(true);
+                validityBitmapBuilder.Append(true);
             }
-            var nullBitmapBuffer = nullBitmapBufferBuilder.Build();
+            ArrowBuffer validityBitmap = validityBitmapBuilder.Build();
 
             StructType structType = new StructType(originalBatch.Schema.Fields.Select((KeyValuePair<string, Field> pair) => pair.Value).ToList());
-            StructArray structArray = new StructArray(structType, originalBatch.Length, originalBatch.Arrays.Cast<Apache.Arrow.Array>(), nullBitmapBuffer);
+            StructArray structArray = new StructArray(structType, originalBatch.Length, originalBatch.Arrays.Cast<Apache.Arrow.Array>(), validityBitmap);
             Schema schema = new Schema.Builder().Field(new Field("Struct", structType, false)).Build();
             RecordBatch recordBatch = new RecordBatch(schema, new[] { structArray }, originalBatch.Length);
 

--- a/tests/Microsoft.Data.Analysis.Tests/ArrowIntegrationTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/ArrowIntegrationTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Data.Analysis.Tests
 
             IEnumerable<RecordBatch> recordBatches = df.ToArrowRecordBatches();
 
-            RecordBatch expected = CreateRecordBatch("Struct.");
+            RecordBatch expected = CreateRecordBatch("Struct_");
             foreach (RecordBatch batch in recordBatches)
             {
                 RecordBatchComparer.CompareBatches(expected, batch);

--- a/tests/Microsoft.Data.Analysis.Tests/ArrowIntegrationTests.cs
+++ b/tests/Microsoft.Data.Analysis.Tests/ArrowIntegrationTests.cs
@@ -50,14 +50,14 @@ namespace Microsoft.Data.Analysis.Tests
                 .Append("UByteColumn", false, new UInt8Array.Builder().AppendRange(Enumerable.Repeat((byte)1, 10)).Build())
                 .Build();
 
-            ArrowBuffer.Builder<bool> nullBitmapBufferBuilder = new ArrowBuffer.Builder<bool>();
+            ArrowBuffer.BitmapBuilder nullBitmapBufferBuilder = new ArrowBuffer.BitmapBuilder();
             for (int i = 0; i < originalBatch.Length; i++)
             {
                 nullBitmapBufferBuilder.Append(true);
             }
             var nullBitmapBuffer = nullBitmapBufferBuilder.Build();
 
-            StructType structType = new StructType(originalBatch.Schema.Fields.Select((KeyValuePair<string, Field> pair) => pair.Value));
+            StructType structType = new StructType(originalBatch.Schema.Fields.Select((KeyValuePair<string, Field> pair) => pair.Value).ToList());
             StructArray structArray = new StructArray(structType, originalBatch.Length, originalBatch.Arrays.Cast<Apache.Arrow.Array>(), nullBitmapBuffer);
             Schema schema = new Schema.Builder().Field(new Field("Struct", structType, false)).Build();
             RecordBatch recordBatch = new RecordBatch(schema, new[] { structArray }, originalBatch.Length);


### PR DESCRIPTION
2 things going on in this PR:

1. Update `FromArrowRecordBatch` just in case we have a `RecordBatch` with a `StructArray` in it. We'll flatten out the `StructArray` into a regular `DataFrame`. Once this goes in, I'll open another PR to update the version number for MDA.
2. Update the Arrow dependency to the latest version. This will prevent accidental "API not found" errors at runtime in the dotnet-spark repo. 

**OLD**
The following methods on `DataFrameColumn` are being made public:
1. GetArrowField
2. GetMaxRecordBatchLength
3. ToArrowArray

These 3 methods are the ones we need to support Spark 3.0.

There is an argument to be made here that these APIs should remain protected. The alternative we have here is to update just the existing `DataFrame.ToArrowRecordBatches()` method to return a Spark 3.0 compatible `RecordBatch`. Because dotnet-spark's dependencies on MDA are specified as exact versions, this should work and no backend changes would be needed on the dotnet-spark side! I'm inclined to update `DataFrame.ToArrowRecordBatches()` personally, but I don't mind making these 3  methods public either.