### PR TITLE
DataFrame.Load(IDataReader)

### DIFF
--- a/src/Microsoft.Data.Analysis/DataFrame.IO.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.IO.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Data.Analysis
             for (int i = 0; i < numberOfColumns; ++i)
             {
                 Type kind = dataTypes == null ? GuessKind(i, linesForGuessType) : dataTypes[i];
-                columns.Add(CreateColumn(kind, columnNames[i], i));
+                columns.Add(CreateColumn(kind, columnNames?[i], i));
             }
 
             DataFrame ret = new DataFrame(columns);

--- a/src/Microsoft.Data.Analysis/DataFrame.LoadDataReader.cs
+++ b/src/Microsoft.Data.Analysis/DataFrame.LoadDataReader.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace Microsoft.Data.Analysis
+{
+    partial class DataFrame
+    {
+        public static DataFrame Load(IDataReader dataReader, int numberOfRowsToRead = -1, bool addIndexColumn = false)
+        {
+            var schema = SchemaTable.GetSchema(dataReader);
+
+            var columns = new List<DataFrameColumn>(schema.Count);
+            for (int i = 0; i < schema.Count; ++i)
+            {
+                var col = schema[i];
+                columns.Add(CreateColumn(col.DataType, col.ColumnName, i));
+            }
+
+            DataFrame dataFrame = new DataFrame(columns);
+
+            object[] rowData = new object[schema.Count];
+
+            long rowNumber = 0;
+            while (dataReader.Read() && (numberOfRowsToRead == -1 || rowNumber < numberOfRowsToRead))
+            {
+                dataReader.GetValues(rowData);
+
+                for (int i = 0; i < rowData.Length; i++)
+                {
+                    if (rowData[i] == DBNull.Value)
+                    {
+                        rowData[i] = null;
+                    }
+                }
+                dataFrame.Append(rowData, true);
+                ++rowNumber;
+            }
+
+            if (addIndexColumn)
+            {
+                var indexColumn = new PrimitiveDataFrameColumn<int>("IndexColumn", columns[0].Length);
+                for (int i = 0; i < columns[0].Length; i++)
+                {
+                    indexColumn[i] = i;
+                }
+                columns.Insert(0, indexColumn);
+            }
+            return dataFrame;
+        }
+    }
+}

--- a/src/Microsoft.Data.Analysis/SchemaTable.cs
+++ b/src/Microsoft.Data.Analysis/SchemaTable.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Data.Common;
+
+namespace Microsoft.Data.Analysis
+{
+    static class SchemaTable
+    {
+        internal static ReadOnlyCollection<DbColumn> GetSchema(IDataReader dataReader)
+        {
+            if (dataReader is DbDataReader ddr && ddr.CanGetColumnSchema())
+            {
+                return ddr.GetColumnSchema();
+            }
+            // this code path is needed to support running on versions prior to net5
+            // in net5 (maybe earlier) the above CanGetColumnSchema() will always be
+            // true, and implements this same logic internally.
+            var schemaTable = dataReader.GetSchemaTable();
+            var schema = new List<DbColumn>(schemaTable.Rows.Count);
+
+            var columns = schemaTable.Columns;
+            foreach (DataRow row in schemaTable.Rows)
+            {
+                schema.Add(new DataRowDbColumn(row, columns));
+            }
+            return new ReadOnlyCollection<DbColumn>(schema);
+        }
+
+        // this implementation is copied from System.Data.Common v5.0.0
+        private sealed class DataRowDbColumn : DbColumn
+        {
+            private readonly DataColumnCollection _schemaColumns;
+            private readonly DataRow _schemaRow;
+
+            public DataRowDbColumn(DataRow readerSchemaRow, DataColumnCollection readerSchemaColumns)
+            {
+                _schemaRow = readerSchemaRow;
+                _schemaColumns = readerSchemaColumns;
+
+                base.ColumnName = GetDbColumnValue<string>(SchemaTableColumn.ColumnName);
+                base.AllowDBNull = GetDbColumnValue<bool?>(SchemaTableColumn.AllowDBNull);
+                base.DataType = GetDbColumnValue<Type>(SchemaTableColumn.DataType);
+            }
+
+            T GetDbColumnValue<T>(string columnName)
+            {
+                if (_schemaColumns.Contains(columnName))
+                {
+                    object obj = _schemaRow[columnName];
+                    if (obj is T)
+                    {
+                        return (T)obj;
+                    }
+                }
+                return default(T);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This was spurred by a discussion here: 
https://github.com/dotnet/runtime/discussions/37711

Basically, this allows loading from any data source that exposes data as IDataReader, which would include pretty much all relational databases, as well as a variety of csv data sources (most CSV apis don't support strongly typed schemas, so somewhat less valuable than LoadCsv). 

This is a draft work in progress. I'm curious if this is functionality you all would be interested in merging before I spend any more time on it. 

Still needs:
1) fix up todos and not implemented
2) docs
3) tests
